### PR TITLE
Update datasheet URL on SCD30 page

### DIFF
--- a/components/sensor/scd30.rst
+++ b/components/sensor/scd30.rst
@@ -6,7 +6,7 @@ SCD30 CO₂, Temperature and Relative Humidty Sensor
     :image: scd30.jpg
 
 The ``scd30`` sensor platform  allows you to use your Sensiron SCD30 CO₂
-(`datasheet <https://www.sensirion.com/fileadmin/user_upload/customers/sensirion/Dokumente/0_Datasheets/CO2/Sensirion_CO2_Sensors_SCD30_Datasheet.pdf>`__) sensors with ESPHome.
+(`datasheet <https://www.sensirion.com/fileadmin/user_upload/customers/sensirion/Dokumente/9.5_CO2/Sensirion_CO2_Sensors_SCD30_Datasheet.pdf>`__) sensors with ESPHome.
 The :ref:`I²C Bus <i2c>` is required to be set up in your configuration for this sensor to work.
 
 .. figure:: images/scd30.jpg


### PR DESCRIPTION
## Description:
Update datasheet URL on the [SCD30 page](https://esphome.io/components/sensor/scd30.html). I found the old link to be a 404 and put the updated URL in its place.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** N/A

## Checklist:

  - [X] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
