### PR TITLE
Fix broken YAML in MQTT on_json_message example

### DIFF
--- a/components/mqtt.rst
+++ b/components/mqtt.rst
@@ -362,7 +362,7 @@ Please note that it's a good idea to check if the key exists in the Json Object 
       # ...
       on_json_message:
         topic: the/topic
-          then:
+        then:
           - light.turn_on:
               id: living_room_lights
 


### PR DESCRIPTION
## Description:
The example YAML for the `on_json_message` trigger of the MQTT component [(mqtt.html#on-json-message-trigger)](https://esphome.io/components/mqtt.html#on-json-message-trigger) attempts to map `then:` to the topic - this doesn't work and fails validation:

```
ERROR Error while reading config: Invalid YAML syntax:

mapping values are not allowed here
  in "/config/esphome/esp32_devkit.yaml", line 32, column 11:
          then:
              ^
```

**Related issue (if applicable):** fixes
**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
