### PR TITLE
Update datasheet URL on STS3X page

### DIFF
--- a/components/sensor/sts3x.rst
+++ b/components/sensor/sts3x.rst
@@ -6,7 +6,7 @@ STS3X Temperature Sensor
     :image: sts3x.jpg
 
 The ``sts3x`` sensor platform Temperature sensor allows you to use your Sensiron STS30-DIS, STS31-DIS or STS35-DIS
-(`datasheet <https://www.sensirion.com/fileadmin/user_upload/customers/sensirion/Dokumente/0_Datasheets/Temperature/Sensirion_Temperature_Sensors_STS3x_Datasheet.pdf>`__,
+(`datasheet <https://www.sensirion.com/fileadmin/user_upload/customers/sensirion/Dokumente/3_Temperature_Sensors/Sensirion_Temperature_Sensors_Table_Overview.pdf>`__,
 `Sensirion STS3x <https://www.sensirion.com/sts3x/>`__) sensors with
 ESPHome. The :ref:`I²C Bus <i2c>` is
 required to be set up in your configuration for this sensor to work.


### PR DESCRIPTION
## Description:
Update datasheet  URL on [STS3X  page](https://esphome.io/components/sensor/sts3x.html). I found the old link to be a 404 and put the updated URL in its place.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** N/A

## Checklist:

  - [X] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
