### PR TITLE
Updated confusing deep_sleep.prevent documentation

### DIFF
--- a/components/deep_sleep.rst
+++ b/components/deep_sleep.rst
@@ -103,7 +103,7 @@ Useful for
 
     You can use this automation to automatically prevent deep sleep when a MQTT message on the topic
     ``livingroom/ota_mode`` is received. Then, to do the OTA update, just
-    use a MQTT client to publish a retained MQTT message described above. When the node wakes up again
+    use a MQTT client to publish a retained MQTT message described below. When the node wakes up again
     it will no longer enter deep sleep mode and you can upload your OTA update.
 
     Remember to turn "OTA mode" off again after the OTA update by sending a MQTT message with the payload

--- a/components/deep_sleep.rst
+++ b/components/deep_sleep.rst
@@ -107,7 +107,7 @@ Useful for
     it will no longer enter deep sleep mode and you can upload your OTA update.
 
     Remember to turn "OTA mode" off again after the OTA update by sending a MQTT message with the payload
-    ``OFF``.
+    ``OFF``. Note that the device won't enter deep sleep again until the next reboot.
 
     .. code-block:: yaml
 
@@ -118,6 +118,7 @@ Useful for
           # ...
           on_message:
             topic: livingroom/ota_mode
+            payload: 'ON'
             then:
               - deep_sleep.prevent: deep_sleep_1
 


### PR DESCRIPTION
## Description:

When I tried to set up preventing deep sleep via MQTT, I faced two confusing problems that the documentation did not mention:

1. If I set a `on_message` trigger without specifying the payload too, then sending an `OFF` message to the topic (trying enable deep sleep again), then this new message would still trigger the automation, thus preventing deep sleep.

2. Correct me if I'm wrong, but my experience is that deep sleep won't be enabled again until the next boot.

This PR adds mention to these problems. 

## Checklist:

  - [X] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
