### PR TITLE
Add a note about HHCCJCY01 battery_level absence

### DIFF
--- a/components/sensor/xiaomi_ble.rst
+++ b/components/sensor/xiaomi_ble.rst
@@ -38,6 +38,10 @@ Configuration example:
         battery_level:
           name: "Xiaomi HHCCJCY01 Battery Level"
 
+.. warning::
+
+    Recent firmware versions (>3.2.1) do not report ``battery_level`` values.
+
 GCLS002
 *******
 
@@ -358,5 +362,6 @@ See Also
   by `@Magalex2x14 <https://github.com/Magalex2x14>`__
 - Xiaomi LYWSD03MMC passive sensor readout `<https://github.com/ahpohl/xiaomi_lywsd03mmc>`__ by `@ahpohl <https://github.com/ahpohl>`__
 - Mi-standardauth `<https://github.com/danielkucera/mi-standardauth>`__
+- HHCCJCY01 not reporting battery_level values `<https://github.com/esphome/issues/issues/107#issuecomment-510403045>`__
 
 - :ghedit:`Edit`


### PR DESCRIPTION
# Description:

A note is added indicating the absence of `battery_level` values for device HHCCJCY01

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
