### PR TITLE
Update Sonoff Mini

### DIFF
--- a/devices/sonoff.rst
+++ b/devices/sonoff.rst
@@ -326,7 +326,7 @@ Sonoff Mini
 .. pintable::
 
     GPIO0, Button (inverted),
-    GPIO4, SW Input,
+    GPIO4, SW Input (inverted),
     GPIO12, Relay and Red LED,
     GPIO13, Blue LED (inverted),
     GPIO16, Optional sensor


### PR DESCRIPTION
GPIO4 is active high and when SW is pressed it is grounded. See details here: https://tasmota.github.io/docs/devices/Sonoff-Mini/

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
