### PR TITLE
Add carrier_frequency for IR device example

### DIFF
--- a/components/remote_transmitter.rst
+++ b/components/remote_transmitter.rst
@@ -432,6 +432,7 @@ earlier, create a new template switch that sends the infrared code when triggere
         name: Raw Code Power Button
         turn_on_action:
           - remote_transmitter.transmit_raw:
+              carrier_frequency: 38kHz
               code: [4088, -1542, 1019, -510, 513, -1019, 510, -509, 511, -510, 1020,
                      -1020, 1022, -1019, 510, -509, 511, -510, 511, -509, 511, -510,
                      1020, -1019, 510, -511, 1020, -510, 512, -508, 510, -1020, 1022]


### PR DESCRIPTION
## Description:
carrier_frequency is needed for most IR devices. The most common for remotes is 38kHz.

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
