### PR TITLE
Fix config name for showing previous page

### DIFF
--- a/components/display/index.rst
+++ b/components/display/index.rst
@@ -374,13 +374,13 @@ different content, and switch between them on a timer.
 
 You can then switch between these with three different actions:
 
-**show_next** / **show_prev**: Shows the next or previous page, wraps around at the end.
+**show_next** / **show_previous**: Shows the next or previous page, wraps around at the end.
 
 .. code-block:: yaml
 
     on_...:
       - display.page.show_next: my_display
-      - display.page.show_prev: my_display
+      - display.page.show_previous: my_display
 
     # For example cycle through pages on a timer
     interval:


### PR DESCRIPTION
Although the documentation says `show_prev` it's `show_previous` in esphome/components/display/\_\_init\_\_.py and `show_prev` results in a build error:

```
Failed config

binary_sensor.gpio: [source badgy.yaml:37]
  platform: gpio
  pin: GPIO10
  id: joystick_left
  on_click:  [source badgy.yaml:41]
    then:
      - [source badgy.yaml:42]

        Unable to find action with the name 'display.page.show_prev'.
        display.page.show_prev: my_display [source badgy.yaml:42]
      - component.update: my_display
```

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>
**Pull request in [esphome-core](https://github.com/esphome/esphome-core) with C++ framework changes (if applicable):** esphome/esphome-core#<esphome-core PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
