### PR TITLE
Add docs for ttgo-b1 version

### DIFF
--- a/components/display/waveshare_epaper.rst
+++ b/components/display/waveshare_epaper.rst
@@ -8,7 +8,7 @@ Waveshare E-Paper Display
 The ``waveshare_epaper`` display platform allows you to use
 some E-Paper displays sold by `Waveshare <https://www.waveshare.com/product/displays/e-paper.htm>`__
 with ESPHome. The 2.13" `TTGO module <https://github.com/lewisxhe/TTGO-EPaper-Series>`__ with an ESP32 on the board is supported as well.
-Depending on your specific revision of the board you might need to try out the `-b73` version (see below).
+Depending on your specific revision of the board you might need to try out the `-b73` or `-b1` version (see below).
 Similar modules sold by other vendors might also work but not have been tested yet. Currently only
 single-color E-Ink displays are implemented and of those only a few modules.
 
@@ -73,8 +73,9 @@ Configuration variables:
 
   - ``1.54in``
   - ``2.13in`` (not tested)
-  - ``2.13in-ttgo`` (T5_V2.3 tested)
+  - ``2.13in-ttgo`` (T5_V2.3 tested, probably B72 display)
   - ``2.13in-ttgo-b73`` (T5_V2.3 with B73 display tested)
+  - ``2.13in-ttgo-b1`` (T5_V2.3 with B1 display tested)
   - ``2.70in``
   - ``2.90in``
   - ``2.90in-b`` (B/W rendering only)


### PR DESCRIPTION
## Description:

Add documentation for new TTGO T5 2.13 inch epaper module hw version B1 (2.13in-ttgo-b1)

**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/1187
**Pull request in esphome with YAML changes (if applicable)**: esphome/esphome#1326

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
Branch `next` seems to be behind `current`? There is no mention of 2.13in-ttgo-b73 in `next` here https://github.com/esphome/esphome-docs/blob/next/components/display/waveshare_epaper.rst
