### PR TITLE
specific MacOS Docker command to launch dashboard

### DIFF
--- a/guides/faq.rst
+++ b/guides/faq.rst
@@ -261,8 +261,12 @@ Command reference:
     # Map /dev/ttyUSB0 into container
     docker run --rm -v "${PWD}":/config --device=/dev/ttyUSB0 -it esphome/esphome ...
 
-    # Start dashboard on port 6052
+    # Start dashboard on port 6052 (general command)
+    # Warning: this command is currently not working with Docker on MacOS. (see note below)
     docker run --rm -v "${PWD}":/config --net=host -it esphome/esphome
+
+    # Start dashboard on port 5062 (MacOS specific command)
+    docker run --rm -p 6052:6052 -e ESPHOME_DASHBOARD_USE_PING=true -v "${PWD}":/config -it esphome/esphome
 
     # Setup a bash alias:
     alias esphome='docker run --rm -v "${PWD}":/config --net=host -it esphome/esphome'
@@ -287,6 +291,10 @@ And a docker compose file looks like this:
 
     ESPHome uses mDNS to show online/offline state in the dashboard view. So for that feature
     to work you need to enable host networking mode
+
+    On MacOS the networking mode ("-net=host" option) doesn't work as expected. You have to use
+    another way to launch the dashboard with a port mapping option and use alternative to mDNS
+    to have the online/offline stat (see below)
 
     mDNS might not work if your Home Assistant server and your ESPHome nodes are on different subnets.
     If your router supports Avahi, you are able to get mDNS working over different subnets.

--- a/guides/getting_started_command_line.rst
+++ b/guides/getting_started_command_line.rst
@@ -175,6 +175,11 @@ To start the ESPHome dashboard, simply start ESPHome with the following command
     # On Docker, host networking mode is required for online status indicators
     docker run --rm --net=host -v "${PWD}":/config -it esphome/esphome
 
+    # On Docker with MacOS, the host networking option doesn't work as expected. An
+    # alternative is to use the following command if you are a MacOS user.
+    docker run --rm -p 6052:6052 -e ESPHOME_DASHBOARD_USE_PING=true -v "${PWD}":/config -it esphome/esphome
+
+
 After that, you will be able to access the dashboard through ``localhost:6052``.
 
 .. figure:: images/dashboard.png


### PR DESCRIPTION
## Description:

Update documentation to explain why the standard Docker command to launch the dashboard is not working on MacOS and give an alternative command.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** N/A
## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
