### PR TITLE
Update WaveShare E-Paper URL on WaveShare E-Paper page

### DIFF
--- a/components/display/waveshare_epaper.rst
+++ b/components/display/waveshare_epaper.rst
@@ -6,7 +6,7 @@ Waveshare E-Paper Display
     :image: waveshare_epaper.jpg
 
 The ``waveshare_epaper`` display platform allows you to use
-some E-Paper displays sold by `Waveshare <https://www.waveshare.com/product/modules/oleds-lcds/e-paper.htm>`__
+some E-Paper displays sold by `Waveshare <https://www.waveshare.com/product/displays/e-paper.htm>`__
 with ESPHome. The 2.13" `TTGO module <https://github.com/lewisxhe/TTGO-EPaper-Series>`__ with an ESP32 on the board is supported as well.
 Similar modules sold by other vendors might also work but not have been tested yet. Currently only
 single-color E-Ink displays are implemented and of those only a few modules.


### PR DESCRIPTION
## Description:
Update WaveShare E-Paper URL on [WaveShare E-Paper page](https://esphome.io/components/display/waveshare_epaper.html). I found the old link to be a 404 and put the updated URL in its place.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** N/A

## Checklist:

  - [X] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
