### PR TITLE
Update GH Actions CI Workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,23 +2,24 @@ name: Lint
 
 on:
   push:
+    # On other branches the `pull_request` trigger will be used
+    branches: [current, next]
+
   pull_request:
+    # Only trigger on certain events (not when comments are added)
+    types: [opened, reopened, synchronize]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.6
+    - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
-        python-version: 3.6
+        python-version: 3.8
     - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      run: pip install -r requirements.txt
     - name: Lint
       run: |
         python travis.py

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,8 +6,6 @@ on:
     branches: [current, next]
 
   pull_request:
-    # Only trigger on certain events (not when comments are added)
-    types: [opened, reopened, synchronize]
 
 jobs:
   build:


### PR DESCRIPTION
## Description:

Primary change is to not build twice for branches on this remote. ~~And restricts the pull request trigger to only certain events (so that it doesn't trigger on anything like comments)~~

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
