### PR TITLE
Deleted Warning because the component is already tested

### DIFF
--- a/components/gps.rst
+++ b/components/gps.rst
@@ -5,14 +5,6 @@ GPS Component
     :description: Instructions for setting up GPS integration in ESPHome.
     :image: crosshair-gps.png
 
-.. warning::
-
-    This component has not been fully tested yet, if you have this component
-    and can confirm it works, please create a quick new issue here
-    https://github.com/esphome/issues/
-
-    Thanks!
-
 The ``gps`` component allows you to connect GPS modules to your ESPHome project.
 Any GPS module that uses the standardized NMEA communication protocol will work.
 


### PR DESCRIPTION
## Description:
Deleted Warning because the component is already tested and working

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
