### PR TITLE
added energy in pzem004 documentation

### DIFF
--- a/components/sensor/pzem004t.rst
+++ b/components/sensor/pzem004t.rst
@@ -44,6 +44,8 @@ to some pins on your board and the baud rate set to 9600.
           name: "PZEM-004T Voltage"
         power:
           name: "PZEM-004T Power"
+        energy:
+          name: "PZEM-004T Energy"
         update_interval: 60s
 
 Configuration variables:


### PR DESCRIPTION
## Description:
The pzem004t sensor (the old version, not v3) has energy metric (kWh). I've updated the code to also read the energy from the sensor, so the kWh consumption over time is known.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#1022

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
