### PR TITLE
Add tuya platforms to changelog table

### DIFF
--- a/changelog/v1.15.0.rst
+++ b/changelog/v1.15.0.rst
@@ -23,7 +23,11 @@ Changelog - Version 1.15.0 - Release Date TBD
     Slow PWM, components/output/slow_pwm, pwm.png
     ESP32 DAC, components/output/esp32_dac, dac.svg
     AC Dimmer, components/output/ac_dimmer, ac_dimmer.svg
-    Tuya Fan, components/fan/tuya, fan.svg
+    Tuya Fan, components/fan/tuya, tuya.png
+    Tuya Binary Sensor, components/binary_sensor/tuya, tuya.png
+    Tuya Sensor, components/sensor/tuya, tuya.png
+    Tuya Switch, components/switch/tuya, tuya.png
+    Tuya Climate, components/climate/tuya, tuya.png
     MAX7219 Dot Matrix, components/display/max7219digit, max7219digit.png
     TM1637, components/display/tm1637, tm1637.jpg
     ST7789V, components/display/st7789v, st7789v.jpg


### PR DESCRIPTION
## Description:
Adds tuya platforms to the image table in the 1.15.0 changelog

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
