### PR TITLE
Change priority from 100 to 40

### DIFF
--- a/cookbook/mirabella-genio-bulb.rst
+++ b/cookbook/mirabella-genio-bulb.rst
@@ -127,7 +127,7 @@ variable ``output_component1``.
 
       # Ensure the light turns on by default if the physical switch is actuated.
       on_boot:
-        priority: 100 # Highest priority, ensures light turns on without delay.
+        priority: 40 # Prioritize light on, ensures light turns on without delay.
         then:
           - light.turn_on: light
 
@@ -164,7 +164,7 @@ variable ``output_component1``.
 
       # Ensure the light turns on by default if the physical switch is actuated.
       on_boot:
-        priority: 100 # Highest priority, ensures light turns on without delay.
+        priority: 40 # Prioritize light on, ensures light turns on without delay.
         then:
           - light.turn_on: light
 
@@ -207,7 +207,7 @@ variable ``output_component1``.
 
       # Ensure the light turns on by default if the physical switch is actuated.
       on_boot:
-        priority: 100 # Highest priority, ensures light turns on without delay.
+        priority: 40 # Prioritize light on, ensures light turns on without delay.
         then:
           - light.turn_on: light
 


### PR DESCRIPTION
Change the priority from 100 to 40 otherwise the light won't turn on at boot.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>
**Pull request in [esphome-core](https://github.com/esphome/esphome-core) with C++ framework changes (if applicable):** esphome/esphome-core#<esphome-core PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
