### PR TITLE
Update h801 cookbook

### DIFF
--- a/cookbook/h801.rst
+++ b/cookbook/h801.rst
@@ -40,11 +40,11 @@ and the :doc:`ESP8266 Software PWM output </components/output/esp8266_pwm>` comp
         frequency: 1000 Hz
         id: pwm_b
       - platform: esp8266_pwm
-        pin: 15
+        pin: 13
         frequency: 1000 Hz
         id: pwm_g
       - platform: esp8266_pwm
-        pin: 13
+        pin: 15
         frequency: 1000 Hz
         id: pwm_r
       - platform: esp8266_pwm


### PR DESCRIPTION
Correction to pinout error for Red and Green

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>
**Pull request in [esphome-core](https://github.com/esphome/esphome-core) with C++ framework changes (if applicable):** esphome/esphome-core#<esphome-core PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
