### PR TITLE
Add Fujitsu General Climate component docs

### DIFF
--- a/components/climate/fujitsu_general.rst
+++ b/components/climate/fujitsu_general.rst
@@ -1,0 +1,52 @@
+Fujitsu General Remote Climate
+==============================
+
+.. seo::
+    :description: Controls a Fujitsu General compatible Climate via IR
+    :image: air-conditioner.png
+
+The ``fujitsu_general`` climate platform allows you to control a Fujitsu General compatible AC unit by sending IR signals
+as your remote unit would do.
+
+This component requires that you have setup a :doc:`/components/remote_transmitter`.
+
+Due to the unidirectional nature of IR remote controllers, this component cannot determine the
+actual state of the device, and will assume the state of the device is the latest state requested.
+
+.. figure:: images/climate-ui.png
+    :align: center
+    :width: 60.0%
+
+.. code-block:: yaml
+
+    # Example configuration entry
+    remote_transmitter:
+      pin: GPIO32
+      carrier_duty_percent: 50%
+
+    climate:
+      - platform: fujitsu_general
+        name: "Living Room AC"
+
+Configuration variables:
+------------------------
+
+- **name** (**Required**, string): The name for the climate.
+- **supports_cool** (*Optional*, boolean): Enables setting cool mode for this climate device. Defaults to ``True``.
+- **supports_heat** (*Optional*, boolean): Enables setting cool heat for this climate device. Defaults to ``True``.
+- **sensor** (*Optional*, :ref:`config-id`): The sensor that is used to measure the ambient
+  temperature. This is only for reporting the current temperature in the frontend.
+- All other options from :ref:`Climate <config-climate>`.
+
+Advanced options:
+
+- **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
+- **transmitter_id** (*Optional*, :ref:`config-id`): Manually specify the ID of the remote transmitter.
+
+See Also
+--------
+
+- :doc:`/components/climate/index`
+- :doc:`/components/remote_transmitter`
+- :apiref:`fujitsu_general/fujitsu_general.h`
+- :ghedit:`Edit`

--- a/index.rst
+++ b/index.rst
@@ -275,6 +275,7 @@ Climate Components
     Coolix IR Remote, components/climate/coolix, air-conditioner.svg
     Tcl112 IR Remote, components/climate/tcl112, air-conditioner.svg
     Yashima IR Remote, components/climate/yashima, air-conditioner.svg
+    Fujitsu General IR Remote, components/climate/fujitsu_general, air-conditioner.svg
 
 Misc Components
 ---------------


### PR DESCRIPTION
## Description:
The docs for the new General  climate component

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#677

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.