### PR TITLE
document the new has_position parameter for the template cover

### DIFF
--- a/components/cover/template.rst
+++ b/components/cover/template.rst
@@ -58,8 +58,9 @@ Configuration variables:
 - **assumed_state** (*Optional*, boolean): Whether the true state of the cover is not known.
   This will make the Home Assistant frontend show buttons for both OPEN and CLOSE actions, instead
   of hiding one of them. Defaults to ``false``.
-- **has_position** (*Optional*, boolean): Whether this cover will publish its position.  If true, you
-  can include the position attribute in the publish command.  Defaults to ``false``.
+- **has_position** (*Optional*, boolean): Whether this cover will publish its position as a floating point number.
+  By default (``false``), the cover only publishes OPEN/CLOSED position.
+  By setting this to true you can also send any position in between using the publish action.
 - **tilt_action** (*Optional*, :ref:`Action <config-action>`): The action that should
   be performed when the remote (like Home Assistant's frontend) requests the cover be set to a specific
   tilt position.

--- a/components/cover/template.rst
+++ b/components/cover/template.rst
@@ -58,6 +58,8 @@ Configuration variables:
 - **assumed_state** (*Optional*, boolean): Whether the true state of the cover is not known.
   This will make the Home Assistant frontend show buttons for both OPEN and CLOSE actions, instead
   of hiding one of them. Defaults to ``false``.
+- **has_position** (*Optional*, boolean): Whether this cover will publish its position.  If true, you
+  can include the position attribute in the publish command.  Defaults to ``false``.
 - **tilt_action** (*Optional*, :ref:`Action <config-action>`): The action that should
   be performed when the remote (like Home Assistant's frontend) requests the cover be set to a specific
   tilt position.


### PR DESCRIPTION
## Description:
Add documentation for the new has_position parameter for the template cover.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#821

## Checklist:

  - [X] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
