### PR TITLE
Update ota.rst

### DIFF
--- a/components/ota.rst
+++ b/components/ota.rst
@@ -48,17 +48,17 @@ Updating the password:
 
 Since the password is used both for compiling and uploading the regular ``esphome <file> run``
 won't work of course. This issue can be worked around by executing the operations separately
-through an ``on_boot`` trigger:
+through an ``on_boot`` trigger. Just make XXX whatever you like (but not ota, which will fail to compile):
 
 .. code-block:: yaml
 
     esphome:
       on_boot:
         - lambda: |-
-            id(ota).set_auth_password("New password");
+            id(XXX).set_auth_password("New password");
     ota:
       password: "Old password"
-      id: ota
+      id: XXX
 
 See Also
 --------


### PR DESCRIPTION
using the ota as id fails to compile. this should be simple enough to update

## Description: using id ota fails to compile.


**Related issue (if applicable):** fixes <link to issue> No reported, experience and discussion on the ESP home discord with Brett, EuroTrash, radar, and Jesserockz

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [next ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
