### PR TITLE
Update gpio.rst

### DIFF
--- a/components/binary_sensor/gpio.rst
+++ b/components/binary_sensor/gpio.rst
@@ -50,7 +50,7 @@ you can do so with the :ref:`Pin Schema <config-pin_schema>`.
 Inverting Values
 ----------------
 
-Use the ``inverted`` property of the :ref:`Pin Schema <config-pin_schema>` to invert the binary
+Use the ``invert`` property of the :ref:`binary sensor filters <binary_sensor-filters>` to invert the binary
 sensor:
 
 .. code-block:: yaml
@@ -60,7 +60,8 @@ sensor:
       - platform: gpio
         pin:
           number: D2
-          inverted: True
+          filters:
+            invert:
         name: ...
 
 Debouncing Values


### PR DESCRIPTION
The inverted binary_sensor property has been replaced by the new 'invert' binary  sensor filter. Please see https://esphome.io/components/binary_sensor/index.html.

## Description:

Just a doc change regarding inverting binary sensors.

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
