### PR TITLE
changed pca9685_id: to id:

### DIFF
--- a/components/output/pca9685.rst
+++ b/components/output/pca9685.rst
@@ -29,7 +29,7 @@ global ``pca9685`` hub and give it an id, and then define the
     # Individual outputs
     output:
       - platform: pca9685
-        pca9685_id: 'pca9685_hub1'
+        id: 'pca9685_hub1'
         channel: 0
 
 Configuration variables:


### PR DESCRIPTION
## Description:

Since ESPhome gave me an error that 'id: ' is required I think it should be only id: instead of pca9685_id:  and the Configuration variables say also id:.
So I wanted to help the next one to not have the same problem and changed it.


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>
**Pull request in [esphome-core](https://github.com/esphome/esphome-core) with C++ framework changes (if applicable):** esphome/esphome-core#<esphome-core PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
