### PR TITLE
Update board for Sonoff and link to Tasmota

### DIFF
--- a/devices/sonoff.rst
+++ b/devices/sonoff.rst
@@ -14,11 +14,15 @@ and shipping from China takes a long time, I've only set up dedicated guides for
     esphome:
       name: <NAME_OF_NODE>
       platform: ESP8266
-      board: esp01_1m
+      board: esp8285
+      arduino_version: 2.4.2
+
+The selected board and arduino_version are required in v1.14.3 (and probably later), see
+https://github.com/esphome/issues/issues/931 for details.
 
 After that use the following list of pin to function mappings to set up your Sonoff device.
 This list has been compiled from the Sonoff Tasmota pin source file which can be found here:
-https://github.com/arendst/Sonoff-Tasmota/blob/development/sonoff/sonoff_template.h ❤️
+https://github.com/arendst/Tasmota/blob/development/tasmota/tasmota_template.h ❤️
 
 Sonoff RF
 ---------

--- a/devices/sonoff_basic.rst
+++ b/devices/sonoff_basic.rst
@@ -54,7 +54,8 @@ exposes all of the basic functions.
     esphome:
       name: <NAME_OF_NODE>
       platform: ESP8266
-      board: esp01_1m
+      board: esp8285
+      arduino_version: 2.4.2
 
     wifi:
       ssid: <YOUR_SSID>

--- a/devices/sonoff_s20.rst
+++ b/devices/sonoff_s20.rst
@@ -128,7 +128,8 @@ or alternatively, you can just take the below configuration file and modify it t
     esphome:
       name: <NAME_OF_NODE>
       platform: ESP8266
-      board: esp01_1m
+      board: esp8285
+      arduino_version: 2.4.2
 
     wifi:
       ssid: <YOUR_SSID>
@@ -206,8 +207,9 @@ of the basic functions.
     esphome:
       name: <NAME_OF_NODE>
       platform: ESP8266
-      board: esp01_1m
-
+      board: esp8285
+      arduino_version: 2.4.2
+      
     wifi:
       ssid: <YOUR_SSID>
       password: <YOUR_PASSWORD>

--- a/devices/sonoff_s20.yaml
+++ b/devices/sonoff_s20.yaml
@@ -1,7 +1,8 @@
 esphome:
   name: <NAME_OF_NODE>
   platform: ESP8266
-  board: esp01_1m
+  board: esp8285
+  arduino_version: 2.4.2
 
 wifi:
   ssid: <YOUR_SSID>


### PR DESCRIPTION
## Description:
Update the recommended `board` and and adds the `arduino_version` to the generic Sonoff setup.

Also updated links to Tasmota for the Sonoff pinouts.

**Related issue (if applicable):** This addresses the issues as outlined here: https://github.com/esphome/issues/issues/931

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** N/A

## Checklist:

  - [X] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
