### PR TITLE
Make initial run variable available to addressable_lambda

### DIFF
--- a/components/light/index.rst
+++ b/components/light/index.rst
@@ -690,8 +690,11 @@ Addressable Lambda Effect
 
 This effect allows you to access each LED individually in a custom light effect.
 
-You're passed in one variable: ``it`` - an :apiclass:`AddressableLight <light::AddressableLight>`
-instance (see API reference for more info).
+Available variables in the lambda:
+
+- **it** - :apiclass:`AddressableLight <light::AddressableLight>` instance (see API reference for more info).
+- **current_color**  - :apiclass:`ESPColor ` <light::ESPColor>` instance (see API reference for more info).
+- **initial_run** - A bool which is true on the execution of the lambda. Useful to reset static variables when restarting a effect.
 
 .. code-block:: yaml
 
@@ -718,6 +721,30 @@ instance (see API reference for more info).
               // Bonus: use .range() and .all() to set many LEDs without having to write a loop.
               it.range(0, 50) = ESPColor::BLACK;
               it.all().fade_to_black(10);
+
+.. code-block:: yaml
+
+    light:
+    - platform: ...
+      effects:
+        - addressable_lambda:
+            name: "My Custom Effect"
+            update_interval: 16ms
+            lambda: |-
+              // Static variables keep their value even when
+              // stopping and starting the effect again
+              static uint16_t progress = 0;
+
+              // normal variables lost their value after each
+              // execution - basically after each update_interval
+              uint16_t changes = 0;
+            
+              // To reset static when stopping and starting the effect
+              // again you can use the initial_run variables
+              if (initial_run) {
+                progress = 0
+              }
+
 
 Examples of this API can be found here:
 https://github.com/esphome/esphome/blob/dev/esphome/components/light/addressable_light_effect.h

--- a/components/light/index.rst
+++ b/components/light/index.rst
@@ -694,7 +694,7 @@ Available variables in the lambda:
 
 - **it** - :apiclass:`AddressableLight <light::AddressableLight>` instance (see API reference for more info).
 - **current_color**  - :apiclass:`ESPColor ` <light::ESPColor>` instance (see API reference for more info).
-- **initial_run** - A bool which is true on the execution of the lambda. Useful to reset static variables when restarting a effect.
+- **initial_run** - A bool which is true on the first execution of the lambda. Useful to reset static variables when restarting a effect.
 
 .. code-block:: yaml
 
@@ -742,7 +742,10 @@ Available variables in the lambda:
               // To reset static when stopping and starting the effect
               // again you can use the initial_run variables
               if (initial_run) {
-                progress = 0
+                progress = 0;
+                it.all() = ESPColor::BLACK;
+                // optionally do a return so nothing happens until the next update_interval
+                return;
               }
 
 


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** -

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** https://github.com/esphome/esphome/pull/1035

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
