### PR TITLE
Correct pull-up value

### DIFF
--- a/components/sensor/dallas.rst
+++ b/components/sensor/dallas.rst
@@ -20,7 +20,7 @@ and similar 1-Wire temperature sensors.
 To use your :ref:`dallas sensor <dallas-sensor>`, first define a dallas “hub” with a pin and
 id, which you will later use to create the sensors. The 1-Wire bus the
 sensors are connected to should have an external pullup resistor of
-about 4.7KΩ. For this, connect a resistor of *about* 4.7KΩ (values around that like 1Ω will, if you don't have
+about 4.7KΩ. For this, connect a resistor of *about* 4.7KΩ (values around that like 1KΩ will, if you don't have
 massively long wires, work fine in most cases) between ``3.3V`` and the data pin.
 
 .. code-block:: yaml


### PR DESCRIPTION
One Ohm most definitely would not work.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
