### PR TITLE
Mismatch in example and text

### DIFF
--- a/esphomeyaml/guides/getting_started_hassio.rst
+++ b/esphomeyaml/guides/getting_started_hassio.rst
@@ -106,7 +106,7 @@ to the configuration like this:
         name: "Living Room Dehumidifier"
         pin: 5
 
-In above example, we're simply adding a switch that's called "Living Room Relay" (could control
+In above example, we're simply adding a switch that's called "Living Room Dehumidifier" (could control
 anything really, for example lights) and is connected to the pin ``GPIO5``.
 
 Now if you have `MQTT


### PR DESCRIPTION
## Description:

The example uses Dehumidifier the text said relay

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphomeyaml](https://github.com/OttoWinter/esphomeyaml) with YAML changes (if applicable):** OttoWinter/esphomeyaml#<esphomeyaml PR number goes here>
**Pull request in [esphomelib](https://github.com/OttoWinter/esphomelib) with C++ framework changes (if applicable):** OttoWinter/esphomelib#<esphomelib PR number goes here>

## Checklist:
  - [ ] The documentation change has been tested and compiles correctly.
  - [x] Branch: `next` is for changes and new documentation that will go public with the next esphomelib release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Check this box if you have read, understand, comply, and agree with the [Code of Conduct](https://github.com/OttoWinter/esphomedocs/blob/master/CODE_OF_CONDUCT.md).
