### PR TITLE
Add additional notes on Formatted Text for Display Core

### DIFF
--- a/components/display/index.rst
+++ b/components/display/index.rst
@@ -303,9 +303,12 @@ use any string you pass it, like ``"ON"`` or ``"OFF"``.
           it.printf(0, 0, id(my_font), "State: %s", id(my_binary_sensor).state ? "ON" : "OFF");
 
 .. note::
-
-    For displaying external data on the display, for example data from your Home Assistant instance,
-    you can use the :doc:`/components/text_sensor/mqtt_subscribe` (see the example there for more information).
+   
+    For displaying data from Home Assistant you can use the :doc:`/components/text_sensor/homeassistant` (see the :doc:`/cookbook/display_time_temp_oled` example for how to use this sensor)
+    
+    For displaying external data on the display you can use the :doc:`/components/text_sensor/mqtt_subscribe` (see the example there for more information).
+    
+    
 
 .. _display-strftime:
 

--- a/components/display/index.rst
+++ b/components/display/index.rst
@@ -303,7 +303,7 @@ use any string you pass it, like ``"ON"`` or ``"OFF"``.
           it.printf(0, 0, id(my_font), "State: %s", id(my_binary_sensor).state ? "ON" : "OFF");
 
 .. note::
-   
+
     For displaying data from Home Assistant you can use the :doc:`/components/text_sensor/homeassistant` (see the :doc:`/cookbook/display_time_temp_oled` example for how to use this sensor)
     
     For displaying external data on the display you can use the :doc:`/components/text_sensor/mqtt_subscribe` (see the example there for more information).


### PR DESCRIPTION
## Description:
Added additional notes on Formatted Text for the Display Core component that a Home Assistant sensor is available, just mentioning MQTT can lead to over complexity if the reader is not aware of the API sensor.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ Y ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ NA ] Link added in `/index.rst` when creating new documents for new components or cookbook.
