### PR TITLE
Fix mcp230xx doc

### DIFF
--- a/components/mcp230xx.rst
+++ b/components/mcp230xx.rst
@@ -53,7 +53,7 @@ Configuration variables:
 MCP23008
 --------
 
-The configuration is essentially the same with the MCP23008 component
+The configuration is essentially the same with the MCP23017 component
 (`datasheet <http://ww1.microchip.com/downloads/en/devicedoc/21919e.pdf>`__,
 `Adafruit <https://www.adafruit.com/product/593>`__):
 


### PR DESCRIPTION
## Description:


**Related issue (if applicable):**

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

Fix misspelling in mcp230xx.

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
