### PR TITLE
Absolute humidity calculation description

### DIFF
--- a/cookbook/bme280_environment.rst
+++ b/cookbook/bme280_environment.rst
@@ -62,7 +62,7 @@ The formula derived from `here <https://github.com/finitespace/BME280/blob/maste
 converts the currently measured pressure to the altitudes in meters including temperature compensation.
 
 The lambda in the second :doc:`/components/sensor/template` defines two physical constants and
-converts the currently measured pressure to absolute humidity (grams/m^3).
+converts the currently measured temperature and relative humidity to absolute humidity (grams/m^3).
 
 .. note::
 


### PR DESCRIPTION
Description of absolute humidity calculation referenced the use of pressure sensor instead of temperature relative humidity sensor.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
