### PR TITLE
Add Hitachi AC344 IR Climate documentation

### DIFF
--- a/components/climate/ir_climate.rst
+++ b/components/climate/ir_climate.rst
@@ -37,6 +37,8 @@ request so it will be added (see FAQ).
 +------------------------+---------------------+----------------------+------------------------------------+
 | LG                     | ``climate_ir_lg``   | yes                  |                                    |
 +------------------------+---------------------+----------------------+------------------------------------+
+| Hitachi                | ``hitachi_ac344``   | yes                  |                                    |
++------------------------+---------------------+----------------------+------------------------------------+
 
 This component requires that you have setup a :doc:`/components/remote_transmitter`.
 
@@ -129,6 +131,7 @@ See Also
 - :apiref:`coolix.h <coolix/coolix.h>`,
   :apiref:`daikin.h <daikin/daikin.h>`
   :apiref:`fujitsu_general.h <fujitsu_general/fujitsu_general.h>`,
+  :apiref:`hitachi_ac344.h <hitachi_ac344/hitachi_ac344.h>`,
   :apiref:`mitsubishi.h <mitsubishi/mitsubishi.h>`,
   :apiref:`tcl112.h <tcl112/tcl112.h>`,
   :apiref:`yashima.h <yashima/yashima.h>`


### PR DESCRIPTION
## Description:


Added Hitachi AC344 Climate IR documentation.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#1336

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
