### PR TITLE
Add send_first_at option to sliding window sensor filter

### DIFF
--- a/esphomeyaml/components/sensor/index.rst
+++ b/esphomeyaml/components/sensor/index.rst
@@ -126,6 +126,9 @@ every filter there is currently:
    -  **send_every**: How often a sensor value should be pushed out. For
       example, in above configuration the weighted average is only
       pushed out on every 15th received sensor value.
+   -  **send_first_at**: By default, the very first raw value on boot is immediately
+      published. With this parameter you can specify when the very first value is to be sent.
+      Defaults to ``1``.
 
 -  **exponential_moving_average**: A simple `exponential moving
    average <https://en.wikipedia.org/wiki/Moving_average#Exponential_moving_average>`__


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphomeyaml](https://github.com/OttoWinter/esphomeyaml) with YAML changes (if applicable):** OttoWinter/esphomeyaml#207
**Pull request in [esphomelib](https://github.com/OttoWinter/esphomelib) with C++ framework changes (if applicable):** OttoWinter/esphomelib#240

## Checklist:
  - [ ] The documentation change has been tested and compiles correctly.
  - [ ] Branch: `next` is for changes and new documentation that will go public with the next esphomelib release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Check this box if you have read, understand, comply, and agree with the [Code of Conduct](https://github.com/OttoWinter/esphomedocs/blob/master/CODE_OF_CONDUCT.md).
