### PR TITLE
BME680 default address is 0x76

### DIFF
--- a/components/sensor/bme680.rst
+++ b/components/sensor/bme680.rst
@@ -70,7 +70,7 @@ Configuration variables:
   - All other options from :ref:`Sensor <config-sensor>`.
 
 - **address** (*Optional*, int): Manually specify the I^2C address of
-  the sensor. Defaults to ``0x77``. Another address can be ``0x76``.
+  the sensor. Defaults to ``0x76``. Another address can be ``0x77``.
 - **iir_filter** (*Optional*): Set up an Infinite Impulse Response filter to increase accuracy. One of
   ``OFF``, ``1x``, ``3x``, ``7x``, ``15x``, ``31x``, ``63x`` and ``127x``. Defaults to ``OFF``.
 - **heater** (*Optional*): The settings for the internal heater for the gas sensor. Set this


### PR DESCRIPTION
## Description:
The BME680 default address config is 0x76, with the secondary address being 0x77.

See https://github.com/esphome/esphome/blob/002861f13b2e3a9dfd16a1157b12894daf08a6cb/esphome/components/bme680/sensor.py#L62

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
