### PR TITLE
Fix typo in transmit_sony documentation

### DIFF
--- a/components/remote_transmitter.rst
+++ b/components/remote_transmitter.rst
@@ -162,7 +162,7 @@ This :ref:`action <config-action>` a Sony infrared remote code to a remote trans
 .. code-block:: yaml
 
     on_...:
-      - remote_transmitter.transmitsony:
+      - remote_transmitter.transmit_sony:
           data: 0x123
           nbits: 12
 


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
