### PR TITLE
remove link to Adafruit

### DIFF
--- a/components/sensor/bh1750.rst
+++ b/components/sensor/bh1750.rst
@@ -7,7 +7,7 @@ BH1750 Ambient Light Sensor
     :keywords: BH1750
 
 The ``bh1750`` sensor platform allows you to use your BH1750
-(`datasheet <http://www.mouser.com/ds/2/348/bh1750fvi-e-186247.pdf>`__, `Adafruit`_, `mklec`_)
+(`datasheet <http://www.mouser.com/ds/2/348/bh1750fvi-e-186247.pdf>`__, `mklec`_)
 ambient light sensor with ESPHome. The :ref:`I²C bus <i2c>` is required to be set up in
 your configuration for this sensor to work.
 
@@ -17,7 +17,6 @@ your configuration for this sensor to work.
 
     BH1750 Ambient Light Sensor.
 
-.. _Adafruit: https://www.adafruit.com/product/1603
 .. _mklec: http://mklec.com/modules/micro-controller-modules/bh1750-bh1750fvi-digital-light-sensor-module
 
 .. figure:: images/bh1750-ui.png

--- a/components/sensor/bh1750.rst
+++ b/components/sensor/bh1750.rst
@@ -7,7 +7,7 @@ BH1750 Ambient Light Sensor
     :keywords: BH1750
 
 The ``bh1750`` sensor platform allows you to use your BH1750
-(`datasheet <http://www.mouser.com/ds/2/348/bh1750fvi-e-186247.pdf>`__, `mklec`_)
+(`datasheet <http://www.mouser.com/ds/2/348/bh1750fvi-e-186247.pdf>`__)
 ambient light sensor with ESPHome. The :ref:`I²C bus <i2c>` is required to be set up in
 your configuration for this sensor to work.
 
@@ -16,8 +16,6 @@ your configuration for this sensor to work.
     :width: 50.0%
 
     BH1750 Ambient Light Sensor.
-
-.. _mklec: http://mklec.com/modules/micro-controller-modules/bh1750-bh1750fvi-digital-light-sensor-module
 
 .. figure:: images/bh1750-ui.png
     :align: center


### PR DESCRIPTION
the link is not pointing at the right product page, and Adafruit looks like is not selling (never sold?) this device

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
