### PR TITLE
Dallas: Update for default update_interval

### DIFF
--- a/esphomeyaml/components/dallas.rst
+++ b/esphomeyaml/components/dallas.rst
@@ -34,7 +34,7 @@ Configuration variables:
 
 - **pin** (**Required**, number): The pin the sensor bus is connected to.
 - **update_interval** (*Optional*, :ref:`config-time`): The interval that the sensors should be checked.
-  Defaults to 15 seconds.
+  Defaults to 60 seconds.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
 
 See Also


### PR DESCRIPTION
Actual default update_interval is 60 seconds (measured with stopwatch) over MQTT, not 15 seconds.

## Description:


**Related issue (if applicable):** fixes https://github.com/OttoWinter/esphomeyaml/issues/360

**Pull request in [esphomeyaml](https://github.com/OttoWinter/esphomeyaml) with YAML changes (if applicable):** OttoWinter/esphomeyaml/issues/360

## Checklist:
  - [ ] The documentation change has been tested and compiles correctly.
  - [ ] Branch: `next` is for changes and new documentation that will go public with the next esphomelib release. Fixes, changes and adjustments for the current release should be created against `current`.
