### PR TITLE
Allow setting the initial mode of HLW8012 sensors

### DIFF
--- a/components/sensor/hlw8012.rst
+++ b/components/sensor/hlw8012.rst
@@ -55,8 +55,34 @@ Configuration variables:
   Defaults to the Sonoff POW's value ``2351``.
 - **change_mode_every** (*Optional*, int): After how many updates to cycle between the current/voltage measurement mode.
   Note that the first value after switching is discarded because it is often inaccurate. Defaults to ``8``.
+- **initial_mode** (*Optional*, string): The initial measurement mode. Defaults to ``VOLTAGE``.
 - **update_interval** (*Optional*, :ref:`config-time`): The interval to check the sensor. Defaults to ``60s``.
 
+Measurement Modes:
+------------------
+
+Possible initial measurement modes are ``VOLTAGE`` or ``CURRENT``.
+
+Some devices have the SEL pin permanently pulled high or low. If this is the case, you can configure
+the initial measurement mode to match whichever mode the device uses, and disable mode switching.
+
+.. code-block:: yaml
+
+    # Example configuration entry for device with fixed measurement mode
+    sensor:
+      - platform: hlw8012
+        sel_pin: 5
+        cf_pin: 14
+        cf1_pin: 13
+        current:
+          name: "HLW8012 Current"
+        voltage:
+          name: "HLW8012 Voltage"
+        power:
+          name: "HLW8012 Power"
+        update_interval: 60s
+        initial_mode: CURRENT
+        change_mode_every: 4294967295
 
 See Also
 --------

--- a/components/sensor/hlw8012.rst
+++ b/components/sensor/hlw8012.rst
@@ -49,18 +49,21 @@ Configuration variables:
   :ref:`Sensor <config-sensor>`.
 - **voltage** (*Optional*): Use the voltage value of the sensor in V (RMS).
   All options from :ref:`Sensor <config-sensor>`.
+- **update_interval** (*Optional*, :ref:`config-time`): The interval to check the sensor. Defaults to ``60s``.
+
+Advanced Options:
+
 - **current_resistor** (*Optional*, float): The value of the shunt resistor for current measurement.
   Defaults to the Sonoff POW's value ``0.001 ohm``.
 - **voltage_divider** (*Optional*, float): The value of the voltage divider on the board as ``(R_upstream + R_downstream) / R_downstream``.
   Defaults to the Sonoff POW's value ``2351``.
 - **change_mode_every** (*Optional*, int): After how many updates to cycle between the current/voltage measurement mode.
   Note that the first value after switching is discarded because it is often inaccurate. Defaults to ``8``.
-
-Advanced Options:
-
-- **update_interval** (*Optional*, :ref:`config-time`): The interval to check the sensor. Defaults to ``60s``.
 - **initial_mode** (*Optional*, string): The initial measurement mode. Defaults to ``VOLTAGE``.
   Possible initial measurement modes are ``VOLTAGE`` or ``CURRENT``.
+
+Permanent SEL Pin
+-----------------
 
 Some devices have the SEL pin permanently pulled high or low. If this is the case, you can configure
 the initial measurement mode to match whichever mode the device uses, and disable mode switching.

--- a/components/sensor/hlw8012.rst
+++ b/components/sensor/hlw8012.rst
@@ -55,13 +55,12 @@ Configuration variables:
   Defaults to the Sonoff POW's value ``2351``.
 - **change_mode_every** (*Optional*, int): After how many updates to cycle between the current/voltage measurement mode.
   Note that the first value after switching is discarded because it is often inaccurate. Defaults to ``8``.
-- **initial_mode** (*Optional*, string): The initial measurement mode. Defaults to ``VOLTAGE``.
+
+Advanced Options:
+
 - **update_interval** (*Optional*, :ref:`config-time`): The interval to check the sensor. Defaults to ``60s``.
-
-Measurement Modes:
-------------------
-
-Possible initial measurement modes are ``VOLTAGE`` or ``CURRENT``.
+- **initial_mode** (*Optional*, string): The initial measurement mode. Defaults to ``VOLTAGE``.
+  Possible initial measurement modes are ``VOLTAGE`` or ``CURRENT``.
 
 Some devices have the SEL pin permanently pulled high or low. If this is the case, you can configure
 the initial measurement mode to match whichever mode the device uses, and disable mode switching.


### PR DESCRIPTION
## Description:

Allow setting the initial mode of HLW8012 sensors.

I've got a couple devices that have a HLW8012 in them with the SEL pin permanently pulled high.

**Related issue (if applicable):** n/a

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#611

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
