### PR TITLE
Update gpio.rst

### DIFF
--- a/components/switch/gpio.rst
+++ b/components/switch/gpio.rst
@@ -83,6 +83,19 @@ or closes the gate. The relay simulates the button press for 500ms.
         - switch.turn_on: relay
         - delay: 500ms
         - switch.turn_off: relay
+.. code-block:: yaml
+
+    # Example 2 (Use "on_turn_on" instead of template) configuration entry
+    switch:
+      - platform: gpio
+        pin: 25
+        id: relay
+        name: "Gate Remote"
+        icon: "mdi:gate"
+        on_turn_on:
+          - switch.turn_on: relay
+          - delay: 500ms
+          - switch.turn_off: relay
 
 .. figure:: images/gate-remote-ui.png
     :align: center


### PR DESCRIPTION
Added "Example 2 (Use "on_turn_on" instead of template) configuration entry" to "Momentary Switch" section

## Description:
By using **on_turn_on** for a _Momentary Switch_, there's no need for a **template** in the switch section/code.
- I have added a 2nd example.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
