### PR TITLE
Sonoff S20 yaml fix

### DIFF
--- a/devices/sonoff_s20.rst
+++ b/devices/sonoff_s20.rst
@@ -271,7 +271,7 @@ in Home Assistant, replace the last part with this:
           number: GPIO13
           inverted: True
       # Note: do *not* make the relay a dimmable (PWM) signal, relays cannot handle that
-      - platform: binary
+      - platform: gpio
         id: s20_relay
         pin: GPIO12
 


### PR DESCRIPTION
The output component used platform: `binary` which not an output component and should be `gpio`.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>
**Pull request in [esphome-core](https://github.com/esphome/esphome-core) with C++ framework changes (if applicable):** esphome/esphome-core#<esphome-core PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
