### PR TITLE
Update waveshare_epaper.rst

### DIFF
--- a/components/display/waveshare_epaper.rst
+++ b/components/display/waveshare_epaper.rst
@@ -81,7 +81,7 @@ Configuration variables:
   - ``4.20in``
   - ``5.83in``
   - ``7.50in``
-  - ``7.50inV2``
+  - ``7.50inV2`` (Can't use with an ESP8266 as it runs out of RAM)
 
 - **busy_pin** (*Optional*, :ref:`Pin Schema <config-pin_schema>`): The BUSY pin. Defaults to not connected.
 - **reset_pin** (*Optional*, :ref:`Pin Schema <config-pin_schema>`): The RESET pin. Defaults to not connected.


### PR DESCRIPTION
## Description:
I tried using a d1_mini_pro for driving an e-ink display. Wouldn't work. Found out why:
Got "[E][display:017]: Could not allocate buffer for display!" from logs.
The Waveshare display 7.50inV2 has a resolution of 800x480 pixels and ESP8266 runs out of RAM.

I hope this is the right way for me to propose change in documentation (only that). First time doing this :)

**Related issue (if applicable):** n/a

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
