### PR TITLE
repository correct naming

### DIFF
--- a/esphomeyaml/components/esphomeyaml.rst
+++ b/esphomeyaml/components/esphomeyaml.rst
@@ -118,7 +118,7 @@ And last, you can make esphomeyaml use a specific branch/commit/tag from a remot
         branch: master
 
       esphomelib_version:
-        repository: https://github.com/somebody/esphomelib.git
+        repository: https://github.com/OttoWinter/esphomelib.git
         commit: d27bac9263e8a0a5a00672245b38db3078f8992c
 
       esphomelib_version:


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphomeyaml](https://github.com/OttoWinter/esphomeyaml) with YAML changes (if applicable):** OttoWinter/esphomeyaml#<esphomeyaml PR number goes here>
**Pull request in [esphomelib](https://github.com/OttoWinter/esphomelib) with C++ framework changes (if applicable):** OttoWinter/esphomelib#<esphomelib PR number goes here>

## Checklist:
  - [ ] The documentation change has been tested and compiles correctly.
  - [ ] Branch: `next` is for changes and new documentation that will go public with the next esphomelib release. Fixes, changes and adjustments for the current release should be created against `current`.
