### PR TITLE
Update Tuya dimmer docs to remove reference to default gamma correction

### DIFF
--- a/components/light/tuya.rst
+++ b/components/light/tuya.rst
@@ -85,9 +85,8 @@ Configuration variables:
 
 .. note::
 
-    The MCU on the Tuya dimmer handles transitions and gamma correction on its own.
-    Therefore the ``gamma_correct`` setting default is ``1.0`` and the the
-    ``default_transition_length`` parameter is ``0s`` by default.
+    The MCU on the Tuya dimmer handles transitions on its own.
+    Therefore the ``default_transition_length`` parameter is ``0s`` by default.
 
 See Also
 --------


### PR DESCRIPTION
## Description:

See https://github.com/esphome/esphome/pull/1289

**Related issue (if applicable):** fixes esphome/issues#852 and fixes esphome/issues#1448

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#1289

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
