### PR TITLE
Remove references to scan_interval

### DIFF
--- a/components/binary_sensor/ble_presence.rst
+++ b/components/binary_sensor/ble_presence.rst
@@ -16,7 +16,6 @@ bluetooth low energy device.
 
     # Example configuration entry
     esp32_ble_tracker:
-      scan_interval: 300s
 
     binary_sensor:
       - platform: ble_presence

--- a/components/sensor/ble_rssi.rst
+++ b/components/sensor/ble_rssi.rst
@@ -14,7 +14,6 @@ instructions for setting up this platform.
 
     # Example configuration entry
     esp32_ble_tracker:
-      scan_interval: 300s
 
     sensor:
       - platform: ble_rssi


### PR DESCRIPTION
## Description:

scan_interval has been depreciated and needs removing from documentation.