### PR TITLE
Added hint that not the subsensor id is meant.

### DIFF
--- a/components/sensor/tx20.rst
+++ b/components/sensor/tx20.rst
@@ -62,7 +62,7 @@ Configuration variables:
 .. note::
 
     In order to create a text sensor to show the textual representation of the wind direction
-    the following config can be used. "tx20_id" needs to be replaced with the id of the TX20 sensor.
+    the following config can be used. "tx20_id" needs to be replaced with the id of the TX20 sensor (**not** with the id of the subsensors).
 
     .. code-block:: yaml
 


### PR DESCRIPTION
## Description:
Added a hint which senor's id is meant as I struggled with this on my own and just wanted to open an issue about the text sensor not working.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
