### PR TITLE
Update Mirabella Genio red LED GPIO

### DIFF
--- a/cookbook/brilliant-mirabella-genio-smart-plugs.rst
+++ b/cookbook/brilliant-mirabella-genio-smart-plugs.rst
@@ -212,10 +212,23 @@ which these adaptions created by `@cryptelli <https://community.home-assistant.i
 
     switch:
       - platform: gpio
+        id: red_led
+        pin:
+          number: GPIO4
+          inverted: true
+          
+      - platform: gpio
         name: "Mirabella Genio Smart Plug"
         pin: GPIO12
         id: relay
+        
+        # Turn on red LED
+        on_turn_on:
+          - switch.turn_on: red_led
 
+        # Turns off red LED
+        on_turn_off:
+          - switch.turn_off: red_led
 
 3.3 Gosund SP1
 **************


### PR DESCRIPTION
Update 3.2 Mirabella Genio Wi-Fi 1 USB Adaptor to use red LED on GPIO4

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
