### PR TITLE
Passing `inverted` to output should be valid, but does not work, use …

### DIFF
--- a/esphomeyaml/devices/sonoff_basic.rst
+++ b/esphomeyaml/devices/sonoff_basic.rst
@@ -96,8 +96,9 @@ exposes all of the basic functions.
     output:
       - platform: esp8266_pwm
         id: basic_green_led
-        pin: GPIO13
-        inverted: True
+        pin: 
+          number: GPIO13
+          inverted: True
 
     light:
       - platform: monochromatic


### PR DESCRIPTION
…working invocation in docs until bug is fixed.