### PR TITLE
Add config types to homepage guides list

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -40,6 +40,8 @@ Guides
     Supporters, guides/supporters, heart.svg
     DIY Examples, guides/diy, earth.svg
 
+    Configuration types, guides/configuration-types, puzzle.svg
+
 .. _devices:
 
 Devices


### PR DESCRIPTION
## Description:
Adds a link to the Config Types page to the Guides section of the homepage.  This is a useful page, but is hard to find.

I've used the existing "puzzle" icon, as config types are an important piece of the puzzle (and I couldn't think of an alternative which would fit better).

**Related issue (if applicable):** N/A
**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** N/A

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
