### PR TITLE
Add Tuya Climate docs

### DIFF
--- a/components/climate/tuya.rst
+++ b/components/climate/tuya.rst
@@ -1,0 +1,59 @@
+Tuya Climate
+============
+
+.. seo::
+    :description: Instructions for setting up a Tuya climate device.
+    :image: air-conditioner.png
+
+The ``tuya`` climate platform creates a climate device from a tuya component.
+
+The Tuya fan requires a :doc:`/components/tuya` to be configured.
+
+.. code-block:: text
+
+    [22:03:11][C][tuya:023]: Tuya:
+    [22:03:11][C][tuya:032]:   Datapoint 1: switch (value: ON)
+    [22:03:11][C][tuya:032]:   Datapoint 2: switch (value: OFF)
+    [22:03:11][C][tuya:034]:   Datapoint 3: int value (value: 20)
+    [22:03:11][C][tuya:034]:   Datapoint 4: int value (value: 19)
+    [22:03:11][C][tuya:034]:   Datapoint 5: int value (value: 0)
+    [22:03:11][C][tuya:036]:   Datapoint 7: enum (value: 1)
+    [22:03:11][C][tuya:046]:   Product: '{"p":"ynjanlglr4qa6dxf","v":"1.0.0","m":0}'
+
+On this controller, the data points are:
+
+- 1 represents the climate on/off state.
+- 2 represents the child lock switch. (use the :doc:`/components/switch/tuya` component to control this)
+- 3 represents the target temperature.
+- 4 represents the current temperature.
+- 5 represents the timer but is not yet available to be used in ESPHome.
+- 7 represents the eco mode switch. (use the :doc:`/components/switch/tuya` component to control this)
+
+Based on this, you can create the climate device as follows:
+
+.. code-block:: yaml
+
+    climate:
+      - platform: tuya
+        name: "My Climate Device"
+        switch_datapoint: 1
+        target_temperature_datapoint: 3
+        current_temperature_datapoint: 4
+
+Configuration variables:
+------------------------
+
+- **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
+- **name** (**Required**, string): The name of the climate device.
+- **switch_datapoint** (**Required**, int): The datapoint id number of the climate switch.
+- **target_temperature_datapoint** (**Required**, int): The datapoint id number of the target temperature.
+- **current_temperature_datapoint** (**Required**, int): The datapoint id number of the current temperature.
+- All other options from :ref:`Climate <config-climate>`.
+
+See Also
+--------
+
+- :doc:`/components/tuya`
+- :doc:`/components/climate/index`
+- :apiref:`tuya/climate/tuya_climate.h`
+- :ghedit:`Edit`

--- a/index.rst
+++ b/index.rst
@@ -304,7 +304,7 @@ Climate Components
     Bang Bang Controller, components/climate/bang_bang, air-conditioner.svg
     Custom Climate, components/climate/custom, language-cpp.svg
     IR Remote Climate, components/climate/ir_climate, air-conditioner-ir.svg
-    Tuya Climate, components/climate/tuya, air-conditioner.svg
+    Tuya Climate, components/climate/tuya, tuya.png
 
 Misc Components
 ---------------

--- a/index.rst
+++ b/index.rst
@@ -304,6 +304,7 @@ Climate Components
     Bang Bang Controller, components/climate/bang_bang, air-conditioner.svg
     Custom Climate, components/climate/custom, language-cpp.svg
     IR Remote Climate, components/climate/ir_climate, air-conditioner-ir.svg
+    Tuya Climate, components/climate/tuya, air-conditioner.svg
 
 Misc Components
 ---------------


### PR DESCRIPTION
## Description:
Adds documentation for Tuya Climate devices.

Depends on #631

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#1076

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
