### PR TITLE
Updated docker command to what worked for me.

### DIFF
--- a/esphomeyaml/guides/contributing.rst
+++ b/esphomeyaml/guides/contributing.rst
@@ -192,7 +192,7 @@ To check your documentation changes locally, you first need install sphinx (**wi
 
     .. code-block:: bash
 
-        docker run --rm -v "$PWD/..":/data -p 8000:8000 -it ottowinter/esphomedocs
+        docker run --rm -v "$PWD/..":/data -v "$PWD":/data/esphomedocs-p 8000:8000 -it ottowinter/esphomedocs
 
     And then go to ``<CONTAINER_IP>:8000`` in your browser.
 


### PR DESCRIPTION
The docker command in the documenation leaves the docker container with an empty /data/esphomedocs directory.  I assume this is because of the "VOLUME" line in the Dockerfile, but specifying that volume in the command-line fixed it for me.

## Description:


## Checklist:
  - [✓] The documentation change has been tested and compiles correctly.
  - [✓] Branch: `next` is for changes and new documentation that will go public with the next esphomelib release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [✓] Check this box if you have read, understand, comply, and agree with the [Code of Conduct](https://github.com/OttoWinter/esphomedocs/blob/master/CODE_OF_CONDUCT.md).
