### PR TITLE
Fixing pin definition error

### DIFF
--- a/components/sensor/zyaura.rst
+++ b/components/sensor/zyaura.rst
@@ -30,8 +30,8 @@ monitors with ESPHome.
     # Example configuration entry
     sensor:
       - platform: zyaura
-        clock_pin: D1
-        data_pin: D2
+        clock_pin: D2
+        data_pin: D1
         co2:
           name: "ZyAura CO2"
         temperature:


### PR DESCRIPTION
## Description:
The example shows the wrong pin definition.

**Related issue (if applicable):** fixes <link to issue>
https://github.com/esphome/issues/issues/943

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
