### PR TITLE
Added Android Beacon MQTT app

### DIFF
--- a/components/esp32_ble_beacon.rst
+++ b/components/esp32_ble_beacon.rst
@@ -63,7 +63,8 @@ this should already work from the bluetooth screen (not tested), on Android, you
 
 For using these beacons to track the location of your phone, you will need to use another app. For example, I used
 `this guide by the owntracks <https://owntracks.org/booklet/features/beacons/>`__ app to let my Home Automation system
-know when I'm home or away.
+know when I'm home or away. Another nice Android app is `Beacon MQTT <https://turbo-lab.github.io/android-beacon-mqtt/>`__.
+It can work with multiple beacons simultaneously.
 
 .. figure:: images/esp32_ble_beacon-ibeacon.png
     :align: center


### PR DESCRIPTION
## Description:
Owntrack doesnt support BLE beacons for Android. It was a reason why have to make own app. 
My app supports some complex features like the closest beacon, the grouping of beacons, tracking beacon's params and other. Please add the link on it. 

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
