### PR TITLE
Enable color_interlock for the Teckin SB50 example

### DIFF
--- a/cookbook/teckin_sb50.rst
+++ b/cookbook/teckin_sb50.rst
@@ -70,6 +70,7 @@ Below is the ESPHome configuration file that will get you up and running. This a
         cold_white: output_cold_white
         cold_white_color_temperature: 6200 K
         warm_white_color_temperature: 2800 K
+        color_interlock: true # avoids simultaneous RGB and W/W
 
 
 See Also


### PR DESCRIPTION
## Description:

RGB and W/W were enabled at the same time drawing very high power and distorting the desired white temperature https://github.com/esphome/issues/issues/1180

Setting ``color_interlock: true`` https://github.com/esphome/esphome/pull/1042 reduces heat noticeably, preventing early bulb failure.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
