### PR TITLE
add samsung IR protocol

### DIFF
--- a/esphomeyaml/components/remote_receiver.rst
+++ b/esphomeyaml/components/remote_receiver.rst
@@ -27,6 +27,7 @@ Configuration variables:
   - **lg**: Decode and dump LG infrared codes.
   - **nec**: Decode and dump NEC infrared codes.
   - **panasonic**: Decode and dump Panasonic infrared codes.
+  - **samsung**: Decode and dump Samsung infrared codes.
   - **sony**: Decode and dump Sony infrared codes.
   - **rc_switch**: Decode and dump RCSwitch RF codes.
   - **raw**: Print all remote codes in their raw form. Useful for using arbitrary protocols.

--- a/esphomeyaml/components/switch/remote_transmitter.rst
+++ b/esphomeyaml/components/switch/remote_transmitter.rst
@@ -78,6 +78,8 @@ Supported remote codes:
       lg:
         data: 0x01234567890ABC
         nbits: 28
+      samsung:
+        data: 0xE0E01234
       sony:
         data: 0xABCDEF
         nbits: 12
@@ -121,6 +123,10 @@ Configuration variables:
 
   - **data**: The data bytes to send.
   - **nbits**: The number of bits to send, defaults to 28.
+
+- **samsung**: Send an Samsung IR code.
+
+  - **data**: The data bytes to send.
 
 - **sony**: Send an Sony IR code.
 


### PR DESCRIPTION
## Description:
Add Samsung IR protocol

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphomeyaml](https://github.com/OttoWinter/esphomeyaml) with YAML changes (if applicable):** OttoWinter/esphomeyaml#176
**Pull request in [esphomelib](https://github.com/OttoWinter/esphomelib) with C++ framework changes (if applicable):** OttoWinter/esphomelib#141

## Checklist:
  - [ ] The documentation change has been tested and compiles correctly.
  - [x] Branch: `next` is for changes and new documentation that will go public with the next esphomelib release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Check this box if you have read, understand, comply, and agree with the [Code of Conduct](https://github.com/OttoWinter/esphomedocs/blob/master/CODE_OF_CONDUCT.md).
