### PR TITLE
Add Shelly RGBW2 pinout to sonoff.rst

### DIFF
--- a/devices/sonoff.rst
+++ b/devices/sonoff.rst
@@ -311,7 +311,7 @@ Shelly 2
     GPIO14, SW Input #2,
     
 Shelly RGBW2
---------
+------------
 
 .. pintable::
 

--- a/devices/sonoff.rst
+++ b/devices/sonoff.rst
@@ -309,6 +309,18 @@ Shelly 2
     GPIO5, Relay #2,
     GPIO12, SW Input #1,
     GPIO14, SW Input #2,
+    
+Shelly RGBW2
+--------
+
+.. pintable::
+
+    GPIO12, LED Red,
+    GPIO15, LED Green,
+    GPIO14, LED Blue,
+    GPIO04, LED White,
+    GPIO??, SW Input,
+    GPIO??, Power Meter,
 
 Teckin
 ------


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
