### PR TITLE
Added examples for uart text sensor

### DIFF
--- a/components/text_sensor/uart.rst
+++ b/components/text_sensor/uart.rst
@@ -87,7 +87,7 @@ And in YAML:
         id: "uart_readline"
 
 Example usage
--------
+-------------
 
 Here is an example template switch using the uart text sensor to set switch state.
 

--- a/components/text_sensor/uart.rst
+++ b/components/text_sensor/uart.rst
@@ -1,0 +1,93 @@
+Custom UART Text Sensor
+===================
+
+.. seo::
+    :description: Instructions for setting up a custom uart text sensor.
+    :image: language-cpp.png
+
+Lots of devices communicate using the UART protocol. If you want to read 
+lines from uart to a Text Sensor you can do so using this code example.
+Note state will change a lot. 
+
+Consider making the sensor internal since this could flood home-assistant state log.
+Use automations to set switch or sensor states.
+
+.. code-block:: cpp
+
+    #include "esphome.h"
+
+    class UartReadLineStateComponent : public Component, public UARTDevice, public TextSensor {
+     public:
+      UartReadLineStateComponent(UARTComponent *parent) : UARTDevice(parent) {}    
+
+      void setup() override {
+        // nothing to do here
+      }    
+
+      int readline(int readch, char *buffer, int len)
+      {
+        static int pos = 0;
+        int rpos;
+      
+        if (readch > 0) {
+          switch (readch) {
+            case '\n': // Ignore new-lines
+              break;
+            case '\r': // Return on CR
+              rpos = pos;
+              pos = 0;  // Reset position index ready for next time
+              return rpos;
+            default:
+              if (pos < len-1) {
+                buffer[pos++] = readch;
+                buffer[pos] = 0;
+              }
+          }
+        }
+        // No end of line has been found, so return -1.
+        return -1;
+      }    
+
+      void loop() override {
+        const int max_line_length = 80;
+        static char buffer[max_line_length];
+        if (available() && readline(read(), buffer, max_line_length) > 0) {
+          publish_state(buffer);
+        }
+      }
+    };
+    
+And in YAML:
+
+.. code-block:: yaml
+
+    # Example configuration entry
+    esphome:
+      includes:
+        - UartReadLineStateComponent.h
+    
+    logger:
+      baud_rate: 0 #disable logging over uart
+
+    uart:
+      id: uart_bus
+      tx_pin: D0
+      rx_pin: D1
+      baud_rate: 9600
+
+    text_sensor:
+    - platform: custom
+      lambda: |-
+        auto my_custom_sensor = new UartReadLineStateComponent(id(uart_bus));
+        App.register_component(my_custom_sensor);
+        return {my_custom_sensor};
+      text_sensors:
+        name: "UART Text Sensor"
+        #internal: true
+
+See Also
+--------
+
+- :doc:`/components/uart`
+- :doc:`/custom/uart`
+- :ghedit:`Edit`

--- a/components/text_sensor/uart.rst
+++ b/components/text_sensor/uart.rst
@@ -15,9 +15,9 @@ Use automations to set switch or sensor states.
 
     #include "esphome.h"
 
-    class UartReadLineStateComponent : public Component, public UARTDevice, public TextSensor {
+    class UartReadLineSensor : public Component, public UARTDevice, public TextSensor {
      public:
-      UartReadLineStateComponent(UARTComponent *parent) : UARTDevice(parent) {}    
+      UartReadLineSensor(UARTComponent *parent) : UARTDevice(parent) {}    
 
       void setup() override {
         // nothing to do here
@@ -55,6 +55,8 @@ Use automations to set switch or sensor states.
         }
       }
     };
+
+(Store this file in your configuration directory, for example ``uart_read_line_sensor.h``)
     
 And in YAML:
 
@@ -63,7 +65,7 @@ And in YAML:
     # Example configuration entry
     esphome:
       includes:
-        - UartReadLineStateComponent.h
+        - uart_read_line_sensor.h
     
     logger:
       level: VERBOSE #makes uart stream available in esphome logstream
@@ -78,7 +80,7 @@ And in YAML:
     text_sensor:
     - platform: custom
       lambda: |-
-        auto my_custom_sensor = new UartReadLineStateComponent(id(uart_bus));
+        auto my_custom_sensor = new UartReadLineSensor(id(uart_bus));
         App.register_component(my_custom_sensor);
         return {my_custom_sensor};
       text_sensors:
@@ -89,13 +91,14 @@ Example usage
 
 Here is an example template switch using the uart text sensor to set switch state.
 
+Is uses interval to request status from the device. The reponse will be stored in uart text sensor.
+Then the switch uses the sensor state to update state.
+
 .. code-block:: yaml
 
     switch:
       - platform: template
-        id: projector_power
-        name: "Projector"
-        icon: "mdi:projector"
+        name: "Switch"
         lambda: |-
           if (id(uart_readline).state == "*POW=ON#") {
             return true;

--- a/components/text_sensor/uart.rst
+++ b/components/text_sensor/uart.rst
@@ -1,5 +1,5 @@
 Custom UART Text Sensor
-===================
+=======================
 
 .. seo::
     :description: Instructions for setting up a custom uart text sensor.
@@ -7,7 +7,6 @@ Custom UART Text Sensor
 
 Lots of devices communicate using the UART protocol. If you want to read 
 lines from uart to a Text Sensor you can do so using this code example.
-Note state will change a lot. 
 
 Consider making the sensor internal since this could flood home-assistant state log.
 Use automations to set switch or sensor states.
@@ -67,6 +66,7 @@ And in YAML:
         - UartReadLineStateComponent.h
     
     logger:
+      level: VERBOSE #makes uart stream available in esphome logstream
       baud_rate: 0 #disable logging over uart
 
     uart:
@@ -82,8 +82,37 @@ And in YAML:
         App.register_component(my_custom_sensor);
         return {my_custom_sensor};
       text_sensors:
-        name: "UART Text Sensor"
-        #internal: true
+        id: "uart_readline"
+
+Example usage
+-------
+
+Here is an example template switch using the uart text sensor to set switch state.
+
+.. code-block:: yaml
+
+    switch:
+      - platform: template
+        id: projector_power
+        name: "Projector"
+        icon: "mdi:projector"
+        lambda: |-
+          if (id(uart_readline).state == "*POW=ON#") {
+            return true;
+          } else if(id(uart_readline).state == "*POW=OFF#") {
+            return false;
+          } else {
+            return {};
+          }
+        turn_on_action:
+          - uart.write: "\r*pow=on#\r"
+        turn_off_action:
+          - uart.write: "\r*pow=off#\r"
+    
+    interval:
+      - interval: 10s
+        then:
+          - uart.write: "\r*pow=?#\r"
 
 See Also
 --------

--- a/components/text_sensor/uart.rst
+++ b/components/text_sensor/uart.rst
@@ -8,8 +8,7 @@ Custom UART Text Sensor
 Lots of devices communicate using the UART protocol. If you want to read 
 lines from uart to a Text Sensor you can do so using this code example.
 
-Consider making the sensor internal since this could flood home-assistant state log.
-Use automations to set switch or sensor states.
+With this you can use automations or lambda to set switch or sensor states.
 
 .. code-block:: cpp
 

--- a/components/text_sensor/uart.rst
+++ b/components/text_sensor/uart.rst
@@ -89,10 +89,10 @@ And in YAML:
 Example usage
 -------------
 
-Here is an example template switch using the uart text sensor to set switch state.
+Here is an example switch using the uart text sensor to set switch state.
 
-Is uses interval to request status from the device. The reponse will be stored in uart text sensor.
-Then the switch uses the sensor state to update state.
+Here we use interval to request status from the device. The reponse will be stored in uart text sensor.
+Then the switch uses the text sensor state to set its own state.
 
 .. code-block:: yaml
 

--- a/index.rst
+++ b/index.rst
@@ -286,6 +286,7 @@ Text Sensor Components
     WiFi Info, components/text_sensor/wifi_info, network-wifi.svg
     Template Text Sensor, components/text_sensor/template, description.svg
     Custom Text Sensor, components/text_sensor/custom, language-cpp.svg
+    Custom UART Text Sensor, components/text_sensor/uart, language-cpp.svg
 
 Climate Components
 ------------------


### PR DESCRIPTION
## Description:
Added examples for reading uart into a text sensor

**Related issue (if applicable):** fixes

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
