### PR TITLE
Brightness feature not included in doc.

### DIFF
--- a/components/display/ssd1306.rst
+++ b/components/display/ssd1306.rst
@@ -68,6 +68,7 @@ Configuration variables:
 - **update_interval** (*Optional*, :ref:`config-time`): The interval to re-draw the screen. Defaults to ``5s``.
 - **pages** (*Optional*, list): Show pages instead of a single lambda. See :ref:`display-pages`.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
+- **brightness** (*Optional*, float): Manually override display brightness in %. Defaults to ``100%``
 
 .. note::
 
@@ -140,6 +141,7 @@ Configuration variables:
 - **spi_id** (*Optional*, :ref:`config-id`): Manually specify the ID of the :ref:`SPI Component <spi>` if you want
   to use multiple SPI buses.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
+- **brightness** (*Optional*, float): Manually override display brightness in %. Defaults to ``100%``
 
 See Also
 --------


### PR DESCRIPTION
Updated the documentation for the SSD1306 with the new brightness feature.
PR: https://github.com/esphome/esphome/pull/681/

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
