### PR TITLE
Add time.has_time documentation

### DIFF
--- a/components/time.rst
+++ b/components/time.rst
@@ -334,6 +334,21 @@ In the ``seconds:``, ``minutes:``, ... fields you can use the following operator
                 then:
                   - switch.toggle: my_switch
 
+.. _time-has_time_condition:
+
+``time.has_time`` Condition
+----------------------------
+
+This :ref:`Condition <config-condition>` checks if time has been set and is valid.
+
+.. code-block:: yaml
+
+    on_...:
+      if:
+        condition:
+          time.has_time:
+        then:
+          - logger.log: Time has been set and is valid!
 
 See Also
 --------

--- a/guides/automations.rst
+++ b/guides/automations.rst
@@ -387,6 +387,7 @@ All Conditions
 - :ref:`sensor.in_range <sensor-in_range_condition>`
 - :ref:`wifi.connected <wifi-connected_condition>` / :ref:`api.connected <api-connected_condition>`
   / :ref:`mqtt.connected <mqtt-connected_condition>`
+- :ref:`time.has_time <time-has_time_condition>`
 - :ref:`script.is_running <script-is_running_condition>`
 - :ref:`sun.is_above_horizon / sun.is_below_horizon <sun-is_above_below_horizon-condition>`
 - :ref:`text_sensor.state <text_sensor-state_condition>`


### PR DESCRIPTION
## Description:

This PR adds basic documentation for the `time.has_time` condition.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#1255

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
