### PR TITLE
add Sonoff Dual R2 (PCB v1.4)

### DIFF
--- a/devices/sonoff.rst
+++ b/devices/sonoff.rst
@@ -85,6 +85,18 @@ Sonoff Dual R2
     GPIO4, Optional sensor
     GPIO14, Optional sensor
 
+Sonoff Dual R2 (PCB v1.4)
+--------------
+
+.. pintable::
+
+    GPIO12, Relay #1 and red color on LED,
+    GPIO5, Relay #2 and green color on LED,
+    GPIO10, Button,
+    GPIO13, Blue LED (inverted),
+    GPIO0, Pin "button 0" on expansion header
+    GPIO9, Pin "button 1" on expansion header
+
 Sonoff Pow R1
 -------------
 

--- a/devices/sonoff.rst
+++ b/devices/sonoff.rst
@@ -86,7 +86,7 @@ Sonoff Dual R2
     GPIO14, Optional sensor
 
 Sonoff Dual R2 (PCB v1.4)
---------------
+-------------------------
 
 .. pintable::
 


### PR DESCRIPTION
## Description:
Sending pinout of Sonoff Dual R2 (PCB v1.4)

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
