### PR TITLE
Add get_setup_priority() to Custom sensor docs

### DIFF
--- a/components/sensor/custom.rst
+++ b/components/sensor/custom.rst
@@ -76,7 +76,7 @@ Let's now also take a closer look at this line, which you might not be too used 
 
 .. code-block:: cpp
 
-    class MyCustomSensor : public Component, public Sensor {
+    class MyCustomSensor : public Component, public Sensor { 
 
 What this line is essentially saying is that we're defining our own class that's called ``MyCustomSensor``
 which is also a subclass of :apiclass:`Component` and :apiclass:`Sensor <sensor::Sensor>`.
@@ -132,6 +132,57 @@ Every time ``update`` is called we will now **publish** a new value to the front
 The rest of ESPHome will then take care of processing this value and ultimately publishing it
 to the outside world (for example using MQTT).
 
+One last thing. Some sensors, such as the BMP180 were are going to explain later, require some other component before they can be used. Remember how we talked about the ``setup()`` method? Well just like when writing in the Arduino IDE, components need to be set up in the right order. For that ESPHome introduces another method in the :apiclass:`Component` class.
+
+.. code-block:: cpp
+
+    float get_setup_priority() const override { return esphome::setup_priority::HARDWARE; }
+    
+Where HARDWARE can be any of:
+
+.. code-block:: cpp
+
+        /// For communication buses like i2c/spi
+        extern const float BUS;
+        /// For components that represent GPIO pins like PCF8573
+        extern const float IO;
+        /// For components that deal with hardware and are very important like GPIO switch
+        extern const float HARDWARE;
+        /// For components that import data from directly connected sensors like DHT.
+        extern const float DATA;
+        /// Alias for DATA (here for compatability reasons)
+        extern const float HARDWARE_LATE;
+        /// For components that use data from sensors like displays
+        extern const float PROCESSOR;
+        extern const float WIFI;
+        /// For components that should be initialized after WiFi is connected.
+        extern const float AFTER_WIFI;
+        /// For components that should be initialized after a data connection (API/MQTT) is connected.
+        extern const float AFTER_CONNECTION;
+        /// For components that should be initialized at the very end of the setup process.
+        extern const float LATE;
+        
+Now don't let the wording confuse you. The ``get_setup_priority()`` method is an override. Instead of fetching the setup priority setup for us, it instead fetches the setup priority for esphome, while being defined by us. The BMP180 would for instance need to be setup with a priority of IO or lower. A serial streaming (TCP) server would require a working WIFI setup and therefore get AFTER_WIFI.
+
+This finalizes our example as:
+
+.. code-block:: cpp
+
+    class MyCustomSensor : public PollingComponent, public Sensor {
+     public:
+      // constructor
+      MyCustomSensor() : PollingComponent(15000) {}
+      
+      float get_setup_priority() const override { return esphome::setup_priority::XXXX; }
+      
+      void setup() override {
+        // This will be called by App.setup()
+      }
+      void update() override {
+        // This will be called every "update_interval" milliseconds.
+      }
+    };
+    
 Step 2: Registering the custom sensor
 -------------------------------------
 

--- a/components/sensor/custom.rst
+++ b/components/sensor/custom.rst
@@ -142,25 +142,25 @@ Where HARDWARE can be any of:
 
 .. code-block:: cpp
 
-        /// For communication buses like i2c/spi
-        extern const float BUS;
-        /// For components that represent GPIO pins like PCF8573
-        extern const float IO;
-        /// For components that deal with hardware and are very important like GPIO switch
-        extern const float HARDWARE;
-        /// For components that import data from directly connected sensors like DHT.
-        extern const float DATA;
-        /// Alias for DATA (here for compatability reasons)
-        extern const float HARDWARE_LATE;
-        /// For components that use data from sensors like displays
-        extern const float PROCESSOR;
-        extern const float WIFI;
-        /// For components that should be initialized after WiFi is connected.
-        extern const float AFTER_WIFI;
-        /// For components that should be initialized after a data connection (API/MQTT) is connected.
-        extern const float AFTER_CONNECTION;
-        /// For components that should be initialized at the very end of the setup process.
-        extern const float LATE;
+    /// For communication buses like i2c/spi
+    extern const float BUS;
+    /// For components that represent GPIO pins like PCF8573
+    extern const float IO;
+    /// For components that deal with hardware and are very important like GPIO switch
+    extern const float HARDWARE;
+    /// For components that import data from directly connected sensors like DHT.
+    extern const float DATA;
+    /// Alias for DATA (here for compatability reasons)
+    extern const float HARDWARE_LATE;
+    /// For components that use data from sensors like displays
+    extern const float PROCESSOR;
+    extern const float WIFI;
+    /// For components that should be initialized after WiFi is connected.
+    extern const float AFTER_WIFI;
+    /// For components that should be initialized after a data connection (API/MQTT) is connected.
+    extern const float AFTER_CONNECTION;
+    /// For components that should be initialized at the very end of the setup process.
+    extern const float LATE;
         
 Now don't let the wording confuse you. The ``get_setup_priority()`` method is an override. Instead of fetching the setup priority setup for us, it instead fetches the setup priority for esphome, while being defined by us. The BMP180 would for instance need to be setup with a priority of IO or lower. A serial streaming (TCP) server would require a working WIFI setup and therefore get AFTER_WIFI.
 


### PR DESCRIPTION
## Description:

added [float get_setup_priority() const override](https://github.com/esphome/esphome/blob/7b157aeff1dafa532fdcabe1f9daac8a918c3a9d/esphome/core/component.h#L15-L37)  method which I couldn't find anywhere else

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
