### PR TITLE
color interlock

### DIFF
--- a/components/light/rgbw.rst
+++ b/components/light/rgbw.rst
@@ -20,7 +20,7 @@ The ``rgbw`` light platform creates an RGBW light from 4 :ref:`float output comp
         color_interlock: true
 
 Color Interlock
-----------------
+---------------
 
 With some LED bulbs, setting the RGB channels to maximum whilst wanting a white light will 
 have a undesired hue affect. Additionally, the brightness command may not work as expected 

--- a/components/light/rgbw.rst
+++ b/components/light/rgbw.rst
@@ -17,7 +17,7 @@ The ``rgbw`` light platform creates an RGBW light from 4 :ref:`float output comp
         green: output_component2
         blue: output_component3
         white: output_component4
-        color_interlock: True
+        color_interlock: true
 
 Color Interlock
 ----------------
@@ -42,7 +42,7 @@ allows the brightness parameter to control the intensity of the white leds.
         green: output_component2
         blue: output_component3
         white: output_component4
-        color_interlock: True
+        color_interlock: true
 
 Configuration variables:
 ------------------------

--- a/components/light/rgbw.rst
+++ b/components/light/rgbw.rst
@@ -17,6 +17,32 @@ The ``rgbw`` light platform creates an RGBW light from 4 :ref:`float output comp
         green: output_component2
         blue: output_component3
         white: output_component4
+        color_interlock: True
+
+Color Interlock
+----------------
+
+With some LED bulbs, setting the RGB channels to maximum whilst wanting a white light will 
+have a undesired hue affect. Additionally, the brightness command may not work as expected 
+depending upon configuration, leaving users to adjust the white component level separately. 
+For these cases a new configration variable has been added: color_interlock. 
+
+Setting this variable to True will turn off RGB leds when white value is above 0 (or if they
+are to 255,255,255) and turn off white leds if color is not set to 255,255,255. This also 
+allows the brightness parameter to control the intensity of the white leds.
+
+
+.. code-block:: yaml
+
+    # Example configuration entry
+    light:
+      - platform: rgbw
+        name: "Livingroom Lights"
+        red: output_component1
+        green: output_component2
+        blue: output_component3
+        white: output_component4
+        color_interlock: True
 
 Configuration variables:
 ------------------------
@@ -28,6 +54,7 @@ Configuration variables:
 - **white** (**Required**, :ref:`config-id`): The id of the float :ref:`output` to use for the white channel.
 - **effects** (*Optional*, list): A list of :ref:`light effects <light-effects>` to use for this light.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
+- **color_interlock** (*Optional*, boolean): When enabled, this will prevent white leds being on at the same time as RGB leds. Defaults to ``false``.
 - All other options from :ref:`Light <config-light>`.
 
 See Also

--- a/components/light/rgbw.rst
+++ b/components/light/rgbw.rst
@@ -19,31 +19,6 @@ The ``rgbw`` light platform creates an RGBW light from 4 :ref:`float output comp
         white: output_component4
         color_interlock: true
 
-Color Interlock
----------------
-
-With some LED bulbs, setting the RGB channels to maximum whilst wanting a white light will 
-have a undesired hue affect. Additionally, the brightness command may not work as expected 
-depending upon configuration, leaving users to adjust the white component level separately. 
-For these cases a new configration variable has been added: color_interlock. 
-
-Setting this variable to True will turn off RGB leds when white value is above 0 (or if they
-are to 255,255,255) and turn off white leds if color is not set to 255,255,255. This also 
-allows the brightness parameter to control the intensity of the white leds.
-
-
-.. code-block:: yaml
-
-    # Example configuration entry
-    light:
-      - platform: rgbw
-        name: "Livingroom Lights"
-        red: output_component1
-        green: output_component2
-        blue: output_component3
-        white: output_component4
-        color_interlock: true
-
 Configuration variables:
 ------------------------
 
@@ -53,9 +28,24 @@ Configuration variables:
 - **blue** (**Required**, :ref:`config-id`): The id of the float :ref:`output` to use for the blue channel.
 - **white** (**Required**, :ref:`config-id`): The id of the float :ref:`output` to use for the white channel.
 - **effects** (*Optional*, list): A list of :ref:`light effects <light-effects>` to use for this light.
+- **color_interlock** (*Optional*, boolean): When enabled, this will prevent white leds being on at the same
+  time as RGB leds. See :ref:`rgbw_color_interlock` for more information. Defaults to ``false``.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
-- **color_interlock** (*Optional*, boolean): When enabled, this will prevent white leds being on at the same time as RGB leds. Defaults to ``false``.
 - All other options from :ref:`Light <config-light>`.
+
+.. _rgbw_color_interlock:
+
+Color Interlock
+***************
+
+With some LED bulbs, setting the RGB channels to maximum whilst wanting a white light will have a undesired
+hue affect. Additionally, the brightness command may not work as expected depending upon configuration,
+leaving users to adjust the white component level separately. For these cases a new configration variable
+has been added: color_interlock.
+
+Setting this variable to True will turn off RGB leds when white value is above 0 (or if they are to 255,255,255)
+and turn off white leds if color is not set to 255,255,255. This also allows the brightness parameter to
+control the intensity of the white leds.
 
 See Also
 --------

--- a/components/light/rgbww.rst
+++ b/components/light/rgbww.rst
@@ -23,6 +23,32 @@ and warm white channels will be mixed using the color temperature configuration 
         cold_white_color_temperature: 6536 K
         warm_white_color_temperature: 2000 K
         constant_brightness: true
+        color_interlock: True
+
+Color Interlock
+----------------
+
+With some LED bulbs, setting the RGB channels to maximum whilst wanting a white light will 
+have a undesired hue affect. Additionally, the brightness command may not work as expected 
+depending upon configuration, leaving users to adjust the white component level separately. 
+For these cases a new configration variable has been added: color_interlock. 
+
+Setting this variable to True will turn off RGB leds when white value is above 0 (or if they
+are to 255,255,255) and turn off white leds if color is not set to 255,255,255. This also 
+allows the brightness parameter to control the intensity of the white leds.
+
+
+.. code-block:: yaml
+
+    # Example configuration entry
+    light:
+      - platform: rgbw
+        name: "Livingroom Lights"
+        red: output_component1
+        green: output_component2
+        blue: output_component3
+        white: output_component4
+        color_interlock: True
 
 Configuration variables:
 ------------------------
@@ -38,6 +64,7 @@ Configuration variables:
 - **warm_white_color_temperature** (**Required**, float): The color temperate (in `mireds <https://en.wikipedia.org/wiki/Mired>`__ or Kelvin)
   of the warm white channel.
 - **constant_brightness** (*Optional*, boolean): When enabled, this will keep the overall brightness of the cold and warm white channels constant by limiting the combined output to 100% of a single channel. This reduces the possible overall brightness but is necessary for some power supplies that are not able to run both channels at full brightness at once. Defaults to ``false``.
+- **color_interlock** (*Optional*, boolean): When enabled, this will prevent white leds being on at the same time as RGB leds. Defaults to ``false``.
 - **effects** (*Optional*, list): A list of :ref:`light effects <light-effects>` to use for this light.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
 - All other options from :ref:`Light <config-light>`.

--- a/components/light/rgbww.rst
+++ b/components/light/rgbww.rst
@@ -23,7 +23,7 @@ and warm white channels will be mixed using the color temperature configuration 
         cold_white_color_temperature: 6536 K
         warm_white_color_temperature: 2000 K
         constant_brightness: true
-        color_interlock: True
+        color_interlock: true
 
 Color Interlock
 ----------------
@@ -48,7 +48,7 @@ allows the brightness parameter to control the intensity of the white leds.
         green: output_component2
         blue: output_component3
         white: output_component4
-        color_interlock: True
+        color_interlock: true
 
 Configuration variables:
 ------------------------

--- a/components/light/rgbww.rst
+++ b/components/light/rgbww.rst
@@ -26,7 +26,7 @@ and warm white channels will be mixed using the color temperature configuration 
         color_interlock: true
 
 Color Interlock
-----------------
+---------------
 
 With some LED bulbs, setting the RGB channels to maximum whilst wanting a white light will 
 have a undesired hue affect. Additionally, the brightness command may not work as expected 

--- a/components/light/rgbww.rst
+++ b/components/light/rgbww.rst
@@ -25,30 +25,6 @@ and warm white channels will be mixed using the color temperature configuration 
         constant_brightness: true
         color_interlock: true
 
-Color Interlock
----------------
-
-With some LED bulbs, setting the RGB channels to maximum whilst wanting a white light will 
-have a undesired hue affect. Additionally, the brightness command may not work as expected 
-depending upon configuration, leaving users to adjust the white component level separately. 
-For these cases a new configration variable has been added: color_interlock. 
-
-Setting this variable to True will turn off RGB leds when white value is above 0 (or if they
-are to 255,255,255) and turn off white leds if color is not set to 255,255,255. This also 
-allows the brightness parameter to control the intensity of the white leds.
-
-
-.. code-block:: yaml
-
-    # Example configuration entry
-    light:
-      - platform: rgbw
-        name: "Livingroom Lights"
-        red: output_component1
-        green: output_component2
-        blue: output_component3
-        white: output_component4
-        color_interlock: true
 
 Configuration variables:
 ------------------------
@@ -57,14 +33,20 @@ Configuration variables:
 - **red** (**Required**, :ref:`config-id`): The id of the float :ref:`output` to use for the red channel.
 - **green** (**Required**, :ref:`config-id`): The id of the float :ref:`output` to use for the green channel.
 - **blue** (**Required**, :ref:`config-id`): The id of the float :ref:`output` to use for the blue channel.
-- **cold_white** (**Required**, :ref:`config-id`): The id of the float :ref:`output` to use for the cold white channel.
-- **warm_white** (**Required**, :ref:`config-id`): The id of the float :ref:`output` to use for the warm white channel.
-- **cold_white_color_temperature** (**Required**, float): The color temperate (in `mireds <https://en.wikipedia.org/wiki/Mired>`__ or Kelvin)
-  of the cold white channel.
-- **warm_white_color_temperature** (**Required**, float): The color temperate (in `mireds <https://en.wikipedia.org/wiki/Mired>`__ or Kelvin)
-  of the warm white channel.
-- **constant_brightness** (*Optional*, boolean): When enabled, this will keep the overall brightness of the cold and warm white channels constant by limiting the combined output to 100% of a single channel. This reduces the possible overall brightness but is necessary for some power supplies that are not able to run both channels at full brightness at once. Defaults to ``false``.
-- **color_interlock** (*Optional*, boolean): When enabled, this will prevent white leds being on at the same time as RGB leds. Defaults to ``false``.
+- **cold_white** (**Required**, :ref:`config-id`): The id of the float :ref:`output` to use for the cold
+  white channel.
+- **warm_white** (**Required**, :ref:`config-id`): The id of the float :ref:`output` to use for the warm
+  white channel.
+- **cold_white_color_temperature** (**Required**, float): The color temperate (in
+  `mireds <https://en.wikipedia.org/wiki/Mired>`__ or Kelvin) of the cold white channel.
+- **warm_white_color_temperature** (**Required**, float): The color temperate (in
+  `mireds <https://en.wikipedia.org/wiki/Mired>`__ or Kelvin) of the warm white channel.
+- **constant_brightness** (*Optional*, boolean): When enabled, this will keep the overall brightness of the
+  cold and warm white channels constant by limiting the combined output to 100% of a single channel. This
+  reduces the possible overall brightness but is necessary for some power supplies that are not able to run
+  both channels at full brightness at once. Defaults to ``false``.
+- **color_interlock** (*Optional*, boolean): When enabled, this will prevent white leds being on at the same
+  time as RGB leds. See :ref:`rgbw_color_interlock` for more information. Defaults to ``false``.
 - **effects** (*Optional*, list): A list of :ref:`light effects <light-effects>` to use for this light.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
 - All other options from :ref:`Light <config-light>`.


### PR DESCRIPTION
## Description:
Adds in the description for the color_interlock variable for RGBW and RGBWW components

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#1042

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
