### PR TITLE
MCP230xx open drain interrupt pins

### DIFF
--- a/components/mcp230xx.rst
+++ b/components/mcp230xx.rst
@@ -58,9 +58,9 @@ Configuration variables:
 - **id** (**Required**, :ref:`config-id`): The id to use for this MCP23008 component.
 - **address** (*Optional*, int): The I²C address of the driver.
   Defaults to ``0x20``.
-- **open_drain** (*Optional*, bool): Configure interrupt pins to open-drain mode.
-  Useful when the MCP23017's power supply is greater than 3.3 volts. Note that these pins
-  will require pull-up resistors (to 3.3 volts) when this mode is enabled.
+- **open_drain** (*Optional*, bool): Configure the interrupt pin to open-drain mode.
+  Useful when the MCP23008's power supply is greater than 3.3 volts. Note that this pin
+  will require a pull-up resistor (to 3.3 volts) when this mode is enabled.
 
 .. _mcp23016-label:
 
@@ -162,9 +162,9 @@ Configuration variables:
 - **id** (**Required**, :ref:`config-id`): The id to use for this MCP23017 component.
 - **address** (*Optional*, int): The I²C address of the driver.
   Defaults to ``0x20``.
-- **open_drain** (*Optional*, bool): Configure the interrupt pin to open-drain mode.
-  Useful when the MCP23008's power supply is greater than 3.3 volts. Note that this pin
-  will require a pull-up resistor (to 3.3 volts) when this mode is enabled.
+- **open_drain** (*Optional*, bool): Configure interrupt pins to open-drain mode.
+  Useful when the MCP23017's power supply is greater than 3.3 volts. Note that these pins
+  will require pull-up resistors (to 3.3 volts) when this mode is enabled.
 
 
 See Also

--- a/components/mcp230xx.rst
+++ b/components/mcp230xx.rst
@@ -58,7 +58,7 @@ Configuration variables:
 - **id** (**Required**, :ref:`config-id`): The id to use for this MCP23008 component.
 - **address** (*Optional*, int): The I²C address of the driver.
   Defaults to ``0x20``.
-- **open_drain** (*Optional*, bool): Configure the interrupt pin to open-drain mode.
+- **open_drain_interrupt** (*Optional*, bool): Configure the interrupt pin to open-drain mode.
   Useful when the MCP23008's power supply is greater than 3.3 volts. Note that this pin
   will require a pull-up resistor (to 3.3 volts) when this mode is enabled.
 
@@ -162,7 +162,7 @@ Configuration variables:
 - **id** (**Required**, :ref:`config-id`): The id to use for this MCP23017 component.
 - **address** (*Optional*, int): The I²C address of the driver.
   Defaults to ``0x20``.
-- **open_drain** (*Optional*, bool): Configure interrupt pins to open-drain mode.
+- **open_drain_interrupt** (*Optional*, bool): Configure interrupt pins to open-drain mode.
   Useful when the MCP23017's power supply is greater than 3.3 volts. Note that these pins
   will require pull-up resistors (to 3.3 volts) when this mode is enabled.
 

--- a/components/mcp230xx.rst
+++ b/components/mcp230xx.rst
@@ -58,6 +58,9 @@ Configuration variables:
 - **id** (**Required**, :ref:`config-id`): The id to use for this MCP23008 component.
 - **address** (*Optional*, int): The I²C address of the driver.
   Defaults to ``0x20``.
+- **open_drain** (**Optional**, bool): Configure interrupt pins to open-drain mode.
+  Useful when the MCP23017's power supply is greater than 3.3 volts. Note that these pins
+  will require pull-up resistors (to 3.3 volts) when this mode is enabled.
 
 .. _mcp23016-label:
 
@@ -159,6 +162,9 @@ Configuration variables:
 - **id** (**Required**, :ref:`config-id`): The id to use for this MCP23017 component.
 - **address** (*Optional*, int): The I²C address of the driver.
   Defaults to ``0x20``.
+- **open_drain** (**Optional**, bool): Configure the interrupt pin to open-drain mode.
+  Useful when the MCP23008's power supply is greater than 3.3 volts. Note that this pin
+  will require a pull-up resistor (to 3.3 volts) when this mode is enabled.
 
 
 See Also

--- a/components/mcp230xx.rst
+++ b/components/mcp230xx.rst
@@ -58,7 +58,7 @@ Configuration variables:
 - **id** (**Required**, :ref:`config-id`): The id to use for this MCP23008 component.
 - **address** (*Optional*, int): The I²C address of the driver.
   Defaults to ``0x20``.
-- **open_drain** (**Optional**, bool): Configure interrupt pins to open-drain mode.
+- **open_drain** (*Optional*, bool): Configure interrupt pins to open-drain mode.
   Useful when the MCP23017's power supply is greater than 3.3 volts. Note that these pins
   will require pull-up resistors (to 3.3 volts) when this mode is enabled.
 
@@ -162,7 +162,7 @@ Configuration variables:
 - **id** (**Required**, :ref:`config-id`): The id to use for this MCP23017 component.
 - **address** (*Optional*, int): The I²C address of the driver.
   Defaults to ``0x20``.
-- **open_drain** (**Optional**, bool): Configure the interrupt pin to open-drain mode.
+- **open_drain** (*Optional*, bool): Configure the interrupt pin to open-drain mode.
   Useful when the MCP23008's power supply is greater than 3.3 volts. Note that this pin
   will require a pull-up resistor (to 3.3 volts) when this mode is enabled.
 


### PR DESCRIPTION
## Description:
Updates the MCP230xx for the patch to add the ability to configure the I/O expander's interrupt output pins as open-drain.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#1243

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook. **N/A**
