### PR TITLE
added warning to waveshare 2.7 inch display

### DIFF
--- a/components/display/waveshare_epaper.rst
+++ b/components/display/waveshare_epaper.rst
@@ -75,7 +75,7 @@ Configuration variables:
   - ``2.13in`` (not tested)
   - ``2.13in-ttgo`` (T5_V2.3 tested)
   - ``2.13in-ttgo-b73`` (T5_V2.3 with B73 display tested)
-  - ``2.70in``
+  - ``2.70in`` (currently not working with the HAT Rev 2.1 version)
   - ``2.90in``
   - ``2.90in-b`` (B/W rendering only)
   - ``4.20in``


### PR DESCRIPTION
Added a warning to the 2.7 inch display because the HAT version seems not to work currently. I opened an issue some time before with is still open   https://github.com/esphome/issues/issues/1491

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
