### PR TITLE
Remove duplicate "includes" line

### DIFF
--- a/components/esphomeyaml.rst
+++ b/components/esphomeyaml.rst
@@ -44,7 +44,6 @@ Advanced options:
   but you can customize this behavior using this option.
 - **platformio_options** (*Optional*, mapping): Additional options to pass over to platformio in the
   platformio.ini file. See :ref:`esphomeyaml-platformio_options`.
-- **includes** (*Optional*, list): Additional files to include in the main.cpp for custom components.
 - **libraries** (*Optional*, list): Additional `platformio libraries <https://platformio.org/lib>`__ to
   include in the build. Mostly for custom code.
 - **use_custom_code** (*Optional*, boolean): Whether to configure the project for writing custom components.


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphomeyaml](https://github.com/OttoWinter/esphomeyaml) with YAML changes (if applicable):** OttoWinter/esphomeyaml#<esphomeyaml PR number goes here>
**Pull request in [esphomelib](https://github.com/OttoWinter/esphomelib) with C++ framework changes (if applicable):** OttoWinter/esphomelib#<esphomelib PR number goes here>

## Checklist:
  - [x] The documentation change has been tested and compiles correctly.
  - [x] Branch: `next` is for changes and new documentation that will go public with the next esphomelib release. Fixes, changes and adjustments for the current release should be created against `current`.
