### PR TITLE
Add support for command-line-substitutions

### DIFF
--- a/guides/cli.rst
+++ b/guides/cli.rst
@@ -11,7 +11,7 @@ ESPHome's command line interface always has the following format
 
 .. code-block:: console
 
-    esphome <CONFIGURATION...> <COMMAND> [ARGUMENTS]
+    esphome [OPTIONS] <CONFIGURATION...> <COMMAND> [ARGUMENTS]
 
 .. note::
 
@@ -22,6 +22,30 @@ ESPHome's command line interface always has the following format
 
         esphome livingroom.yaml kitchen.yaml run
 
+``--verbose`` Option
+--------------
+
+.. option:: -v|--verbose
+
+    Enable verbose esphome logs.
+
+``--quiet`` Option
+--------------
+
+.. option:: -q|--quiet
+
+    Disable all esphome logs.
+
+``--substitution`` Option
+--------------
+
+*(can be issued multiple times)*
+
+.. option:: -s|--substitution KEY VALUE
+
+    Defines or overrides substitution KEY with value VALUE.
+
+Please see :ref:`command line substitutions <command-line-substitutions>` for details.
 
 ``run`` Command
 ---------------

--- a/guides/cli.rst
+++ b/guides/cli.rst
@@ -23,21 +23,21 @@ ESPHome's command line interface always has the following format
         esphome livingroom.yaml kitchen.yaml run
 
 ``--verbose`` Option
---------------
+--------------------
 
 .. option:: -v|--verbose
 
     Enable verbose esphome logs.
 
 ``--quiet`` Option
---------------
+------------------
 
 .. option:: -q|--quiet
 
     Disable all esphome logs.
 
 ``--substitution`` Option
---------------
+-------------------------
 
 *(can be issued multiple times)*
 

--- a/guides/configuration-types.rst
+++ b/guides/configuration-types.rst
@@ -173,11 +173,52 @@ validating your configuration, ESPHome will automatically replace all occurrence
 by their value. The syntax for a substitution is based on bash and is case-sensitive: ``$substitution_key`` or
 ``${substitution_key}`` (same).
 
-You can also add or override substitutions from the command line by adding e.g. ``-s devicename mydevice``
-which overrides the ``devicename`` substitution and gives it value ``mydevice``.
-Command line substitutions take precedence over the ones in your configuration file.
-This can also be used to create more generic 'template' configuration files which can be used for multiple devices,
-based on substitutions which are provided on the command line.
+You can also define or override substitutions from the command line by adding e.g. ``-s devicename mydevice``
+which overrides the ``devicename`` substitution and gives it value ``mydevice``. This can be issued multiple times,
+so e.g. with the following ``example.yaml`` file:
+
+.. code-block:: yaml
+
+    substitutions:
+      name: default
+      platform: ESP8266
+
+    esphome:
+      name: $name
+      platform: $platform
+      board: $board
+
+and the following command:
+
+.. code-block:: sh
+
+  esphome -s name device01 -s board esp01_1m example.yaml config
+  
+You will get something like the following output (please note the unchanged ``platform``,
+added ``board``, and overridden ``name`` substitutions):
+
+.. code-block:: yaml
+
+  substitutions:
+    name: device01
+    platform: ESP8266
+    board: esp01_1m
+  esphome:
+    name: device01
+    platform: ESP8266
+    board: esp01_1m
+    includes: []
+    board_flash_mode: dout
+    libraries: []
+    esp8266_restore_from_flash: false
+    build_path: device01
+    platformio_options: {}
+    arduino_version: espressif8266@2.2.3
+
+We can observe here that command line substitutions take precedence over the ones in
+your configuration file. This can be used to create generic 'template' configuration
+files (like the ``example.yaml`` above) which can be used for multiple devices,
+using substitutions which are provided on the command line.
 
 Additionally, you can use the YAML ``<<`` syntax to create a single YAML file from which a number
 of nodes inherit:

--- a/guides/configuration-types.rst
+++ b/guides/configuration-types.rst
@@ -173,8 +173,47 @@ validating your configuration, ESPHome will automatically replace all occurrence
 by their value. The syntax for a substitution is based on bash and is case-sensitive: ``$substitution_key`` or
 ``${substitution_key}`` (same).
 
-You can also define or override substitutions from the command line by adding e.g. ``-s devicename mydevice``
-which overrides the ``devicename`` substitution and gives it value ``mydevice``. This can be issued multiple times,
+Additionally, you can use the YAML ``<<`` syntax to create a single YAML file from which a number
+of nodes inherit:
+
+.. code-block:: yaml
+
+    # In common.yaml
+    esphome:
+      name: $devicename
+      # ...
+
+    sensor:
+    - platform: dht
+      # ...
+      temperature:
+        name: ${upper_devicename} Temperature
+      humidity:
+        name: ${upper_devicename} Humidity
+
+.. code-block:: yaml
+
+    # In nodemcu1.yaml
+    substitutions:
+      devicename: nodemcu1
+      upper_devicename: NodeMCU 1
+
+    <<: !include common.yaml
+
+.. tip::
+
+    To hide these base files from the dashboard, you can
+
+    - Place them in a subdirectory (dashboard only shows files in top-level dir)
+    - Prepend a dot to the filename, like ``.base.yaml``
+
+.. _command-line-substitutions:
+
+Command line substitutions
+**************************
+
+You can define or override substitutions from the command line by adding e.g. ``-s KEY VALUE``
+which overrides substitution KEY and gives it value VALUE. This can be issued multiple times,
 so e.g. with the following ``example.yaml`` file:
 
 .. code-block:: yaml
@@ -219,40 +258,6 @@ We can observe here that command line substitutions take precedence over the one
 your configuration file. This can be used to create generic 'template' configuration
 files (like the ``example.yaml`` above) which can be used for multiple devices,
 using substitutions which are provided on the command line.
-
-Additionally, you can use the YAML ``<<`` syntax to create a single YAML file from which a number
-of nodes inherit:
-
-.. code-block:: yaml
-
-    # In common.yaml
-    esphome:
-      name: $devicename
-      # ...
-
-    sensor:
-    - platform: dht
-      # ...
-      temperature:
-        name: ${upper_devicename} Temperature
-      humidity:
-        name: ${upper_devicename} Humidity
-
-.. code-block:: yaml
-
-    # In nodemcu1.yaml
-    substitutions:
-      devicename: nodemcu1
-      upper_devicename: NodeMCU 1
-
-    <<: !include common.yaml
-
-.. tip::
-
-    To hide these base files from the dashboard, you can
-
-    - Place them in a subdirectory (dashboard only shows files in top-level dir)
-    - Prepend a dot to the filename, like ``.base.yaml``
 
 See Also
 --------

--- a/guides/configuration-types.rst
+++ b/guides/configuration-types.rst
@@ -173,6 +173,12 @@ validating your configuration, ESPHome will automatically replace all occurrence
 by their value. The syntax for a substitution is based on bash and is case-sensitive: ``$substitution_key`` or
 ``${substitution_key}`` (same).
 
+You can also add or override substitutions from the command line by adding e.g. ``-s devicename mydevice``
+which overrides the ``devicename`` substitution and gives it value ``mydevice``.
+Command line substitutions take precedence over the ones in your configuration file.
+This can also be used to create more generic 'template' configuration files which can be used for multiple devices,
+based on substitutions which are provided on the command line.
+
 Additionally, you can use the YAML ``<<`` syntax to create a single YAML file from which a number
 of nodes inherit:
 

--- a/guides/configuration-types.rst
+++ b/guides/configuration-types.rst
@@ -190,30 +190,30 @@ so e.g. with the following ``example.yaml`` file:
 
 and the following command:
 
-.. code-block:: sh
+.. code-block:: bash
 
-  esphome -s name device01 -s board esp01_1m example.yaml config
+    esphome -s name device01 -s board esp01_1m example.yaml config
   
 You will get something like the following output (please note the unchanged ``platform``,
 added ``board``, and overridden ``name`` substitutions):
 
 .. code-block:: yaml
 
-  substitutions:
-    name: device01
-    platform: ESP8266
-    board: esp01_1m
-  esphome:
-    name: device01
-    platform: ESP8266
-    board: esp01_1m
-    includes: []
-    board_flash_mode: dout
-    libraries: []
-    esp8266_restore_from_flash: false
-    build_path: device01
-    platformio_options: {}
-    arduino_version: espressif8266@2.2.3
+    substitutions:
+      name: device01
+      platform: ESP8266
+      board: esp01_1m
+    esphome:
+      name: device01
+      platform: ESP8266
+      board: esp01_1m
+      includes: []
+      board_flash_mode: dout
+      libraries: []
+      esp8266_restore_from_flash: false
+      build_path: device01
+      platformio_options: {}
+      arduino_version: espressif8266@2.2.3
 
 We can observe here that command line substitutions take precedence over the ones in
 your configuration file. This can be used to create generic 'template' configuration


### PR DESCRIPTION
## Description:
This adds support for command line substitutions. These can be provided by --substitution|-s <key> <value> items which are optional can be provided more then once.
The purpose is to add or override substitutions from the command line which allows for more generic 'template' configuration files which can be used for multiple devices of the same kind which can be deployed with some device-specific substitutions (like e.q. $devicename).
**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#1014

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.