### PR TITLE
Add clarification about "update_interval" to SDS011 sensor documentation

### DIFF
--- a/components/sensor/sds011.rst
+++ b/components/sensor/sds011.rst
@@ -44,6 +44,8 @@ If ``update_interval`` is between 1-30 minutes, the SDS011 periodically turns on
 For the remaining time the sensor is shut off. As a result, this mode can reduce power consumption and increases
 the lifetime of the SDS011.
 
+Note that ``update_interval`` may not be set to ``never``.
+
 Configuration variables:
 ------------------------
 


### PR DESCRIPTION
## Description:
Add note that ``update_interval`` must not be set to ``never``, even though it has the type `time` (https://esphome.io/guides/configuration-types.html#config-time) that can have that value.


**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/1267

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
