### PR TITLE
Update time.rst to add GPS as source

### DIFF
--- a/components/time.rst
+++ b/components/time.rst
@@ -6,11 +6,11 @@ Time
 .. seo::
     :description: Instructions for setting up real time clock sources in ESPHome like network based time.
     :image: clock-outline.png
-    :keywords: NTP, SNTP, RTC
+    :keywords: GPS, NTP, RTC, SNTP
 
 The ``time`` component allows you to set up real time clock time sources for ESPHome.
 You can then get the current time in :ref:`lambdas <config-lambda>`.
-Currently only sntp (internet-based) and homeassistant time sources are supported.
+Currently only sntp (internet-based), homeassistant time and GPS sources are supported.
 
 Home Assistant Time Source
 --------------------------
@@ -61,6 +61,29 @@ Configuration variables:
 - **on_time** (*Optional*, :ref:`Automation <automation>`): Automation to run at specific intervals using
   a cron-like syntax. See :ref:`time-on_time`.
 
+GPS Time Source
+--------------------------
+
+You first need to set up the :doc:`GPS </components/gps>` component.
+
+.. code-block:: yaml
+
+    # Example configuration entry
+    time:
+      - platform: gps
+        id: gps_time
+
+Configuration variables:
+
+- **id** (*Optional*, :ref:`config-id`): Specify the ID of the time for use in lambdas.
+- **timezone** (*Optional*, string): Manually tell ESPHome what timezone to use with `this format
+  <https://www.gnu.org/software/libc/manual/html_node/TZ-Variable.html>`__ (warning: the format is quite complicated)
+  or the simpler `TZ database name <https://en.wikipedia.org/wiki/List_of_tz_database_time_zones>`__ in the form
+  <Region>/<City>. ESPHome tries to automatically infer the timezone string based on the timezone of the computer
+  that is running ESPHome, but this might not always be accurate.
+- **on_time** (*Optional*, :ref:`Automation <automation>`): Automation to run at specific intervals using
+  a cron-like syntax. See :ref:`time-on_time`.
+  
 Use In Lambdas
 --------------
 

--- a/components/time.rst
+++ b/components/time.rst
@@ -62,7 +62,7 @@ Configuration variables:
   a cron-like syntax. See :ref:`time-on_time`.
 
 GPS Time Source
---------------------------
+---------------
 
 You first need to set up the :doc:`GPS </components/gps>` component.
 
@@ -83,7 +83,7 @@ Configuration variables:
   that is running ESPHome, but this might not always be accurate.
 - **on_time** (*Optional*, :ref:`Automation <automation>`): Automation to run at specific intervals using
   a cron-like syntax. See :ref:`time-on_time`.
-  
+
 Use In Lambdas
 --------------
 


### PR DESCRIPTION
## Description:
Just saw that GPS was missing in the time documentation as a time source (the GPS component documentation redirect to the time page for configuration details)

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
