### PR TITLE
Added docs for ignore bit setting on rc_switch_raw and fixed ref links

### DIFF
--- a/components/cover/template.rst
+++ b/components/cover/template.rst
@@ -101,7 +101,7 @@ Configuration options:
 .. note::
 
     This action can also be written in lambdas:
-L
+
     .. code-block:: cpp
 
         id(template_cov).position = COVER_OPEN;

--- a/components/remote_receiver.rst
+++ b/components/remote_receiver.rst
@@ -151,9 +151,8 @@ Remote code selection (exactly one of these has to be included):
 
 - **rc_switch_raw**: Trigger on a decoded RC Switch raw remote code with the given data.
 
-  - **code** (**Required**, string): The remote code to listen for, copy this from the dumper output.
-  - **mask** (*Optional*, string): The mask to define which bits of the code to use (``1``) or ignore (``0``)
-    in the comparison to inputs. Defaults to ``"11111111111111111111111111111111"`` (use all 32 bits).
+  - **code** (**Required**, string): The remote code to listen for, copy this from the dumper output. To ignore a bit
+    in the received data, use ``x`` at that place in the **code**.
   - **protocol** (*Optional*): The RC Switch protocol to use, see :ref:`remote_transmitter-rc_switch-protocol` for more info.
 
 - **rc_switch_type_a**: Trigger on a decoded RC Switch Type A remote code with the given data.

--- a/components/remote_receiver.rst
+++ b/components/remote_receiver.rst
@@ -14,7 +14,7 @@ handles setting the pin and some other settings, and individual
 :ref:`remote receiver binary sensors <remote-receiver-binary-sensor>`
 which will trigger when they hear their own configured signal.
 
-**See :ref:`remote-setting-up-infrared` and :ref:`remote-setting-up-rf` for set up guides.**
+**See** :ref:`remote-setting-up-infrared` **and** :ref:`remote-setting-up-rf` **for set up guides.**
 
 .. code-block:: yaml
 
@@ -152,6 +152,8 @@ Remote code selection (exactly one of these has to be included):
 - **rc_switch_raw**: Trigger on a decoded RC Switch raw remote code with the given data.
 
   - **code** (**Required**, string): The remote code to listen for, copy this from the dumper output.
+  - **mask** (*Optional*, string): The mask to define which bits of the code to use (``1``) or ignore (``0``)
+    in the comparison to inputs. Defaults to ``"11111111111111111111111111111111"`` (use all 32 bits).
   - **protocol** (*Optional*): The RC Switch protocol to use, see :ref:`remote_transmitter-rc_switch-protocol` for more info.
 
 - **rc_switch_type_a**: Trigger on a decoded RC Switch Type A remote code with the given data.

--- a/components/remote_transmitter.rst
+++ b/components/remote_transmitter.rst
@@ -14,7 +14,7 @@ First, you need to setup a global hub that specifies which pin your remote
 sender is connected to. Then you can use the available actions to send encoded
 remote signals.
 
-**See :ref:`remote-setting-up-infrared` and :ref:`remote-setting-up-rf` for set up guides.**
+**See** :ref:`remote-setting-up-infrared` **and** :ref:`remote-setting-up-rf` **for set up guides.**
 
 .. note::
 


### PR DESCRIPTION
## Description:
Adding docs for the new ``mask`` configuration entry on the ``rc_switch_raw`` configuration of [Remote Receiver](https://esphome.io/components/remote_receiver.html).

**Related issue (if applicable):** fixes [feature request #292](https://github.com/esphome/feature-requests/issues/292)

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#650

## Checklist:

  - [X] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
