### PR TITLE
Update sonoff-t1-3.rst

### DIFF
--- a/cookbook/sonoff-t1-3.rst
+++ b/cookbook/sonoff-t1-3.rst
@@ -38,7 +38,7 @@ T1
           number: GPIO0
           mode: INPUT_PULLUP
           inverted: True
-        id: button
+        id: button_1
         on_press:
           then:
             - light.toggle: light_1
@@ -101,7 +101,7 @@ T2
           number: GPIO0
           mode: INPUT_PULLUP
           inverted: True
-        id: button
+        id: button_1
         on_press:
           then:
             - light.toggle: light_1
@@ -111,7 +111,7 @@ T2
           number: GPIO9
           mode: INPUT_PULLUP
           inverted: True
-        id: button
+        id: button_2
         on_press:
           then:
             - light.toggle: light_2
@@ -172,7 +172,7 @@ T3
           number: GPIO0
           mode: INPUT_PULLUP
           inverted: True
-        id: button
+        id: button_1
         on_press:
           then:
             - light.toggle: light_1
@@ -182,7 +182,7 @@ T3
           number: GPIO9
           mode: INPUT_PULLUP
           inverted: True
-        id: button
+        id: button_2
         on_press:
           then:
             - light.toggle: light_2
@@ -192,7 +192,7 @@ T3
           number: GPIO10
           mode: INPUT_PULLUP
           inverted: True
-        id: button
+        id: button_3
         on_press:
           then:
             - light.toggle: light_3


### PR DESCRIPTION
I'd got an error during configure my Sonoff T1 EU 2C switch
```
$ esphome sonoff_t1_eu_2c.yaml run
INFO Reading configuration sonoff_t1_eu_2c.yaml...
WARNING ESP8266: Pin 9 (6-11) might already be used by the flash interface. Be warned.
Failed config

binary_sensor.gpio: 
  platform: gpio
  pin: 
    number: 9
    mode: INPUT_PULLUP
    inverted: True
  
  ID button redefined! Check binary_sensor->0->id.
  id: button
  on_press: 
    - then: 
        - light.toggle: 
            id: light_2
  name: button
  internal: True
```
And I made these changes for to avoid that error

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
