### PR TITLE
Update total_daily_energy.rst

### DIFF
--- a/esphomeyaml/components/sensor/total_daily_energy.rst
+++ b/esphomeyaml/components/sensor/total_daily_energy.rst
@@ -17,9 +17,9 @@ daily energy usage in ``Wh`` or ``kWh``.
     # Example configuration entry
     sensor:
       - platform: total_daily_energy
-        pin: 12
         name: "Total Daily Energy"
         power_id: my_power
+        time_id: my_time
 
       # The power sensor to convert, can be any power sensor
       - platform: hlw8012
@@ -31,6 +31,7 @@ daily energy usage in ``Wh`` or ``kWh``.
     time:
       - platform: sntp
         id: my_time
+        timezone: Europe/Amsterdam
 
 Configuration variables:
 ------------------------
@@ -40,6 +41,7 @@ Configuration variables:
 - **name** (**Required**, string): The name of the sensor.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
 - All other options from :ref:`Sensor <config-sensor>` and :ref:`MQTT Component <config-mqtt-component>`.
+- **time_id** (**Required**, :ref:`config-id`): The ID of the time component.
 
 Converting from W to kW
 -----------------------


### PR DESCRIPTION
Pin was shown in example while it should not have it. time_id was missing in the example. Time component was missing the timezone option (it did not compile without on my linux machine)

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphomeyaml](https://github.com/OttoWinter/esphomeyaml) with YAML changes (if applicable):** OttoWinter/esphomeyaml#<esphomeyaml PR number goes here>
**Pull request in [esphomelib](https://github.com/OttoWinter/esphomelib) with C++ framework changes (if applicable):** OttoWinter/esphomelib#<esphomelib PR number goes here>

## Checklist:
  - [ ] The documentation change has been tested and compiles correctly.
  - [ ] Branch: `next` is for changes and new documentation that will go public with the next esphomelib release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Check this box if you have read, understand, comply, and agree with the [Code of Conduct](https://github.com/OttoWinter/esphomedocs/blob/master/CODE_OF_CONDUCT.md).
