### PR TITLE
Note added about resetting the ESP after serial upload before OTA upload

### DIFF
--- a/esphomeyaml/components/ota.rst
+++ b/esphomeyaml/components/ota.rst
@@ -7,7 +7,7 @@ uploads. esphomeyaml natively supports this through its ``run`` and
 ``upload`` helper scripts.
 
 .. note::
-  Please be aware that the ESP module must be reset after a serial 
+  Please be aware that ESP8266 modules must be reset after a serial 
   upload before OTA can work.
   When you are trying to conduct an OTA update and receive an error message
   ``Bad Answer: ERR: ERROR[11]: Invalid bootstrapping`` the reason is

--- a/esphomeyaml/components/ota.rst
+++ b/esphomeyaml/components/ota.rst
@@ -6,6 +6,15 @@ firmware binaries to your node without having to use an USB cable for
 uploads. esphomeyaml natively supports this through its ``run`` and
 ``upload`` helper scripts.
 
+.. note::
+  Please be aware that the ESP module must be reset after a serial 
+  upload before OTA can work.
+  When you are trying to conduct an OTA update and receive an error message
+  ``Bad Answer: ERR: ERROR[11]: Invalid bootstrapping`` the reason is
+  very likely that power-cycling the ESP module is required once after
+  the serial upload.
+  
+
 Optionally, you can also define a password to use for OTA updates so
 that an intruder isn’t able to upload any firmware to the ESP without
 having hardware access to it. This password is also hashed


### PR DESCRIPTION
The OTA update wasn't working for me initially (after a serial upload) and the error message I received (`ERR: ERROR[11]: Invalid bootstrapping`) wasn't much help either. Apparently the ESP module requires a power cycle once after a serial upload before the OTA upload can work. (Source: https://arduino-esp8266.readthedocs.io/en/latest/ota_updates/readme.html, "Note: ESP module should be reset after serial upload. ...")
I added a note to the OTA section on this. Please let me know if you prefer this to be added to the FAQ section instead (or both?).