### PR TITLE
Add doc for color correction of rgb* lights

### DIFF
--- a/components/light/rgb.rst
+++ b/components/light/rgb.rst
@@ -35,6 +35,32 @@ The ``rgb`` light platform creates an RGB light from 3 :ref:`float output compon
         pin: D1
       # Repeat for green and blue output
 
+Color Correction
+----------------
+
+It is often favourable to calibrate/correct the color produced by an LED strip light as the
+perceived intensity of different colors will generally vary. This can be done by using
+:ref:`max_power` on individual output channels:
+
+.. code-block:: yaml
+
+    # Example configuration entry
+    light:
+      - platform: rgb
+        name: "Living Room Lights"
+        red: output_component1
+        green: output_component2
+        blue: output_component3
+
+    # Example output entry
+    output:
+      - platform: esp8266_pwm
+        id: output_component1
+        pin: D1
+        max_power: 80%
+      # Repeat for green and blue output
+
+
 Configuration variables:
 ------------------------
 

--- a/components/light/rgb.rst
+++ b/components/light/rgb.rst
@@ -40,7 +40,8 @@ Color Correction
 
 It is often favourable to calibrate/correct the color produced by an LED strip light as the
 perceived intensity of different colors will generally vary. This can be done by using
-:ref:`max_power` on individual output channels:
+`max_power </components/output/index#base-output-configuration>` on individual output
+channels:
 
 .. code-block:: yaml
 

--- a/components/light/rgb.rst
+++ b/components/light/rgb.rst
@@ -40,8 +40,7 @@ Color Correction
 
 It is often favourable to calibrate/correct the color produced by an LED strip light as the
 perceived intensity of different colors will generally vary. This can be done by using
-`max_power </components/output/index#base-output-configuration>` on individual output
-channels:
+:ref:`max_power <config-output>` on individual output channels:
 
 .. code-block:: yaml
 

--- a/components/light/rgbw.rst
+++ b/components/light/rgbw.rst
@@ -23,8 +23,7 @@ Color Correction
 
 It is often favourable to calibrate/correct the color produced by an LED strip light as the
 perceived intensity of different colors will generally vary. This can be done by using
-`max_power </components/output/index#base-output-configuration>` on individual output
-channels:
+:ref:`max_power <config-output>` on individual output channels:
 
 .. code-block:: yaml
 

--- a/components/light/rgbw.rst
+++ b/components/light/rgbw.rst
@@ -23,7 +23,8 @@ Color Correction
 
 It is often favourable to calibrate/correct the color produced by an LED strip light as the
 perceived intensity of different colors will generally vary. This can be done by using
-:ref:`max_power` on individual output channels:
+`max_power </components/output/index#base-output-configuration>` on individual output
+channels:
 
 .. code-block:: yaml
 

--- a/components/light/rgbw.rst
+++ b/components/light/rgbw.rst
@@ -18,6 +18,31 @@ The ``rgbw`` light platform creates an RGBW light from 4 :ref:`float output comp
         blue: output_component3
         white: output_component4
 
+Color Correction
+----------------
+
+It is often favourable to calibrate/correct the color produced by an LED strip light as the
+perceived intensity of different colors will generally vary. This can be done by using
+:ref:`max_power` on individual output channels:
+
+.. code-block:: yaml
+
+    # Example configuration entry
+    light:
+      - platform: rgbw
+        name: "Livingroom Lights"
+        red: output_component1
+        green: output_component2
+        blue: output_component3
+        white: output_component4
+
+    # Example output entry
+    output:
+      - platform: esp8266_pwm
+        id: output_component1
+        pin: D1
+        max_power: 80%
+
 Configuration variables:
 ------------------------
 

--- a/components/light/rgbww.rst
+++ b/components/light/rgbww.rst
@@ -28,8 +28,8 @@ Color Correction
 
 It is often favourable to calibrate/correct the color produced by an LED strip light as the
 perceived intensity of different colors will generally vary. This can be done by using
-`max_power </components/output/index#base-output-configuration>` on individual output
-channels:
+:ref:`max_power <config-output>` on individual output channels:
+
 
 .. code-block:: yaml
 

--- a/components/light/rgbww.rst
+++ b/components/light/rgbww.rst
@@ -23,6 +23,32 @@ and warm white channels will be mixed using the color temperature configuration 
         cold_white_color_temperature: 6536 K
         warm_white_color_temperature: 2000 K
 
+Color Correction
+----------------
+
+It is often favourable to calibrate/correct the color produced by an LED strip light as the
+perceived intensity of different colors will generally vary. This can be done by using
+:ref:`max_power` on individual output channels:
+
+.. code-block:: yaml
+
+    # Example configuration entry
+    light:
+      - platform: rgbw
+        name: "Livingroom Lights"
+        red: output_component1
+        green: output_component2
+        blue: output_component3
+        white: output_component4
+
+    # Example output entry
+    output:
+      - platform: esp8266_pwm
+        id: output_component1
+        pin: D1
+        max_power: 80%
+
+
 Configuration variables:
 ------------------------
 

--- a/components/light/rgbww.rst
+++ b/components/light/rgbww.rst
@@ -28,7 +28,8 @@ Color Correction
 
 It is often favourable to calibrate/correct the color produced by an LED strip light as the
 perceived intensity of different colors will generally vary. This can be done by using
-:ref:`max_power` on individual output channels:
+`max_power </components/output/index#base-output-configuration>` on individual output
+channels:
 
 .. code-block:: yaml
 


### PR DESCRIPTION
## Description:

I began implementing color correction for RGB lights in `esphome/esphome`, and thought it would be worth checking for previous feature requests for exactly this. 

Fortunately I managed to find [this comment](https://github.com/esphome/feature-requests/issues/463). I think it would be worthwhile adding this to the documentation for others like me who might need this in the future.


## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
