### PR TITLE
Added RSSI wifi sensor reference.

### DIFF
--- a/components/wifi.rst
+++ b/components/wifi.rst
@@ -193,4 +193,5 @@ See Also
 --------
 
 - :apiref:`wifi/wifi_component.h`
+- :wifirssi:`sensor/wifi_signal.h`
 - :ghedit:`Edit`


### PR DESCRIPTION
Added RSSI wifi sensor reference.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
