### PR TITLE
Add 2.13in-ttgo-b73 to list of waveshare models

### DIFF
--- a/components/display/waveshare_epaper.rst
+++ b/components/display/waveshare_epaper.rst
@@ -8,6 +8,7 @@ Waveshare E-Paper Display
 The ``waveshare_epaper`` display platform allows you to use
 some E-Paper displays sold by `Waveshare <https://www.waveshare.com/product/displays/e-paper.htm>`__
 with ESPHome. The 2.13" `TTGO module <https://github.com/lewisxhe/TTGO-EPaper-Series>`__ with an ESP32 on the board is supported as well.
+Depending on your specific revision of the board you might need to try out the `-b73` version (see below).
 Similar modules sold by other vendors might also work but not have been tested yet. Currently only
 single-color E-Ink displays are implemented and of those only a few modules.
 
@@ -73,6 +74,7 @@ Configuration variables:
   - ``1.54in``
   - ``2.13in`` (not tested)
   - ``2.13in-ttgo`` (T5_V2.3 tested)
+  - ``2.13in-ttgo-b73`` (T5_V2.3 with B73 display tested)
   - ``2.70in``
   - ``2.90in``
   - ``2.90in-b`` (B/W rendering only)


### PR DESCRIPTION
## Description:

Add [2.13in-ttgo-b73](https://github.com/esphome/esphome/blob/master/esphome/components/waveshare_epaper/display.py#L28
) to list of waveshare e-paper display models



## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
