### PR TITLE
Add missing (required) name to example Remote Receiver Binary Sensor.

### DIFF
--- a/esphomeyaml/components/binary_sensor/remote_receiver.rst
+++ b/esphomeyaml/components/binary_sensor/remote_receiver.rst
@@ -15,6 +15,7 @@ then immediately OFF.
 
     binary_sensor:
       - platform: remote_receiver
+        name: "Panasonic Remote Input"
         panasonic:
           address: 0x4004
           command: 0x100BCBD


### PR DESCRIPTION
I just noticed that the documented example was missing a required field.