### PR TITLE
Update sonoff.rst

### DIFF
--- a/devices/sonoff.rst
+++ b/devices/sonoff.rst
@@ -61,6 +61,7 @@ Sonoff TH10/TH16
     GPIO3, UART RX pin (for external sensors)
     GPIO4, Optional sensor
     GPIO14, Optional sensor
+    GPIO2, Optional Pin EXP-LOG (TH16 Ver 2.1 2019)
 
 Sonoff Dual R1
 --------------


### PR DESCRIPTION
Added PIN EXP-LOG to TH10/16
New Models have an extra PIN labeled EXP-LOG beside EXP-LOG,GND,RX,TX,VCC;
reference 
https://github.com/arendst/Tasmota/wiki/sonoff-th
https://edavies.me.uk/2019/07/sonoff/

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
