### PR TITLE
Add Tuya Binary Sensor docs

### DIFF
--- a/components/binary_sensor/tuya.rst
+++ b/components/binary_sensor/tuya.rst
@@ -1,0 +1,33 @@
+Tuya Binary Sensor
+==================
+
+.. seo::
+    :description: Instructions for setting up a Tuya device binary sensor.
+
+The ``tuya`` binary sensor platform creates a binary sensor from a
+tuya serial component and requires :doc:`/components/tuya` to be configured.
+
+You can create the binary sensor as follows:
+
+.. code-block:: yaml
+
+    # Create a binary sensor
+    binary_sensor:
+      - platform: "tuya"
+        name: "MyBinarySensor"
+        sensor_datapoint: 1
+
+Configuration variables:
+------------------------
+
+- **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
+- **name** (**Required**, string): The name of the binary sensor.
+- **sensor_datapoint** (**Required**, int): The datapoint id number of the binary sensor.
+- All other options from :ref:`Binary Sensor <config-binary_sensor>`.
+
+See Also
+--------
+
+- :doc:`/components/binary_sensor/index`
+- :apiref:`tuya/switch/tuya_binary_sensor.h`
+- :ghedit:`Edit`

--- a/components/binary_sensor/tuya.rst
+++ b/components/binary_sensor/tuya.rst
@@ -30,5 +30,5 @@ See Also
 
 - :doc:`/components/tuya`
 - :doc:`/components/binary_sensor/index`
-- :apiref:`tuya/switch/tuya_binary_sensor.h`
+- :apiref:`tuya/binary_sensor/tuya_binary_sensor.h`
 - :ghedit:`Edit`

--- a/components/binary_sensor/tuya.rst
+++ b/components/binary_sensor/tuya.rst
@@ -5,7 +5,7 @@ Tuya Binary Sensor
     :description: Instructions for setting up a Tuya device binary sensor.
 
 The ``tuya`` binary sensor platform creates a binary sensor from a
-tuya serial component and requires :doc:`/components/tuya` to be configured.
+tuya component and requires :doc:`/components/tuya` to be configured.
 
 You can create the binary sensor as follows:
 
@@ -28,6 +28,7 @@ Configuration variables:
 See Also
 --------
 
+- :doc:`/components/tuya`
 - :doc:`/components/binary_sensor/index`
 - :apiref:`tuya/switch/tuya_binary_sensor.h`
 - :ghedit:`Edit`

--- a/index.rst
+++ b/index.rst
@@ -186,7 +186,7 @@ Binary Sensor Components
     PN532, components/binary_sensor/pn532, pn532.jpg
     RDM6300, components/binary_sensor/rdm6300, rdm6300.jpg
     TTP229, components/binary_sensor/ttp229, ttp229.jpg
-    Tuya Binary Sensor, components/binary_sensor/tuya, tuya.jpg
+    Tuya Binary Sensor, components/binary_sensor/tuya, tuya.png
     Custom Binary Sensor, components/binary_sensor/custom, language-cpp.svg
 
 Output Components

--- a/index.rst
+++ b/index.rst
@@ -186,6 +186,7 @@ Binary Sensor Components
     PN532, components/binary_sensor/pn532, pn532.jpg
     RDM6300, components/binary_sensor/rdm6300, rdm6300.jpg
     TTP229, components/binary_sensor/ttp229, ttp229.jpg
+    Tuya, components/binary_sensor/tuya, tuya.jpg
     Custom Binary Sensor, components/binary_sensor/custom, language-cpp.svg
 
 Output Components

--- a/index.rst
+++ b/index.rst
@@ -186,7 +186,7 @@ Binary Sensor Components
     PN532, components/binary_sensor/pn532, pn532.jpg
     RDM6300, components/binary_sensor/rdm6300, rdm6300.jpg
     TTP229, components/binary_sensor/ttp229, ttp229.jpg
-    Tuya, components/binary_sensor/tuya, tuya.jpg
+    Tuya Binary Sensor, components/binary_sensor/tuya, tuya.jpg
     Custom Binary Sensor, components/binary_sensor/custom, language-cpp.svg
 
 Output Components


### PR DESCRIPTION
## Description:
Adds documentation for Tuya Binary Sensors

Depends on #631

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#1089

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
