### PR TITLE
Add Daikin IR Climate documentation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,2 @@
 {
-    "restructuredtext.confPath": "${workspaceFolder}"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,2 +1,3 @@
 {
+    "restructuredtext.confPath": "${workspaceFolder}"
 }

--- a/components/climate/ir_climate.rst
+++ b/components/climate/ir_climate.rst
@@ -21,6 +21,8 @@ request so it will be added (see FAQ).
 +========================+=====================+======================+
 | Coolix                 | ``coolix``          | yes                  |
 +------------------------+---------------------+----------------------+
+| Daikin                 | ``daikin``          | no                   |
++------------------------+---------------------+----------------------+
 | Fujitsu General        | ``fujitsu_general`` | no                   |
 +------------------------+---------------------+----------------------+
 | Mitsubishi             | ``mitsubishi``      | no                   |
@@ -105,6 +107,7 @@ See Also
 - :doc:`/components/climate/index`
 - :doc:`/components/remote_transmitter`
 - :apiref:`coolix.h <coolix/coolix.h>`,
+  :apiref:`daikin.h <daikin/daikin.h>`
   :apiref:`fujitsu_general.h <fujitsu_general/fujitsu_general.h>`,
   :apiref:`mitsubishi.h <mitsubishi/mitsubishi.h>`,
   :apiref:`tcl112.h <tcl112/tcl112.h>`,


### PR DESCRIPTION
## Description:
Added Daikin Climate IR documentation.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#964

## Checklist:

  - [X] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
