### PR TITLE
Voltage range of ADC is at the chip pin

### DIFF
--- a/components/sensor/adc.rst
+++ b/components/sensor/adc.rst
@@ -42,7 +42,7 @@ Configuration variables:
     such as the NodeMCU include a voltage divider circuit such that a voltage range at the board pin of 0 to 3.2V translates
     to a voltage range at the chip pin of 0 to 1.0V. To measure any higher voltage, you need to scale the voltage down using,
     for example, a voltage divider circuit.
-    
+
 .. _adc-esp32_attenuation:
 
 ESP32 Attenuation

--- a/components/sensor/adc.rst
+++ b/components/sensor/adc.rst
@@ -42,9 +42,9 @@ Configuration variables:
     Some development boards like the Wemos D1 mini include external voltage divider circuitry to scale down
     a 3.3V input signal to the chip-internal 1.0V. If your board has this circuitry, add a multiply filter to
     get correct values:
-    
+
     .. code-block:: yaml
-    
+
         sensor:
           - platform: adc
             # ...

--- a/components/sensor/adc.rst
+++ b/components/sensor/adc.rst
@@ -38,8 +38,10 @@ Configuration variables:
 
 .. note::
 
-    On the ESP8266, the voltage range is 0 to 1.0V - so to measure any higher voltage you need to scale the voltage
-    down using, for example, a voltage divider circuit.
+    This component uses the voltage at the chip pin. On the ESP8266, the voltage range is 0 to 1.0V. Development boards 
+    such as the NodeMCU include a voltage divider circuit such that a voltage range at the board pin of 0 to 3.2V translates 
+    to a voltage range at the chip pin of 0 to 1.0V. To measure any higher voltage, you need to scale the voltage down using, 
+    for example, a voltage divider circuit. 
 
 .. _adc-esp32_attenuation:
 

--- a/components/sensor/adc.rst
+++ b/components/sensor/adc.rst
@@ -38,11 +38,11 @@ Configuration variables:
 
 .. note::
 
-    This component uses the voltage at the chip pin. On the ESP8266, the voltage range is 0 to 1.0V. Development boards 
-    such as the NodeMCU include a voltage divider circuit such that a voltage range at the board pin of 0 to 3.2V translates 
-    to a voltage range at the chip pin of 0 to 1.0V. To measure any higher voltage, you need to scale the voltage down using, 
-    for example, a voltage divider circuit. 
-
+    This component uses the voltage at the chip pin. On the ESP8266, the voltage range is 0 to 1.0V. Development boards
+    such as the NodeMCU include a voltage divider circuit such that a voltage range at the board pin of 0 to 3.2V translates
+    to a voltage range at the chip pin of 0 to 1.0V. To measure any higher voltage, you need to scale the voltage down using,
+    for example, a voltage divider circuit.
+    
 .. _adc-esp32_attenuation:
 
 ESP32 Attenuation

--- a/components/sensor/adc.rst
+++ b/components/sensor/adc.rst
@@ -38,10 +38,18 @@ Configuration variables:
 
 .. note::
 
-    This component uses the voltage at the chip pin. On the ESP8266, the voltage range is 0 to 1.0V. Development boards
-    such as the NodeMCU include a voltage divider circuit such that a voltage range at the board pin of 0 to 3.2V translates
-    to a voltage range at the chip pin of 0 to 1.0V. To measure any higher voltage, you need to scale the voltage down using,
-    for example, a voltage divider circuit.
+    This component prints the voltage as seen by the chip pin. On the ESP8266, this is always 0.0V to 1.0V
+    Some development boards like the Wemos D1 mini include external voltage divider circuitry to scale down
+    a 3.3V input signal to the chip-internal 1.0V. If your board has this circuitry, add a multiply filter to
+    get correct values:
+    
+    .. code-block:: yaml
+    
+        sensor:
+          - platform: adc
+            # ...
+            filters:
+              - multiply: 3.3
 
 .. _adc-esp32_attenuation:
 


### PR DESCRIPTION
Clarify that this component uses voltage range at the chip pin, but voltage range at the board pin can be greater (e.g., for NodeMCU)

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>
**Pull request in [esphome-core](https://github.com/esphome/esphome-core) with C++ framework changes (if applicable):** esphome/esphome-core#<esphome-core PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
