### PR TITLE
dht: Add DHT22_TYPE2 model

### DIFF
--- a/components/sensor/dht.rst
+++ b/components/sensor/dht.rst
@@ -64,7 +64,7 @@ Configuration variables:
   - All other options from :ref:`Sensor <config-sensor>`.
 
 - **model** (*Optional*, int): Manually specify the DHT model, can be
-  one of ``AUTO_DETECT``, ``DHT11``, ``DHT22``, ``AM2302``, ``RHT03``, ``SI7021``
+  one of ``AUTO_DETECT``, ``DHT11``, ``DHT22``, ``DHT22_TYPE2``, ``AM2302``, ``RHT03``, ``SI7021``
   and helps with some connection issues. Defaults to ``AUTO_DETECT``.  Auto detection doesn't work for the SI7021 chip.
 - **update_interval** (*Optional*, :ref:`config-time`): The interval to check the
   sensor. Defaults to ``60s``.


### PR DESCRIPTION
## Description:

Add the DHT22_TYPE2 temperature/humidity sensor model.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

esphome/esphome#926

## Checklist:

  - [X] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [X] Link added in `/index.rst` when creating new documents for new components or cookbook.
