### PR TITLE
Added equal symbol for MAX7219 7-segment display

### DIFF
--- a/components/display/images/max7219/seg09.svg
+++ b/components/display/images/max7219/seg09.svg
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="300"
+   height="300"
+   version="1"
+   id="svg14"
+   sodipodi:docname="seg09.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <metadata
+     id="metadata20">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs18" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1581"
+     inkscape:window-height="480"
+     id="namedview16"
+     showgrid="false"
+     inkscape:zoom="1.5733333"
+     inkscape:cx="142.17599"
+     inkscape:cy="160.323"
+     inkscape:window-x="718"
+     inkscape:window-y="580"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg14" />
+  <g
+     id="g12"
+     stroke="#000">
+    <path
+       d="m 190.797,154.49152 -15.212,15.5 h -59 l -15.517,-15.5 15.517,-15.5 h 59 z m 0,81.5 -15.212,15.5 h -59 l -15.517,-15.5 15.517,-15.5 h 59 z"
+       id="path2"
+       inkscape:connector-curvature="0"
+       style="fill:#ff0000;fill-rule:evenodd" />
+    <path
+       d="M98 75.385l15.5 15.212v45L98 151.115l-15.5-15.518v-45L98 75.385zM194 75.385l15.5 15.212v45L194 151.115l-15.5-15.518v-45L194 75.385z"
+       id="path4"
+       fill="none" />
+    <path
+       d="M 190.797,72.5 175.585,88 h -59 L 101.068,72.5 116.585,57 h 59 z"
+       id="path6"
+       style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd"
+       inkscape:connector-curvature="0" />
+    <path
+       d="M98 157.443l15.5 15.212v45L98 233.172l-15.5-15.517v-45L98 157.443zM194 157.443l15.5 15.212v45L194 233.172l-15.5-15.517v-45l15.5-15.212z"
+       id="path8"
+       fill="none" />
+    <path
+       d="M237.5 239.25a12.25 12.25 0 1 1-24.5 0 12.25 12.25 0 1 1 24.5 0z"
+       id="path10"
+       stroke-linecap="round"
+       fill="none" />
+  </g>
+</svg>

--- a/components/display/max7219.rst
+++ b/components/display/max7219.rst
@@ -207,6 +207,8 @@ All 7-Segment Characters
 ------------------------------ ------------------------------
 |max721908|                    ``_``
 ------------------------------ ------------------------------
+|max721909|                    ``=``
+------------------------------ ------------------------------
 |max721906|                    ``|``
 ------------------------------ ------------------------------
 |max72190D|                    ``c``
@@ -307,6 +309,8 @@ All 7-Segment Characters
 .. |max721901| image:: images/max7219/seg01.svg
     :class: component-image
 .. |max721908| image:: images/max7219/seg08.svg
+    :class: component-image
+.. |max721909| image:: images/max7219/seg09.svg
     :class: component-image
 .. |max721906| image:: images/max7219/seg06.svg
     :class: component-image


### PR DESCRIPTION
## Description:
Show the equal sign = on the max7219 display when the ascii code 0x3d is given.
Done by lighting segments d and g.

**Related issue (if applicable):** none

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#986

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
