### PR TITLE
Remove deprecated filter_nan: option

### DIFF
--- a/components/sensor/index.rst
+++ b/components/sensor/index.rst
@@ -104,7 +104,6 @@ for platforms with multiple sensors)
           - 40.0 -> 45.0
           - 100.0 -> 102.5
       - filter_out: 42.0
-      - filter_nan:
       - sliding_window_moving_average:
           window_size: 15
           send_every: 15


### PR DESCRIPTION
Remove deprecated filter_nan: option

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>
**Pull request in [esphome-core](https://github.com/esphome/esphome-core) with C++ framework changes (if applicable):** esphome/esphome-core#<esphome-core PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
