### PR TITLE
Update diy.rst

### DIFF
--- a/guides/diy.rst
+++ b/guides/diy.rst
@@ -68,6 +68,7 @@ Custom Components & Code
 - `Jura Impressa J6 coffee machine custom component <https://github.com/ryanalden/esphome-jura-component>`__ by :ghuser:`ryanalden`
 - `Paradox alarm system sensors custom component <https://github.com/Margriko/Paradox-ESPHome>`__ by :ghuser:`Margriko`
 - `DSC POWER832 (PC5010) alarm system custom component <https://github.com/Dilbert66/esphome-dsckeybus>`__ by :ghuser:`Dilbert66`
+- `Custom UART component for WS3 weather station and air particulate matter sensor <https://github.com/kquinsland/ws3-to-esphome-bridge>`__ by :ghuser:`kquinsland`
 
 Sample Configurations
 ---------------------
@@ -90,3 +91,4 @@ Sample Configurations
 - `ESPHome Home Assistant Cheap Cat Feeder <https://github.com/rubengargar/diy-cheap-cat-feeder>`__ by :ghuser:`rubengargar`
 - `ESPHome configs <https://github.com/nuttytree/ESPHome-Devices>`__ by :ghuser:`nuttytree`
 - `ESPHome Home Assistant stepper motor blinds/curtain <https://github.com/icarome/esphome/blob/master/cortina.yaml>`__ by :ghuser:`icarome`
+- `Control LG UD79-B monitor via UART <https://github.com/kquinsland/lg-m43mu79-esp-home-bridge>`__ by :ghuser:`kquinsland`


### PR DESCRIPTION
Added two links for custom projects that ESPHome powered:

1. A custom UART based component that parses data from weather station and gets the values into MQTT
2. Using the 'built in' UART component in ESPHome to send commands to a LG Monitor. This can easily be adopted to other LG monitors as they usually share similar payloads.




-----


This does not fix any issues, only links to a few projects.