### PR TITLE
Fix api.proto url

### DIFF
--- a/components/api.rst
+++ b/components/api.rst
@@ -16,7 +16,7 @@ the device manually by clicking "CONFIGURE" on the ESPHome integration and enter
 "<NODE_NAME>.local" as the address.
 
 The ESPHome native API is based on a custom TCP protocol using protocol buffers. You can find
-the protocol data structure definitions here: https://github.com/esphome/esphome/blob/dev/src/esphome/components/api/api.proto
+the protocol data structure definitions here: https://github.com/esphome/esphome/blob/dev/esphome/components/api/api.proto
 A python library that implements this protocol can be found `here <https://github.com/esphome/aioesphomeapi>`__.
 
 .. code-block:: yaml


### PR DESCRIPTION
## Description:

The api.proto url linked to a different directory, which didn't exist. This PR uses the new url.

No related issues or PRs.

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
