### PR TITLE
Revert "Add documentation for cwww and rgbww constant_brightness vari…

### DIFF
--- a/components/light/cwww.rst
+++ b/components/light/cwww.rst
@@ -19,7 +19,6 @@ channels will be mixed using the color temperature configuration options.
         warm_white: output_component2
         cold_white_color_temperature: 6536 K
         warm_white_color_temperature: 2000 K
-        constant_brightness: true
 
 Configuration variables:
 ------------------------
@@ -31,7 +30,6 @@ Configuration variables:
   of the cold white channel.
 - **warm_white_color_temperature** (**Required**, float): The color temperate (in `mireds <https://en.wikipedia.org/wiki/Mired>`__ or Kelvin)
   of the warm white channel.
-- **constant_brightness** (*Optional*, boolean): When enabled, this will keep the overall brightness of the cold and warm white channels constant by limiting the combined output to 100% of a single channel. This reduces the possible overall brightness but is necessary for some power supplies that are not able to run both channels at full brightness at once. Defaults to ``false``.
 - **effects** (*Optional*, list): A list of :ref:`light effects <light-effects>` to use for this light.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
 - All other options from :ref:`Light <config-light>`.

--- a/components/light/rgbww.rst
+++ b/components/light/rgbww.rst
@@ -22,7 +22,6 @@ and warm white channels will be mixed using the color temperature configuration 
         warm_white: output_component5
         cold_white_color_temperature: 6536 K
         warm_white_color_temperature: 2000 K
-        constant_brightness: true
 
 Color Correction
 ----------------
@@ -64,7 +63,6 @@ Configuration variables:
   of the cold white channel.
 - **warm_white_color_temperature** (**Required**, float): The color temperate (in `mireds <https://en.wikipedia.org/wiki/Mired>`__ or Kelvin)
   of the warm white channel.
-- **constant_brightness** (*Optional*, boolean): When enabled, this will keep the overall brightness of the cold and warm white channels constant by limiting the combined output to 100% of a single channel. This reduces the possible overall brightness but is necessary for some power supplies that are not able to run both channels at full brightness at once. Defaults to ``false``.
 - **effects** (*Optional*, list): A list of :ref:`light effects <light-effects>` to use for this light.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
 - All other options from :ref:`Light <config-light>`.


### PR DESCRIPTION
…ables. (#530)"

This reverts commit f832223c417126d66dc7554cdc7d426956f1dd69.

## Description:
Reverting because created against `current` instead of `next`

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
