### PR TITLE
add has_built_in_endstop docs

### DIFF
--- a/components/cover/time_based.rst
+++ b/components/cover/time_based.rst
@@ -46,13 +46,21 @@ Configuration variables:
 - **close_duration** (**Required**, :ref:`config-time`): The amount of time it takes the cover
   to close from the fully-open state.
 - **stop_action** (**Required**, :ref:`Action <config-action>`): The action that should
-  be performed when the remote requests the cover to be closed or the cover has been opening/closing
-  for the given durations.
+  be performed to stop the cover when the remote requests the cover to be stopped or
+  when the cover has been opening/closing for the given durations.
 - **has_built_in_endstop** (*Optional*, boolean): Indicates that the cover has built in end stop
-  detectors and ESPHome should not execute ``stop_action`` when the open or close time is completed.
-  Defaults to ``False``.
+  detectors. In this configuration the ``stop_action`` is not perfomed when the open or close
+  time is completed and if the cover is commanded to open or close the corresponding actions
+  will be performed without checking current state. Defaults to ``False``.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
 - All other options from :ref:`Cover <config-cover>`.
+
+
+.. note::
+
+    The stop button on the UI is always enabled even when the cover is stopped and each press
+    on the button will cause the ``stop_action`` to be performed.
+
 
 See Also
 --------

--- a/components/cover/time_based.rst
+++ b/components/cover/time_based.rst
@@ -48,6 +48,9 @@ Configuration variables:
 - **stop_action** (**Required**, :ref:`Action <config-action>`): The action that should
   be performed when the remote requests the cover to be closed or the cover has been opening/closing
   for the given durations.
+- **has_built_in_endstop** (*Optional*, boolean): Indicates that the cover has built in end stop
+  detectors and ESPHome should not execute ``stop_action`` when the open or close time is completed.
+  Defaults to ``False``.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
 - All other options from :ref:`Cover <config-cover>`.
 


### PR DESCRIPTION
## Description:
Adds docs for has_built_in_endstop 

**Related issue (if applicable):** fixes 
**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#https://github.com/esphome/esphome/pull/665

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
