### PR TITLE
FastLED: Add docs for new YAML option data_rate

### DIFF
--- a/components/light/fastled.rst
+++ b/components/light/fastled.rst
@@ -123,6 +123,8 @@ Configuration variables:
 - **max_refresh_rate** (*Optional*, :ref:`config-time`):
   A time interval used to limit the number of commands a light can handle per second. For example
   16ms will limit the light to a refresh rate of about 60Hz. Defaults to the default value for the used chipset.
+- **data_rate** (*Optional*, frequency): The data rate to use for shifting data to the light. Can help if you 
+  have long cables or slow level-shifters.
 - **effects** (*Optional*, list): A list of :ref:`light effects <light-effects>` to use for this light.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
 - All other options from :ref:`Light <config-light>`.


### PR DESCRIPTION
## Description:

Add docs for the new `data_rate` option.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#1338

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
