### PR TITLE
MQTT: change type of port from int to string

### DIFF
--- a/components/mqtt.rst
+++ b/components/mqtt.rst
@@ -30,7 +30,7 @@ Configuration variables:
 ------------------------
 
 - **broker** (**Required**, string): The host of your MQTT broker.
-- **port** (*Optional*, int): The port to connect to. Defaults to 1883.
+- **port** (*Optional*, string): The port to connect to. Defaults to 1883.
 - **username** (*Optional*, string): The username to use for
   authentication. Empty (the default) means no authentication.
 - **password** (*Optional*, string): The password to use for


### PR DESCRIPTION
## Description:

Using string "1883" instead of int 1883 fixes error reading logs over MQTT:
ERROR Cannot connect to MQTT broker: Int or String expected.
**Fix for current version.**

**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/850

## Problem
```
# esphome dev.yaml logs
INFO Reading configuration dev.yaml...
Found multiple options, please choose one:
  [1] Over The Air (192.168.1.2)
  [2] MQTT (farmer.cloudmqtt.com)
(number): 2
INFO Starting log output from logs/dev
ERROR Cannot connect to MQTT broker: Int or String expected
```

Can be fixed:

```diff
mqtt:
  broker: farmer.cloudmqtt.com
  username: user
  password: password
-  port: 12538
+  port: "12538"
  log_topic: logs/esph_rack_heater
```

It's fit both ESP device and for Python client.

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
