### PR TITLE
Update docs about MQTT lambdas

### DIFF
--- a/components/mqtt.rst
+++ b/components/mqtt.rst
@@ -334,9 +334,15 @@ Configuration variables:
 
     This action can also be used in :ref:`lambdas <config-lambda>`:
 
+    .. code-block:: yaml
+
+        mqtt:
+          # Give the mqtt component an ID
+          id: mqtt_client
+
     .. code-block:: cpp
 
-        App.get_mqtt_client()->subscribe("the/topic", [=](const std::string &payload) {
+        id(mqtt_client).subscribe("the/topic", [=](const std::string &payload) {
             // do something with payload
         });
 
@@ -397,9 +403,15 @@ Configuration variables:
 
     This action can also be used in :ref:`lambdas <config-lambda>`:
 
+    .. code-block:: yaml
+
+        mqtt:
+          # Give the mqtt component an ID
+          id: mqtt_client
+
     .. code-block:: cpp
 
-        App.get_mqtt_client()->subscribe_json("the/topic", [=](JsonObject &root) {
+        id(mqtt_client).subscribe_json("the/topic", [=](JsonObject &root) {
             // do something with JSON-decoded value root
         });
 
@@ -521,6 +533,22 @@ the MQTT broker.
           mqtt.connected:
         then:
           - logger.log: MQTT is connected!
+
+.. note::
+
+    This action can also be written in :ref:`lambdas <config-lambda>`:
+
+    .. code-block:: yaml
+
+        mqtt:
+          # Give the mqtt component an ID
+          id: mqtt_client
+
+    .. code-block:: cpp
+
+        if (id(mqtt_client)->is_connected()) {
+	  // do something if MQTT is connected
+        }
 
 See Also
 --------

--- a/components/mqtt.rst
+++ b/components/mqtt.rst
@@ -547,7 +547,7 @@ the MQTT broker.
     .. code-block:: cpp
 
         if (id(mqtt_client)->is_connected()) {
-	  // do something if MQTT is connected
+          // do something if MQTT is connected
         }
 
 See Also


### PR DESCRIPTION
## Description:
Update docs about mqtt subscription in lambdas, add docs on mqtt connected in lambdas

Note that I am not 100% sure that subscription will work, but I would expect it to: when I tried to call the code in docs I got:

```
src/main.cpp:968:15: error: 'class esphome::Application' has no member named 'get_mqtt_client'
       if (App.get_mqtt_client()->is_connected()) {
```

**Related issue (if applicable):** fixes - no issue yet, simple fix
**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
