### PR TITLE
Add B/W support for Waveshare 2.90in (B) screen

### DIFF
--- a/components/display/waveshare_epaper.rst
+++ b/components/display/waveshare_epaper.rst
@@ -75,6 +75,7 @@ Configuration variables:
   - ``2.13in-ttgo`` (T5_V2.3 tested)
   - ``2.70in`` (not tested)
   - ``2.90in``
+  - ``2.90in-b`` (B/W rendering only)
   - ``4.20in``
   - ``7.50in``
 


### PR DESCRIPTION
## Description:

**Rebase of pull request** esphome/esphome-docs#422 from /current to /next

Add partial support for Waveshare 2.90in (B) black-white-red screen. Only B/W mode is currently supported, until underlying ESPHome display framework is extended with color support.

**Related issue:** partially implements [#239](https://github.com/esphome/feature-requests/issues/239l) for a single display type with B/W rendering only

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#889


## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.