### PR TITLE
Update enterprise authentication docs to indicate support for ESP8266s

### DIFF
--- a/components/wifi.rst
+++ b/components/wifi.rst
@@ -182,7 +182,7 @@ Configuration variables:
 Enterprise Authentication
 -------------------------
 
-WPA2_EAP Enterprise Authentication is supported on ESP32s.
+WPA2_EAP Enterprise Authentication is supported on ESP32s and ESP8266s.
 In order to configure this feature you must use the :ref:`wifi-networks` style configuration.
 The ESP32 is known to work with PEAP, EAP-TTLS, and the certificate based EAP-TLS.
 These are advanced settings and you will usually need to consult your enterprise network administrator.


### PR DESCRIPTION
## Description:
Add ESP8266s to list of devices that support WPA2-EAP authentication. This may be better removing hte entire line as all ESPs are now supported. Comments welcome.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#1332

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
