### PR TITLE
fixed copy paste error

### DIFF
--- a/components/display/nextion.rst
+++ b/components/display/nextion.rst
@@ -15,7 +15,7 @@ with ESPHome.
 
     Nextion LCD Display.
 
-As the communication with the MH-Z19 is done using UART, you need to have an :ref:`UART bus <uart>`
+As the communication with the Nextion LCD display is done using UART, you need to have an :ref:`UART bus <uart>`
 in your configuration with ``rx_pin`` both the ``tx_pin`` set to the respective pins on the display.
 Additionally, you need to set the baud rate to 9600.
 


### PR DESCRIPTION
I assume that the MH-Z19 was from copy pasting the uart part in this page, fixed it to Nextion LCD Display

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>
**Pull request in [esphome-core](https://github.com/esphome/esphome-core) with C++ framework changes (if applicable):** esphome/esphome-core#<esphome-core PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
