### PR TITLE
Update remote_receiver.rst

### DIFF
--- a/components/remote_receiver.rst
+++ b/components/remote_receiver.rst
@@ -14,8 +14,6 @@ handles setting the pin and some other settings, and individual
 :ref:`remote receiver binary sensors <remote-receiver-binary-sensor>`
 which will trigger when they hear their own configured signal.
 
-**See :ref:`remote-setting-up-infrared` and :ref:`remote-setting-up-rf` for set up guides.**
-
 .. code-block:: yaml
 
     # Example configuration entry


### PR DESCRIPTION
## Description:
References `remote-setting-up-infrared` and `remote-setting-up-rf` do not exist anymore

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ x ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
