### PR TITLE
Update bh1750.rst (fix incorrect link text)

### DIFF
--- a/components/sensor/bh1750.rst
+++ b/components/sensor/bh1750.rst
@@ -7,7 +7,7 @@ BH1750 Ambient Light Sensor
     :keywords: BH1750
 
 The ``bh1750`` sensor platform allows you to use your BH1750
-(`datasheet <http://www.mouser.com/ds/2/348/bh1750fvi-e-186247.pdf>`__, `Aliexpress`_, `mklec`_)
+(`datasheet <http://www.mouser.com/ds/2/348/bh1750fvi-e-186247.pdf>`__, `Adafruit`_, `mklec`_)
 ambient light sensor with ESPHome. The :ref:`I²C bus <i2c>` is required to be set up in
 your configuration for this sensor to work.
 
@@ -17,7 +17,7 @@ your configuration for this sensor to work.
 
     BH1750 Ambient Light Sensor.
 
-.. _Aliexpress: https://www.adafruit.com/product/1603
+.. _Adafruit: https://www.adafruit.com/product/1603
 .. _mklec: http://mklec.com/modules/micro-controller-modules/bh1750-bh1750fvi-digital-light-sensor-module
 
 .. figure:: images/bh1750-ui.png


### PR DESCRIPTION
Fix adafruit link text to "Adafruit" instead of "Aliexpress".

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>
**Pull request in [esphome-core](https://github.com/esphome/esphome-core) with C++ framework changes (if applicable):** esphome/esphome-core#<esphome-core PR number goes here>

## Checklist:

  - [X] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
