### PR TITLE
HM3301 - Change type to calculation_type

### DIFF
--- a/components/sensor/hm3301.rst
+++ b/components/sensor/hm3301.rst
@@ -26,7 +26,7 @@ The sensor communicate with board by ``I2C`` protocol, and requires 3.3v.
           name: "PM10.0"
         aqi:
           name: "AQI"
-          type: "CAQI"
+          calculation_type: "CAQI"
 
 Configuration variables:
 ------------------------
@@ -51,7 +51,7 @@ Configuration variables:
 
 - **aqi** (*Optional*): AQI sensor. Requires the ``pm_2_5`` and ``pm_10_0`` sensors defined. See below.
 
-  - **type** (**Required**): One of: ``AQI`` or ``CAQI``.
+  - **calculation_type** (**Required**): One of: ``AQI`` or ``CAQI``.
   - **name** (**Required**, string): The name for the temperature sensor.
   - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.
   - All other options from :ref:`Sensor <config-sensor>`.
@@ -75,7 +75,7 @@ There are two implementations:
           name: "PM10.0"
         aqi:
           name: "AQI"
-          type: "CAQI"
+          calculation_type: "CAQI"
 
 
 See Also


### PR DESCRIPTION
According to the esphome dashboard, AQI type should be calculation_type

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
