### PR TITLE
using docker image to build esphome-docs locally

### DIFF
--- a/guides/contributing.rst
+++ b/guides/contributing.rst
@@ -222,9 +222,9 @@ Build
 
     .. code-block:: bash
 
-        docker run --rm -v "${PWD}/":/data -p 8000:8000 -it esphome/esphome-docs
+        docker run --rm -v "${PWD}/":/data/esphomedocs -p 8000:8000 -it esphome/esphome-docs
 
-    And then go to ``<CONTAINER_IP>:8000`` in your browser.
+    With ``PWD`` refering to the root of the ``esphome-docs`` git repository. Then go to ``<CONTAINER_IP>:8000`` in your browser.
 
     This way, you don't have to install the dependencies to build the documentation.
 


### PR DESCRIPTION
## Description:

Clarification on how to use the esphome-docs docker image for bulding docs locally. As a first time contributor, I had to dig into the Dockerfile for figure out which volume binding would work.

**Related issue (if applicable):** no issue opened

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** not applicable

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
