### PR TITLE
Hint how to include HA secrets.yaml instead

### DIFF
--- a/guides/faq.rst
+++ b/guides/faq.rst
@@ -11,7 +11,13 @@ Tips for using ESPHome
 1. ESPHome supports (most of) `Home Assistant's YAML configuration directives
    <https://www.home-assistant.io/docs/configuration/splitting_configuration/>`__ like
    ``!include``, ``!secret``. So you can store all your secret WiFi passwords and so on
-   in a file called ``secrets.yaml`` within the directory where the configuration file is.
+   in a file called ``secrets.yaml`` within the directory where the configuration file is. 
+   If you want to keep all your secrets in one place, make a ``secrets.yaml`` file in the 
+   esphome directory with this contents (so it pulls in the contents of your main Home Assistant 
+   ``secrets.yaml`` file):
+   
+   .. code-block:: yaml
+   <<: !include ../secrets.yaml
 
    For even more configuration templating, take a look at :ref:`config-substitutions`.
 

--- a/guides/faq.rst
+++ b/guides/faq.rst
@@ -12,13 +12,7 @@ Tips for using ESPHome
    <https://www.home-assistant.io/docs/configuration/splitting_configuration/>`__ like
    ``!include``, ``!secret``. So you can store all your secret WiFi passwords and so on
    in a file called ``secrets.yaml`` within the directory where the configuration file is. 
-   If you want to keep all your secrets in one place, make a ``secrets.yaml`` file in the 
-   esphome directory with this contents (so it pulls in the contents of your main Home Assistant 
-   ``secrets.yaml`` file):
    
-   .. code-block:: yaml
-   <<: !include ../secrets.yaml
-
    For even more configuration templating, take a look at :ref:`config-substitutions`.
 
 2. If you want to see how ESPHome interprets your configuration, run
@@ -182,6 +176,18 @@ To install the dev version of ESPHome:
       docker build -t esphome-dev -f docker/Dockerfile .
 
 The latest dev docs are here: `next.esphome.io <https://next.esphome.io/>`__
+
+How do I use my Home Assistant secrets.yaml?
+---------------------------------------------
+
+If you want to keep all your secrets in one place, make a ``secrets.yaml`` file in the 
+   esphome directory with these contents (so it pulls in the contents of your main Home Assistant 
+   ``secrets.yaml`` file from one directory higher):
+   
+   .. code-block:: yaml
+   
+       <<: !include ../secrets.yaml
+
 
 Does ESPHome support [this device/feature]?
 -------------------------------------------

--- a/guides/faq.rst
+++ b/guides/faq.rst
@@ -181,12 +181,12 @@ How do I use my Home Assistant secrets.yaml?
 ---------------------------------------------
 
 If you want to keep all your secrets in one place, make a ``secrets.yaml`` file in the 
-   esphome directory with these contents (so it pulls in the contents of your main Home Assistant 
-   ``secrets.yaml`` file from one directory higher):
+esphome directory with these contents (so it pulls in the contents of your main Home Assistant 
+``secrets.yaml`` file from one directory higher):
    
-   .. code-block:: yaml
+.. code-block:: yaml
    
-       <<: !include ../secrets.yaml
+    <<: !include ../secrets.yaml
 
 
 Does ESPHome support [this device/feature]?

--- a/guides/faq.rst
+++ b/guides/faq.rst
@@ -11,8 +11,8 @@ Tips for using ESPHome
 1. ESPHome supports (most of) `Home Assistant's YAML configuration directives
    <https://www.home-assistant.io/docs/configuration/splitting_configuration/>`__ like
    ``!include``, ``!secret``. So you can store all your secret WiFi passwords and so on
-   in a file called ``secrets.yaml`` within the directory where the configuration file is. 
-   
+   in a file called ``secrets.yaml`` within the directory where the configuration file is.
+
    For even more configuration templating, take a look at :ref:`config-substitutions`.
 
 2. If you want to see how ESPHome interprets your configuration, run
@@ -178,14 +178,14 @@ To install the dev version of ESPHome:
 The latest dev docs are here: `next.esphome.io <https://next.esphome.io/>`__
 
 How do I use my Home Assistant secrets.yaml?
----------------------------------------------
+--------------------------------------------
 
-If you want to keep all your secrets in one place, make a ``secrets.yaml`` file in the 
-esphome directory with these contents (so it pulls in the contents of your main Home Assistant 
+If you want to keep all your secrets in one place, make a ``secrets.yaml`` file in the
+esphome directory with these contents (so it pulls in the contents of your main Home Assistant
 ``secrets.yaml`` file from one directory higher):
-   
+
 .. code-block:: yaml
-   
+
     <<: !include ../secrets.yaml
 
 


### PR DESCRIPTION
## Description:
Easy way to include the main Home Assistant secrets.yaml instead of having to keep secrets in 2 different places.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
