### PR TITLE
Add 'internal' to GPIO switch

### DIFF
--- a/components/switch/gpio.rst
+++ b/components/switch/gpio.rst
@@ -28,6 +28,8 @@ Configuration variables:
   GPIO pin to use for the switch.
 - **name** (**Required**, string): The name for the switch.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
+- **internal** (*Optional*, boolean): Mark this component as internal. Internal components will
+  not be exposed to the frontend (like Home Assistant).
 - **restore_mode** (*Optional*): Control how the GPIO Switch attempts to restore state on bootup.
   For restoring on ESP8266s, also see ``esp8266_restore_from_flash`` in the
   :doc:`esphome section </components/esphome>`.


### PR DESCRIPTION
In testing, ESPHome does honour `internal: true` for a GPIO switch.

Didn't add the following as I'm not sure if it's accurate:

```
Only specifying an ``id`` without  a ``name`` will implicitly set this to true.
```

## Description:


**No related issue**
**No related PR for [esphome](https://github.com/esphome/esphome) or [esphome-core](https://github.com/esphome/esphome-core)**

## Checklist:

  - [X] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
