### PR TITLE
Add Arilux LC02 pinout

### DIFF
--- a/esphomeyaml/devices/sonoff.rst
+++ b/esphomeyaml/devices/sonoff.rst
@@ -248,6 +248,24 @@ Arilux LC01
 See :doc:`/esphomeyaml/components/light/rgbw` for controlling the lights together with
 :doc:`/esphomeyaml/components/output/esp8266_pwm`.
 
+Arilux LC02
+-----------
+
+.. pintable::
+
+    GPIO0, Button (inverted),
+    GPIO2, Blue LED,
+    GPIO5, Red Channel,
+    GPIO14, Green Channel,
+    GPIO12, Blue Channel,
+    GPIO13, White Channel,
+
+    GPIO1, UART TX pin (for external sensors)
+    GPIO3, UART RX pin (for external sensors)
+
+See :doc:`/esphomeyaml/components/light/rgbw` for controlling the lights together with
+:doc:`/esphomeyaml/components/output/esp8266_pwm`.
+
 Arilux LC11
 -----------
 


### PR DESCRIPTION
## Description:
Add pinout info for Arilux LC02
This one have different pinout compare to LC01

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphomeyaml](https://github.com/OttoWinter/esphomeyaml) with YAML changes (if applicable):** OttoWinter/esphomeyaml#<esphomeyaml PR number goes here>
**Pull request in [esphomelib](https://github.com/OttoWinter/esphomelib) with C++ framework changes (if applicable):** OttoWinter/esphomelib#<esphomelib PR number goes here>

## Checklist:
  - [ ] The documentation change has been tested and compiles correctly.
  - [ ] Branch: `next` is for changes and new documentation that will go public with the next esphomelib release. Fixes, changes and adjustments for the current release should be created against `current`.
