### PR TITLE
Sensor: correct example for on_raw_value

### DIFF
--- a/components/sensor/index.rst
+++ b/components/sensor/index.rst
@@ -355,16 +355,16 @@ Configuration variables:
 ``on_raw_value``
 ****************
 
-This automation will be triggered when a new value that has passed through all filters
-is published. In :ref:`Lambdas <config-lambda>` you can get the value from the trigger
-with ``x``.
+This automation will be triggered when a new value is received that hasn't passed
+through any filters. In :ref:`Lambdas <config-lambda>` you can get the value from the
+trigger with ``x``.
 
 .. code-block:: yaml
 
     sensor:
       - platform: dallas
         # ...
-        on_value:
+        on_raw_value:
           then:
             - light.turn_on:
                 id: light_1


### PR DESCRIPTION
## Description:
Example for `on_raw_value` was copy-paste error from `on_value` section.

**Related issue (if applicable):** fixes <link to issue>
Fixes https://github.com/esphome/issues/issues/319

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>
**Pull request in [esphome-core](https://github.com/esphome/esphome-core) with C++ framework changes (if applicable):** esphome/esphome-core#<esphome-core PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
