### PR TITLE
Update getting_started_command_line.rst

### DIFF
--- a/esphomeyaml/guides/getting_started_command_line.rst
+++ b/esphomeyaml/guides/getting_started_command_line.rst
@@ -41,7 +41,7 @@ file called ``livingroom.yaml``:
 
     esphomeyaml livingroom.yaml wizard
     # On Docker:
-    docker run --rm -v "`pwd`":/config -it ottowinter/esphomeyaml livingroom.yaml wizard
+    docker run --rm -v ${PWD}:/config -it ottowinter/esphomeyaml livingroom.yaml wizard
 
 .. note::
 


### PR DESCRIPTION
Use ${PWD} to set current directory are works on both Powershell and Linux

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphomeyaml](https://github.com/OttoWinter/esphomeyaml) with YAML changes (if applicable):** OttoWinter/esphomeyaml#<esphomeyaml PR number goes here>
**Pull request in [esphomelib](https://github.com/OttoWinter/esphomelib) with C++ framework changes (if applicable):** OttoWinter/esphomelib#<esphomelib PR number goes here>

## Checklist:
  - [ ] The documentation change has been tested and compiles correctly.
  - [ ] Branch: `next` is for changes and new documentation that will go public with the next esphomelib release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Check this box if you have read, understand, comply, and agree with the [Code of Conduct](https://github.com/OttoWinter/esphomedocs/blob/master/CODE_OF_CONDUCT.md).
