### PR TITLE
Documentation for templated output

### DIFF
--- a/components/output/template.rst
+++ b/components/output/template.rst
@@ -46,7 +46,7 @@ See :apiclass:`output::BinaryOutput` and :apiclass:`output::FloatOutput`.
 
 .. warning::
 
-    This is an **output component** and will not visible from the frontend. Output components are intermediary
+    This is an **output component** and will not be visible from the frontend. Output components are intermediary
     components that can be attached to for example lights.
 
 .. _output-template-on_write_action:

--- a/components/output/template.rst
+++ b/components/output/template.rst
@@ -72,7 +72,7 @@ It is possible to access the state value inside Lambdas:
                 - output.turn_off: button_off
 
 
-Complete example from the cookbook: </cookbook/sonoff-dual-light-switch>`.
+Complete example from the cookbook: :doc:`Sonoff Dual Light Switch</cookbook/sonoff-dual-light-switch>`.
 
 See Also
 --------

--- a/components/output/template.rst
+++ b/components/output/template.rst
@@ -1,0 +1,82 @@
+Template Output
+===============
+
+.. seo::
+    :description: Instructions for setting up template outputs with ESPHome.
+    :image: description.png
+
+The ``template`` output component can be used to create templated binary and float outputs in ESPHome.
+
+.. code-block:: yaml
+
+    # Example configuration entry
+    output:
+      - platform: template
+        id: outputsplit
+        type: float
+        write_action:
+          - output.set_level:
+              id: output1
+              level: !lambda return state;
+          - output.set_level:
+              id: output2
+              level: !lambda return state;
+
+      - platform: esp8266_pwm
+        id: output1
+        pin: GPIO12
+        inverted: true
+      - platform: esp8266_pwm
+        id: output2
+        pin: GPIO14
+        inverted: true
+
+
+
+Configuration variables:
+------------------------
+
+- **id** (**Required**, :ref:`config-id`): The id to use for this output component.
+- **type** (**Required**, string): The type of output. One of ``binary`` and ``float``.
+- **on_write_action** (*Required*, :ref:`Action <config-action>`): The action that should
+  be performed when the state of the output is updated.
+- All other options from :ref:`Output <config-output>`.
+
+See :apiclass:`output::BinaryOutput` and :apiclass:`output::FloatOutput`.
+
+.. warning::
+
+    This is an **output component** and will not visible from the frontend. Output components are intermediary
+    components that can be attached to for example lights.
+
+.. _output-template-on_write_action:
+
+``output.template.on_write`` Action
+-----------------------------------
+
+When the state for this output is updated, the on_write action is executed. 
+It is possible to access the state value inside Lambdas:
+
+.. code-block:: yaml  
+
+    - platform: template
+        id: my_output
+        type: float
+        write_action:
+          - if:
+              condition:
+                lambda: return ((state > 0) && (state < .4));
+              then:
+                - output.turn_on: button_off
+                - delay: 500ms
+                - output.turn_off: button_off
+
+
+Complete example from the cookbook: </cookbook/sonoff-dual-light-switch>`.
+
+See Also
+--------
+
+- :doc:`/components/output/index`
+- :ref:`automation`
+- :ghedit:`Edit`

--- a/index.rst
+++ b/index.rst
@@ -196,6 +196,7 @@ Output Components
     MY9231/MY9291, components/output/my9231, my9231.svg
     SM16716, components/output/sm16716, sm16716.svg
     Custom Output, components/output/custom, language-cpp.svg
+    Template Output, components/output/template, description.svg
 
 Light Components
 ----------------


### PR DESCRIPTION
## Description:

Created a documentation page for template output

## Checklist:

  - [X] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [X] Link added in `/index.rst` when creating new documents for new components or cookbook.
