### PR TITLE
Add battery_level note for xiaomi_hhccjcy01

### DIFF
--- a/components/sensor/xiaomi_ble.rst
+++ b/components/sensor/xiaomi_ble.rst
@@ -38,6 +38,11 @@ Configuration example:
         battery_level:
           name: "Xiaomi HHCCJCY01 Battery Level"
 
+.. note::
+
+    Newer versions of HHCCJCY01 ship with firmware 3.2.1, and they
+    `don't send the battery level data anymore <https://github.com/esphome/esphome/pull/1288#issuecomment-695809481>`__.
+
 GCLS002
 *******
 


### PR DESCRIPTION
## Description

In https://github.com/esphome/esphome/pull/1027/files#diff-7db33c55aa814ed3c8ad001b3fc60471,
the `battery_level` attribute was removed from `xiaomi_hhccjcy01` as it was [no longer being
advertised by the device](https://github.com/esphome/issues/issues/107#issuecomment-510403045).

This PR removes the `battery_level` from the `xiaomi_hhccjcy01` example and adds a note why.

Review app: https://deploy-preview-761--esphome.netlify.app/components/sensor/xiaomi_ble.html#hhccjcy01

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
