### PR TITLE
Update mirabella-genio-bulb.rst

### DIFF
--- a/cookbook/mirabella-genio-bulb.rst
+++ b/cookbook/mirabella-genio-bulb.rst
@@ -10,6 +10,8 @@ The Mirabella Genio is a Tuya-based smart bulb sold by Kmart in Australia.
 Originally intended to be used with their companion app once flashed using `tuya-convert <https://github.com/ct-Open-Source/tuya-convert>`__ ESPHome generated
 firmware can be uploaded allowing you to control the bulbs via Home Assistant.
 
+Please note that the new version of this bulb that comes in a cardboard box does NOT have an ESP chipset inside and cannot be flashed.
+
 1. Create the ESPHome Firmware
 ------------------------------
 


### PR DESCRIPTION
New version of this bulb does not have a ESP chip anymore

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
