### PR TITLE
Fix APDS9960 datasheet link

### DIFF
--- a/components/sensor/apds9960.rst
+++ b/components/sensor/apds9960.rst
@@ -6,7 +6,7 @@ APDS9960 Sensor
     :image: apds9960.jpg
 
 The ``apds9960`` sensor platform allows you to use your APDS9960 RGB and gesture sensors
-(`datasheet <https://cdn-shop.adafruit.com/datasheets/BST-BME280_DS001-10.pdf>`__,
+(`datasheet <https://cdn.sparkfun.com/datasheets/Sensors/Proximity/apds9960.pdf>`__,
 `SparkFun`_) with ESPHome.
 The :ref:`I²C <i2c>` is
 required to be set up in your configuration for this sensor to work.


### PR DESCRIPTION
## Description:
The datasheet link in the APDS9960 sensor description currently points to a datasheet for the BME280 sensor, wich is completely unrelated.

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
