### PR TITLE
Revert add power_on_value to gpio switch

### DIFF
--- a/esphomeyaml/components/switch/gpio.rst
+++ b/esphomeyaml/components/switch/gpio.rst
@@ -23,11 +23,16 @@ Configuration variables:
 - **pin** (**Required**, :ref:`Pin Schema <config-pin_schema>`): The
   GPIO pin to use for the switch.
 - **name** (**Required**, string): The name for the switch.
-- **power_on_value** (*Optional*, boolean): The state this switch should be initialized with on boot.
-  Please note that certain pins can have pull-up/down resistors that activate/deactivate a pin before
-  esphomelib can initialize them. Please check with a multimeter and use another pin if necessary.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
 - All other options from :ref:`Switch <config-switch>` and :ref:`MQTT Component <config-mqtt-component>`.
+
+.. note::
+
+    esphomelib will attempt to restore the state of the switch on boot-up and write the value
+    very early in the boot process.
+
+    Please note that certain pins can have pull-up/down resistors that activate/deactivate a pin before
+    esphomelib can initialize them. Please check with a multimeter and use another pin if necessary.
 
 See Also
 --------


### PR DESCRIPTION
## Description:


**Pull request in [esphomeyaml](https://github.com/OttoWinter/esphomeyaml) with YAML changes (if applicable):** OttoWinter/esphomeyaml#223
**Pull request in [esphomelib](https://github.com/OttoWinter/esphomelib) with C++ framework changes (if applicable):** OttoWinter/esphomelib#258

## Checklist:
  - [x] The documentation change has been tested and compiles correctly.
  - [x] Branch: `next` is for changes and new documentation that will go public with the next esphomelib release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Check this box if you have read, understand, comply, and agree with the [Code of Conduct](https://github.com/OttoWinter/esphomedocs/blob/master/CODE_OF_CONDUCT.md).
