### PR TITLE
add a note about the log level of dump: all

### DIFF
--- a/components/remote_receiver.rst
+++ b/components/remote_receiver.rst
@@ -27,8 +27,8 @@ Configuration variables:
 ------------------------
 
 - **pin** (**Required**, :ref:`config-pin`): The pin to receive the remote signal on.
-- **dump** (*Optional*, list): Decode and dump these remote codes in the logs. Set to ``all`` to
-  dump all available codecs:
+- **dump** (*Optional*, list): Decode and dump these remote codes in the logs (at log.level=DEBUG). 
+  Set to ``all`` to dump all available codecs:
 
   - **lg**: Decode and dump LG infrared codes.
   - **nec**: Decode and dump NEC infrared codes.


### PR DESCRIPTION
It would have saved me a bunch of time just now if I knew that remote_receiver's dump=all logging is at level DEBUG.
