### PR TITLE
Add a warning for missing name

### DIFF
--- a/components/mqtt.rst
+++ b/components/mqtt.rst
@@ -249,6 +249,10 @@ MQTT Component Base Configuration
 All components in ESPHome that do some sort of communication through
 MQTT can have some overrides for specific options.
 
+.. warning::
+
+    Components without **name** are internal only, thus they will not send or receive mqtt messages.
+
 .. code-block:: yaml
 
     name: "Component Name"


### PR DESCRIPTION
## Description:

Minor change to docs: In MQTT warn about that unnamed (internal) components don't work with mqtt.

Reason: took me several hours to figure it out (including several hours of chat in gitter). The log says the unnamed component has topics bit it just ignores any mqtt message and does not send any.

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
