### PR TITLE
Add missing doc for rc_switch event

### DIFF
--- a/components/remote_receiver.rst
+++ b/components/remote_receiver.rst
@@ -71,6 +71,9 @@ Automations:
 - **on_rc5** (*Optional*, :ref:`Automation <automation>`): An automation to perform when a
   RC5 remote code has been decoded. A variable ``x`` of type :apiclass:`remote_base::RC5Data`
   is passed to the automation for use in lambdas.
+- **on_rc_switch** (*Optional*, :ref:`Automation <automation>`): An automation to perform when a
+  RCSwitch RF code has been decoded. A variable ``x`` of type :apiclass:`remote_base::RCSwitchData`
+  is passed to the automation for use in lambdas.
 - **on_samsung** (*Optional*, :ref:`Automation <automation>`): An automation to perform when a
   Samsung remote code has been decoded. A variable ``x`` of type :apiclass:`remote_base::SamsungData`
   is passed to the automation for use in lambdas.


### PR DESCRIPTION
The event was added with https://github.com/esphome/esphome/pull/983 but the doc does not reflect this change.

## Description:

https://github.com/esphome/esphome/pull/983

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
