### PR TITLE
small mistype fix

### DIFF
--- a/components/sensor/ccs811.rst
+++ b/components/sensor/ccs811.rst
@@ -45,7 +45,7 @@ Configuration variables:
   - All other options from :ref:`Sensor <config-sensor>`.
 
 - **tvoc** (**Required**): The information for the total volatile organic compound sensor in
-  parts per billion (ppm).
+  parts per billion (ppb).
 
   - **name** (**Required**, string): The name for the tvoc sensor.
   - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.


### PR DESCRIPTION
fix small mistype, should be ppb instead of ppm

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
