### PR TITLE
remove uppercase allowed in names

### DIFF
--- a/components/esphome.rst
+++ b/components/esphome.rst
@@ -23,7 +23,7 @@ Configuration variables:
 ------------------------
 
 - **name** (**Required**, string): This is the name of the node. It
-  should always be unique in your esphome network. May only contain upper/lowercase
+  should always be unique in your esphome network. May only contain lowercase
   characters, digits and underscores. See :ref:`esphome-changing_node_name`.
 - **platform** (**Required**, string): The platform your board is on,
   either ``ESP32`` or ``ESP8266``. See :ref:`esphome-arduino_version`.


### PR DESCRIPTION
name: cannot contain uppercase, but the docs say uppercase. Fixed

## Description:
Core docs say name: can be uppercase or lowecase. Uppercase should not be there.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
