### PR TITLE
Put 'MAC_ADDRESS' instead of MAC_ADDRESS

### DIFF
--- a/components/sensor/xiaomi_miflora.rst
+++ b/components/sensor/xiaomi_miflora.rst
@@ -19,7 +19,7 @@ MiFlora devices at once as you want.
 
     sensor:
       - platform: xiaomi_miflora
-        mac_address: 94:2B:FF:5C:91:61
+        mac_address: '94:2B:FF:5C:91:61'
         temperature:
           name: "Xiaomi MiFlora Temperature"
         moisture:


### PR DESCRIPTION
Better yaml implementation, at least, better human readable.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>
**Pull request in [esphome-core](https://github.com/esphome/esphome-core) with C++ framework changes (if applicable):** esphome/esphome-core#<esphome-core PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
