### PR TITLE
Remove esphome_core_version

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,7 @@
+ports:
+- port: 8000
+  onOpen: open-preview
+
+tasks:
+- before: pip3 install -r requirements.txt
+  command: make webserver

--- a/components/binary_sensor/index.rst
+++ b/components/binary_sensor/index.rst
@@ -305,6 +305,8 @@ This :ref:`Condition <config-condition>` checks if the given binary sensor is ON
             id: my_binary_sensor
             for: 5s
 
+.. _binary_sensor-lambda_calls:
+
 lambda calls
 ************
 

--- a/components/cover/index.rst
+++ b/components/cover/index.rst
@@ -72,6 +72,7 @@ This action stops the cover with the given ID when executed.
 
         id(cover_1).stop();
 
+.. _cover-lambda_calls:
 
 lambda calls
 ------------

--- a/components/esphome.rst
+++ b/components/esphome.rst
@@ -35,8 +35,6 @@ Configuration variables:
 
 Advanced options:
 
-- **esphome_core_version** (*Optional*): The version of the C++ `ESPHome-Core framework <https://github.com/esphome/esphome-core>`__
-  to use. See :ref:`esphome-esphome_core_version`.
 - **arduino_version** (*Optional*): The version of the arduino framework to link the project against.
   See :ref:`esphome-arduino_version`.
 - **build_path** (*Optional*, string): Customize where ESPHome will store the build files
@@ -67,67 +65,6 @@ Automations:
   right before the node shuts down. See :ref:`esphome-on_shutdown`.
 - **on_loop** (*Optional*, :ref:`Automation <automation>`): An automation to perform
   on each ``loop()`` iteration. See :ref:`esphome-on_loop`.
-
-.. _esphome-esphome_core_version:
-
-``esphome_core_version``
-------------------------
-
-With the ``esphome_core_version`` parameter you can tell ESPHome which version of the C++ framework
-to use when compiling code. For example, you can configure using the most recent (potentially unstable)
-version of ESPHome straight from github. Or you can configure the use of a local copy of esphome-core
-using this configuration option.
-
-First, you can configure the use of either the latest esphome-core stable release (``latest``),
-the latest development code from GitHub (``dev``), or a specific version number (``1.8.0``).
-
-.. code-block:: yaml
-
-    # Example configuration entry
-    esphome:
-      # ...
-      # Use the latest ESPHome stable release
-      esphome_core_version: latest
-
-      # Or use the latest code from github
-      esphome_core_version: dev
-
-      # Use a specific version number
-      esphome_core_version: 1.8.0
-
-Alternatively, if you want to develop for ESPHome, you can download the
-`latest code from GitHub <https://github.com/esphome/esphome-core/archive/dev.zip>`__, extract the contents,
-and point ESPHome to your local copy. Then you can modify the ESPHome to your needs or to fix bugs.
-
-.. code-block:: yaml
-
-    # Example configuration entry
-    esphome:
-      # ...
-      # Use a local copy of ESPHome
-      esphome_core_version:
-        local: path/to/esphome-core
-
-And last, you can make ESPHome use a specific branch/commit/tag from a remote git repository:
-
-.. code-block:: yaml
-
-    # Example configuration entry
-    esphome:
-      # ...
-      # Use a specific commit/branch/tag from a remote repository
-      esphome_core_version:
-        # Repository defaults to https://github.com/esphome/esphome-core.git
-        repository: https://github.com/esphome/esphome-core.git
-        branch: master
-
-      esphome_core_version:
-        repository: https://github.com/somebody/esphome-core.git
-        commit: d27bac9263e8a0a5a00672245b38db3078f8992c
-
-      esphome_core_version:
-        repository: https://github.com/esphome/esphome-core.git
-        tag: v1.8.0
 
 .. _esphome-arduino_version:
 

--- a/components/sensor/index.rst
+++ b/components/sensor/index.rst
@@ -399,6 +399,8 @@ Configuration variables:
 - **above** (*Optional*, float): The minimum for the condition.
 - **below** (*Optional*, float): The maximum for the condition.
 
+.. _sensor-lambda_calls:
+
 lambda calls
 ************
 

--- a/components/sensor/xiaomi_miflora.rst
+++ b/components/sensor/xiaomi_miflora.rst
@@ -65,6 +65,10 @@ Configuration variables:
   - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.
   - All other options from :ref:`Sensor <config-sensor>`.
 
+.. note::
+
+    The ``battery_level`` does not appear to work with some firmware versions of the device (the other sensors
+    do work though). See https://github.com/esphome/issues/issues/107#issuecomment-483693214 for more information.
 
 Setting Up Devices
 ------------------

--- a/components/sensor/xiaomi_miflora.rst
+++ b/components/sensor/xiaomi_miflora.rst
@@ -68,7 +68,7 @@ Configuration variables:
 .. note::
 
     The ``battery_level`` does not appear to work with some firmware versions of the device (the other sensors
-    do work though). See https://github.com/esphome/issues/issues/107#issuecomment-483693214 for more information.
+    do work though). See https://github.com/esphome/issues/issues/107 for more information.
 
 Setting Up Devices
 ------------------

--- a/components/switch/index.rst
+++ b/components/switch/index.rst
@@ -93,6 +93,8 @@ This :ref:`Condition <config-condition>` checks if the given switch is ON (or OF
           # Same syntax for is_off
           switch.is_on: my_switch
 
+.. _switch-lambda_calls:
+
 lambda calls
 ************
 

--- a/components/text_sensor/index.rst
+++ b/components/text_sensor/index.rst
@@ -62,6 +62,8 @@ In :ref:`Lambdas <config-lambda>` you can get the value from the trigger with ``
 
 Configuration variables: See :ref:`Automation <automation>`.
 
+.. _text_sensor-lambda_calls:
+
 lambda calls
 ************
 

--- a/guides/automations.rst
+++ b/guides/automations.rst
@@ -364,7 +364,7 @@ All Lambda Calls
 - :ref:`Sensor <sensor-lambda_calls>`
 - :ref:`Binary Sensor <binary_sensor-lambda_calls>`
 - :ref:`Switch <switch-lambda_calls>`
-- :ref:`Display <display-display_rendering_engine>`
+- :ref:`Display <display-engine>`
 - :ref:`Cover <cover-lambda_calls>`
 - :ref:`Text Sensor <text_sensor-lambda_calls>`
 - :ref:`Stepper <stepper-lambda_calls>`

--- a/guides/contributing.rst
+++ b/guides/contributing.rst
@@ -531,6 +531,32 @@ it in the configuration. Specifically, it may contain these fields:
 
 Run ``pip2 install -e .`` to install a development version of ESPHome.
 
+ESPHome via Gitpod
+******************
+
+An alternative to a local checkout and build is doing so via `Gitpod <https://www.gitpod.io>`__.
+ESPHome will be installed for you and the dashboard wizard will run on startup.
+
+You can also run the steps manually.
+
+.. code-block:: bash
+
+    python setup.py install
+
+To start a command line wizard, run
+
+.. code-block:: bash
+
+    python esphome my_configuration.yaml wizard
+
+To get the web-based dashboard, use
+
+.. code-block:: bash
+
+    python esphome my_configuration.yaml dashboard
+
+and allow exposing the web app at port 6052.
+
 See Also
 --------
 

--- a/guides/supporters.rst
+++ b/guides/supporters.rst
@@ -50,6 +50,7 @@ You guys are awesome!
 - Daan Damhuis
 - Dennis Münchgesang
 - DrZzs
+- fabi
 
 
 Contributors
@@ -62,7 +63,7 @@ that have made it into the `ESPHome organization's <https://github.com/esphome>`
 Author & Main Developer
 ***********************
 
-- `Otto Winter (@OttoWinter) <https://github.com/OttoWinter>`__ - 1556 contributions
+- `Otto Winter (@OttoWinter) <https://github.com/OttoWinter>`__ - 1570 contributions
 
 Contributors
 ************
@@ -70,6 +71,7 @@ Contributors
 (in alphabetical order)
 
 - `2016for (@2016for) <https://github.com/2016for>`__ - 1 contribution
+- `Aalian Khan (@AalianKhan) <https://github.com/AalianKhan>`__ - 2 contributions
 - `Alexandre Danault (@AlexDanault) <https://github.com/AlexDanault>`__ - 1 contribution
 - `Rutger Nijhuis (@BananaPukeh) <https://github.com/BananaPukeh>`__ - 1 contribution
 - `Bierchermuesli (@Bierchermuesli) <https://github.com/Bierchermuesli>`__ - 1 contribution
@@ -91,6 +93,7 @@ Contributors
 - `Florian Mösch (@badbadc0ffee) <https://github.com/badbadc0ffee>`__ - 4 contributions
 - `balk77 (@balk77) <https://github.com/balk77>`__ - 1 contribution
 - `Paulus Schoutsen (@balloob) <https://github.com/balloob>`__ - 1 contribution
+- `Patrik Hermansson (@bphermansson) <https://github.com/bphermansson>`__ - 1 contribution
 - `Brandon Davidson (@brandond) <https://github.com/brandond>`__ - 11 contributions
 - `brianrjones69 (@brianrjones69) <https://github.com/brianrjones69>`__ - 1 contribution
 - `chris-jennings (@chris-jennings) <https://github.com/chris-jennings>`__ - 1 contribution
@@ -114,6 +117,7 @@ Contributors
 - `Ivan Kravets (@ivankravets) <https://github.com/ivankravets>`__ - 1 contribution
 - `Jan Pieper (@janpieper) <https://github.com/janpieper>`__ - 2 contributions
 - `JbLb (@jblb) <https://github.com/jblb>`__ - 1 contribution
+- `jcullen86 (@jcullen86) <https://github.com/jcullen86>`__ - 1 contribution
 - `Joshua Dadswell (@jdads1) <https://github.com/jdads1>`__ - 1 contribution
 - `Jesse Hills (@jesserockz) <https://github.com/jesserockz>`__ - 3 contributions
 - `John Erik Halse (@johnerikhalse) <https://github.com/johnerikhalse>`__ - 1 contribution
@@ -123,6 +127,7 @@ Contributors
 - `Lazar Obradovic (@lobradov) <https://github.com/lobradov>`__ - 3 contributions
 - `Lewis Juggins (@lwis) <https://github.com/lwis>`__ - 1 contribution
 - `Magnus Øverli (@magnusoverli) <https://github.com/magnusoverli>`__ - 1 contribution
+- `MeIchthys (@meichthys) <https://github.com/meichthys>`__ - 1 contribution
 - `meijerwynand (@meijerwynand) <https://github.com/meijerwynand>`__ - 2 contributions
 - `mjoshd (@mjoshd) <https://github.com/mjoshd>`__ - 2 contributions
 - `Matt N. (@mnoorenberghe) <https://github.com/mnoorenberghe>`__ - 1 contribution
@@ -144,6 +149,7 @@ Contributors
 - `r-jordan (@r-jordan) <https://github.com/r-jordan>`__ - 1 contribution
 - `Pär Stålberg (@rabbadab) <https://github.com/rabbadab>`__ - 1 contribution
 - `Robbie Page (@rorpage) <https://github.com/rorpage>`__ - 1 contribution
+- `sethcohn (@sethcohn) <https://github.com/sethcohn>`__ - 1 contribution
 - `Emanuele Tessore (@setola) <https://github.com/setola>`__ - 1 contribution
 - `sherbang (@sherbang) <https://github.com/sherbang>`__ - 4 contributions
 - `thubot (@thubot) <https://github.com/thubot>`__ - 1 contribution
@@ -155,4 +161,4 @@ Contributors
 - `Vladimir Eremin (@yottatsa) <https://github.com/yottatsa>`__ - 1 contribution
 - `YuanL.Lee (@yuanl) <https://github.com/yuanl>`__ - 1 contribution
 
-*This page was last updated Sun Apr  7 12:19:13 2019 UTC.*
+*This page was last updated Mon Apr 15 20:09:38 2019 UTC.*

--- a/guides/supporters.rst
+++ b/guides/supporters.rst
@@ -38,19 +38,22 @@ Patrons
 People that support ESPHome's development over `Patreon <https://www.patreon.com/ottowinter>`__.
 You guys are awesome!
 
-- Nick Rout
-- Kenvase
-- Magnus Overli
-- Dattas Moonchaser
-- Intermittent Technology
 - Andrea Donno
-- Ryan Bahm
-- Jung Ervin
 - Book of the Future
 - Daan Damhuis
+- Dattas Moonchaser
 - Dennis Münchgesang
 - DrZzs
 - fabi
+- Intermittent Technology
+- Jung Ervin
+- Kenvase
+- Magnus Overli
+- Nick Rout
+- Paul Krischer
+- Paul Morley
+- Ryan
+- Ryan Bahm
 
 
 Contributors
@@ -63,7 +66,7 @@ that have made it into the `ESPHome organization's <https://github.com/esphome>`
 Author & Main Developer
 ***********************
 
-- `Otto Winter (@OttoWinter) <https://github.com/OttoWinter>`__ - 1570 contributions
+- `Otto Winter (@OttoWinter) <https://github.com/OttoWinter>`__ - 1578 contributions
 
 Contributors
 ************
@@ -110,6 +113,7 @@ Contributors
 - `escoand (@escoand) <https://github.com/escoand>`__ - 5 contributions
 - `Malte Franken (@exxamalte) <https://github.com/exxamalte>`__ - 2 contributions
 - `Fabian Affolter (@fabaff) <https://github.com/fabaff>`__ - 10 contributions
+- `gitolicious (@gitolicious) <https://github.com/gitolicious>`__ - 3 contributions
 - `The Gitter Badger (@gitter-badger) <https://github.com/gitter-badger>`__ - 1 contribution
 - `Guillermo Ruffino (@glmnet) <https://github.com/glmnet>`__ - 1 contribution
 - `Antoine GRÉA (@grea09) <https://github.com/grea09>`__ - 3 contributions
@@ -122,6 +126,7 @@ Contributors
 - `Jesse Hills (@jesserockz) <https://github.com/jesserockz>`__ - 3 contributions
 - `John Erik Halse (@johnerikhalse) <https://github.com/johnerikhalse>`__ - 1 contribution
 - `JonnyaiR (@jonnyair) <https://github.com/jonnyair>`__ - 2 contributions
+- `kimonm (@kimonm) <https://github.com/kimonm>`__ - 1 contribution
 - `Ken Davidson (@kwdavidson) <https://github.com/kwdavidson>`__ - 1 contribution
 - `Jeppe Ladefoged (@ladefoged81) <https://github.com/ladefoged81>`__ - 2 contributions
 - `Lazar Obradovic (@lobradov) <https://github.com/lobradov>`__ - 3 contributions
@@ -161,4 +166,4 @@ Contributors
 - `Vladimir Eremin (@yottatsa) <https://github.com/yottatsa>`__ - 1 contribution
 - `YuanL.Lee (@yuanl) <https://github.com/yuanl>`__ - 1 contribution
 
-*This page was last updated Mon Apr 15 20:09:38 2019 UTC.*
+*This page was last updated Mon Apr 22 14:14:00 2019 UTC.*


### PR DESCRIPTION
## Description:

ESPHome has merged the core into the primary repo, thus the core version is now tied to the version of ESPHome, thus deprecating the need for esphome_core_version
**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>
**Pull request in [esphome-core](https://github.com/esphome/esphome-core) with C++ framework changes (if applicable):** esphome/esphome-core#<esphome-core PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
