### PR TITLE
Update to I2C docs to explain I2C daisy chaining

### DIFF
--- a/components/i2c.rst
+++ b/components/i2c.rst
@@ -8,10 +8,13 @@ I²C Bus
     :image: i2c.png
     :keywords: i2c, iic, bus
 
-This component sets up the I²C bus for your ESP32 or ESP8266. In order for those components
+This component sets up the I²C bus for your ESP32 or ESP8266. In order for these components
 to work correctly, you need to define the I²C bus in your configuration. Please note the ESP
 will enable its internal 10kΩ pullup resistors for these pins, so you usually don't need to
-put on external ones.
+put on external ones. You can use multiple devices on one I²C bus as each device is given a 
+unique address for communicating between between it and the ESP. You can do this by hopping 
+wires from the two lines (SDA and SCL) from each device board to the next device board or by 
+connecting the wires from each device back to the two I²C pins on the ESP.
 
 .. code-block:: yaml
 


### PR DESCRIPTION
Added further information on how I2C devices can be daisy-chained together on one bus to make this clearer for new users for the I2C bus and to ESPHome.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
