### PR TITLE
Document two missing hmc5883l config settings

### DIFF
--- a/components/sensor/hmc5883l.rst
+++ b/components/sensor/hmc5883l.rst
@@ -44,6 +44,11 @@ Configuration variables:
 - **heading** (*Optional*): The heading of the sensor in degrees. All options from
   :ref:`Sensor <config-sensor>`.
 - **update_interval** (*Optional*, :ref:`config-time`): The interval to check the sensor. Defaults to ``60s``.
+- **oversampling** (*Optional*): Number of readings to average over for each sample. One of ``1x``, ``2x``,
+  ``4x``, ``8x``. Defaults to ``1x``.
+- **range** (*Optional*): Select a range / gain preset. This does not affect the scale of the values published
+  but allows one to avoid overflows at the cost of reading resolution. Supported values are 88µT, 130µT, 190µT,
+  250µT, 400µT, 470µT, 560µT, 810µT. Default range is ±130µT.
 
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
 


### PR DESCRIPTION
There are two HMC5883L settings: ``oversampling`` and ``range``, that are supported by the esphome sensor but were missing from the docs.