### PR TITLE
Use .timestamp instead of .time in time docs

### DIFF
--- a/components/time.rst
+++ b/components/time.rst
@@ -122,7 +122,7 @@ created based on a given format. If you want to get the current time attributes,
 -------------------- ---------------------------------------- ---------------------------------------- --------------------
 ``.is_dst``          Is daylight savings time                 false, true                              true
 -------------------- ---------------------------------------- ---------------------------------------- --------------------
-``.time``            Unix epoch time (seconds since UTC       [-2147483648 - 2147483647] (negative     1534606002
+``.timestamp``       Unix epoch time (seconds since UTC       [-2147483648 - 2147483647] (negative     1534606002
                      Midnight January 1, 1970)                values for time past January 19th 2038)
 -------------------- ---------------------------------------- ---------------------------------------- --------------------
 ``.is_valid()``      Basic check if the time is valid         false, true                              true


### PR DESCRIPTION
## Description:

`.time` is deprecated since https://github.com/esphome/esphome/pull/531; this updates the reference in the documentation so that warnings like the following can be avoided:

```
src/main.cpp: In lambda function:
src/main.cpp:462:20: warning: 'esphome::time::ESPTime::<anonymous union>::time' is deprecated (declared at src/esphome/components/time/real_time_clock.h:35): .time is deprecated, use .timestamp instead [-Wdeprecated-declarations]
       return (time.time);
 ```

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#531

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
