### PR TITLE
Added a section for all lambda calls

### DIFF
--- a/guides/automations.rst
+++ b/guides/automations.rst
@@ -358,6 +358,15 @@ All Conditions
 - :ref:`switch.is_on <switch-is_on_condition>` / :ref:`switch.is_off <switch-is_off_condition>`
 - :ref:`sensor.in_range <sensor-in_range_condition>`
 
+All Lambda Calls
+----------------
+- :ref:`Sensor <sensor-lambda_calls>`
+- :ref:`Binary Sensor <binary_sensor-lambda_calls>`
+- :ref:`Switch <switch-lambda_calls>`
+- :ref:`Display <display-display_rendering_engine>`
+- :ref:`Cover <cover-lambda_calls>`
+- :ref:`Text Sensor <text_sensor-lambda_calls>`
+
 .. _delay_action:
 
 ``delay`` Action

--- a/guides/automations.rst
+++ b/guides/automations.rst
@@ -366,6 +366,7 @@ All Lambda Calls
 - :ref:`Display <display-display_rendering_engine>`
 - :ref:`Cover <cover-lambda_calls>`
 - :ref:`Text Sensor <text_sensor-lambda_calls>`
+- :ref:`Stepper <stepper-lambda_calls>`
 
 .. _delay_action:
 


### PR DESCRIPTION
It was really hard for me to find lambda calls so I made a list. I want to add the light, stepper and servo components to this list but they don't have a heading for lambda instead they have [note: this can also be written in lambda], so I will change those to have a lambda calls heading.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>
**Pull request in [esphome-core](https://github.com/esphome/esphome-core) with C++ framework changes (if applicable):** esphome/esphome-core#<esphome-core PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
