### PR TITLE
Individual BMXXXXX sensor configs are optional

### DIFF
--- a/components/sensor/bme280.rst
+++ b/components/sensor/bme280.rst
@@ -37,7 +37,7 @@ required to be set up in your configuration for this sensor to work.
 Configuration variables:
 ------------------------
 
-- **temperature** (**Required**): The information for the temperature.
+- **temperature** (*Optional*): The information for the temperature.
   sensor
 
   - **name** (**Required**, string): The name for the temperature
@@ -47,7 +47,7 @@ Configuration variables:
   - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.
   - All other options from :ref:`Sensor <config-sensor>`.
 
-- **pressure** (**Required**): The information for the pressure sensor.
+- **pressure** (*Optional*): The information for the pressure sensor.
 
   - **name** (**Required**, string): The name for the pressure sensor.
   - **oversampling** (*Optional*): The oversampling parameter for the temperature sensor.
@@ -55,7 +55,7 @@ Configuration variables:
   - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.
   - All other options from :ref:`Sensor <config-sensor>`.
 
-- **humidity** (**Required**): The information for the pressure sensor.
+- **humidity** (*Optional*): The information for the pressure sensor.
 
   - **name** (**Required**, string): The name for the humidity sensor.
   - **oversampling** (*Optional*): The oversampling parameter for the temperature sensor.

--- a/components/sensor/bme680.rst
+++ b/components/sensor/bme680.rst
@@ -39,7 +39,7 @@ your configuration for this sensor to work.
 Configuration variables:
 ------------------------
 
-- **temperature** (**Required**): The information for the temperature sensor.
+- **temperature** (*Optional*): The information for the temperature sensor.
 
   - **name** (**Required**, string): The name for the temperature sensor.
   - **oversampling** (*Optional*): The oversampling parameter for the temperature sensor.
@@ -47,7 +47,7 @@ Configuration variables:
   - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.
   - All other options from :ref:`Sensor <config-sensor>`.
 
-- **pressure** (**Required**): The information for the pressure sensor.
+- **pressure** (*Optional*): The information for the pressure sensor.
 
   - **name** (**Required**, string): The name for the pressure sensor.
   - **oversampling** (*Optional*): The oversampling parameter for the temperature sensor.
@@ -55,7 +55,7 @@ Configuration variables:
   - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.
   - All other options from :ref:`Sensor <config-sensor>`.
 
-- **humidity** (**Required**): The information for the humidity sensor.
+- **humidity** (*Optional*): The information for the humidity sensor.
 
   - **name** (**Required**, string): The name for the humidity sensor.
   - **oversampling** (*Optional*): The oversampling parameter for the temperature sensor.
@@ -63,7 +63,7 @@ Configuration variables:
   - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.
   - All other options from :ref:`Sensor <config-sensor>`.
 
-- **gas_resistance** (**Required**): The information for the gas sensor.
+- **gas_resistance** (*Optional*): The information for the gas sensor.
 
   - **name** (**Required**, string): The name for the gas resistance sensor.
   - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.

--- a/components/sensor/bmp085.rst
+++ b/components/sensor/bmp085.rst
@@ -38,14 +38,14 @@ your configuration for this sensor to work.
 Configuration variables:
 ------------------------
 
-- **temperature** (**Required**): The information for the temperature sensor.
+- **temperature** (*Optional*): The information for the temperature sensor.
 
   - **name** (**Required**, string): The name for the temperature
     sensor.
   - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.
   - All other options from :ref:`Sensor <config-sensor>`.
 
-- **pressure** (**Required**): The information for the pressure sensor.
+- **pressure** (*Optional*): The information for the pressure sensor.
 
   - **name** (**Required**, string): The name for the pressure sensor.
   - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.

--- a/components/sensor/bmp280.rst
+++ b/components/sensor/bmp280.rst
@@ -35,7 +35,7 @@ required to be set up in your configuration for this sensor to work.
 Configuration variables:
 ------------------------
 
-- **temperature** (**Required**): The information for the temperature.
+- **temperature** (*Optional*): The information for the temperature.
   sensor
 
   - **name** (**Required**, string): The name for the temperature
@@ -45,7 +45,7 @@ Configuration variables:
   - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.
   - All other options from :ref:`Sensor <config-sensor>`.
 
-- **pressure** (**Required**): The information for the pressure sensor.
+- **pressure** (*Optional*): The information for the pressure sensor.
 
   - **name** (**Required**, string): The name for the pressure sensor.
   - **oversampling** (*Optional*): The oversampling parameter for the temperature sensor.


### PR DESCRIPTION
## Description:
For the BME280, BME680, BMP085 and BMP280 sensors the individual sensors are optional.

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
