### PR TITLE
Add missing filter name for ct_clamp

### DIFF
--- a/components/sensor/ct_clamp.rst
+++ b/components/sensor/ct_clamp.rst
@@ -63,11 +63,12 @@ a 4.0 A device is showing a value of 0.1333 in the logs. Now go into your config
         name: "Measured Current"
         update_interval: 60s
         filters:
-          # Measured value of 0 maps to 0A
-          - 0 -> 0
-          # Known load: 4.0A
-          # Value shown in logs: 0.1333A
-          - 0.1333 -> 4.0
+          - calibrate_linear:
+              # Measured value of 0 maps to 0A
+              - 0 -> 0
+              # Known load: 4.0A
+              # Value shown in logs: 0.1333A
+              - 0.1333 -> 4.0
 
 Recompile and upload, now your CT clamp sensor is calibrated!
 


### PR DESCRIPTION
## Description:
Missing filter name in CT Clamp docs

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
