### PR TITLE
Adds Tuya Climate temperature multiplier

### DIFF
--- a/components/climate/tuya.rst
+++ b/components/climate/tuya.rst
@@ -48,7 +48,14 @@ Configuration variables:
 - **switch_datapoint** (**Required**, int): The datapoint id number of the climate switch.
 - **target_temperature_datapoint** (**Required**, int): The datapoint id number of the target temperature.
 - **current_temperature_datapoint** (**Required**, int): The datapoint id number of the current temperature.
+- **temperature_multiplier** (**Optional**, float): A multiplier to modify the incoming and outgoing temperature values - :ref:`see below <temperature-multiplier>`.
 - All other options from :ref:`Climate <config-climate>`.
+
+Temperature multiplier
+----------------------
+
+Some Tuya climate devices report the temperature with a multiplied factor. This is because the MCU only utlizes
+integers for data reporting and to get a .5 temperature you need to divide by 2 on the ESPHome side.
 
 See Also
 --------

--- a/components/climate/tuya.rst
+++ b/components/climate/tuya.rst
@@ -51,6 +51,8 @@ Configuration variables:
 - **temperature_multiplier** (**Optional**, float): A multiplier to modify the incoming and outgoing temperature values - :ref:`see below <temperature-multiplier>`.
 - All other options from :ref:`Climate <config-climate>`.
 
+.. _temperature-multiplier:
+
 Temperature multiplier
 ----------------------
 


### PR DESCRIPTION
## Description:

Some tuya based climate devices report the temperature with a multiplied factor. Tuya only uses int as its data type so this is required to get .5 values.

```
[17:14:11][C][tuya:023]: Tuya:
[17:14:11][C][tuya:032]:   Datapoint 1: switch (value: OFF)     -- on/off
[17:14:11][C][tuya:034]:   Datapoint 2: int value (value: 42)   -- setpoint (21)
[17:14:11][C][tuya:034]:   Datapoint 3: int value (value: 47)   -- current temp (23.5)
[17:14:11][C][tuya:034]:   Datapoint 102: int value (value: 44) -- current floor temp (22)
```

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#1276

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
