### PR TITLE
Fix minor typo in ESP32 camera docs

### DIFF
--- a/components/esp32_camera.rst
+++ b/components/esp32_camera.rst
@@ -122,7 +122,7 @@ Configuration for M5Stack Camera
 
     This camera board has insufficient cooling and will overheat over time,
     ESPHome does only activate the camera when Home Assistant requests an image, but
-    the camera until can still heat up considerably for some boards.
+    the camera unit can still heat up considerably for some boards.
 
     If the camera is not recognized after a reboot and the unit feels warm, try waiting for
     it to cool down and check again - if that still doesn't work try enabling the test pattern.


### PR DESCRIPTION
## Description:

Fixed incorrectly written word, "until" -> "unit".

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>
**Pull request in [esphome-core](https://github.com/esphome/esphome-core) with C++ framework changes (if applicable):** esphome/esphome-core#<esphome-core PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
