### PR TITLE
Fixed missing link to BME cookbook

### DIFF
--- a/esphomeyaml/index.rst
+++ b/esphomeyaml/index.rst
@@ -259,6 +259,7 @@ This list contains items that are technically already supported by other compone
     TEMT6000, cookbook/temt6000, temt6000.jpg
     Non-Invasive Power Meter, cookbook/power_meter, power_meter.jpg
     Dual Relay Motor Cover, cookbook/dual-r2-cover, sonoff_dual_r2.jpg
+    BME280 Environment, cookbook/bme280_environment, bme280.jpg
 
 Do you have other awesome automations or 2nd order components? Please feel free to add them to the
 documentation for others to copy. See :doc:`Contributing <guides/contributing>`.


### PR DESCRIPTION
Fixed missing link to BME cookbook

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphomeyaml](https://github.com/OttoWinter/esphomeyaml) with YAML changes (if applicable):** OttoWinter/esphomeyaml#<esphomeyaml PR number goes here>
**Pull request in [esphomelib](https://github.com/OttoWinter/esphomelib) with C++ framework changes (if applicable):** OttoWinter/esphomelib#<esphomelib PR number goes here>

## Checklist:
  - [] The documentation change has been tested and compiles correctly.
  - [x] Branch: `next` is for changes and new documentation that will go public with the next esphomelib release. Fixes, changes and adjustments for the current release should be created against `current`.
