### PR TITLE
Add smart intercom blogpost

### DIFF
--- a/guides/diy.rst
+++ b/guides/diy.rst
@@ -37,6 +37,7 @@ Blog Posts & Videos
 - `Detecting Sound with ESP8266 <https://thibmaek.com/post/detecting-sound-level-using-esp8266-and-esphome>`__ by `Thibault Maekelbergh <https://thibmaek.com>`__
 - `SW420 Vibration Sensor with Remote Notifications <https://github.com/rmooreID/Home-Assistant-Appliance-Monitor/>`__ by :ghuser:`rmooreID`
 - `DIY Irrigation Controller (with Internal Scheduler + Lovelace UI) <https://brianhanifin.com/posts/diy-irrigation-controller-esphome-home-assistant/>`__ by :ghuser:`BrianHanifin`
+- `Smart Intercom <https://frog32.ch/smart-intercom.html>`__ by `Marc Egli <https://frog32.ch/>`__ 
 
 Custom Components & Code
 ------------------------


### PR DESCRIPTION
Extend blog post list with an ESPhome related blogpost I wrote some time ago. It uses remote_receiver/remote_transmitter to intergrate with an existing bus intercom and will likely work with some adaptations with other intercoms.

## Description:


**Related issue (if applicable):** fixes none

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** none

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
