### PR TITLE
ESP8266 change recommended framework version to 2.7.2

### DIFF
--- a/components/esphome.rst
+++ b/components/esphome.rst
@@ -97,10 +97,13 @@ option you can tell ESPHome which Arduino framework to use for compiling.
 For the ESP8266, you currently can manually pin the Arduino version to these values (see the full
 list of Arduino frameworks `here <https://github.com/esp8266/Arduino/releases>`__):
 
+* `2.7.2 <https://github.com/esp8266/Arduino/releases/tag/2.7.2>`__ (default)
+* `2.7.1 <https://github.com/esp8266/Arduino/releases/tag/2.7.1>`__
+* `2.7.0 <https://github.com/esp8266/Arduino/releases/tag/2.7.0>`__
 * `2.6.3 <https://github.com/esp8266/Arduino/releases/tag/2.6.3>`__
 * `2.6.2 <https://github.com/esp8266/Arduino/releases/tag/2.6.2>`__
 * `2.6.1 <https://github.com/esp8266/Arduino/releases/tag/2.6.1>`__
-* `2.5.2 <https://github.com/esp8266/Arduino/releases/tag/2.5.2>`__ (default)
+* `2.5.2 <https://github.com/esp8266/Arduino/releases/tag/2.5.2>`__
 * `2.5.1 <https://github.com/esp8266/Arduino/releases/tag/2.5.1>`__
 * `2.5.0 <https://github.com/esp8266/Arduino/releases/tag/2.5.0>`__
 * `2.4.2 <https://github.com/esp8266/Arduino/releases/tag/2.4.2>`__


### PR DESCRIPTION
**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** https://github.com/esphome/esphome/pull/1208

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [N/A] Link added in `/index.rst` when creating new documents for new components or cookbook.
