### PR TITLE
Add Prometheus-Documentation

### DIFF
--- a/components/web_server.rst
+++ b/components/web_server.rst
@@ -30,29 +30,6 @@ interface are hosted by esphome.io. If you want to use your own service, use the
     web_server:
       port: 80
 
-Prometheus Exporter:
---------------------
-
-The webserver can provide an `Prometheus <https://prometheus.io/>`__-Exporter under ``/metrics``.
-
-This can be used to scrape data directly into your Prometheus-based monitoring and alerting-system,
-without the need of any other software.
-
-The prometheus-endpoint is activated by setting ``prometheus: true`` in the ``web_server``-area of the configuration.
-
-The list of available metrics can be found by directly browsing your node under ``<ip or node_name.local>/metrics``, and may be increased in the future.
-
-.. note::
-
-    Example integration into the configuration of your prometheus:
-
-    .. code-block:: yaml
-
-        scrape_configs:
-          - job_name: esphome
-            static_configs:
-              - targets: [<ip or node_name.local>]
-
 
 Configuration variables:
 ------------------------
@@ -73,8 +50,8 @@ Configuration variables:
   - **username** (**Required**, string): The username to use for authentication.
   - **password** (**Required**, string): The password to check for authentication.
 
+- **prometheus** (*Optional*, boolean): Enable the prometheus-endpoint. See :ref:`prometheus-exporter`.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
-- **prometheus** (*Optional*, boolean): Enable the prometheus-endpoint
 
 .. note::
 
@@ -102,6 +79,34 @@ Configuration variables:
           css_url: ""
           js_include: "../../../esphome-docs/_static/webserver-v1.min.js"
           js_url: ""
+
+
+.. _prometheus-exporter:
+
+Prometheus Exporter:
+--------------------
+
+The webserver can provide an `Prometheus <https://prometheus.io/>`__-Exporter under ``/metrics``.
+
+This can be used to scrape data directly into your Prometheus-based monitoring and alerting-system,
+without the need of any other software.
+
+The prometheus-endpoint is activated by setting ``prometheus: true`` in the ``web_server``-area of
+the configuration.
+
+The list of available metrics can be found by directly browsing your node under
+``<ip or node_name.local>/metrics``, and may be increased in the future.
+
+.. note::
+
+    Example integration into the configuration of your prometheus:
+
+    .. code-block:: yaml
+
+        scrape_configs:
+          - job_name: esphome
+            static_configs:
+              - targets: [<ip or node_name.local>]
 
 See Also
 --------

--- a/components/web_server.rst
+++ b/components/web_server.rst
@@ -30,6 +30,30 @@ interface are hosted by esphome.io. If you want to use your own service, use the
     web_server:
       port: 80
 
+Prometheus Exporter:
+--------------------
+
+The webserver can provide an `Prometheus <https://prometheus.io/>`__-Exporter under ``/metrics``.
+
+This can be used to scrape data directly into your Prometheus-based monitoring and alerting-system,
+without the need of any other software.
+
+The prometheus-endpoint is activated by setting ``prometheus: true`` in the ``web_server``-area of the configuration.
+
+The list of available metrics can be found by directly browsing your node under ``<ip or node_name.local>/metrics``, and may be increased in the future.
+
+.. note::
+
+    Example integration into the configuration of your prometheus:
+
+    .. code-block:: yaml
+
+      scrape_configs:
+        - job_name: esphome
+          static_configs:
+            - targets: [<ip or node_name.local>]
+
+
 Configuration variables:
 ------------------------
 
@@ -50,6 +74,7 @@ Configuration variables:
   - **password** (**Required**, string): The password to check for authentication.
 
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
+- **prometheus** (*Optional*, boolean): Enable the prometheus-endpoint
 
 .. note::
 
@@ -63,6 +88,7 @@ Configuration variables:
           auth:
             username: admin
             password: !secret web_server_password
+          prometheus: true
 
     Example web_server configuration with CSS and JS included from esphome-docs.
     CSS and JS URL's are set to empty value, so no internet access is needed for this device to show it's web interface.

--- a/components/web_server.rst
+++ b/components/web_server.rst
@@ -48,10 +48,10 @@ The list of available metrics can be found by directly browsing your node under 
 
     .. code-block:: yaml
 
-      scrape_configs:
-        - job_name: esphome
-          static_configs:
-            - targets: [<ip or node_name.local>]
+        scrape_configs:
+          - job_name: esphome
+            static_configs:
+              - targets: [<ip or node_name.local>]
 
 
 Configuration variables:
@@ -60,7 +60,7 @@ Configuration variables:
 - **port** (*Optional*, int): The port the web server should open its socket on.
 - **css_url** (*Optional*, url): The URL that should be used for the CSS stylesheet. Defaults
   to https://esphome.io/_static/webserver-v1.min.css (updates will go to ``v2``, ``v3``, etc). Can be set to empty string.
-- **css_include** (*Optional*, local file): Path to local file to be included in web server index page. 
+- **css_include** (*Optional*, local file): Path to local file to be included in web server index page.
   Contents of this file will be served as ``/0.css`` and used as CSS stylesheet by internal webserver.
   Useful when building device without internet access, where you want to use built-in AP and webserver.
 - **js_url** (*Optional*, url): The URL that should be used for the JS script. Defaults


### PR DESCRIPTION
## Description:
Add documentation for the prometheus-exporter-part of the web_server

**Related issue (if applicable):** fixes https://github.com/esphome/feature-requests/issues/692

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#1032

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be c$
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.