### PR TITLE
Add docs for rotary encoder on_clockwise and on_anticlockwise triggers

### DIFF
--- a/components/sensor/rotary_encoder.rst
+++ b/components/sensor/rotary_encoder.rst
@@ -60,9 +60,9 @@ Configuration variables:
 - **max_value** (*Optional*, int): The maximum value this rotary encoder will go to, turning
   the knob further will not increase the number. Defaults to no maximum.
 - **on_clockwise** (*Optional*, :ref:`Automation <automation>`): Actions to be performed when
-  the knob is turned clockwise. See :ref:`_sensor-rotary_encoder-triggers_`.
+  the knob is turned clockwise. See :ref:`_sensor-rotary_encoder-triggers`.
 - **on_anticlockwise** (*Optional*, :ref:`Automation <automation>`): Actions to be performed when
-  the knob is turned anticlockwise. See :ref:`_sensor-rotary_encoder-triggers_`.
+  the knob is turned anticlockwise. See :ref:`_sensor-rotary_encoder-triggers`.
 - All other options from :ref:`Sensor <config-sensor>`.
 
 .. _sensor-rotary_encoder-set_value_action:
@@ -99,7 +99,7 @@ Configuration options:
 - **value** (**Required**, int, :ref:`templatable <config-templatable>`):
   The value to set the internal counter to.
 
-.. _sensor-rotary_encoder-triggers_:
+.. _sensor-rotary_encoder-triggers:
 
 ``on_clockwise`` and ``on_anticlockwise`` Triggers
 --------------------------------------------------

--- a/components/sensor/rotary_encoder.rst
+++ b/components/sensor/rotary_encoder.rst
@@ -59,6 +59,10 @@ Configuration variables:
   the knob further will not decrease the number. Defaults to no minimum.
 - **max_value** (*Optional*, int): The maximum value this rotary encoder will go to, turning
   the knob further will not increase the number. Defaults to no maximum.
+- **on_clockwise** (*Optional*, :ref:`Automation <automation>`): Actions to be performed when
+  the knob is turned clockwise. See :ref:`_sensor-rotary_encoder-triggers_`.
+- **on_anticlockwise** (*Optional*, :ref:`Automation <automation>`): Actions to be performed when
+  the knob is turned anticlockwise. See :ref:`_sensor-rotary_encoder-triggers_`.
 - All other options from :ref:`Sensor <config-sensor>`.
 
 .. _sensor-rotary_encoder-set_value_action:
@@ -94,6 +98,23 @@ Configuration options:
 - **id** (**Required**, :ref:`config-id`): The ID of the rotary encoder.
 - **value** (**Required**, int, :ref:`templatable <config-templatable>`):
   The value to set the internal counter to.
+
+.. _sensor-rotary_encoder-triggers_:
+
+``on_clockwise`` and ``on_anticlockwise`` Triggers
+--------------------------------------------------
+
+With these configuration options, you can run automations based on the direction
+that the encoder has been turned, and not the value that it currently holds.
+These triggers ignore the min and max values and will trigger on every step.
+
+.. code-block:: yaml
+
+    on_clockwise:
+      - logger.log: "Turned Clockwise"
+    on_anticlockwise:
+      - logger.log: "Turned Anticlockwise"
+
 
 See Also
 --------

--- a/components/sensor/rotary_encoder.rst
+++ b/components/sensor/rotary_encoder.rst
@@ -60,9 +60,9 @@ Configuration variables:
 - **max_value** (*Optional*, int): The maximum value this rotary encoder will go to, turning
   the knob further will not increase the number. Defaults to no maximum.
 - **on_clockwise** (*Optional*, :ref:`Automation <automation>`): Actions to be performed when
-  the knob is turned clockwise. See :ref:`_sensor-rotary_encoder-triggers`.
+  the knob is turned clockwise. See :ref:`sensor-rotary_encoder-triggers`.
 - **on_anticlockwise** (*Optional*, :ref:`Automation <automation>`): Actions to be performed when
-  the knob is turned anticlockwise. See :ref:`_sensor-rotary_encoder-triggers`.
+  the knob is turned anticlockwise. See :ref:`sensor-rotary_encoder-triggers`.
 - All other options from :ref:`Sensor <config-sensor>`.
 
 .. _sensor-rotary_encoder-set_value_action:


### PR DESCRIPTION
## Description:

Adds 2 new triggers to the `rotary_encoder` sensor component. This allows you to run actions based on the direction of the turning and not the value.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#1330

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
