### PR TITLE
feat: Added documentation to support for MCP23016

### DIFF
--- a/components/mcp230xx.rst
+++ b/components/mcp230xx.rst
@@ -2,12 +2,113 @@ MCP230xx I/O Expander
 =====================
 
 .. seo::
-    :description: Instructions for setting up MCP23017 or MCP23008 digital port expanders in ESPHome.
+    :description: Instructions for setting up MCP23008, MCP23016 or MCP23017 digital port expander in ESPHome.
     :image: mcp230xx.png
 
-The Microchip MCP230xx series of general purpose, parallel I/O expansion for I²C
-bus applications come in two different variants: the 8-bit MCP23008 and the 16-bit
-MCP23017, which provide 8 and 16 additional GPIO pins, respectively.
+The Microchip MCP230xx series of general purpose, parallel I/O expansion for I²C bus applications.
+
+**Supported Variants :**
+
+- :ref:`mcp23008-label`
+- :ref:`mcp23016-label`
+- :ref:`mcp23017-label`
+
+.. _mcp23008-label:
+
+MCP23008
+--------
+
+The MCP23008 component (`datasheet <http://ww1.microchip.com/downloads/en/devicedoc/21919e.pdf>`__,
+`Adafruit <https://www.adafruit.com/product/593>`__) has 8 GPIOs that can be configured independently.
+
+.. code-block:: yaml
+
+    # Example configuration entry
+    mcp23008:
+      - id: 'mcp23008_hub'
+        address: 0x20
+
+    # Individual outputs
+    switch:
+      - platform: gpio
+        name: "MCP23008 Pin #0"
+        pin:
+          mcp23008: mcp23008_hub
+          # Use pin number 0
+          number: 0
+          # One of INPUT, INPUT_PULLUP or OUTPUT
+          mode: INPUT_PULLUP
+          inverted: False
+
+    # Individual inputs
+    binary_sensor:
+      - platform: gpio
+        name: "MCP23008 Pin #1"
+        pin:
+          mcp23008: mcp23008_hub
+          # Use pin number 1
+          number: 1
+          # One of INPUT or INPUT_PULLUP
+          mode: INPUT
+          inverted: False
+
+Configuration variables:
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+- **id** (**Required**, :ref:`config-id`): The id to use for this MCP23008 component.
+- **address** (*Optional*, int): The I²C address of the driver.
+  Defaults to ``0x20``.
+
+.. _mcp23016-label:
+
+MCP23016
+--------
+
+The MCP23016 component (`datasheet <http://ww1.microchip.com/downloads/en/devicedoc/20090c.pdf>`__)
+has 16 GPIOs and can be configured the same way than the other variants.
+
+.. note::
+
+    The 'INPUT_PULLUP' mode is not supported on this device.
+
+.. code-block:: yaml
+
+    # Example configuration entry
+    mcp23016:
+      - id: 'mcp23016_hub'
+        address: 0x20
+
+    # Individual outputs
+    switch:
+      - platform: gpio
+        name: "MCP23016 Pin #0"
+        pin:
+          mcp23016: mcp23016_hub
+          # Use pin number 0
+          number: 0
+          mode: OUTPUT
+          inverted: False
+
+    # Individual inputs
+    binary_sensor:
+      - platform: gpio
+        name: "MCP23016 Pin #1"
+        pin:
+          mcp23016: mcp23016_hub
+          # Use pin number 1
+          number: 1
+          mode: INPUT
+          inverted: False
+
+
+Configuration variables:
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+- **id** (**Required**, :ref:`config-id`): The id to use for this MCP23016 component.
+- **address** (*Optional*, int): The I²C address of the driver.
+  Defaults to ``0x20``.
+
+.. _mcp23017-label:
 
 MCP23017
 --------
@@ -37,8 +138,19 @@ binary sensor or GPIO switch.
           mcp23017: mcp23017_hub
           # Use pin number 0
           number: 0
-          # One of INPUT, INPUT_PULLUP or OUTPUT
           mode: OUTPUT
+          inverted: False
+
+    # Individual inputs
+    binary_sensor:
+      - platform: gpio
+        name: "MCP23017 Pin #1"
+        pin:
+          mcp23017: mcp23017_hub
+          # Use pin number 1
+          number: 1
+          # One of INPUT or INPUT_PULLUP
+          mode: INPUT_PULLUP
           inverted: False
 
 Configuration variables:
@@ -46,43 +158,7 @@ Configuration variables:
 
 - **id** (**Required**, :ref:`config-id`): The id to use for this MCP23017 component.
 - **address** (*Optional*, int): The I²C address of the driver.
-  Defaults to ``0x21``.
-
-
-
-MCP23008
---------
-
-The configuration is essentially the same with the MCP23008 component
-(`datasheet <http://ww1.microchip.com/downloads/en/devicedoc/21919e.pdf>`__,
-`Adafruit <https://www.adafruit.com/product/593>`__):
-
-.. code-block:: yaml
-
-    # Example configuration entry
-    mcp23008:
-      - id: 'mcp23008_hub'
-        address: 0x20
-
-    # Individual outputs
-    switch:
-      - platform: gpio
-        name: "MCP23008 Pin #0"
-        pin:
-          mcp23008: mcp23008_hub
-          # Use pin number 0
-          number: 0
-          # One of INPUT, INPUT_PULLUP or OUTPUT
-          mode: INPUT_PULLUP
-          inverted: False
-
-
-Configuration variables:
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-- **id** (**Required**, :ref:`config-id`): The id to use for this MCP23008 component.
-- **address** (*Optional*, int): The I²C address of the driver.
-  Defaults to ``0x21``.
+  Defaults to ``0x20``.
 
 
 See Also
@@ -91,6 +167,7 @@ See Also
 - :ref:`i2c`
 - :doc:`switch/gpio`
 - :doc:`binary_sensor/gpio`
-- :apiref:`mcp23017/mcp23017.h`
+- :apiref:`API Reference (MCP23008) <mcp23008/mcp23008.h>`
+- :apiref:`API Reference (MCP23016) <mcp23016/mcp23016.h>`
+- :apiref:`API Reference (MCP23017) <mcp23017/mcp23017.h>`
 - :ghedit:`Edit`
-


### PR DESCRIPTION
## Description:
- Added documentation to support for MCP23016 16 GPIOs Expander
- Fixed default addresses (according the code) for MCP23008 and MCP 23017
- Added API refs for the 3 devices

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#1012

## Checklist:

  - [X] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
