### PR TITLE
NeopixelBus Light: Fix GPIO2 not GPIO3 for uart1 method

### DIFF
--- a/components/light/neopixelbus.rst
+++ b/components/light/neopixelbus.rst
@@ -67,9 +67,9 @@ Configuration variables:
 
   - ``ESP8266_DMA`` (default for ESP8266, only on pin GPIO3)
   - ``ESP8266_UART0`` (only on pin GPIO1)
-  - ``ESP8266_UART1`` (only on pin GPIO3)
+  - ``ESP8266_UART1`` (only on pin GPIO2)
   - ``ESP8266_ASYNC_UART0`` (only on pin GPIO1)
-  - ``ESP8266_ASYNC_UART1`` (only on pin GPIO3)
+  - ``ESP8266_ASYNC_UART1`` (only on pin GPIO2)
   - ``ESP32_I2S_0``
   - ``ESP32_I2S_1`` (default for ESP32)
   - ``BIT_BANG`` (can flicker a bit)


### PR DESCRIPTION
regarding... https://github.com/Makuna/NeoPixelBus/wiki/ESP8266-NeoMethods compilation works (D4 or GPIO2 as value)
