### PR TITLE
Update SGP30 for the correct eCO2 and TVOC baseline

### DIFF
--- a/components/sensor/sgp30.rst
+++ b/components/sensor/sgp30.rst
@@ -53,9 +53,9 @@ Advanced:
 
 - **baseline** (*Optional*): The block containing baselines for calibration purposes. See :ref:`sgp30-calibrating` for more info.
 
-  - **eco2_baseline** (*Required*, int): The eCO2 baseline for calibration purposes.
+  - **eco2_baseline** (**Required**, int): The eCO2 baseline for calibration purposes.
 
-  - **tvoc_baseline** (*Required*, int): The TVOC baseline for calibration purposes.
+  - **tvoc_baseline** (**Required**, int): The TVOC baseline for calibration purposes.
 
 - **compensation** (*Optional*): The block containing sensors used for compensation.
 

--- a/components/sensor/sgp30.rst
+++ b/components/sensor/sgp30.rst
@@ -51,8 +51,11 @@ Configuration variables:
 
 Advanced:
 
-- **baseline** (*Optional*, int): The baseline value for the unit, for calibration
-  purposes. See :ref:`sgp30-calibrating` for more info.
+- **baseline** (*Optional*): The block containing baselines for calibration purposes. See :ref:`sgp30-calibrating` for more info.
+
+  - **eco2_baseline** (*Required*, int): The eCO2 baseline for calibration purposes.
+
+  - **tvoc_baseline** (*Required*, int): The TVOC baseline for calibration purposes.
 
 - **compensation** (*Optional*): The block containing sensors used for compensation.
 
@@ -67,7 +70,7 @@ Advanced:
 Calibrating Baseline
 --------------------
 
-The SGP30 sensor will re-calibrate its baseline each time it is powered on. During the first power-up this can take upto 12 hours.
+The SGP30 sensor will re-calibrate its baseline each time it is powered on. During the first power-up this can take up to 12 hours.
 
 For best performance and faster startup times, the current **baseline** needs to be persistently stored on the device before shutting it down and set again accordingly after boot up
 that also means that if the sensor reboots at a time when the air is less clean than normal,
@@ -75,7 +78,7 @@ the values will have a constant offset and cannot be compared to the values befo
 boot.
 
 To do this, let the sensor boot up with no baseline set and let the sensor calibrate itself. After around 12 hours you can then view the remote logs on the ESP. The next
-time the sensor is read out, you will see a log message with something like ``Current eCO2 & TVOC baseline: 0x44D4``.
+time the sensor is read out, you will see a log message with something like ``Current eCO2 baseline: 0x86C5, TVOC baseline: 0x8B38``.
 
 Now set the baseline property in your configuration file like so with the value you got
 via the logs:
@@ -86,7 +89,9 @@ via the logs:
     sensor:
       - platform: sgp30
         # ...
-        baseline: 0x44D4
+        baseline:
+          eco2_baseline: 0x86C5
+          tvoc_baseline: 0x8B38
 
 The next time you upload the code, the SGP30 will be continue its operation with this baseline and you will get consistent values.
 
@@ -101,5 +106,6 @@ See Also
 - :doc:`dht12`
 - :doc:`hdc1080`
 - :doc:`htu21d`
+- :doc:`sht3xd`
 - :apiref:`sgp30/sgp30.h`
 - :ghedit:`Edit`


### PR DESCRIPTION
## Description:
The SGP30 is the eCO2 and TVOC sensor needs calibration with the eCO2 and TVOC baseline. The current implementation only reads the LSB of the 2-byte value of each of the eCO2 and TVOC baselines. This ends up in an incorrect baseline reading as well as writing at the initialization.

Based on the [SGP30 datasheet](https://www.mouser.com/datasheet/2/682/Sensirion_Gas_Sensors_SGP30_Datasheet_EN-1148053.pdf)
> The SGP30 also provides the possibility to read and write the baseline values of the baseline correction algorithm. This feature is used to save the baseline in regular intervals on an external non-volatile memory and restore it after a new power-up or soft reset of the sensor. The command “Get_baseline” returns the baseline values for the two air quality signals. The sensor responds with 2 data bytes (MSB first) and 1 CRC byte for each of the two values in the order CO2eq and TVOC. These two values should be stored on an external memory. After a power-up or soft reset, the baseline of the baseline correction algorithm can be restored by sending first an “Init_air_quality” command followed by a “Set_baseline” command with the two baseline values as parameters in the order as (TVOC, CO2eq). 

**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/950

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#936

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
