### PR TITLE
Add Ethernet pin config for olimex esp32-poe board

### DIFF
--- a/components/ethernet.rst
+++ b/components/ethernet.rst
@@ -79,6 +79,18 @@ Configuration for wESP32 board
       clk_mode: GPIO0_IN
       phy_addr: 0
 
+Configuration for Olimex ESP32-POE
+----------------------------------
+
+.. code-block:: yaml
+
+    ethernet:
+      type: LAN8720
+      mdc_pin: GPIO23
+      mdio_pin: GPIO18
+      clk_mode: GPIO17_OUT
+      phy_addr: 0
+      power_pin: GPIO12
 
 See Also
 --------


### PR DESCRIPTION
## Description:
Adde pin configuration for Olimex ESP32-POE board

**Related issue (if applicable):** adds documentation for a single board
**Pull request in [esphomeyaml](https://github.com/OttoWinter/esphomeyaml) with YAML changes (if applicable):** OttoWinter/esphomeyaml#<esphomeyaml PR number goes here>
**Pull request in [esphomelib](https://github.com/OttoWinter/esphomelib) with C++ framework changes (if applicable):** OttoWinter/esphomelib#<esphomelib PR number goes here>

## Checklist:
  - [ ] The documentation change has been tested and compiles correctly.
  - [ ] Branch: `next` is for changes and new documentation that will go public with the next esphomelib release. Fixes, changes and adjustments for the current release should be created against `current`.
