### PR TITLE
SSD1325 documentation update for grayscale support

### DIFF
--- a/changelog/v1.15.0.rst
+++ b/changelog/v1.15.0.rst
@@ -82,6 +82,7 @@ Notable Changes & New Features
 - New Thermostat Controller implements ESPHome actions for all available Home Assistant climate actions,
   climate modes, fan modes, and fan swing modes (#1061)
 - Color (and grayscale) display support! (#1050)
+- SSD1325 component updated to facilitate use of grayscale
 
 All changes
 -----------

--- a/components/display/ssd1325.rst
+++ b/components/display/ssd1325.rst
@@ -53,6 +53,7 @@ Configuration Variables
   - ``SSD1325 128x64``
   - ``SSD1325 96x16``
   - ``SSD1325 64x48``
+  - ``SSD1327 128x128`` **# Note the number seven!**
 
 - **reset_pin** (:ref:`Pin Schema <config-pin_schema>`): The RESET pin.
 - **cs_pin** (*Optional*, :ref:`Pin Schema <config-pin_schema>`): The pin on the ESP that that the CS line is connected to.
@@ -64,26 +65,67 @@ Configuration Variables
 - **pages** (*Optional*, list): Show pages instead of a single lambda. See :ref:`display-pages`.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
 
-Grayscale Support
-*****************
+Configuration examples
+**********************
 
-This display module supports four bits of grayscale -- that is, sixteen shades of gray, 0 through 15.
-A larger value means (a) brighter pixel(s). Add the desired pixel intensity to the function call that
-draws the object/text in your lambda. The examples below should help to get you started.
+As of version 1.15, ESPHome supports grayscale (and color) displays. To utilize the grayscale capabilities
+of this display module, you'll likely want to add a ``color:`` section to your YAML configuration; please see
+:ref:`color <config-color>` for more detail on this configuration section. As this is a grayscale display, it
+only uses the white color element (as opposed to red, green, and/or blue).
+
+To use grayscale in your lambada:
 
 .. code-block:: yaml
 
+    color:
+      - id: medium_gray
+        white: 50%
+
+    ...
+
     display:
-      - platform: ssd1325_spi
-        model: "SSD1325 128x64"
-        reset_pin: D0
-        cs_pin: D8
-        dc_pin: D1
+        ...
         lambda: |-
-          # Dark gray box around the perimeter of the display; last argument is the intensity of the pixels.
-          it.rectangle(0, 0, it.get_width(), it.get_height(), 1);
-          # Text in medium-gray; pixel intensity goes between the font and TextAlign arguments.
-          it.print(2, 2, id(font), 8, TextAlign::TOP_LEFT, "Hello, Gray World!");
+          it.rectangle(0,  0, it.get_width(), it.get_height(), id(medium_gray));
+
+
+To bring in grayscale images:
+
+.. code-block:: yaml
+
+    image:
+      - file: "image.jpg"
+        id: my_image
+        resize: 120x120
+        type: GRAYSCALE
+
+    ...
+
+    display:
+        ...
+        lambda: |-
+          it.image(0, 0, id(my_image));
+
+In this case, the image will be converted to grayscale and rendered as such when drawn on the display.
+
+Note that if ``type: GRAYSCALE`` is omitted, the image will render as a binary image (no grayscale); in this
+case, a color attribute may be passed to the ``image()`` method as follows:
+
+.. code-block:: yaml
+
+    image:
+      - file: "image.jpg"
+        id: my_image
+        resize: 120x120
+
+    ...
+
+    display:
+        ...
+        lambda: |-
+          it.image(0, 0, id(medium_gray), id(my_image));
+
+This will draw the complete image with the given shade of gray.
 
 See Also
 --------

--- a/components/display/ssd1325.rst
+++ b/components/display/ssd1325.rst
@@ -68,10 +68,9 @@ Configuration Variables
 Configuration examples
 **********************
 
-As of version 1.15, ESPHome supports grayscale (and color) displays. To utilize the grayscale capabilities
-of this display module, you'll likely want to add a ``color:`` section to your YAML configuration; please see
-:ref:`color <config-color>` for more detail on this configuration section. As this is a grayscale display, it
-only uses the white color element (as opposed to red, green, and/or blue).
+To utilize the grayscale capabilities of this display module, add a ``color:`` section to your YAML configuration;
+please see :ref:`color <config-color>` for more details. As this is a grayscale display, it only uses the white color
+element as shown below.
 
 To use grayscale in your lambada:
 
@@ -106,7 +105,9 @@ To bring in grayscale images:
         lambda: |-
           it.image(0, 0, id(my_image));
 
-In this case, the image will be converted to grayscale and rendered as such when drawn on the display.
+In this case, the image will be converted to grayscale (regardless of its original format) and rendered as such
+when drawn on the display. Note that the original image may require some adjustment as not all images immediately
+convert nicely to the 4-bit grayscale format this display supports.
 
 Note that if ``type: GRAYSCALE`` is omitted, the image will render as a binary image (no grayscale); in this
 case, a color attribute may be passed to the ``image()`` method as follows:
@@ -126,6 +127,20 @@ case, a color attribute may be passed to the ``image()`` method as follows:
           it.image(0, 0, id(medium_gray), id(my_image));
 
 This will draw the complete image with the given shade of gray.
+
+To create a new color as needed in code:
+
+.. code-block:: yaml
+
+    display:
+        ...
+        lambda: |-
+          float white_intensity = 0.5;
+          Color variable_gray(0, 0, 0, white_intensity);
+          it.rectangle(0,  0, it.get_width(), it.get_height(), variable_gray);
+
+The last argument of the ``Color`` constructor is the intensity of the white element; it is a percentage
+(value of range 0 to 1). It may be defined by another variable so it is adjustable in code.
 
 See Also
 --------

--- a/components/display/ssd1325.rst
+++ b/components/display/ssd1325.rst
@@ -22,7 +22,11 @@ displays with ESPHome. Note that this component is for displays that are connect
     SSD1325 OLED Display
 
 Connect CLK, DIN, CS, DC, and RST to pins on your ESP. For power, connect
-VCC to 3.3V and GND to GND.
+VCC to 3.3V and GND to GND. Note that two jumper resistors on the back of the
+display PCB may need to be moved to put the display into SPI mode.
+`Adafruit <https://www.adafruit.com/product/2674>`__ has a
+`guide <https://learn.adafruit.com/2-7-monochrome-128x64-oled-display-module/assembly>`__
+that explains how to do this, if necessary.
 
 .. code-block:: yaml
 
@@ -40,8 +44,8 @@ VCC to 3.3V and GND to GND.
         lambda: |-
           it.print(0, 0, id(font), "Hello World!");
 
-Configuration variables:
-************************
+Configuration Variables
+***********************
 
 - **model** (**Required**): The model of the display. Options are:
 
@@ -59,6 +63,27 @@ Configuration variables:
 - **update_interval** (*Optional*, :ref:`config-time`): The interval to re-draw the screen. Defaults to ``5s``.
 - **pages** (*Optional*, list): Show pages instead of a single lambda. See :ref:`display-pages`.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
+
+Grayscale Support
+*****************
+
+This display module supports four bits of grayscale -- that is, sixteen shades of gray, 0 through 15.
+A larger value means (a) brighter pixel(s). Add the desired pixel intensity to the function call that
+draws the object/text in your lambda. The examples below should help to get you started.
+
+.. code-block:: yaml
+
+    display:
+      - platform: ssd1325_spi
+        model: "SSD1325 128x64"
+        reset_pin: D0
+        cs_pin: D8
+        dc_pin: D1
+        lambda: |-
+          # Dark gray box around the perimeter of the display; last argument is the intensity of the pixels.
+          it.rectangle(0, 0, it.get_width(), it.get_height(), 1);
+          # Text in medium-gray; pixel intensity goes between the font and TextAlign arguments.
+          it.print(2, 2, id(font), 8, TextAlign::TOP_LEFT, "Hello, Gray World!");
 
 See Also
 --------


### PR DESCRIPTION
## Description:

Documents the patch that adds grayscale support to the SSD1325 display component.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#1064

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
