### PR TITLE
Fix typo: as3935 sensor docs

### DIFF
--- a/components/sensor/as3935.rst
+++ b/components/sensor/as3935.rst
@@ -11,7 +11,7 @@ The ``as3935`` sensor platform allows you to use your as3935 sensor
 in order to get notified when a thunderstorm is getting close.
 
 The AS3935 can detect the presence of lightning activity and provide an estimation
-on the diestance to the head of the storm. The chip issues a notification through an interrupt
+on the distance to the head of the storm. The chip issues a notification through an interrupt
 pin.
 
 The AS3935 can be configured to use either the SPI **or** I2C protocol for data communication.


### PR DESCRIPTION
## Description:
"diestance" -> "distance"
(Mentioned by Wanty#5883 on the esphome Discord)

**Related issue (if applicable):**

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

## Checklist:

  - [X] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
