### PR TITLE
Mention internal flag in api docs

### DIFF
--- a/esphomeyaml/components/api.rst
+++ b/esphomeyaml/components/api.rst
@@ -23,6 +23,13 @@ Configuration variables:
   Can be disabled by setting this to ``0s``. Defaults to ``5min``.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
 
+Per Component variables:
+------------------------
+
+-  **internal** (*Optional*, boolean): Mark this component as internal. Internal components will
+   not send any MQTT messages and can be used for :ref:`on-device automations <automation>`. Only
+   specifying an ``id`` without a ``name`` will implicitly set this to true.
+
 .. _api-mqtt_to_native:
 
 Migrating from MQTT to Native API Setup in Home Assistant


### PR DESCRIPTION
## Description:
Since this got asked several times it probably makes sense to mention it in the docs for the native api component. To clarify that this is not to be used on the api component but on a per component basis I separated it from configuration variables. Let me know if you have a better idea. I hope the github editor does not break anything.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphomeyaml](https://github.com/OttoWinter/esphomeyaml) with YAML changes (if applicable):** OttoWinter/esphomeyaml#<esphomeyaml PR number goes here>
**Pull request in [esphomelib](https://github.com/OttoWinter/esphomelib) with C++ framework changes (if applicable):** OttoWinter/esphomelib#<esphomelib PR number goes here>

## Checklist:
  - [ ] The documentation change has been tested and compiles correctly.
  - [x] Branch: `next` is for changes and new documentation that will go public with the next esphomelib release. Fixes, changes and adjustments for the current release should be created against `current`.

I tested that github is able to render the rst in this file only.