### PR TITLE
Fix description of the sensor

### DIFF
--- a/components/sensor/tcs34725.rst
+++ b/components/sensor/tcs34725.rst
@@ -8,7 +8,7 @@ TCS34725 RGB Color Sensor
 
 The ``tcs34725`` sensor platform allows you to use your TCS34725 RGB color sensors
 (`datasheet <https://cdn-shop.adafruit.com/datasheets/TCS34725.pdf>`__,
-`Adafruit`_) temperature and pressure sensors with ESPHome. The :ref:`I²C <i2c>` is
+`Adafruit`_), color temperature and illuminance sensors with ESPHome. The :ref:`I²C <i2c>` is
 required to be set up in your configuration for this sensor to work.
 
 .. figure:: images/tcs34725-full.jpg


### PR DESCRIPTION
## Description:
Correct the description of the sensor - doesn't measure pressure or temperature, but does measure color temperature and illuminance. Looks like was originally copied from BME280 description

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
