### PR TITLE
Set correct link to ESPColor struct

### DIFF
--- a/components/light/index.rst
+++ b/components/light/index.rst
@@ -718,7 +718,7 @@ This effect allows you to access each LED individually in a custom light effect.
 Available variables in the lambda:
 
 - **it** - :apiclass:`AddressableLight <light::AddressableLight>` instance (see API reference for more info).
-- **current_color**  - :apiclass:`ESPColor ` <light::ESPColor>` instance (see API reference for more info).
+- **current_color**  - :apistruct:`ESPColor <light::ESPColor>` instance (see API reference for more info).
 - **initial_run** - A bool which is true on the first execution of the lambda. Useful to reset static variables when restarting a effect.
 
 .. code-block:: yaml


### PR DESCRIPTION
## Description:
Set correct link to ESPColor struct

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
