### PR TITLE
Update sonoff.rst

### DIFF
--- a/devices/sonoff.rst
+++ b/devices/sonoff.rst
@@ -300,7 +300,7 @@ Sonoff Mini
     GPIO4, SW Input,
     GPIO12, Relay and Red LED,
     GPIO13, Blue LED (inverted),
-    GPIO17, Optional sensor
+    GPIO16, Optional sensor
 
 
 Shelly 1


### PR DESCRIPTION
## Description: Wrong optional sesor pin ,Sonoff mini


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
