### PR TITLE
Update datasheet URL on SGP30 page

### DIFF
--- a/components/sensor/sgp30.rst
+++ b/components/sensor/sgp30.rst
@@ -6,7 +6,7 @@ SGP30 CO₂ and Volatile Organic Compound Sensor
     :image: sgp30.png
 
 The ``sgp30`` sensor platform  allows you to use your Sensiron SGP30 multi-pixel gas
-(`datasheet <https://www.sensirion.com/fileadmin/user_upload/customers/sensirion/Dokumente/0_Datasheets/Gas/Sensirion_Gas_Sensors_SGP30_Datasheet.pdf>`__) sensors or the SVM30 breakout-boards  (`product page <https://www.sensirion.com/en/environmental-sensors/gas-sensors/multi-gas-humidity-temperature-module-svm30/>`__) with ESPHome.
+(`datasheet <https://www.sensirion.com/fileadmin/user_upload/customers/sensirion/Dokumente/9_Gas_Sensors/Datasheets/Sensirion_Gas_Sensors_SGP30_Datasheet.pdf>`__) sensors or the SVM30 breakout-boards  (`product page <https://www.sensirion.com/en/environmental-sensors/gas-sensors/multi-gas-humidity-temperature-module-svm30/>`__) with ESPHome.
 The :ref:`I²C Bus <i2c>` is required to be set up in your configuration for this sensor to work.
 
 .. figure:: images/eco2-tvoc.png


### PR DESCRIPTION
## Description:
Update datasheet URL on [SGP30 page](https://esphome.io/components/sensor/sgp30.html). I found the old link to be a 404 and put the updated URL in its place.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** N/A

## Checklist:

  - [X] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
