### PR TITLE
Document missing servo restore option

### DIFF
--- a/components/servo.rst
+++ b/components/servo.rst
@@ -52,6 +52,9 @@ Advanced Options:
   to. This is also the state of the servo at startup. Defaults to ``7.5%``.
 - **max_level** (*Optional*, percentage): The PWM duty cycle the maximum value (100%) will map
   to. Defaults to ``12.0%``.
+- **restore** (*Optional*, boolean): Whether to restore the state of the servo motor at startup.
+  This is useful if you have an absolute servo motor and it goes back to its 0 position at startup.
+  Defaults to ``false``.
 
 .. note::
 


### PR DESCRIPTION
## Description:

See also https://github.com/esphome/esphome/pull/829

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
