### PR TITLE
Update incorrect GPIO pin for Mirabella Genio Cold + Warm White…

### DIFF
--- a/cookbook/mirabella-genio-bulb.rst
+++ b/cookbook/mirabella-genio-bulb.rst
@@ -172,7 +172,7 @@ variable ``output_component1``.
     output:
       - platform: esp8266_pwm
         id: output_warm_white
-        pin: GPIO14
+        pin: GPIO13
       - platform: esp8266_pwm
         id: output_daylight
         pin: GPIO5


### PR DESCRIPTION
## Description: Fixed an incorrectly referenced GPIO pin in the Mirabella Genio documentation which was causing tunable bulbs to not actually be tunable.


**Related issue (if applicable):** partially fixes https://github.com/esphome/issues/issues/228

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
