### PR TITLE
fixed typo

### DIFF
--- a/guides/contributing.rst
+++ b/guides/contributing.rst
@@ -306,7 +306,7 @@ a fork of the repository that you can modify and create git branches on.
 
     # Add "upstream" remote
     git remote add upstream https://github.com/esphome/<REPO_NAME>.git
-    # For example: git clone https://github.com/esphome/esphome.git
+    # For example: git remote add upstream https://github.com/esphome/esphome.git
 
     # For each patch, create a new branch from latest dev
     git checkout dev


### PR DESCRIPTION
git remote add upstream https://github.com/esphome/<REPO_NAME>.git
 # For example: git remote add upstream https://github.com/esphome/esphome.git

## Description:
Fixed typo in example

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
