### PR TITLE
MH-Z19 calibration support

### DIFF
--- a/components/sensor/mhz19.rst
+++ b/components/sensor/mhz19.rst
@@ -37,6 +37,7 @@ TX/RX labels are from the perspective of the MH-Z19). Additionally, you need to 
         temperature:
           name: "MH-Z19 Temperature"
         update_interval: 60s
+        automatic_baseline_calibration: false
 
 Configuration variables:
 ------------------------

--- a/components/sensor/mhz19.rst
+++ b/components/sensor/mhz19.rst
@@ -62,6 +62,8 @@ Configuration variables:
 - **uart_id** (*Optional*, :ref:`config-id`): Manually specify the ID of the :ref:`UART Component <uart>` if you want
   to use multiple UART buses.
 
+- **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for actions.
+
 - **automatic_baseline_calibration** (*Optional*, boolean): MH-Z19 has automatic calibration procedure.
   The automatic calibration cycle is every 24 hours after powered on.
   Set this value to ``false`` to disable ABC on boot (it's better if you use sensor indoor).

--- a/components/sensor/mhz19.rst
+++ b/components/sensor/mhz19.rst
@@ -61,11 +61,82 @@ Configuration variables:
 - **uart_id** (*Optional*, :ref:`config-id`): Manually specify the ID of the :ref:`UART Component <uart>` if you want
   to use multiple UART buses.
 
+- **automatic_baseline_calibration** (*Optional*, boolean): MH-Z19 has automatic calibration procedure.
+  The automatic calibration cycle is every 24 hours after powered on.
+  Set this value to ``false`` to disable ABC on boot (it's better if you use sensor indoor).
+  Set this value to ``true`` to enable ABC on boot.
+  Doesn't send calibration command if not set (default sensor logic will be used).
+
 .. figure:: images/mhz19-pins.jpg
     :align: center
     :width: 80.0%
 
     Pins on the MH-Z19. Only the ones marked with a red circle need to be connected.
+
+.. _mhz19-calibrate_zero_action:
+
+``mhz19.calibrate_zero`` Action
+-------------------------------
+
+This :ref:`action <config-action>` executes zero point calibration command on the sensor with the given ID.
+
+If you want to execute zero point calibration, the MH-Z19 sensor must work in stable gas environment (400ppm)
+for over 20 minutes and you execute this function.
+
+.. code-block:: yaml
+
+    on_...:
+      then:
+        - mhz19.calibrate_zero: my_mhz19_id
+
+You can provide :ref:`service <api-services>` to call it from Home Assistant
+
+.. code-block:: yaml
+
+    api:
+      services:
+        - service: mhz19_calibrate_zero
+          then:
+            - mhz19.calibrate_zero: my_mhz19_id
+
+.. _mhz19-abc_enable_action:
+
+``mhz19.abc_enable`` Action
+---------------------------
+
+This :ref:`action <config-action>` enables automatic baseline calibration on the sensor with the given ID.
+
+.. code-block:: yaml
+
+    on_...:
+      then:
+        - mhz19.abc_enable: my_mhz19_id
+
+.. _mhz19-abc_disable_action:
+
+``mhz19.abc_disable`` Action
+----------------------------
+
+This :ref:`action <config-action>` disables automatic baseline calibration on the sensor with the given ID.
+
+.. code-block:: yaml
+
+    on_...:
+      then:
+        - mhz19.abc_disable: my_mhz19_id
+
+You can provide switch and control ABC from Home Assistant
+
+.. code-block:: yaml
+
+    switch:
+      - platform: template
+        name: "MH-Z19 ABC"
+        optimistic: true
+        on_turn_on:
+          mhz19.abc_enable: my_mhz19_id
+        on_turn_off:
+          mhz19.abc_disable: my_mhz19_id
 
 See Also
 --------

--- a/guides/automations.rst
+++ b/guides/automations.rst
@@ -362,6 +362,7 @@ All Actions
 - :ref:`display.page.show_* <display-pages>`
 - :ref:`uart.write <uart-write_action>`
 - :ref:`sim800l.send_sms <sim800l-send_sms_action>`
+- :ref:`mhz19.calibrate_zero <mhz19-calibrate_zero_action>` / :ref:`mhz19.abc_enable <mhz19-abc_enable_action>` / :ref:`mhz19.abc_disable <mhz19-abc_disable_action>`
 
 .. _config-condition:
 


### PR DESCRIPTION
## Description:
* Enable or disable automatic baseline calibration on boot
* Actions to enable or disable automatic baseline calibration by hands
* Action to calibrate zero point

**Related issue (if applicable):** fixes https://github.com/esphome/feature-requests/issues/350

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#683

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
