### PR TITLE
Add TorchStar LED controller to 'Generic Sonoff' page

### DIFF
--- a/devices/sonoff.rst
+++ b/devices/sonoff.rst
@@ -355,6 +355,19 @@ Teckin SP20 (US)
 See :doc:`/components/sensor/hlw8012` for measuring power.
 Example config: `teckin_sp20_us.yaml <https://github.com/esphome/esphome-docs/blob/current/devices/teckin_sp20_us.yaml>`__
 
+TorchStar LED Controller (Nov 2018)
+----------------
+
+.. pintable::
+
+    GPIO13, Button (inverted),
+    GPIO16, Blue LED (inverted),
+    GPIO4, Red LED (inverted),
+    GPIO14, Red Channel,
+    GPIO12, Green Channel,
+    GPIO5, Blue Channel,
+    GPIO15, White Channel,
+
 See Also
 --------
 

--- a/devices/sonoff.rst
+++ b/devices/sonoff.rst
@@ -356,7 +356,7 @@ See :doc:`/components/sensor/hlw8012` for measuring power.
 Example config: `teckin_sp20_us.yaml <https://github.com/esphome/esphome-docs/blob/current/devices/teckin_sp20_us.yaml>`__
 
 TorchStar LED Controller (Nov 2018)
-----------------
+-----------------------------------
 
 .. pintable::
 


### PR DESCRIPTION
## Description:
This PR adds the TorchStar LED controller mappings to the 'Generic Sonoff' page.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** N/A

## Checklist:
**NOTE:** `next` branch is behind, therefore I am submitting the PR against the `current` branch.

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
