### PR TITLE
Lambas won't just work with the short name

### DIFF
--- a/components/cover/template.rst
+++ b/components/cover/template.rst
@@ -92,11 +92,11 @@ Configuration options:
 
 - **id** (**Required**, :ref:`config-id`): The ID of the template cover.
 - **state** (*Optional*, :ref:`templatable <config-templatable>`):
-  The state to publish. One of ``OPEN``, ``CLOSED``.
+  The state to publish. One of ``OPEN``, ``CLOSED``. If using a lambda, use ```COVER_OPEN``` or ```COVER_CLOSED```. 
 - **position** (*Optional*, :ref:`templatable <config-templatable>`, float):
-  The position to publish, from 0 (CLOSED) to 1.0 (OPEN)
+  The position to publish, from 0.0 (CLOSED) to 1.0 (OPEN)
 - **current_operation** (*Optional*, :ref:`templatable <config-templatable>`, string):
-  The current operation mode to publish. One of ``COVER_OPERATION_IDLE``, ``COVER_OPERATION_OPENING`` and ``COVER_OPERATION_CLOSING``.
+  The current operation mode to publish. One of ``IDLE``, ``OPENING`` and ``CLOSING``. If using a lambda, use ```COVER_OPERATION_IDLE```, ```COVER_OPERATION_OPENING```, and ```COVER_OPERATION_CLOSING```.
 
 .. note::
 

--- a/components/cover/template.rst
+++ b/components/cover/template.rst
@@ -96,7 +96,7 @@ Configuration options:
 - **position** (*Optional*, :ref:`templatable <config-templatable>`, float):
   The position to publish, from 0 (CLOSED) to 1.0 (OPEN)
 - **current_operation** (*Optional*, :ref:`templatable <config-templatable>`, string):
-  The current operation mode to publish. One of ``IDLE``, ``OPENING`` and ``CLOSING``.
+  The current operation mode to publish. One of ``COVER_OPERATION_IDLE``, ``COVER_OPERATION_OPENING`` and ``COVER_OPERATION_CLOSING``.
 
 .. note::
 


### PR DESCRIPTION
lambdas won't accept IDLE, OPENING, or CLOSING. Need to specify COVER_OPERATION_IDLE, COVER_OPERATION_OPENING, or COVER_OPERATION_CLOSING.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
