### PR TITLE
Typo fix

### DIFF
--- a/components/light/custom.rst
+++ b/components/light/custom.rst
@@ -52,7 +52,7 @@ And in YAML:
     # Example configuration entry
     esphome:
       includes:
-        - my_cover.h
+        - my_light.h
 
     light:
     - platform: custom


### PR DESCRIPTION
likely left over from when documentation was adapted from the custom cover component

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
