### PR TITLE
Remove bh7150 API reference

### DIFF
--- a/components/sensor/bh1750.rst
+++ b/components/sensor/bh1750.rst
@@ -59,5 +59,6 @@ See Also
 
 - :ref:`sensor-filters`
 - :doc:`tsl2561`
+- :apiref:`bh1750/bh1750.h`
 - `BH1750 Library <https://github.com/claws/BH1750>`__ by `@claws <https://github.com/claws>`__
 - :ghedit:`Edit`

--- a/components/sensor/bh1750.rst
+++ b/components/sensor/bh1750.rst
@@ -59,6 +59,5 @@ See Also
 
 - :ref:`sensor-filters`
 - :doc:`tsl2561`
-- :apiref:`bh7150/bh7150.h`
 - `BH1750 Library <https://github.com/claws/BH1750>`__ by `@claws <https://github.com/claws>`__
 - :ghedit:`Edit`


### PR DESCRIPTION
## Description:
This PR moves to remove the API reference from the [BH1750 page](https://esphome.io/components/sensor/bh1750.html#see-also) as it seems to no longer exist. I couldn't find an equivalent link to replace it with, so I decided to remove it entirely, but if someone knows the new URL to the API reference (if it still exists), please let me know and I can replace it with that new URL.

**Related issue (if applicable):** N/A
**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** N/A

## Checklist:

  - [X] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [X] Link added in `/index.rst` when creating new documents for new components or cookbook.
