### PR TITLE
Fix copy/paste error in turn_off_action

### DIFF
--- a/esphomeyaml/components/switch/template.rst
+++ b/esphomeyaml/components/switch/template.rst
@@ -47,7 +47,7 @@ Configuration variables:
 - **turn_on_action** (*Optional*, :ref:`Action <config-action>`): The action that should
   be performed when the remote (like Home Assistant's frontend) requests the switch to be turned on.
 - **turn_off_action** (*Optional*, :ref:`Action <config-action>`): The action that should
-  be performed when the remote (like Home Assistant's frontend) requests the switch to be turned on.
+  be performed when the remote (like Home Assistant's frontend) requests the switch to be turned off.
 - **restore_state** (*Optional*, boolean): Sets whether esphomelib should attempt to restore the
   state on boot-up and call the turn on/off actions with the recovered values. Defaults to ``yes``.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.


### PR DESCRIPTION
## Description:
Simple copy/paste error. Replace "on" with "off" for _turn_off_action_ description.

## Checklist:
  - [x] The documentation change has been tested and compiles correctly.
  - [ ] Branch: `next` is for changes and new documentation that will go public with the next esphomelib release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Check this box if you have read, understand, comply, and agree with the [Code of Conduct](https://github.com/OttoWinter/esphomedocs/blob/master/CODE_OF_CONDUCT.md).
