### PR TITLE
Add esp32_camera ttgo-camera example

### DIFF
--- a/components/esp32_camera.rst
+++ b/components/esp32_camera.rst
@@ -170,6 +170,30 @@ Configuration for Wrover Kit Boards
       name: My Camera
       # ...
 
+Configuration for TTGO T-Camera
+-----------------------------------
+
+.. code-block:: yaml
+
+    # Example configuration entry
+    esp32_camera:
+      external_clock:
+        pin: GPIO32
+        frequency: 20MHz
+      i2c_pins:
+        sda: GPIO13
+        scl: GPIO12
+      data_pins: [GPIO5, GPIO14, GPIO4, GPIO15, GPIO18, GPIO23, GPIO36, GPIO39]
+      vsync_pin: GPIO27
+      href_pin: GPIO25
+      pixel_clock_pin: GPIO19
+      power_down_pin: GPIO26
+
+      # Image settings
+      name: My Camera
+      # ...
+
+
 See Also
 --------
 

--- a/components/esp32_camera.rst
+++ b/components/esp32_camera.rst
@@ -171,7 +171,7 @@ Configuration for Wrover Kit Boards
       # ...
 
 Configuration for TTGO T-Camera
------------------------------------
+-------------------------------
 
 .. code-block:: yaml
 


### PR DESCRIPTION
## Description:
Added example configuration for the TTGO camera board with integrated display and PIR sensor. Confirmed that it's working on my own setup!

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>
**Pull request in [esphome-core](https://github.com/esphome/esphome-core) with C++ framework changes (if applicable):** esphome/esphome-core#<esphome-core PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
