### PR TITLE
Typo, pressure->humidity

### DIFF
--- a/components/sensor/bme680.rst
+++ b/components/sensor/bme680.rst
@@ -55,7 +55,7 @@ Configuration variables:
   - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.
   - All other options from :ref:`Sensor <config-sensor>`.
 
-- **humidity** (**Required**): The information for the pressure sensor.
+- **humidity** (**Required**): The information for the humidity sensor.
 
   - **name** (**Required**, string): The name for the humidity sensor.
   - **oversampling** (*Optional*): The oversampling parameter for the temperature sensor.


### PR DESCRIPTION
## Description:
Fix typo, pressure should be humidity on this line.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
