### PR TITLE
add climate core docs fan, swing

### DIFF
--- a/components/climate/index.rst
+++ b/components/climate/index.rst
@@ -81,6 +81,11 @@ Configuration variables:
   higher target temperature of a climate device with a two-point target temperature.
 - **away** (*Optional*, boolean, :ref:`templatable <config-templatable>`): Set the away mode
   of the climate device.
+- **fan_mode** (*Optional*, boolean, :ref:`templatable <config-templatable>`): Set the fan mode
+  of the climate device. One of ``ON``, ``OFF``, ``AUTO``, ``LOW``, ``MEDIUM``, ``HIGH``, ``MIDDLE``,
+  ``FOCUS``, ``DIFFUSE``.
+- **swing_mode** (*Optional*, boolean, :ref:`templatable <config-templatable>`): Set the fan mode
+  of the climate device. Onf of ``OFF``, ``BOTH``, ``VERTICAL``, ``HORIZONTAL``.
 
 .. _climate-lambda_calls:
 
@@ -106,6 +111,10 @@ advanced stuff.
       id(my_climate).target_temperature_high
       // Away mode, type: bool
       id(my_climate).away
+      // Fan mode, type: FanMode (enum)
+      id(my_climate).fan_mode
+      // Swing mode, type: SwingMode (enum)
+      id(my_climate).swing_mode
 
 - ``.make_call``: Control the climate device
 

--- a/components/climate/index.rst
+++ b/components/climate/index.rst
@@ -85,7 +85,7 @@ Configuration variables:
   of the climate device. One of ``ON``, ``OFF``, ``AUTO``, ``LOW``, ``MEDIUM``, ``HIGH``, ``MIDDLE``,
   ``FOCUS``, ``DIFFUSE``.
 - **swing_mode** (*Optional*, boolean, :ref:`templatable <config-templatable>`): Set the swing mode
-  of the climate device. Onf of ``OFF``, ``BOTH``, ``VERTICAL``, ``HORIZONTAL``.
+  of the climate device. One of ``OFF``, ``BOTH``, ``VERTICAL``, ``HORIZONTAL``.
 
 .. _climate-lambda_calls:
 

--- a/components/climate/index.rst
+++ b/components/climate/index.rst
@@ -84,7 +84,7 @@ Configuration variables:
 - **fan_mode** (*Optional*, boolean, :ref:`templatable <config-templatable>`): Set the fan mode
   of the climate device. One of ``ON``, ``OFF``, ``AUTO``, ``LOW``, ``MEDIUM``, ``HIGH``, ``MIDDLE``,
   ``FOCUS``, ``DIFFUSE``.
-- **swing_mode** (*Optional*, boolean, :ref:`templatable <config-templatable>`): Set the fan mode
+- **swing_mode** (*Optional*, boolean, :ref:`templatable <config-templatable>`): Set the swing mode
   of the climate device. Onf of ``OFF``, ``BOTH``, ``VERTICAL``, ``HORIZONTAL``.
 
 .. _climate-lambda_calls:


### PR DESCRIPTION
## Description:

Add climate core docs for `fan_mode` and `swing_mode`

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#https://github.com/esphome/esphome/pull/845

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
