### PR TITLE
Docs for Setting control parameters on PID

### DIFF
--- a/components/climate/pid.rst
+++ b/components/climate/pid.rst
@@ -213,7 +213,7 @@ Configuration variables:
   Defaults to ``-1.0``.
 
 ``climate.pid.set_control_parameters`` Action
--------------------------------
+---------------------------------------------
 
 This action sets new values for the control parameters of the PID controller. This can be 
 used to manually tune the PID controller. Make sure to take update the values you want on 

--- a/components/climate/pid.rst
+++ b/components/climate/pid.rst
@@ -215,7 +215,9 @@ Configuration variables:
 ``climate.pid.set_control_parameters`` Action
 -------------------------------
 
-This action sets new values for the control parameters of the PID controller.
+This action sets new values for the control parameters of the PID controller. This can be 
+used to manually tune the PID controller. Make sure to take update the values you want on 
+the YAML file! They will reset on the next reboot.
 
 .. code-block:: yaml
 

--- a/components/climate/pid.rst
+++ b/components/climate/pid.rst
@@ -212,6 +212,28 @@ Configuration variables:
 - **negative_output** (*Optional*, float): The positive output power to drive the cool output at.
   Defaults to ``-1.0``.
 
+``climate.pid.set_control_parameters`` Action
+-------------------------------
+
+This action sets new values for the control parameters of the PID controller.
+
+.. code-block:: yaml
+
+    on_...:
+      - climate.pid.set_control_parameters:
+          id: pid_climate
+          kp: 0.0
+          ki: 0.0
+          kd: 0.0
+
+Configuration variables:
+
+- **id** (**Required**, :ref:`config-id`): ID of the PID Climate to start autotuning for.
+- **kp** (**Required**, float): The factor for the proportional term of the PID controller.
+- **ki** (*Optional*, float): The factor for the integral term of the PID controller.
+  Defaults to ``0``.
+- **kd** (*Optional*, float): The factor for the derivative term of the PID controller.
+  Defaults to ``0``.
 
 ``climate.pid.reset_integral_term`` Action
 ------------------------------------------
@@ -254,6 +276,9 @@ Configuration variables:
   - ``DERIVATIVE`` - The derivative term of the PID controller.
   - ``HEAT`` - The resulting heating power to the supplied to the ``heat_output``.
   - ``COOL`` - The resulting cooling power to the supplied to the ``cool_output``.
+  - ``KP`` - The current factor for the proportional term of the PID controller.
+  - ``KI`` - The current factor for the integral term of the PID controller.
+  - ``KD`` - The current factor for the differential term of the PID controller.
 
 Advanced options:
 


### PR DESCRIPTION
## Description:
Added documentation for sensors and action used to set the PID control parameters manually after flashing the firmware

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#1115

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
