### PR TITLE
cover time based add assumed state option

### DIFF
--- a/components/cover/time_based.rst
+++ b/components/cover/time_based.rst
@@ -52,6 +52,9 @@ Configuration variables:
   detectors. In this configuration the ``stop_action`` is not perfomed when the open or close
   time is completed and if the cover is commanded to open or close the corresponding actions
   will be performed without checking current state. Defaults to ``False``.
+- **assumed_state** (*Optional*, boolean): Whether the true state of the cover is not known.
+  This will make the Home Assistant frontend show buttons for both OPEN and CLOSE actions, instead
+  of hiding or disabling one of them. Defaults to ``True``.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
 - All other options from :ref:`Cover <config-cover>`.
 


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** https://github.com/esphome/esphome/pull/979
## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
