### PR TITLE
Partially Revert make SPI CS pin optional

### DIFF
--- a/components/binary_sensor/pn532.rst
+++ b/components/binary_sensor/pn532.rst
@@ -47,8 +47,8 @@ to have an :ref:`SPI bus <spi>` in your configuration with both the **miso_pin**
 Configuration variables:
 ************************
 
-- **cs_pin** (*Optional*, :ref:`Pin Schema <config-pin_schema>`): The pin on the ESP that that the CS line is connected to.
-  The CS line can be connected to GND if this is the only device on the SPI bus.
+- **cs_pin** (**Required**, :ref:`Pin Schema <config-pin_schema>`): The pin on the ESP that the chip select line
+  is connected to.
 - **update_interval** (*Optional*, :ref:`config-time`): The duration of each scan on the PN532. This affects the
   duration that the individual binary sensors stay active when they're found.
   If a device is not found within this time window, it will be marked as not present. Defaults to 1s.

--- a/components/display/max7219.rst
+++ b/components/display/max7219.rst
@@ -19,7 +19,7 @@ with ESPHome. Please note that this integration is *only* for 7-segment display,
 As the communication with the MAX7219 is done using SPI for this integration, you need
 to have an :ref:`SPI bus <spi>` in your configuration with both the **mosi_pin** set (miso_pin is not required).
 Connect VCC to 3.3V (the manufacturer recommends 4+ V, but 3.3V seems to work fine), DIN to your ``mosi_pin`` and
-CS to your set ``cs_pin`` (or to GND if this is the only device on the SPI bus) and finally GND to GND.
+CS to your set ``cs_pin`` and finally GND to GND.
 
 You can even daisy-chain multiple MAX7219s by connecting the DOUT of the previous chip in the chain to the
 next DIN. With more than ~3 chips the 3.3V will probably not be enough, so then you will have to potentially
@@ -42,8 +42,7 @@ use a logic level converted.
 Configuration variables:
 ------------------------
 
-- **cs_pin** (*Optional*, :ref:`Pin Schema <config-pin_schema>`): The pin on the ESP that that the CS line is connected to.
-  The CS line can be connected to GND if this is the only device on the SPI bus.
+- **cs_pin** (**Required**, :ref:`Pin Schema <config-pin_schema>`): The pin you have the CS line hooked up to.
 - **num_chips** (*Optional*, integer): The number of chips you wish to use for daisy chaining. Defaults to
   ``1``.
 - **intensity** (*Optional*, integer): The intensity with which the MAX7219 should drive the outputs. Range is from

--- a/components/display/ssd1306.rst
+++ b/components/display/ssd1306.rst
@@ -94,9 +94,9 @@ If your SSD1306 or SH1106 is connected via the :ref:`I²C Bus <i2c>`, see :ref:`
     SSD1306 OLED Display
 
 Connect D0 to the CLK pin you chose for the :ref:`SPI bus <spi>`, connect D1 to the MOSI pin and ``DC`` and ``CS``
-to some GPIO pins on the ESP. If this is the only device on the SPI bus, the ``CS`` pin can be connected to GND.
-For power, connect VCC to 3.3V and GND to GND.
-Optionally you can also connect the ``RESET`` pin to a pin on the ESP which may improve reliability.
+to some GPIO pins on the ESP. For power, connect
+VCC to 3.3V and GND to GND. Optionally you can also connect the ``RESET`` pin to a pin on the ESP which may
+improve reliability.
 
 .. code-block:: yaml
 
@@ -128,8 +128,7 @@ Configuration variables:
   - ``SH1106 96x16``
   - ``SH1106 64x48``
 
-- **cs_pin** (*Optional*, :ref:`Pin Schema <config-pin_schema>`): The pin on the ESP that that the CS line is connected to.
-  The CS line can be connected to GND if this is the only device on the SPI bus.
+- **cs_pin** (**Required**, :ref:`Pin Schema <config-pin_schema>`): The Chip Select (CS) pin.
 - **dc_pin** (**Required**, :ref:`Pin Schema <config-pin_schema>`): The DC pin.
 - **reset_pin** (*Optional*, :ref:`Pin Schema <config-pin_schema>`): The RESET pin. Defaults to not connected.
 - **rotation** (*Optional*): Set the rotation of the display. Everything you draw in ``lambda:`` will be rotated

--- a/components/display/ssd1325.rst
+++ b/components/display/ssd1325.rst
@@ -58,7 +58,8 @@ Configuration Variables
   - ``SSD1327 128x128`` **# Note the number seven!**
 
 - **reset_pin** (:ref:`Pin Schema <config-pin_schema>`): The RESET pin.
-- **cs_pin** (:ref:`Pin Schema <config-pin_schema>`): The CS pin.
+- **cs_pin** (:ref:`Pin Schema <config-pin_schema>`): The pin on the ESP that that the CS line is connected to.
+  The CS line can be connected to GND if this is the only device on the SPI bus.
 - **dc_pin** (:ref:`Pin Schema <config-pin_schema>`): The DC pin.
 - **lambda** (*Optional*, :ref:`lambda <config-lambda>`): The lambda to use for rendering the content on the display.
   See :ref:`display-engine` for more information.

--- a/components/display/waveshare_epaper.rst
+++ b/components/display/waveshare_epaper.rst
@@ -66,8 +66,7 @@ configuration.
 Configuration variables:
 ------------------------
 
-- **cs_pin** (*Optional*, :ref:`Pin Schema <config-pin_schema>`): The pin on the ESP that that the CS line is connected to.
-  The CS line can be connected to GND if this is the only device on the SPI bus.
+- **cs_pin** (**Required**, :ref:`Pin Schema <config-pin_schema>`): The CS pin.
 - **dc_pin** (**Required**, :ref:`Pin Schema <config-pin_schema>`): The DC pin.
 - **model** (**Required**): The model of the E-Paper display. Options are:
 

--- a/components/sensor/atm90e32.rst
+++ b/components/sensor/atm90e32.rst
@@ -36,9 +36,7 @@ The `CircuitSetup 6-Channel Energy Monitor <https://circuitsetup.us/index.php/pr
 Configuration variables:
 ------------------------
 
-- **cs_pin** (**Required**, :ref:`Pin Schema <config-pin_schema>`): The pin CS is connected to. For the 6 channel
-  meter main board, this will always be 5 and 4. For the add-on boards a jumper can be selected for each CS pin,
-  but default to 0 and 16.
+- **cs_pin** (**Required**, :ref:`Pin Schema <config-pin_schema>`): The pin CS is connected to. For the 6 channel meter main board, this will always be 5 and 4. For the add-on boards a jumper can be selected for each CS pin, but default to 0 and 16.
 - **line_frequency** (**Required**, string): The AC line frequency of the supply voltage. One of ``50Hz``, ``60Hz``.
 - **phase_a** (*Optional*): The configuration options for the 1st phase.
 
@@ -48,9 +46,9 @@ Configuration variables:
     :ref:`Sensor <config-sensor>`.
   - **power** (*Optional*): Use the power value on this phase in watts. All options from
     :ref:`Sensor <config-sensor>`.
-  - **reactive_power** (*Optional*): Use the reactive power value on this phase. All options from
+  - **reactive_power** (*Optional*): Use the reactive power value on this phase. All options from 
     :ref:`Sensor <config-sensor>`.
-  - **power_factor** (*Optional*): Use the power factor value on this phase. All options from
+  - **power_factor** (*Optional*): Use the power factor value on this phase. All options from 
     :ref:`Sensor <config-sensor>`.
   - **gain_voltage** (*Optional*, int): Voltage gain to scale the low voltage AC power pack to household mains feed.
     Defaults to ``7305``.
@@ -59,9 +57,9 @@ Configuration variables:
 
 - **phase_b** (*Optional*): The configuration options for the 2nd phase. Same options as 1st phase.
 - **phase_c** (*Optional*): The configuration options for the 3rd phase. Same options as 1st phase.
-- **frequency** (*Optional*): Use the frequenycy value calculated by the meter. All options from
+- **frequency** (*Optional*): Use the frequenycy value calculated by the meter. All options from 
   :ref:`Sensor <config-sensor>`.
-- **chip_temperature** (*Optional*): Use the chip temperature value. All options from
+- **chip_temperature** (*Optional*): Use the chip temperature value. All options from 
   :ref:`Sensor <config-sensor>`.
 - **gain_pga** (*Optional*, string): The gain for the CT clamp, ``2X`` for 100A, ``4X`` for 100A - 200A. One of ``1X``, ``2X``, ``4X``.
   Defaults to ``2X`` which is suitable for the popular SCT-013-000 clamp.
@@ -82,7 +80,7 @@ A load which uses a known amount of current can be used to calibrate. For for a 
 Voltage
 ^^^^^^^
 
-Use the expected mains voltage for your region 110V/230V or plug in the Kill-A-Watt and select voltage. See what
+Use the expected mains voltage for your region 110V/230V or plug in the Kill-A-Watt and select voltage. See what 
 value the ATM90E32 sensor reports for voltage. To adjust the sensor use the calculation:
 
 ``New gain_voltage = (your voltage reading / ESPHome voltage reading) * existing gain_voltage value``
@@ -158,7 +156,7 @@ Additional Examples
             name: "EMON CT1 Current"
           power:
             name: "EMON Active Power CT1"
-          reactive_power:
+          reactive_power: 
             name: "EMON Reactive Power CT1"
           power_factor:
             name: "EMON Power Factor CT1"
@@ -169,7 +167,7 @@ Additional Examples
             name: "EMON CT2 Current"
           power:
             name: "EMON Active Power CT2"
-          reactive_power:
+          reactive_power: 
             name: "EMON Reactive Power CT2"
           power_factor:
             name: "EMON Power Factor CT2"
@@ -250,18 +248,18 @@ Additional Examples
         current_phases: 3
         gain_pga: 1X
         update_interval: 60s
-
+        
 
 .. code-block:: yaml
 
     # Example CircuitSetup 6-channel without jumpers jp9-jp11 joined or < meter v1.4
     # power is calculated in a template
-
+    
     substitutions:
       disp_name: 6C
       update_time: 10s
       current_cal: '27961'
-
+  
     spi:
       clk_pin: 18
       miso_pin: 19
@@ -323,7 +321,7 @@ Additional Examples
         current_phases: 3
         gain_pga: 1X
         update_interval: ${update_time}
-
+    
     #Watts per channel
       - platform: template
         name: ${disp_name} CT1 Watts
@@ -332,7 +330,7 @@ Additional Examples
         accuracy_decimals: 0
         unit_of_measurement: W
         icon: "mdi:flash-circle"
-        update_interval: ${update_time}
+        update_interval: ${update_time}         
       - platform: template
         name: ${disp_name} CT2 Watts
         id: ct2Watts
@@ -340,7 +338,7 @@ Additional Examples
         accuracy_decimals: 0
         unit_of_measurement: W
         icon: "mdi:flash-circle"
-        update_interval: ${update_time}
+        update_interval: ${update_time}         
       - platform: template
         name: ${disp_name} CT3 Watts
         id: ct3Watts
@@ -348,7 +346,7 @@ Additional Examples
         accuracy_decimals: 0
         unit_of_measurement: W
         icon: "mdi:flash-circle"
-        update_interval: ${update_time}
+        update_interval: ${update_time}         
       - platform: template
         name: ${disp_name} CT4 Watts
         id: ct4Watts
@@ -356,7 +354,7 @@ Additional Examples
         accuracy_decimals: 0
         unit_of_measurement: W
         icon: "mdi:flash-circle"
-        update_interval: ${update_time}
+        update_interval: ${update_time}         
       - platform: template
         name: ${disp_name} CT5 Watts
         id: ct5Watts
@@ -364,7 +362,7 @@ Additional Examples
         accuracy_decimals: 0
         unit_of_measurement: W
         icon: "mdi:flash-circle"
-        update_interval: ${update_time}
+        update_interval: ${update_time}         
       - platform: template
         name: ${disp_name} CT6 Watts
         id: ct6Watts
@@ -372,8 +370,8 @@ Additional Examples
         accuracy_decimals: 0
         unit_of_measurement: W
         icon: "mdi:flash-circle"
-        update_interval: ${update_time}
-    #Total Amps
+        update_interval: ${update_time}         
+    #Total Amps   
       - platform: template
         name: ${disp_name} Total Amps
         id: totalAmps
@@ -381,7 +379,7 @@ Additional Examples
         accuracy_decimals: 2
         unit_of_measurement: A
         icon: "mdi:flash"
-        update_interval: ${update_time}
+        update_interval: ${update_time}         
     #Total Watts
       - platform: template
         name: ${disp_name} Total Watts

--- a/components/sensor/max31855.rst
+++ b/components/sensor/max31855.rst
@@ -35,8 +35,7 @@ Configuration variables:
 ------------------------
 
 - **name** (**Required**, string): The name for the temperature sensor.
-- **cs_pin** (*Optional*, :ref:`Pin Schema <config-pin_schema>`): The pin on the ESP that that the CS line is connected to.
-  The CS line can be connected to GND if this is the only device on the SPI bus.
+- **cs_pin** (**Required**, :ref:`Pin Schema <config-pin_schema>`): The Chip Select pin of the SPI interface.
 - **update_interval** (*Optional*, :ref:`config-time`): The interval to check the sensor. Defaults to ``60s``.
 - **reference_temperature** (*Optional*, :ref:`Sensor <config-sensor>`): Access the internal temperature sensor of the MAX31855. Requires a **name** and/or **id**.
 - **spi_id** (*Optional*, :ref:`config-id`): Manually specify the ID of the :ref:`SPI Component <spi>` if you want to use multiple SPI buses.

--- a/components/sensor/max6675.rst
+++ b/components/sensor/max6675.rst
@@ -43,8 +43,7 @@ Configuration variables:
 ------------------------
 
 - **name** (**Required**, string): The name for the temperature sensor.
-- **cs_pin** (*Optional*, :ref:`Pin Schema <config-pin_schema>`): The pin on the ESP that that the CS line is connected to.
-  The CS line can be connected to GND if this is the only device on the SPI bus.
+- **cs_pin** (**Required**, :ref:`Pin Schema <config-pin_schema>`): The Chip Select pin of the SPI interface.
 - **update_interval** (*Optional*, :ref:`config-time`): The interval to check the sensor. Defaults to ``60s``.
 
 - **spi_id** (*Optional*, :ref:`config-id`): Manually specify the ID of the :ref:`SPI Component <spi>` if you want

--- a/components/spi.rst
+++ b/components/spi.rst
@@ -13,8 +13,7 @@ SPI is a very common high-speed protocol for a lot of devices. The SPI bus usual
 - **CLK**: Is used to tell the receiving device when to read data. All devices on the bus can
   share this line. Sometimes also called ``SCK``.
 - **CS** (chip select): Is used to tell the receiving device when it should listen for data. Each device has
-  an individual CS line. Sometimes also called ``SS``. If the SPI bus has a single device, it's CS pin
-  can usually be connected to ground to tell it that it is allways selected.
+  an individual CS line. Sometimes also called ``SS``.
 - **MOSI** (also DIN): Is used to send data from the master (the ESP) to the receiving device. All devices on the bus can
   share this line.
 - **MISO** (also DOUT): Is used to receive data. All devices on the bus can

--- a/components/spi.rst
+++ b/components/spi.rst
@@ -13,7 +13,8 @@ SPI is a very common high-speed protocol for a lot of devices. The SPI bus usual
 - **CLK**: Is used to tell the receiving device when to read data. All devices on the bus can
   share this line. Sometimes also called ``SCK``.
 - **CS** (chip select): Is used to tell the receiving device when it should listen for data. Each device has
-  an individual CS line. Sometimes also called ``SS``.
+  an individual CS line. Sometimes also called ``SS``. If the SPI bus has a single device, its CS pin
+  can somtimes be connected to ground to tell it that it is allways selected.
 - **MOSI** (also DIN): Is used to send data from the master (the ESP) to the receiving device. All devices on the bus can
   share this line.
 - **MISO** (also DOUT): Is used to receive data. All devices on the bus can


### PR DESCRIPTION
See also https://github.com/esphome/esphome/pull/988#discussion_r460126366

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
This reverts commit d738a58a60a961b4e98f07be87098b4e15e82b8f.