### PR TITLE
Brightness support for Nextion display

### DIFF
--- a/components/display/nextion.rst
+++ b/components/display/nextion.rst
@@ -39,7 +39,8 @@ Configuration variables:
 
 - **uart_id** (*Optional*, :ref:`config-id`): The ID of the :ref:`UART bus <uart>` you wish to use for this display.
   Use this if you want to use multiple UART buses at once.
-- **brightness** (*Optional*): Set the screen brightness in percents 0.0-1.0. Defaults to `1.0` that corresponds to 100%.
+- **brightness** (*Optional*, percentage): Set the screen brightness. Must be in range
+  ``0%`` to ``100%`` or ``0.0`` to ``1.0``. Defaults to ``100%``.
 - **lambda** (*Optional*, :ref:`lambda <config-lambda>`): The lambda to use for rendering the content on the nextion display.
   See :ref:`display-nextion_lambda` for more information.
 - **update_interval** (*Optional*, :ref:`config-time`): The interval to call the lambda to update the display.

--- a/components/display/nextion.rst
+++ b/components/display/nextion.rst
@@ -39,6 +39,7 @@ Configuration variables:
 
 - **uart_id** (*Optional*, :ref:`config-id`): The ID of the :ref:`UART bus <uart>` you wish to use for this display.
   Use this if you want to use multiple UART buses at once.
+- **brightness** (*Optional*): Set the screen brightness in percents 0.0-1.0. Defaults to `1.0` that corresponds to 100%.
 - **lambda** (*Optional*, :ref:`lambda <config-lambda>`): The lambda to use for rendering the content on the nextion display.
   See :ref:`display-nextion_lambda` for more information.
 - **update_interval** (*Optional*, :ref:`config-time`): The interval to call the lambda to update the display.


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** 

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#1109

Support setting Nextion brightness in the configuration file.

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
