### PR TITLE
Fix copy paste error on WiFi Signal Strength page

### DIFF
--- a/esphomeyaml/components/sensor/wifi_signal.rst
+++ b/esphomeyaml/components/sensor/wifi_signal.rst
@@ -26,7 +26,7 @@ measured in decibels. These values are always negative and the closer they are t
 Configuration variables:
 ------------------------
 
-- **name** (**Required**, string): The name of the hall effect sensor.
+- **name** (**Required**, string): The name of the WiFi signal sensor.
 - **update_interval** (*Optional*, :ref:`config-time`): The interval
   to check the sensor. Defaults to ``15s``. See :ref:`sensor-default_filter`.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphomeyaml](https://github.com/OttoWinter/esphomeyaml) with YAML changes (if applicable):** OttoWinter/esphomeyaml#<esphomeyaml PR number goes here>
**Pull request in [esphomelib](https://github.com/OttoWinter/esphomelib) with C++ framework changes (if applicable):** OttoWinter/esphomelib#<esphomelib PR number goes here>

## Checklist:
  - [x] The documentation change has been tested and compiles correctly.
  - [x] Branch: `next` is for changes and new documentation that will go public with the next esphomelib release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Check this box if you have read, understand, comply, and agree with the [Code of Conduct](https://github.com/OttoWinter/esphomedocs/blob/master/CODE_OF_CONDUCT.md).
