### PR TITLE
Fix a broken link to setting up a BLE tracker.

### DIFF
--- a/esphomeyaml/components/esp32_ble_tracker.rst
+++ b/esphomeyaml/components/esp32_ble_tracker.rst
@@ -4,7 +4,7 @@ ESP32 Bluetooth Low Energy Tracker Hub
 The ``esp32_ble_tracker`` component creates a global hub so that you can track bluetooth low
 energy devices using your ESP32 node.
 
-See `Setting up devices </esphomeyaml/components/binary_sensor/esp32_ble.html#setting-up-devices>`__
+See `Setting up devices </esphomeyaml/components/binary_sensor/esp32_ble_tracker.html#esp32-ble-tracker-setting-up-devices>`__
 for information on how you can find out the MAC address of a device and track it using esphomelib.
 
 .. code:: yaml

--- a/esphomeyaml/components/esp32_ble_tracker.rst
+++ b/esphomeyaml/components/esp32_ble_tracker.rst
@@ -4,7 +4,7 @@ ESP32 Bluetooth Low Energy Tracker Hub
 The ``esp32_ble_tracker`` component creates a global hub so that you can track bluetooth low
 energy devices using your ESP32 node.
 
-See `Setting up devices </esphomeyaml/components/binary_sensor/esp32_ble_tracker.html#esp32-ble-tracker-setting-up-devices>`__
+See :ref:`Setting up devices <esp32_ble_tracker-setting_up_devices>`
 for information on how you can find out the MAC address of a device and track it using esphomelib.
 
 .. code:: yaml


### PR DESCRIPTION
## Description:
Fix a broken link about setting up a BLE tracker.
Old link points [here](https://esphomelib.com/esphomeyaml/components/binary_sensor/esp32_ble.html#setting-up-devices) (which 404s).
New link points [here](https://esphomelib.com/esphomeyaml/components/binary_sensor/esp32_ble_tracker.html#esp32-ble-tracker-setting-up-devices), which seems to be what was intended.

## Checklist:
  - [X] The documentation change has been tested and compiles correctly.
  - [X] Branch: `next` is for changes and new documentation that will go public with the next esphomelib release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [X] Check this box if you have read, understand, comply, and agree with the [Code of Conduct](https://github.com/OttoWinter/esphomedocs/blob/master/CODE_OF_CONDUCT.md).
