### PR TITLE
Added Paradox alarm system custom component

### DIFF
--- a/guides/diy.rst
+++ b/guides/diy.rst
@@ -66,6 +66,7 @@ Custom Components & Code
 - `Custom Smart meter P1 port reader <https://github.com/nldroid/CustomP1UartComponent>`__ by :ghuser:`nldroid`
 - `Custom Mitsubishi HVAC HeatPump control using UART <https://github.com/geoffdavis/esphome-mitsubishiheatpump>`__ by :ghuser:`geoffdavis`
 - `Jura Impressa J6 coffee machine custom component <https://github.com/ryanalden/esphome-jura-component>`__ by :ghuser:`ryanalden`
+- `Paradox alarm system sensors custom component <https://github.com/Margriko/Paradox-ESPHome>`__ by :ghuser:`Margriko`
 
 Sample Configurations
 ---------------------


### PR DESCRIPTION
## Description:
Added a DIY custom component example of reading Paradox alarm system sensor states. 

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** N/A

## Checklist:

  - [X] Branch: `current`.
  - [N/A] Link added in `/index.rst` when creating new documents for new components or cookbook.
