### PR TITLE
docs: necessary registration of node in HA 

### DIFF
--- a/components/sensor/homeassistant.rst
+++ b/components/sensor/homeassistant.rst
@@ -23,7 +23,7 @@ states from your Home Assistant instance using the :doc:`native API </components
     
     Albeit you might not plan to __export__ states from the node and you do not need an entity of the node
     in Home Assistant, this component still requires you to register the node under Home Assistant. See:
-    :doc: `Getting started with Hassio </guides/getting_started_hassio>
+    :doc:`Getting started with Hassio </guides/getting_started_hassio>`
 
     Importing attributes is currently not supported, but you can create template sensors in Home Assistant
     that return the attribute of a sensor and then import the template sensor here.

--- a/components/sensor/homeassistant.rst
+++ b/components/sensor/homeassistant.rst
@@ -20,6 +20,10 @@ states from your Home Assistant instance using the :doc:`native API </components
 
     This component is only for numeral states. If you want to import arbitrary text states
     from Home Assistant, use the :doc:`Home Assistant Text Sensor </components/text_sensor/homeassistant>`.
+    
+    Albeit you might not plan to __export__ states from the node and you do not need an entity of the node
+    in Home Assistant, this component still requires you to register the node under Home Assistant. See:
+    :doc: `Getting started with Hassio </guides/getting_started_hassio>
 
     Importing attributes is currently not supported, but you can create template sensors in Home Assistant
     that return the attribute of a sensor and then import the template sensor here.


### PR DESCRIPTION
Add remark about registration in home assistant.
## Description:
Even one never plan to export data to home assistant and therefore do not need any entity of the node itself created in home assistant, it is still required to  register the node in home assistant if you want to __import__ data from home assistant into the node. That might not be clear if you come from the "other" side just trying to get data into a node. The paragraph should remind people to do that.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
