### PR TITLE
Update PN532 docs to add I2C

### DIFF
--- a/components/binary_sensor/pn532.rst
+++ b/components/binary_sensor/pn532.rst
@@ -13,7 +13,7 @@ Component/Hub
 
 The ``pn532`` component allows you to use PN532 NFC/RFID controllers
 (`datasheet <https://cdn-shop.adafruit.com/datasheets/pn532ds.pdf>`__, `Adafruit <https://www.adafruit.com/product/364>`__)
-with ESPHome. This component is a global hub that establishes the connection to the PN532 via :ref:`SPI <spi>` and
+with ESPHome. This component is a global hub that establishes the connection to the PN532 via :ref:`SPI <spi>` or :ref:`I^2C <i2c>` and
 outputs its data. Using the :ref:`PN532 binary sensors <pn532-tag>` you can then
 create individual binary sensors that track if an NFC/RFID tag is currently detected by the PN532.
 
@@ -23,20 +23,20 @@ create individual binary sensors that track if an NFC/RFID tag is currently dete
 
 See :ref:`pn532-setting_up_tags` for information on how to setup individual binary sensors for this component.
 
-As the communication with the PN532 is done using SPI for this integration, you need to set the two switches on
-the board to the SPI mode (usually by setting the first one to OFF and the second one to ON). Additionally, you need
-to have an :ref:`SPI bus <spi>` in your configuration with both the **miso_pin** and **mosi_pin** set.
+The PN532 can be configured to use either the SPI **or** I^2C protocol for data communication.
+You will need to switch the dip switches located on the module according to the table printed on the board.
+SPI is usually switch 1 OFF and switch 2 ON and I^2C is usually switch 1 ON and switch 2 OFF.
+You will need to have the :ref:`SPI Bus <spi>` or the :ref:`I^2C Bus <i2c>` configured depending on your choice.
 
 .. code-block:: yaml
 
-    # Example configuration entry
-    spi:
-      clk_pin: D0
-      miso_pin: D1
-      mosi_pin: D2
-
-    pn532:
+    # Example configuration for SPI (choose which one!)
+    pn532_spi:
       cs_pin: D3
+      update_interval: 1s
+
+    # Example configuration for I2C (choose which one!)
+    pn532_i2c:
       update_interval: 1s
 
     binary_sensor:
@@ -47,7 +47,7 @@ to have an :ref:`SPI bus <spi>` in your configuration with both the **miso_pin**
 Configuration variables:
 ************************
 
-- **cs_pin** (**Required**, :ref:`Pin Schema <config-pin_schema>`): The pin on the ESP that the chip select line
+- **cs_pin** (**Required for SPI**, :ref:`Pin Schema <config-pin_schema>`): The pin on the ESP that the chip select line
   is connected to.
 - **update_interval** (*Optional*, :ref:`config-time`): The duration of each scan on the PN532. This affects the
   duration that the individual binary sensors stay active when they're found.
@@ -56,6 +56,8 @@ Configuration variables:
   when a tag is read. See :ref:`pn532-on_tag`.
 - **spi_id** (*Optional*, :ref:`config-id`): Manually specify the ID of the :ref:`SPI Component <spi>` if you want
   to use multiple SPI buses.
+- **i2c_id** (*Optional*, :ref:`config-id`): Manually specify the ID of the :ref:`I^2C Component <spi>` if you want
+  to use multiple I^2C buses.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID for this component.
 
 .. figure:: images/pn532-spi.jpg
@@ -69,9 +71,8 @@ Configuration variables:
 ``on_tag``
 ----------
 
-This automation will be triggered when the PN532 module responds with a tag. Please note that this
-can be called quite often (with an interval of ``update_interval``) as it's triggered repeatedly
-if the tag is re-read many times.
+This automation will be triggered when the PN532 module responds with a tag. This will only be triggered
+if the tag is changed or goes away for one cycle of ``update_interval``.
 
 The parameter ``x`` this trigger provides is of type ``std::string`` and is the tag UID in the format
 ``74-10-37-94``. The configuration below will for example publish the tag ID on the MQTT topic ``pn532/tag``.
@@ -113,7 +114,7 @@ unique id (``uid``) is currently being detected by the PN532 or not.
       miso_pin: D1
       mosi_pin: D2
 
-    pn532:
+    pn532_spi:
       cs_pin: D3
       update_interval: 1s
 


### PR DESCRIPTION
## Description:
Add docs updates to specify PN532 can be used on either SPI or I2C

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#1302

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
