### PR TITLE
Drop documentation of use_custom_code option

### DIFF
--- a/components/esphome.rst
+++ b/components/esphome.rst
@@ -43,8 +43,6 @@ Advanced options:
   but you can customize this behavior using this option.
 - **platformio_options** (*Optional*, mapping): Additional options to pass over to platformio in the
   platformio.ini file. See :ref:`esphome-platformio_options`.
-- **use_custom_code** (*Optional*, boolean): Whether to configure the project for writing custom components.
-  This sets up some flags so that custom code should compile correctly
 - **includes** (*Optional*, list of files): A list of C[++] files to include in the main (auto-generated) sketch file
   for custom components. The paths in this list are relative to the directory where the YAML configuration file
   is in. Should have file extension ``.h`` - See :ref:`esphome-includes` for more info.


### PR DESCRIPTION
This option no longer exists.

## Description:

**Related issue (if applicable):** N/A.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** N/A.

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
