### PR TITLE
Improve RGBW(W) docs

### DIFF
--- a/components/light/rgbw.rst
+++ b/components/light/rgbw.rst
@@ -17,7 +17,6 @@ The ``rgbw`` light platform creates an RGBW light from 4 :ref:`float output comp
         green: output_component2
         blue: output_component3
         white: output_component4
-        color_interlock: true
 
 Configuration variables:
 ------------------------

--- a/components/light/rgbww.rst
+++ b/components/light/rgbww.rst
@@ -22,8 +22,6 @@ and warm white channels will be mixed using the color temperature configuration 
         warm_white: output_component5
         cold_white_color_temperature: 6536 K
         warm_white_color_temperature: 2000 K
-        constant_brightness: true
-        color_interlock: true
 
 
 Configuration variables:


### PR DESCRIPTION
## Description:

The example configuration should preferably contain values that most users want to use.

Reason: Many users will copy-paste this into their configs, without looking at what the config options mean. As these options are for minor (in frequency) use cases, I removed them from the example config.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
