### PR TITLE
Custom Binary Sensor: Add missing ";" and fix indentation in YAML

### DIFF
--- a/components/binary_sensor/custom.rst
+++ b/components/binary_sensor/custom.rst
@@ -29,7 +29,7 @@ same as the gpio binary sensor.
         // This will be called every "update_interval" milliseconds.
 
         // Publish an OFF state
-        bool state = digitalRead(5)
+        bool state = digitalRead(5);
         publish_state(state);
       }
     };
@@ -46,14 +46,14 @@ And in YAML:
         - my_binary_sensor.h
 
     binary_sensor:
-    - platform: custom
-      lambda: |-
-        auto my_custom_sensor = new MyCustomBinarySensor();
-        App.register_component(my_custom_sensor);
-        return {my_custom_sensor};
+      - platform: custom
+        lambda: |-
+          auto my_custom_sensor = new MyCustomBinarySensor();
+          App.register_component(my_custom_sensor);
+          return {my_custom_sensor};
 
-      binary_sensors:
-        name: "My Custom Binary Sensor"
+        binary_sensors:
+          name: "My Custom Binary Sensor"
 
 Configuration variables:
 


### PR DESCRIPTION
Example would not compile while the semicolon ";" was missing.

## Description:
Added missing ";" and fixed indentation under "binary_sensor:"

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphomeyaml](https://github.com/OttoWinter/esphomeyaml) with YAML changes (if applicable):** OttoWinter/esphomeyaml#<esphomeyaml PR number goes here>
**Pull request in [esphomelib](https://github.com/OttoWinter/esphomelib) with C++ framework changes (if applicable):** OttoWinter/esphomelib#<esphomelib PR number goes here>

## Checklist:
  - [ ] The documentation change has been tested and compiles correctly.
  - [ ] Branch: `next` is for changes and new documentation that will go public with the next esphomelib release. Fixes, changes and adjustments for the current release should be created against `current`.
