### PR TITLE
display: st7789v: Set GPIO0 as INPUT_PULLUP

### DIFF
--- a/components/display/st7789v.rst
+++ b/components/display/st7789v.rst
@@ -201,6 +201,7 @@ appropriate lines of C code in the lambada to hide or show the image or text as 
         pin:
           number: GPIO0
           inverted: true
+          mode: INPUT_PULLUP
         name: "T-Display Button Input 0"
         id: tdisplay_button_input_0
       - platform: gpio


### PR DESCRIPTION
## Description:

GPIO0 is floating on the TTGO ESP32 T-Display board and causes Button Input 0 to have undefined behavior and sometimes missed.  I observed this problem on two modules (sourced from different distributors) and this resolved issues with both.

Seems that the default PULLUP is sometimes disabled by other software. This makes it explicit as there is no external pull-up.

The other button has an external 100k pull-up.

[TTGO ESP32 T-Display schematic](https://github.com/Xinyuan-LilyGO/TTGO-T-Display/tree/master/schematic)

**Related issue (if applicable):** none

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** none

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
