### PR TITLE
Update Home Assistant custom component URL on contributing guide page

### DIFF
--- a/guides/contributing.rst
+++ b/guides/contributing.rst
@@ -414,7 +414,7 @@ by the integration developer.
 .. note::
 
     Additionally, ESPHome has a ``custom_components`` mechanism like
-    `Home Assistant does <https://developers.home-assistant.io/docs/en/creating_component_loading.html>`__.
+    `Home Assistant does <https://developers.home-assistant.io/docs/creating_component_index>`__.
     So for testing you can also create a new ``custom_components`` folder inside of your ESPHome
     config folder and create new integrations in there.
 


### PR DESCRIPTION
## Description:
Update the Home Assistant custom component URL on the [contributing guide page](https://esphome.io/guides/contributing.html#directory-structure). I found the old link to be a 404 and put the updated URL in its place.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** N/A

## Checklist:

  - [X] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
