### PR TITLE
Add eco mode to climate

### DIFF
--- a/components/climate/index.rst
+++ b/components/climate/index.rst
@@ -81,6 +81,8 @@ Configuration variables:
   higher target temperature of a climate device with a two-point target temperature.
 - **away** (*Optional*, boolean, :ref:`templatable <config-templatable>`): Set the away mode
   of the climate device.
+- **eco_mode** (*Optional*, boolean, :ref:`templatable <config-templatable>`): Set eco mode
+  of the climate device.
 - **fan_mode** (*Optional*, boolean, :ref:`templatable <config-templatable>`): Set the fan mode
   of the climate device. One of ``ON``, ``OFF``, ``AUTO``, ``LOW``, ``MEDIUM``, ``HIGH``, ``MIDDLE``,
   ``FOCUS``, ``DIFFUSE``.
@@ -111,6 +113,8 @@ advanced stuff.
       id(my_climate).target_temperature_high
       // Away mode, type: bool
       id(my_climate).away
+      // Eco mode, type: bool
+      id(my_climate).eco_mode
       // Fan mode, type: FanMode (enum)
       id(my_climate).fan_mode
       // Swing mode, type: SwingMode (enum)


### PR DESCRIPTION
## Description:
Adds documentation for eco_mode on climate devices

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#1075

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
