### PR TITLE
xiaomi_miflora is now called xiaomi_hhccjcy01

### DIFF
--- a/components/esp32_ble_tracker.rst
+++ b/components/esp32_ble_tracker.rst
@@ -25,7 +25,7 @@ for information on how you can find out the MAC address of a device and track it
       - platform: ble_rssi
         mac_address: AC:37:43:77:5F:4C
         name: "BLE Google Home Mini RSSI value"
-      - platform: xiaomi_miflora
+      - platform: xiaomi_hhccjcy01
         mac_address: 94:2B:FF:5C:91:61
         temperature:
           name: "Xiaomi MiFlora Temperature"


### PR DESCRIPTION
## Description:

xiaomi_miflora is now called xiaomi_hhccjcy01

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [n/a] Link added in `/index.rst` when creating new documents for new components or cookbook.
