### PR TITLE
Fixed lint and ref errors

### DIFF
--- a/components/binary_sensor/index.rst
+++ b/components/binary_sensor/index.rst
@@ -305,6 +305,8 @@ This :ref:`Condition <config-condition>` checks if the given binary sensor is ON
             id: my_binary_sensor
             for: 5s
 
+.. _binary_sensor-lambda_calls:
+
 lambda calls
 ************
 

--- a/components/cover/index.rst
+++ b/components/cover/index.rst
@@ -72,6 +72,7 @@ This action stops the cover with the given ID when executed.
 
         id(cover_1).stop();
 
+.. _cover-lambda_calls:
 
 lambda calls
 ------------

--- a/components/sensor/index.rst
+++ b/components/sensor/index.rst
@@ -399,6 +399,8 @@ Configuration variables:
 - **above** (*Optional*, float): The minimum for the condition.
 - **below** (*Optional*, float): The maximum for the condition.
 
+.. _sensor-lambda_calls:
+
 lambda calls
 ************
 

--- a/components/switch/index.rst
+++ b/components/switch/index.rst
@@ -93,6 +93,8 @@ This :ref:`Condition <config-condition>` checks if the given switch is ON (or OF
           # Same syntax for is_off
           switch.is_on: my_switch
 
+.. _switch-lambda_calls:
+
 lambda calls
 ************
 

--- a/components/text_sensor/index.rst
+++ b/components/text_sensor/index.rst
@@ -62,6 +62,8 @@ In :ref:`Lambdas <config-lambda>` you can get the value from the trigger with ``
 
 Configuration variables: See :ref:`Automation <automation>`.
 
+.. _text_sensor-lambda_calls:
+
 lambda calls
 ************
 

--- a/guides/automations.rst
+++ b/guides/automations.rst
@@ -364,7 +364,7 @@ All Lambda Calls
 - :ref:`Sensor <sensor-lambda_calls>`
 - :ref:`Binary Sensor <binary_sensor-lambda_calls>`
 - :ref:`Switch <switch-lambda_calls>`
-- :ref:`Display <display-display_rendering_engine>`
+- :ref:`Display <display-engine>`
 - :ref:`Cover <cover-lambda_calls>`
 - :ref:`Text Sensor <text_sensor-lambda_calls>`
 - :ref:`Stepper <stepper-lambda_calls>`

--- a/guides/automations.rst
+++ b/guides/automations.rst
@@ -360,6 +360,7 @@ All Conditions
 
 All Lambda Calls
 ----------------
+
 - :ref:`Sensor <sensor-lambda_calls>`
 - :ref:`Binary Sensor <binary_sensor-lambda_calls>`
 - :ref:`Switch <switch-lambda_calls>`


### PR DESCRIPTION
## Description:
Some invalid syntax and missing links were introduced with https://github.com/esphome/esphome-docs/pull/222 - they are now fixed with this PR.

**Related issue (if applicable):** fixes https://github.com/esphome/esphome-docs/pull/222

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
