### PR TITLE
Enable use of alternate hardware UARTs for logging 

### DIFF
--- a/components/logger.rst
+++ b/components/logger.rst
@@ -21,15 +21,36 @@ Configuration variables:
 
 -  **baud_rate** (*Optional*, int): The baud rate to use for the serial
    UART port. Defaults to ``115200``. Set to ``0`` to disable logging via UART.
--  **tx_buffer_size** (*Optional*, string): The size of the buffer used
+-  **tx_buffer_size** (*Optional*, int): The size of the buffer used
    for log messages. Decrease this if you’re having memory problems.
-   Defaults to 512.
+   Defaults to ``512``.
+-  **hw_uart** (*Optional*, string): The Hardware UART to use for logging.
+   Defaults to ``UART0``.
 -  **level** (*Optional*, string): The global log level. Any log message
-   with a lower severity will not be shown. Defaults to DEBUG.
+   with a lower severity will not be shown. Defaults to ``DEBUG``.
 -  **logs** (*Optional*, mapping): Manually set the log level for a
    specific component or tag. See :ref:`Manual Log Levels for more
    information <logger-manual_tag_specific_levels>`.
 -  **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
+
+.. _logger-hw_uarts:
+
+Hardware UARTs
+--------------
+
+The logger component makes use of platform-specific hardware UARTs.
+By default, the logger will occupy ``UART0``. The ESP32 has three hardware UARTs, all of
+which can be used for both transmit and receive. The ESP8266 only has two hardware UARTs,
+one of which is transmit-only. The ESP8266 ``UART0`` can also be 'swapped' to TX/RX on the
+CTS/RTS pins, if you need to use GPIO1 and GPIO3 for something else.
+
+Possible Hardware UART configurations:
+
+- ``UART0`` - TX: GPIO1, RX: GPIO3
+- ``UART0_SWAP`` - TX: GPIO15, RX: GPIO13  (Only on ESP8266)
+- ``UART1`` - TX: GPIO2, RX: None  (Only on ESP8266)
+- ``UART1`` - TX: GPIO9, RX: GPIO10  (Only on ESP832)
+- ``UART2`` - TX: GPIO16, RX: GPIO17  (Only on ESP832)
 
 .. _logger-log_levels:
 
@@ -135,6 +156,7 @@ Configuration options:
 See Also
 --------
 
+- :doc:`/components/uart`
 - :apiref:`log_component.h`
 - :ghedit:`Edit`
 

--- a/components/logger.rst
+++ b/components/logger.rst
@@ -24,7 +24,7 @@ Configuration variables:
 -  **tx_buffer_size** (*Optional*, int): The size of the buffer used
    for log messages. Decrease this if you’re having memory problems.
    Defaults to ``512``.
--  **hw_uart** (*Optional*, string): The Hardware UART to use for logging.
+-  **hardware_uart** (*Optional*, string): The Hardware UART to use for logging.
    Defaults to ``UART0``.
 -  **level** (*Optional*, string): The global log level. Any log message
    with a lower severity will not be shown. Defaults to ``DEBUG``.
@@ -33,12 +33,12 @@ Configuration variables:
    information <logger-manual_tag_specific_levels>`.
 -  **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
 
-.. _logger-hw_uarts:
+.. _logger-hardware_uarts:
 
 Hardware UARTs
 --------------
 
-The logger component makes use of platform-specific hardware UARTs.
+The logger component makes use of platform-specific hardware UARTs for serial logging.
 By default, the logger will occupy ``UART0``. The ESP32 has three hardware UARTs, all of
 which can be used for both transmit and receive. The ESP8266 only has two hardware UARTs,
 one of which is transmit-only. The ESP8266 ``UART0`` can also be 'swapped' to TX/RX on the

--- a/components/output/gpio.rst
+++ b/components/output/gpio.rst
@@ -7,7 +7,7 @@ GPIO Output
 
 The GPIO output component is quite simple: It exposes a single GPIO pin
 as an output component. Note that output components are **not** switches and
-will not show up in Home Assistant. See :doc:`/esphomeyaml/components/switch/gpio`.
+will not show up in Home Assistant. See :doc:`/components/switch/gpio`.
 
 .. code-block:: yaml
 

--- a/components/uart.rst
+++ b/components/uart.rst
@@ -27,10 +27,20 @@ In some cases only **TX** or **RX** exists as the device at the other end only a
 
 .. note::
 
-    On the ESP32, this component uses the hardware UART units and is thus very accurate. On the ESP8266 however,
-    esphomelib has to use a software implementation as there are no other hardware UART units available other than the
-    ones used for logging. Therefore the UART data on the ESP8266 can have occasional data glitches especially with
-    higher baud rates..
+    Whenever possible, esphome will use the Hardware UART unit on the processor for fast and accurate communication.
+    When the hardware UARTs are all occupied, esphome will fall back to a software implementation that may not
+    be accurate at higher baud rates.
+
+    ``UART0`` is (by default) used by the :doc:`logger component </components/logger>`, connected to ``GPIO1`` and
+    ``GPIO3``. If you configure a UART that overlaps with these pins, you can share the hardware with the logger
+    and leave others available. If you have configured the logger to use a different hardware UART, the pins used
+    for hardware sharing change accordingly.
+
+    The ESP32 has three UARTs. Any pair of GPIO pins can be used, as long as they support the proper output/input modes.
+
+    The ESP8266 has two UARTs; the second of which is TX-only. Only a limited set of pins can be used. ``UART0`` may
+    use either ``GPIO1`` and ``GPIO3``, or ``GPIO15`` and ``GPIO13``. ``UART1`` must use ``GPIO2``. Any other
+    combination of pins will result in use of a software UART.
 
 .. code-block:: yaml
 
@@ -52,6 +62,7 @@ Configuration variables:
 See Also
 --------
 
+- :doc:`/components/logger`
 - :apiref:`uart_component.h`
 - :ghedit:`Edit`
 

--- a/components/uart.rst
+++ b/components/uart.rst
@@ -25,23 +25,6 @@ receive/send data at using the ``baud_rate`` option. The most common baud rates 
 
 In some cases only **TX** or **RX** exists as the device at the other end only accepts data or sends data.
 
-.. note::
-
-    Whenever possible, esphome will use the Hardware UART unit on the processor for fast and accurate communication.
-    When the hardware UARTs are all occupied, esphome will fall back to a software implementation that may not
-    be accurate at higher baud rates.
-
-    ``UART0`` is (by default) used by the :doc:`logger component </components/logger>`, connected to ``GPIO1`` and
-    ``GPIO3``. If you configure a UART that overlaps with these pins, you can share the hardware with the logger
-    and leave others available. If you have configured the logger to use a different hardware UART, the pins used
-    for hardware sharing change accordingly.
-
-    The ESP32 has three UARTs. Any pair of GPIO pins can be used, as long as they support the proper output/input modes.
-
-    The ESP8266 has two UARTs; the second of which is TX-only. Only a limited set of pins can be used. ``UART0`` may
-    use either ``GPIO1`` and ``GPIO3``, or ``GPIO15`` and ``GPIO13``. ``UART1`` must use ``GPIO2``. Any other
-    combination of pins will result in use of a software UART.
-
 .. code-block:: yaml
 
     # Example configuration entry
@@ -50,7 +33,6 @@ In some cases only **TX** or **RX** exists as the device at the other end only a
       rx_pin: D1
       baud_rate: 9600
 
-
 Configuration variables:
 ------------------------
 
@@ -58,6 +40,26 @@ Configuration variables:
 - **tx_pin** (*Optional*, :ref:`config-pin`): The pin to send data to from the ESP's perspective.
 - **rx_pin** (*Optional*, :ref:`config-pin`): The pin to receive data on from the ESP's perspective.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID for this UART hub if you need multiple UART hubs.
+
+.. _uart-hardware_uarts:
+
+Hardware UARTs
+--------------
+
+Whenever possible, esphome will use the Hardware UART unit on the processor for fast and accurate communication.
+When the hardware UARTs are all occupied, esphome will fall back to a software implementation that may not
+be accurate at higher baud rates.
+
+``UART0`` is (by default) used by the :doc:`logger component </components/logger>`, using ``tx_pin: GPIO1`` and
+``rx_pin: GPIO3``. If you configure a UART that overlaps with these pins, you can share the hardware with the
+logger and leave others available. If you have configured the logger to use a different hardware UART, the pins
+used for hardware sharing change accordingly.
+
+The ESP32 has three UARTs. Any pair of GPIO pins can be used, as long as they support the proper output/input modes.
+
+The ESP8266 has two UARTs; the second of which is TX-only. Only a limited set of pins can be used. ``UART0`` may
+use either ``tx_pin: GPIO1`` and ``rx_pin: GPIO3``, or ``tx_pin: GPIO15`` and ``rx_pin: GPIO13``. ``UART1`` must
+use ``tx_pin: GPIO2``. Any other combination of pins will result in use of a software UART.
 
 See Also
 --------

--- a/cookbook/sonoff-fishpond-pump.rst
+++ b/cookbook/sonoff-fishpond-pump.rst
@@ -163,7 +163,7 @@ Both options USB and OTA are done by running the command:
 
     esphomeyaml <some-yaml-file> run
 
-More details on programming can be found on :doc:`Sonoff Basic section </esphomeyaml/devices/sonoff_basic>`
+More details on programming can be found on :doc:`/devices/sonoff_basic`
 
 3. Prepping and installing
 ****************************
@@ -214,7 +214,7 @@ You can now add your device to home assistant via the configurations page and un
 See Also
 --------
 
-- :doc:`/esphomeyaml/devices/sonoff_basic`
+- :doc:`/devices/sonoff_basic`
 - `Flashing sonoff basic <https://randomnerdtutorials.com/how-to-flash-a-custom-firmware-to-sonoff/>`__.
 - `Adding ESPHome to Home Assistant <https://www.home-assistant.io/components/esphome/>`__.
 


### PR DESCRIPTION
## Description:
Add documentation for use of alternate hardware UARTs for logging and HardwareSerial interop with Serial UART component.

**Pull request in [esphomeyaml](https://github.com/OttoWinter/esphomeyaml) with YAML changes (if applicable):** OttoWinter/esphomeyaml#427
**Pull request in [esphomelib](https://github.com/OttoWinter/esphomelib) with C++ framework changes (if applicable):** OttoWinter/esphomelib#483

## Checklist:
  - [X] The documentation change has been tested and compiles correctly.
  - [X] Branch: `next` is for changes and new documentation that will go public with the next esphomelib release. Fixes, changes and adjustments for the current release should be created against `current`.
