### PR TITLE
added D1,2 numbering on ESP8266 to avoid confusion

### DIFF
--- a/components/i2c.rst
+++ b/components/i2c.rst
@@ -25,10 +25,10 @@ Configuration variables:
 ------------------------
 
 - **sda** (*Optional*, :ref:`config-pin`): The pin for the data line of the I²C bus.
-  Defaults to the default of your board (usually GPIO21 for ESP32 and GPIO4 for ESP8266).
+  Defaults to the default of your board (usually GPIO21 for ESP32 and GPIO4(Pin D2) for ESP8266).
 - **scl** (*Optional*, :ref:`config-pin`): The pin for the clock line of the I²C bus.
   Defaults to the default of your board (usually GPIO22 for ESP32 and
-  GPIO5 for ESP8266).
+  GPIO5(Pin D1) for ESP8266 ).
 - **scan** (*Optional*, boolean): If ESPHome should do a search of the I²C address space on startup.
   Defaults to ``True``.
 - **frequency** (*Optional*, float): Set the frequency the I²C bus should operate on.


### PR DESCRIPTION
Spent about 2 hours debugging why the I2C bus wasn't seeing any components until I realised that GPIO4 = D2 and GPIO5 = D1.
Will hopefully help other who are using the same board.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
