### PR TITLE
Remove Count Water Bottles by vigonotion example from DIY examples page

### DIFF
--- a/guides/diy.rst
+++ b/guides/diy.rst
@@ -27,7 +27,6 @@ Blog Posts & Videos
 - `Smart $2 doorbell <https://frenck.dev/diy-smart-doorbell-for-just-2-dollar/>`__ by `Frenck <https://frenck.dev>`__
 - `Cheap Car Presence Detection <https://adonno.com/car-presence-position-detection/>`__ by `Adonno <https://adonno.com>`__
 - `Calibrating Power Sensors <https://frenck.dev/calibrating-an-esphome-flashed-power-plug/>`__ by `Frenck <https://frenck.dev>`__
-- `Count Water Bottles <https://vigonotion.com/blog/monitor-remainding-water-bottles/>`__ by `vigonotion <https://vigonotion.com>`__
 - `ESPHome Weather Station with Nextion display <https://github.com/bruxy70/Home-Assistant-ESPHome-Weather-Station>`__ by :ghuser:`bruxy70`
 - `ESPHome Wall Mount with Nextion Display <https://github.com/Andoramb/Nextion-wall-mount>`__ by :ghuser:`Andoramb` (`video <https://www.youtube.com/watch?v=TL8wZNnS4jI>`__)
 - `Sonoff 4CH Irrigation Controller with Nextion Display <https://github.com/bruxy70/Irrigation-with-display>`__ by :ghuser:`bruxy70`


### PR DESCRIPTION
## Description:
Remove the "Count Water Bottles" by vigonotion example from DIY examples page. The existing URL returns a 404 and after doing numerous Google searches, I could not find the new URL to this project's page. If anyone has the new URL, I would like to replace it with that, but unfortunately, I could not find it so I've removed the URL.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** N/A

## Checklist:

  - [X] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
