### PR TITLE
Update remote_transmitter.rst

### DIFF
--- a/esphomeyaml/components/remote_transmitter.rst
+++ b/esphomeyaml/components/remote_transmitter.rst
@@ -23,7 +23,7 @@ Use-cases are for example infrared remotes or 433MHz signals.
     # Example configuration entry
     remote_transmitter:
       pin: GPIO32
-      carrier_duty_percent: 50%
+      carrier_duty_percent: 47%
 
     # Individual switches
     switch:
@@ -38,7 +38,7 @@ Configuration variables:
 
 -  **pin** (**Required**, :ref:`config-pin`): The pin to transmit the remote signal on.
 -  **carrier_duty_percent** (*Optional*, int): How much of the time the remote is on. For example, infrared
-   protocols modulate the signal using a carrier signal. Set this is ``50%`` if you're working with IR leds and to
+   protocols modulate the signal using a carrier signal. Set this is ``47%`` if you're working with IR leds and to
    ``100%`` if working with a other things like 433MHz transmitters.
 -  **id** (*Optional*, :ref:`config-id`): Manually specify
    the ID used for code generation. Use this if you have multiple remote transmitters.


### PR DESCRIPTION
Carrier Duty Percentage should be 47% as this will set the Carrier Frequency to 38kHz.  With 50% it will set to 40kHz, which still works but may cause issues with some IR receivers.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphomeyaml](https://github.com/OttoWinter/esphomeyaml) with YAML changes (if applicable):** OttoWinter/esphomeyaml#<esphomeyaml PR number goes here>
**Pull request in [esphomelib](https://github.com/OttoWinter/esphomelib) with C++ framework changes (if applicable):** OttoWinter/esphomelib#<esphomelib PR number goes here>

## Checklist:
  - [x] The documentation change has been tested and compiles correctly.
  - [x] Branch: `next` is for changes and new documentation that will go public with the next esphomelib release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Check this box if you have read, understand, comply, and agree with the [Code of Conduct](https://github.com/OttoWinter/esphomedocs/blob/master/CODE_OF_CONDUCT.md).
