### PR TITLE
Cookbook: BME280 Environment added dew point calculations

### DIFF
--- a/cookbook/bme280_environment.rst
+++ b/cookbook/bme280_environment.rst
@@ -40,6 +40,7 @@ After validating the sensor is working, we can proceed and add some formulas.
           return ((id(bme280_temperature).state + 273.15) / 0.0065) *
             (powf((STANDARD_SEA_LEVEL_PRESSURE / id(bme280_pressure).state), 0.190234) - 1); // in meter
         update_interval: 15s
+        icon: 'mdi:signal'
         unit_of_measurement: 'm'
       - platform: template
         name: "Absolute Humidity"
@@ -51,7 +52,13 @@ After validating the sensor is working, we can proceed and add some formulas.
             ((273.15 + id(bme280_temperature).state) * r); // in grams/m^3
         accuracy_decimals: 2
         update_interval: 15s
+        icon: 'mdi:water'
         unit_of_measurement: 'g/m³'
+      - platform: template
+        name: "Dew Point"
+        lambda: return return (243.5*(log(id(bme280_humidity).state/100)+((17.67*id(bme280_temperature).state)/(243.5+id(bme280_temperature).state)))/(17.67-log(id(bme280_humidity).state/100)-((17.67*id(bme280_temperature).state)/(243.5+id(bme280_temperature).state))));
+        unit_of_measurement: °C
+        icon: 'mdi:thermometer-alert'
 
 Altitude and absolute humidity:
 -------------------------------
@@ -112,6 +119,7 @@ Formula explanation
 
 - `Relative humidity calculations <https://carnotcycle.wordpress.com/2012/08/04/how-to-convert-relative-humidity-to-absolute-humidity/>`__
 - `Altitude calculation <https://en.wikipedia.org/wiki/Atmospheric_pressure#Altitude_variation>`__
+- `Dew Point calculation <https://carnotcycle.wordpress.com/2017/08/01/compute-dewpoint-temperature-from-rh-t/>`__
 
 See Also
 --------

--- a/cookbook/bme280_environment.rst
+++ b/cookbook/bme280_environment.rst
@@ -56,7 +56,9 @@ After validating the sensor is working, we can proceed and add some formulas.
         unit_of_measurement: 'g/m³'
       - platform: template
         name: "Dew Point"
-        lambda: return (243.5*(log(id(bme280_humidity).state/100)+((17.67*id(bme280_temperature).state)/(243.5+id(bme280_temperature).state)))/(17.67-log(id(bme280_humidity).state/100)-((17.67*id(bme280_temperature).state)/(243.5+id(bme280_temperature).state))));
+        lambda: return (243.5*(log(id(bme280_humidity).state/100)+((17.67*id(bme280_temperature).state)/
+        (243.5+id(bme280_temperature).state)))/(17.67-log(id(bme280_humidity).state/100)-
+        ((17.67*id(bme280_temperature).state)/(243.5+id(bme280_temperature).state))));
         unit_of_measurement: °C
         icon: 'mdi:thermometer-alert'
 

--- a/cookbook/bme280_environment.rst
+++ b/cookbook/bme280_environment.rst
@@ -56,7 +56,7 @@ After validating the sensor is working, we can proceed and add some formulas.
         unit_of_measurement: 'g/m³'
       - platform: template
         name: "Dew Point"
-        lambda: return return (243.5*(log(id(bme280_humidity).state/100)+((17.67*id(bme280_temperature).state)/(243.5+id(bme280_temperature).state)))/(17.67-log(id(bme280_humidity).state/100)-((17.67*id(bme280_temperature).state)/(243.5+id(bme280_temperature).state))));
+        lambda: return (243.5*(log(id(bme280_humidity).state/100)+((17.67*id(bme280_temperature).state)/(243.5+id(bme280_temperature).state)))/(17.67-log(id(bme280_humidity).state/100)-((17.67*id(bme280_temperature).state)/(243.5+id(bme280_temperature).state))));
         unit_of_measurement: °C
         icon: 'mdi:thermometer-alert'
 


### PR DESCRIPTION
**Description:**
Cookbook BME280 Environment with added dew point :thermometer: calculations and formula explanation link :link: 

Also added icon's to altitude :signal_strength: and absolute humidity :droplet: 

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
