### PR TITLE
Add transmit pioneer

### DIFF
--- a/components/remote_receiver.rst
+++ b/components/remote_receiver.rst
@@ -33,6 +33,7 @@ Configuration variables:
   - **lg**: Decode and dump LG infrared codes.
   - **nec**: Decode and dump NEC infrared codes.
   - **panasonic**: Decode and dump Panasonic infrared codes.
+  - **pioneer**: Decode and dump Pioneer infrared codes.
   - **jvc**: Decode and dump JVC infrared codes.
   - **samsung**: Decode and dump Samsung infrared codes.
   - **sony**: Decode and dump Sony infrared codes.
@@ -76,6 +77,9 @@ Automations:
   is passed to the automation for use in lambdas.
 - **on_panasonic** (*Optional*, :ref:`Automation <automation>`): An automation to perform when a
   panasonic remote code has been decoded. A variable ``x`` of type :apiclass:`remote_base::PanasonicData`
+  is passed to the automation for use in lambdas.
+- **on_pioneer** (*Optional*, :ref:`Automation <automation>`): An automation to perform when a
+  pioneer remote code has been decoded. A variable ``x`` of type :apiclass:`remote_base::PioneerData`
   is passed to the automation for use in lambdas.
 
 .. _remote-receiver-binary-sensor:
@@ -148,6 +152,10 @@ Remote code selection (exactly one of these has to be included):
 
   - **address** (**Required**, int): The address to trigger on, see dumper output for more info.
   - **command** (**Required**, int): The command.
+
+- **pioneer**: Trigger on a decoded Pioneer remote code with the given data.
+
+  - **rc_code_1** (**Required**, int): The remote control code trigger on, see dumper output for more details.
 
 - **rc_switch_raw**: Trigger on a decoded RC Switch raw remote code with the given data.
 

--- a/components/remote_transmitter.rst
+++ b/components/remote_transmitter.rst
@@ -6,7 +6,6 @@ Remote Transmitter
     :image: remote.png
     :keywords: Infrared, IR, RF, Remote, TX
 
-
 The ``remote_transmitter`` component lets you send digital packets to control
 devices in your home. For example this includes infrared data or 433MHz RF signals.
 
@@ -223,6 +222,35 @@ Configuration variables:
 - **address** (**Required**, int): The address to send the command to, see dumper output for more details.
 - **command** (**Required**, int): The command to send.
 - All other options from :ref:`remote_transmitter-transmit_action`.
+
+``remote_transmitter.transmit_pioneer`` Action
+************************************************
+
+This :ref:`action <config-action>` sends a Pioneer infrared remote code to a remote transmitter.
+
+.. code-block:: yaml
+
+    on_...:
+      - remote_transmitter.transmit_pioneer:
+          rc_code_1: 0xA556
+          rc_code_2: 0xA506
+          repeat:
+            times: 2
+
+Configuration variables:
+
+- **rc_code_1** (**Required**, int): The remote control code to send, see dumper output for more details.
+- **rc_code_2** (**Optional**, int): The secondary remote control code to send; some codes are sent in
+  two parts.
+- Note that ``repeat`` is still optional, however **Pioneer devices may require that a given code is
+  received multiple times before they will act on it.** Add this if your device does not respond to
+  commands sent with this action.
+- All other options from :ref:`remote_transmitter-transmit_action`.
+
+At the time this action was created, Pioneer maintained listings of IR codes used for their devices
+`here <https://www.pioneerelectronics.com/PUSA/Support/Home-Entertainment-Custom-Install/IR+Codes>`__.
+If unable to find your specific device in the documentation, find a device in the same class; the codes
+are largely shared among devices within a given class.
 
 ``remote_transmitter.transmit_rc_switch_raw`` Action
 ****************************************************

--- a/components/remote_transmitter.rst
+++ b/components/remote_transmitter.rst
@@ -224,7 +224,7 @@ Configuration variables:
 - All other options from :ref:`remote_transmitter-transmit_action`.
 
 ``remote_transmitter.transmit_pioneer`` Action
-************************************************
+**********************************************
 
 This :ref:`action <config-action>` sends a Pioneer infrared remote code to a remote transmitter.
 


### PR DESCRIPTION
## Description:
Documents the `transmit_pioneer` action recently added to the `remote_transmitter` component. The Pioneer IR code transmission scheme is just different enough that it is difficult (although technically possible) to get working with the existing actions. This new action aims to make the process easier for those who have such hardware.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#992

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
