### PR TITLE
Stepper component: fix typo in doc

### DIFF
--- a/components/stepper/index.rst
+++ b/components/stepper/index.rst
@@ -151,7 +151,7 @@ Configuration options:
             - stepper.report_position:
                 id: my_stepper
                 position: 0
-            - stepper:set_target:
+            - stepper.set_target:
                 id: my_stepper
                 target: 150
 


### PR DESCRIPTION
## Description:
Fix typo for the `stepper-set-target-action`

**Related issue (if applicable):** fixes <link to issue>
https://github.com/esphome/issues/issues/343

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>
**Pull request in [esphome-core](https://github.com/esphome/esphome-core) with C++ framework changes (if applicable):** esphome/esphome-core#<esphome-core PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
