### PR TITLE
Update pip to pip3

### DIFF
--- a/guides/getting_started_command_line.rst
+++ b/guides/getting_started_command_line.rst
@@ -14,11 +14,11 @@ Installation
 
 Installing ESPHome is very easy. All you need to do is have `Python
 <https://www.python.org/>`__ installed and install the console script through
-``pip``.
+``pip3``.
 
 .. code-block:: bash
 
-    pip install esphome
+    pip3 install esphome
 
 Alternatively, there’s also a Docker image available for easy
 installation (the Docker hub image is only available for AMD64 right now; if you have


### PR DESCRIPTION
Changing the instruction of "pip install" to "pip3 install" instead, due to the warning: "You're using ESPHome with python 2. Support for python 2 is deprecated and will be removed in 1.15.0. Please reinstall ESPHome with python 3.6 or higher."

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
