### PR TITLE
Fix link syntax

### DIFF
--- a/guides/diy.rst
+++ b/guides/diy.rst
@@ -60,7 +60,7 @@ Custom Components & Code
 - `ESPHome <-> Homebridge <https://www.npmjs.com/package/homebridge-esphome>`__ by `basdelfos <https://www.npmjs.com/~basdelfos>`__
 - `Custom ESPHome for Wofea V10 Alarm <https://github.com/nbergont/wofea_v10_hack>`__ by :ghuser:`nbergont`
 - `Custom Smart meter P1 port reader <https://github.com/nldroid/CustomP1UartComponent>`__ by :ghuser:`nldroid`
-- `Custom Mitsubishi HVAC HeatPump control using UART <https://github.com/geoffdavis/esphome-mitsubishiheatpump>` by :ghuser:`geoffdavis`
+- `Custom Mitsubishi HVAC HeatPump control using UART <https://github.com/geoffdavis/esphome-mitsubishiheatpump>`__ by :ghuser:`geoffdavis`
 
 Sample Configurations
 ---------------------


### PR DESCRIPTION
Link wasn't rendering correctly.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
