### PR TITLE
Link Home Assistant's include system in FAQ

### DIFF
--- a/guides/faq.rst
+++ b/guides/faq.rst
@@ -8,7 +8,7 @@ Frequently Asked Questions
 Tips for using esphomeyaml
 --------------------------
 
-1. esphomeyaml supports (most of) Home Assistant's YAML configuration directives like
+1. esphomeyaml supports (most of) `Home Assistant's YAML configuration directives <https://www.home-assistant.io/docs/configuration/splitting_configuration/>`__ like
    ``!include``, ``!secret``. So you can store all your secret WiFi passwords and so on
    in a file called ``secrets.yaml`` within the directory where the configuration file is.
 


### PR DESCRIPTION
I found Home Assistant's splitting configuration page was helpful in explaining how to use the directives, and also had a more complete list. So I linked it.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphomeyaml](https://github.com/OttoWinter/esphomeyaml) with YAML changes (if applicable):** OttoWinter/esphomeyaml#<esphomeyaml PR number goes here>
**Pull request in [esphomelib](https://github.com/OttoWinter/esphomelib) with C++ framework changes (if applicable):** OttoWinter/esphomelib#<esphomelib PR number goes here>

## Checklist:
  - [X] The documentation change has been tested and compiles correctly.
  - [X] Branch: `next` is for changes and new documentation that will go public with the next esphomelib release. Fixes, changes and adjustments for the current release should be created against `current`.
