### PR TITLE
Tiny typo fix.

### DIFF
--- a/esphomeyaml/guides/faq.rst
+++ b/esphomeyaml/guides/faq.rst
@@ -164,7 +164,7 @@ not have a real solution.
 
 Some steps that can help with the issue:
 
--  Use the most recent version of th arduino framework. The platformio arduino package
+-  Use the most recent version of the arduino framework. The platformio arduino package
    always takes some time to update and the most recent version often includes some awesome
    patches. See :ref:`esphomeyaml-arduino_version`.
 -  The issue seems to be happen with cheap boards more frequently. Especially the "cheap" NodeMCU


### PR DESCRIPTION
## Description:
Typo fixing `th` -> `the`.

## Checklist:
  - [X] The documentation change has been tested and compiles correctly.
  - [X] Branch: `next` is for changes and new documentation that will go public with the next esphomelib release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [X] Check this box if you have read, understand, comply, and agree with the [Code of Conduct](https://github.com/OttoWinter/esphomedocs/blob/master/CODE_OF_CONDUCT.md).
