### PR TITLE
Remove BMP280 (doesn't work)

### DIFF
--- a/esphomeyaml/components/sensor/bmp085.rst
+++ b/esphomeyaml/components/sensor/bmp085.rst
@@ -3,11 +3,9 @@ BMP085 Temperature+Pressure Sensor
 
 The BMP085 sensor platform allows you to use your BMP085
 (`datasheet <https://www.sparkfun.com/datasheets/Components/General/BST-BMP085-DS000-05.pdf>`__,
-`adafruit <https://www.adafruit.com/product/391>`__), BMP180
+`adafruit <https://www.adafruit.com/product/391>`__) and BMP180
 (`datasheet <https://cdn-shop.adafruit.com/datasheets/BST-BMP180-DS000-09.pdf>`__,
-`adafruit <https://www.adafruit.com/product/1603>`__) and BMP280
-(`datasheet <https://cdn-shop.adafruit.com/datasheets/BST-BMP280-DS001-11.pdf>`__,
-`adafruit <https://www.adafruit.com/product/2651>`__) temperature and
+`adafruit <https://www.adafruit.com/product/1603>`__) temperature and
 pressure sensors with esphomelib. The :ref:`I²C <i2c>` is required to be set up in
 your configuration for this sensor to work.
 
@@ -48,7 +46,7 @@ Configuration variables:
   - All other options from :ref:`Sensor <config-sensor>` and :ref:`MQTT Component <config-mqtt-component>`.
   - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.
 
--  **address** (*Optional*, int): Manually specify the i^2c address of
+-  **address** (*Optional*, int): Manually specify the I²C address of
    the sensor. Defaults to ``0x77``.
 -  **update_interval** (*Optional*, :ref:`config-time`): The interval to check the
    sensor. Defaults to ``15s``. See :ref:`sensor-default_filter`.


### PR DESCRIPTION
Gives back wrong measurments with the following configuration:

```yaml
sensor:
  - platform: bmp085
    address: 0x76
    temperature:
      name: "Outside Temperature"
    pressure:
      name: "Outside Pressure"
    update_interval: 15s
```

```bash
[19:43:47][D][sensor.bmp085:084]: Got Temperature=82.6°C
[19:43:47][D][sensor.mqtt:039]: 'Outside Temperature': Pushing out value 82.599998 with 1 decimals of accuracy
[19:43:47][D][sensor.bmp085:124]: Got Pressure=801133.2hPa
[19:43:47][D][sensor.mqtt:039]: 'Outside Pressure': Pushing out value 801133.187500 with 1 decimals of accuracy
```

My guess is that's more like a BME280 (https://github.com/OttoWinter/esphomeyaml/issues/23).