### PR TITLE
Add documentation for new WPA2-EAP authentication.

### DIFF
--- a/components/wifi.rst
+++ b/components/wifi.rst
@@ -165,6 +165,7 @@ Configuration variables:
 
 - **ssid** (*Optional*, string): The SSID or WiFi network name.
 - **password** (*Optional*, string): The password to use for authentication. Leave empty for no password.
+- **eap** (*Optional*): See :ref:`eap`.
 - **channel** (*Optional*, int): The channel of the network (1-14). If given, only connects to networks
   that are on this channel.
 - **bssid** (*Optional*, string): Optionally define a BSSID (MAC-Address) of the network to connect to.
@@ -174,6 +175,52 @@ Configuration variables:
 - **priority** (*Optional*, float): The priority of this network. After each time, the network with
   the highest priority is chosen. If the connection fails, the priority is decreased by one.
   Defaults to ``0``.
+
+.. _eap:
+
+Enterprise Authentication
+-------------------------
+
+WPA2_EAP Enterprise Authentication is supported on ESP32s.
+In order to configure this feature you must use the :ref:`wifi-networks` style configuration.
+The ESP32 is known to work with PEAP, EAP-TTLS, and the certificate based EAP-TLS.
+These are advanced settings and you will usually need to consult your enterprise network administrator.
+
+.. code-block:: yaml
+
+    # Example EAP configuration
+    wifi:
+      networks:
+      - ssid: EAP-TTLS_EnterpriseNetwork
+        eap:
+          username: bob
+          password: VerySafePassword
+      - ssid: EAP-TLS_EnterpriseNetwork
+        eap:
+          certificate_authority: |
+            -----BEGIN CERTIFICATE-----
+            ...
+            -----END CERTIFICATE-----
+          certificate: |
+            -----BEGIN CERTIFICATE-----
+            ...
+            -----END CERTIFICATE-----
+          key: |
+            -----BEGIN PRIVATE KEY-----
+            ...
+            -----END PRIVATE KEY-----
+
+Configuration variables:
+
+- **identity** (*Optional*, string): The outer identity to pass to the EAP authentication server.
+  This is required for EAP-TLS.
+- **username** (*Optional*, string): The username to present to the authenticating server.
+- **password** (*Optional*, string): The password to present to the authentication server.
+  For EAP-TLS this password may be set to decrypt to private key instead.
+- **certificate_authority** (*Optional*, block): A PEM encoded certificate to use when validating the authentication server.
+- **certificate** (*Optional*, block): A PEM encoded certificate to use for EAP-TLS authentication.
+- **key** (*Optional*, block): A PEM encoded private key matching ``certificate`` for EAP-TLS authentication.
+  Optionally encrypted with ``password``.
 
 .. _wifi-connected_condition:
 


### PR DESCRIPTION
## Description:
Add documentation for new WPA2-EAP Authentication configuration options. Allows multiple different types of configuration to be specified through selection of variables. 

**Related issue (if applicable):** closes esphome/feature-requests#35

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#1080

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
