### PR TITLE
Updated the multi click example code block

### DIFF
--- a/esphomeyaml/components/binary_sensor/index.rst
+++ b/esphomeyaml/components/binary_sensor/index.rst
@@ -249,7 +249,6 @@ presses.
         then:
           - logger.log: "Double Clicked"
       - timing:
-          - OFF for 1s to 2s
           - ON for 1s to 2s
           - OFF for at least 0.5s
         then:


### PR DESCRIPTION
I had no luck triggering the "Single Long Clicked" with the timing of
- OFF for 1s to 2s
- ON for 1s to 2s
- OFF for at least 0.5s
I removed the waiting first time of OFF for, and now i can trigger it as expected.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphomeyaml](https://github.com/OttoWinter/esphomeyaml) with YAML changes (if applicable):** OttoWinter/esphomeyaml#<esphomeyaml PR number goes here>
**Pull request in [esphomelib](https://github.com/OttoWinter/esphomelib) with C++ framework changes (if applicable):** OttoWinter/esphomelib#<esphomelib PR number goes here>

## Checklist:
  - [ ] The documentation change has been tested and compiles correctly.
  - [ ] Branch: `next` is for changes and new documentation that will go public with the next esphomelib release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x ] Check this box if you have read, understand, comply, and agree with the [Code of Conduct](https://github.com/OttoWinter/esphomedocs/blob/master/CODE_OF_CONDUCT.md).
