### PR TITLE
Fix esp8266_pwm example, IDs cannot have hyphens

### DIFF
--- a/esphomeyaml/components/output/esp8266_pwm.rst
+++ b/esphomeyaml/components/output/esp8266_pwm.rst
@@ -21,7 +21,7 @@ successor of the ESP8266, the ESP32, and its :doc:`ESP32 LEDC PWM <ledc>` instea
       - platform: esp8266_pwm
         pin: D1
         frequency: 1000 Hz
-        id: pwm-output
+        id: pwm_output
 
 Configuration variables:
 ------------------------


### PR DESCRIPTION
ID:s can't have - in the name. Changed it to underscore _

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphomeyaml](https://github.com/OttoWinter/esphomeyaml) with YAML changes (if applicable):** OttoWinter/esphomeyaml#<esphomeyaml PR number goes here>
**Pull request in [esphomelib](https://github.com/OttoWinter/esphomelib) with C++ framework changes (if applicable):** OttoWinter/esphomelib#<esphomelib PR number goes here>

## Checklist:
  - [ ] The documentation change has been tested and compiles correctly.
  - [ ] Branch: `next` is for changes and new documentation that will go public with the next esphomelib release. Fixes, changes and adjustments for the current release should be created against `current`.
