### PR TITLE
Scaneffectlength

### DIFF
--- a/components/light/index.rst
+++ b/components/light/index.rst
@@ -563,14 +563,14 @@ currently active light color.
           - addressable_scan:
               name: Scan Effect With Custom Values
               move_interval: 100ms
-              scan_length: 15
+              scan_width: 1
 
 Configuration variables:
 
 - **name** (*Optional*, string): The name of the effect. Defaults to ``Scan``.
 - **move_interval** (*Optional*, :ref:`config-time`): The interval with which to move the dot/line one LED forward.
   Defaults to ``100ms``.
-- **scan_length** (*Optional*, integer): The number of LED's to use.
+- **scan_width** (*Optional*, integer): The number of LEDs to use.
   Defaults to ``1``.
 
 Addressable Twinkle Effect

--- a/components/light/index.rst
+++ b/components/light/index.rst
@@ -563,12 +563,15 @@ currently active light color.
           - addressable_scan:
               name: Scan Effect With Custom Values
               move_interval: 100ms
+              scan_length: 15
 
 Configuration variables:
 
 - **name** (*Optional*, string): The name of the effect. Defaults to ``Scan``.
-- **move_interval** (*Optional*, :ref:`config-time`): The interval with which to move the dot one LED forward.
+- **move_interval** (*Optional*, :ref:`config-time`): The interval with which to move the dot/line one LED forward.
   Defaults to ``100ms``.
+- **scan_length** (*Optional*, integer): The number of LED's to use.
+  Defaults to ``1``.
 
 Addressable Twinkle Effect
 **************************


### PR DESCRIPTION
## Description:

Added 'scan_length' option to Addressable Scan effect, so that it uses a range of LED's instead of just the one.

**Related issue (if applicable):** -

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#608

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
