### PR TITLE
The 4.20in display works fine

### DIFF
--- a/components/display/waveshare_epaper.rst
+++ b/components/display/waveshare_epaper.rst
@@ -73,7 +73,7 @@ Configuration variables:
   - ``2.13in`` (not tested)
   - ``2.70in`` (not tested)
   - ``2.90in``
-  - ``4.20in`` (not tested)
+  - ``4.20in``
   - ``7.50in``
 
 - **busy_pin** (*Optional*, :ref:`Pin Schema <config-pin_schema>`): The BUSY pin. Defaults to not connected.


### PR DESCRIPTION
## Description:

I've been running ESPhome with a 4.20in display successfully for some time.


## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
