### PR TITLE
Update edit URL on Sonoff Basic page

### DIFF
--- a/devices/sonoff_basic.rst
+++ b/devices/sonoff_basic.rst
@@ -271,4 +271,4 @@ See Also
 - :doc:`sonoff_4ch`
 - :doc:`sonoff_s20`
 - `GPIO locations <https://github.com/arendst/Sonoff-Tasmota/wiki/GPIO-Locations>`__
-- `Edit this page on GitHub <https://github.com/OttoWinter/esphomedocs/blob/current/esphomeyaml/devices/sonoff_basic.rst>`__
+- `Edit this page on GitHub <https://github.com/OttoWinter/esphomedocs/blob/current/devices/sonoff_basic.rst>`__


### PR DESCRIPTION
## Description:
This PR updates the URL found to edit the page on the [Sonoff Basic page](https://esphome.io/devices/sonoff_basic.html#see-also). It was previously a 404 that led to an old directory that no longer exists and the updated URL should be the direct replacement for it.


**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** N/A

## Checklist:

  - [X] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [X] Link added in `/index.rst` when creating new documents for new components or cookbook.
