### PR TITLE
documentation for version sensor hide timestamp option

### DIFF
--- a/components/text_sensor/version.rst
+++ b/components/text_sensor/version.rst
@@ -23,8 +23,25 @@ Configuration variables:
 ------------------------
 
 - **name** (**Required**, string): The name of the text sensor.
+- **hide_timestamp** (*Optional*, boolean): Allows you to hide the compilation timestamp from the version string. Defaults to ``False``.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
 - All other options from :ref:`Text Sensor <config-text_sensor>`.
+
+Disabling the compilation timestamp:
+------------------------------------
+
+.. code-block:: yaml    
+
+    # Example configuration entry
+    text_sensor:
+      - platform: version
+        name: "ESPHome Version"
+        hide_timestamp: True
+
+This will, for example, change the output of the senser from:
+
+``1.15.0-dev (Jun 8 2020, 18:53:16)`` to ``1.15.0-dev``
+
 
 See Also
 --------


### PR DESCRIPTION
## Description:

add option to version text sensor to hide the compilation timestamp

**Related issue (if applicable):** fixes https://github.com/esphome/feature-requests/issues/398

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#1085

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.