### PR TITLE
Add documentation for climate.pid.reset_integral_term action

### DIFF
--- a/components/climate/pid.rst
+++ b/components/climate/pid.rst
@@ -212,6 +212,23 @@ Configuration variables:
 - **negative_output** (*Optional*, float): The positive output power to drive the cool output at.
   Defaults to ``-1.0``.
 
+
+``climate.pid.reset_integral_term`` Action
+------------------------------------------
+
+This action resets the integral term of the PID controller to 0. This might be necessary under certain
+to avoid the control loop to overshoot (or undershoot) a target.
+
+.. code-block:: yaml
+
+    on_...:
+      # Basic
+      - climate.pid.reset_integral_term: pid_climate     
+
+Configuration variables:
+
+- **id** (**Required**, :ref:`config-id`): ID of the PID Climate to start autotuning for.
+
 PID Climate Sensor
 ------------------
 

--- a/components/climate/pid.rst
+++ b/components/climate/pid.rst
@@ -217,7 +217,7 @@ Configuration variables:
 ------------------------------------------
 
 This action resets the integral term of the PID controller to 0. This might be necessary under certain
-to avoid the control loop to overshoot (or undershoot) a target.
+conditions to avoid the control loop to overshoot (or undershoot) a target.
 
 .. code-block:: yaml
 
@@ -227,7 +227,7 @@ to avoid the control loop to overshoot (or undershoot) a target.
 
 Configuration variables:
 
-- **id** (**Required**, :ref:`config-id`): ID of the PID Climate to start autotuning for.
+- **id** (**Required**, :ref:`config-id`): ID of the PID Climate being reset.
 
 PID Climate Sensor
 ------------------


### PR DESCRIPTION
## Description:
Add documentation for this the climate.pid.reset_integral_term action.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#1104

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
