### PR TITLE
Update datagram URL on TX20 page

### DIFF
--- a/components/sensor/tx20.rst
+++ b/components/sensor/tx20.rst
@@ -81,6 +81,6 @@ See Also
 - :apiref:`tx20/tx20.h`
 - `Amazon Tx20 <https://www.amazon.de/Technoline-Tx-20/dp/B01HXZ3KLA>`__
 - `La Crosse Tx23 <https://www.lacrossetechnology.com/tx23-wind-sensor>`__
-- `Datagram Tx20 <http://www.sdpro.eu/jm/images/allegati/Tx20_Documentazione.pdf>`__
+- `Datagram Tx20 <http://www.sdpro.eu/jm/images/allegati/TX20_Documentazione.pdf>`__
 - `Datagram Tx23 <https://www.lacrossetechnology.com/tx23-wind-sensor>`__-
 - :ghedit:`Edit`


### PR DESCRIPTION
## Description:
Update datagram URL on [TX20 page](https://esphome.io/components/sensor/tx20.html). I found the old link to be a 404 and put the updated URL in its place.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** N/A

## Checklist:

  - [X] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
