### PR TITLE
Update output documentation for min_power configuration

### DIFF
--- a/components/output/index.rst
+++ b/components/output/index.rst
@@ -27,6 +27,7 @@ Each output platform extends this configuration schema.
         id: my_output_id
         power_supply: power_supply_id
         inverted: False
+        min_power: 0.01
         max_power: 0.75
 
 Configuration variables:
@@ -38,9 +39,14 @@ Configuration variables:
   automatically be switched on too.
 - **inverted** (*Optional*, boolean): If the output should be treated
   as inverted. Defaults to ``False``.
+- **min_power** (*Optional*, float): Only for float outputs. Sets the
+  minimum output value of this output platform. Each value will be
+  multiplied by max_power - min_power and offset from 0 by the min_power.
+  Must be in range from 0 to max_power. Defaults to 0.
 - **max_power** (*Optional*, float): Only for float outputs. Sets the
   maximum output value of this output platform. Each value will be
-  multiplied by this. Must be in range from 0 to 1. Defaults to 1.
+  multiplied by max_power - min_power and offset from 0 by the min_power.
+  Must be in range from min_power to 1. Defaults to 1.
 
 
 .. _output-turn_on_action:

--- a/components/output/index.rst
+++ b/components/output/index.rst
@@ -40,12 +40,10 @@ Configuration variables:
 - **inverted** (*Optional*, boolean): If the output should be treated
   as inverted. Defaults to ``False``.
 - **min_power** (*Optional*, float): Only for float outputs. Sets the
-  minimum output value of this output platform. Each value will be
-  multiplied by max_power - min_power and offset from 0 by the min_power.
+  minimum output value of this output platform.
   Must be in range from 0 to max_power. Defaults to 0.
 - **max_power** (*Optional*, float): Only for float outputs. Sets the
-  maximum output value of this output platform. Each value will be
-  multiplied by max_power - min_power and offset from 0 by the min_power.
+  maximum output value of this output platform.
   Must be in range from min_power to 1. Defaults to 1.
 
 


### PR DESCRIPTION
## Description:
Documentation changes to support adding a min_power configuration to the output component, complementary to the max_power configuration already present. This setting will let the user clamp the output of any floating point variable component like [ESP8266 PWM](https://esphome.io/components/output/esp8266_pwm) to make the full range between min and max available to the frontend in HA. Servos especially will benefit from this, since many standard servos operate in a range between 10%-20% duty cycle.

**Related issue (if applicable):** fixes OttoWinter/esphome/feature-requests#64

**Pull request in [esphomeyaml](https://github.com/OttoWinter/esphomeyaml) with YAML changes (if applicable):** OttoWinter/esphomeyaml#448
**Pull request in [esphomelib](https://github.com/OttoWinter/esphomelib) with C++ framework changes (if applicable):** OttoWinter/esphomelib#516

## Checklist:
  - [X] The documentation change has been tested and compiles correctly.
  - [X] Branch: `next` is for changes and new documentation that will go public with the next esphomelib release. Fixes, changes and adjustments for the current release should be created against `current`.
