### PR TITLE
Change example ota id 

### DIFF
--- a/components/ota.rst
+++ b/components/ota.rst
@@ -55,10 +55,10 @@ through an ``on_boot`` trigger:
     esphome:
       on_boot:
         - lambda: |-
-            id(ota).set_auth_password("New password");
+            id(my_ota).set_auth_password("New password");
     ota:
       password: "Old password"
-      id: ota
+      id: my_ota
 
 See Also
 --------


### PR DESCRIPTION
## Description:
Changing the id as `ota` "conflicts with the name of an esphome integration"


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
