### PR TITLE
Added TTGO-Camera Plus PIN configuration

### DIFF
--- a/components/esp32_camera.rst
+++ b/components/esp32_camera.rst
@@ -241,6 +241,32 @@ Configuration for TTGO T-Journal
       # Image settings
       name: My Camera
       # ...
+      
+      
+Configuration for TTGO-Camera Plus
+--------------------------------
+
+.. code-block:: yaml
+
+    # Example configuration entry
+    esp32_camera:
+      external_clock:
+        pin: GPIO4
+        frequency: 20MHz
+      i2c_pins:
+        sda: GPIO18
+        scl: GPIO23
+      data_pins: [GPIO34, GPIO13, GPIO26, GPIO35, GPIO39, GPIO38, GPIO37, GPIO36]
+      vsync_pin: GPIO5
+      href_pin: GPIO27
+      pixel_clock_pin: GPIO25
+      vertical_flip: false
+      horizontal_mirror: false
+
+
+      # Image settings
+      name: My Camera
+      # ...
 
 See Also
 --------

--- a/components/esp32_camera.rst
+++ b/components/esp32_camera.rst
@@ -244,7 +244,7 @@ Configuration for TTGO T-Journal
       
       
 Configuration for TTGO-Camera Plus
---------------------------------
+----------------------------------
 
 .. code-block:: yaml
 


### PR DESCRIPTION
## Description:

Added Pin configuration for TTGO-Camera Plus. Tested this configuration myself, works on esphome/homeassistant. 

For more details on TTGO-Camera Plus please see: https://github.com/Xinyuan-LilyGo/esp32-camera-screen

PS: First PR here, so please let me know in case I missed something.

**Related issue (if applicable):** fixes #509 

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
