### PR TITLE
Update for multiple receiver document

### DIFF
--- a/components/remote_receiver.rst
+++ b/components/remote_receiver.rst
@@ -22,6 +22,15 @@ which will trigger when they hear their own configured signal.
     remote_receiver:
       pin: GPIO32
       dump: all
+      
+    # Example multiple receiver configuration entry
+    remote_receiver:
+      - id: receiver_1
+        pin: GPIO32
+        dump: all
+      - id: receiver_2
+        pin: GPIO16
+        dump: all
 
 Configuration variables:
 ------------------------


### PR DESCRIPTION
Clarity on multiple receivers.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
