### PR TITLE
Not every nodeMCU board supports 12V

### DIFF
--- a/devices/nodemcu_esp8266.rst
+++ b/devices/nodemcu_esp8266.rst
@@ -49,8 +49,7 @@ Note that in certain conditions you *can* use the pins marked as ``INTERNAL`` in
   not be pulled low on startup. You can, however, still use them as output pins.
 - ``A0``: This pin can be used as a normal GPIO pin (like ``D1`` etc) but additionally can measure
   voltages from 0 to 1.0V using the :doc:`/components/sensor/adc`.
-- ``VIN``: This board can be powered by an external power supply by using this pin. Supply a voltage between
-  3.3V to 12V to this pin and the linear voltage regulator on the board will power the board.
+- ``VIN``: This board can be powered by an external power supply by using this pin. Supply a voltage depends on the board you use. Some boards support up to 12V, some up to 5V.
 - ``ENABLE``/``RESET``: When these pins are triggered, the board resets. The difference between the pins
   is how they can handle voltages above 3.3V.
 


### PR DESCRIPTION
## Description:
It could destroy the board if users just try and power it using 12V. There are boards that don't support 12V but only up to 5V.
