### PR TITLE
Update pzemac.rst set stop_bits to 1

### DIFF
--- a/components/sensor/pzemac.rst
+++ b/components/sensor/pzemac.rst
@@ -38,7 +38,7 @@ to some pins on your board and the baud rate set to 9600.
       rx_pin: D1
       tx_pin: D2
       baud_rate: 9600
-      stop_bits: 2
+      stop_bits: 1
 
     sensor:
       - platform: pzemac


### PR DESCRIPTION
Could not get the sensor to work with stop_bits set to 2, found [this comment](https://github.com/esphome/issues/issues/817#issuecomment-552798845) recommending to use stop_bits: 1 and now it works.
