### PR TITLE
Add retain commands

### DIFF
--- a/components/mqtt.rst
+++ b/components/mqtt.rst
@@ -282,7 +282,11 @@ Configuration variables:
    ``<TOPIC_PREFIX>/<COMPONENT_TYPE>/<COMPONENT_NAME>/command``.
 -  **retain_commands** (*Optional*, boolean): If the discovery
    configuration should include the retain option so that MQTT commands
-   are retained. Note that this is potentially dangerous if this single
+   are retained.
+
+   .. note::
+
+   Note that retain_commands is potentially dangerous if this single
    MQTT command isn't the only thing used to control the component.
    However when nothing else is controlling this component, it can because
    useful to restore the state from the MQTT server rather than storing

--- a/components/mqtt.rst
+++ b/components/mqtt.rst
@@ -284,7 +284,7 @@ Configuration variables:
    configuration should include the retain option so that MQTT commands
    are retained.
 
-   .. note::
+.. note::
 
     Note that retain_commands is potentially dangerous if this single
     MQTT command isn't the only thing used to control the component.

--- a/components/mqtt.rst
+++ b/components/mqtt.rst
@@ -282,7 +282,7 @@ Configuration variables:
    ``<TOPIC_PREFIX>/<COMPONENT_TYPE>/<COMPONENT_NAME>/command``.
 -  **retain_commands** (*Optional*, boolean): If the discovery
    configuration should include the retain option so that MQTT commands
-   are retained.
+   are retained. Defaults to ``False``.
 
 .. note::
 

--- a/components/mqtt.rst
+++ b/components/mqtt.rst
@@ -286,16 +286,16 @@ Configuration variables:
 
    .. note::
 
-   Note that retain_commands is potentially dangerous if this single
-   MQTT command isn't the only thing used to control the component.
-   However when nothing else is controlling this component, it can because
-   useful to restore the state from the MQTT server rather than storing
-   the value in the limited flash (especially for esp8266). Retaining
-   commands is also useful for creating a switch to control deep sleep.
-   Use this option at your own risk, and if your component is cycling
-   through multiple states, try disabling this option and using
-   ``>> esphome <my_file>.yaml clean-mqtt`` to remove all retained
-   MQTT messages.
+    Note that retain_commands is potentially dangerous if this single
+    MQTT command isn't the only thing used to control the component.
+    However when nothing else is controlling this component, it can because
+    useful to restore the state from the MQTT server rather than storing
+    the value in the limited flash (especially for esp8266). Retaining
+    commands is also useful for creating a switch to control deep sleep.
+    Use this option at your own risk, and if your component is cycling
+    through multiple states, try disabling this option and using
+    ``>> esphome <my_file>.yaml clean-mqtt`` to remove all retained
+    MQTT messages.
 
 .. warning::
 

--- a/components/mqtt.rst
+++ b/components/mqtt.rst
@@ -261,6 +261,7 @@ MQTT can have some overrides for specific options.
       payload_not_available: offline
     state_topic: livingroom/custom_state_topic
     command_topic: livingroom/custom_command_topic
+    retain_commands: False
 
 Configuration variables:
 
@@ -279,6 +280,18 @@ Configuration variables:
 -  **command_topic** (*Optional*, string): The topic to subscribe to for
    commands from the remote. Defaults to
    ``<TOPIC_PREFIX>/<COMPONENT_TYPE>/<COMPONENT_NAME>/command``.
+-  **retain_commands** (*Optional*, boolean): If the discovery
+   configuration should include the retain option so that MQTT commands
+   are retained. Note that this is potentially dangerous if this single
+   MQTT command isn't the only thing used to control the component.
+   However when nothing else is controlling this component, it can because
+   useful to restore the state from the MQTT server rather than storing
+   the value in the limited flash (especially for esp8266). Retaining
+   commands is also useful for creating a switch to control deep sleep.
+   Use this option at your own risk, and if your component is cycling
+   through multiple states, try disabling this option and using
+   ``>> esphome <my_file>.yaml clean-mqtt`` to remove all retained
+   MQTT messages.
 
 .. warning::
 


### PR DESCRIPTION
## Description:
This change adds documentation for the option to enable retaining MQTT commands in the discovery message. From what I can tell, retaining MQTT commands is a controversial topic, but that shouldn't prevent us from offering the functionality. For any component that is only controlled by an MQTT command, it's very useful to restore the state from MQTT (especially for esp8266 which have a limited ability to store state in flash). This can cause issues if there are other ways of controlling the component with retained MQTT commands, but this is no different than other ways of doing bad things like having multiple switches control the same component, etc.


**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#1056

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
