### PR TITLE
H801 Cookbook Edit Language about holding GPIOs during flashing

### DIFF
--- a/cookbook/h801.rst
+++ b/cookbook/h801.rst
@@ -92,7 +92,7 @@ You will need to solder pins to the board inside the h801 (fortunately its prett
 not a lot of components or stuff in the way part from the 2 wires on the back)
 
 3.3v, GND, TX and RX (RX to RX and TX to TX) needs to be connected to your serial adapter, the
-two other pins must be shorted by a jumper or a breadboard cable when flashing.
+two other pins must be shorted throughout the flashing process by a jumper or a breadboard cable.
 (Remember to remove it after flashing)
 
 See Also


### PR DESCRIPTION
…clear

Unlike Sonoff basics where you can just short GPIO and GND for a second at boot.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>
**Pull request in [esphome-core](https://github.com/esphome/esphome-core) with C++ framework changes (if applicable):** esphome/esphome-core#<esphome-core PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
