### PR TITLE
Add missing module

### DIFF
--- a/esphomeyaml/guides/contributing.rst
+++ b/esphomeyaml/guides/contributing.rst
@@ -176,7 +176,7 @@ To check your documentation changes locally, you first need install sphinx (**wi
 
 .. code:: bash
 
-    pip3 install sphinx
+    pip3 install sphinx breathe
 
 Then, use the provided Makefile to build the changes and start a simple web server:
 


### PR DESCRIPTION
Looks like that Sphinx is not enough.

```bash
(esphomedocs) [fab@localhost esphomedocs]$ make html
sphinx-build -M html "." "_build"  
Running Sphinx v1.7.5

Extension error:
Could not import extension breathe (exception: No module named 'breathe')
make: *** [Makefile:13: html] Error 2
```