### PR TITLE
my9231->bit_depth: parameter name and sonoff B1

### DIFF
--- a/components/output/my9231.rst
+++ b/components/output/my9231.rst
@@ -51,7 +51,7 @@ Configuration variables:
    chain. Must be in range from 3 to 1020. Defaults to 6.
 -  **num_chips** (*Optional*, int): Number of chips in the chain. Must be
    in range from 1 to 255. Defaults to 2.
--  **bit_depths** (*Optional*, int): The bit depth to use for all output
+-  **bit_depth** (*Optional*, int): The bit depth to use for all output
    channels in this chain. Must be one of 8, 12, 14 or 16. Defaults to 16.
 -  **id** (*Optional*, :ref:`config-id`): The id to use for
    this ``my9231`` component. Use this if you have multiple MY9231/MY9291 chains
@@ -92,6 +92,7 @@ complete configuration for a Sonoff B1 looks like:
       clock_pin: GPIO14  # GPIO15 for AiLight
       num_channels: 6
       num_chips: 2
+      bit_depth: 8
 
     output:
       - platform: my9231


### PR DESCRIPTION
## Description:
- Fix the parameter name bit_depth (current referred to as bit_depths)
- Add bit_depth: 8 to sonoff B1 example config. This fixed my application on a Sonoff B1


**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/991

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** N/A

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
