### PR TITLE
Make it clearer that only one deep sleep component is allowed.

### DIFF
--- a/components/deep_sleep.rst
+++ b/components/deep_sleep.rst
@@ -27,8 +27,6 @@ even Over The Air updates.
     deep_sleep:
       run_duration: 10s
       sleep_duration: 10min
-      
-Note: only one Deep Sleep Component may be configured.
 
 Configuration variables:
 ------------------------
@@ -51,6 +49,10 @@ Advanced features:
   - **pins** (**Required**, list of pin numbers): The pins to wake up on.
   - **mode** (*Optional*): The mode to use for the wakeup source. Must be one of ``ALL_LOW`` (wake up when
     all pins go LOW) or ``ANY_HIGH`` (wake up when any pin goes HIGH).
+
+.. note::
+
+    Only one deep sleep component may be configured.
 
 .. _deep_sleep-esp32_wakeup_pin_mode:
 

--- a/components/deep_sleep.rst
+++ b/components/deep_sleep.rst
@@ -27,6 +27,8 @@ even Over The Air updates.
     deep_sleep:
       run_duration: 10s
       sleep_duration: 10min
+      
+Note: only one Deep Sleep Component may be configured.
 
 Configuration variables:
 ------------------------


### PR DESCRIPTION
## Description:

It's possibly just me, but I didn't realise you could only have one deep sleep component. I'm guessing there are other components which also have the same restriction, so in that case, for consistency, either this PR should be ignored or all of those pages should have a similar comment. I'm happy to create a PR to do so if you are able to list the components which only allow one to be created.

**Related issue (if applicable):** fixes <link to issue>
https://github.com/esphome/issues/issues/528

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.