### PR TITLE
Specify clock to be used in Tuya MCU

### DIFF
--- a/components/tuya.rst
+++ b/components/tuya.rst
@@ -56,7 +56,7 @@ Here is an example output for a Tuya fan controller:
 Configuration variables:
 ------------------------
 
-- **clock** (*Optional*, :ref:`config-id`): Some Tuya devices support obtaining local time from ESPHome. 
+- **time_id** (*Optional*, :ref:`config-id`): Some Tuya devices support obtaining local time from ESPHome. 
   Specify the ID of the :ref:`Time Component <time>` which will be used.
 
 

--- a/components/tuya.rst
+++ b/components/tuya.rst
@@ -53,6 +53,13 @@ Here is an example output for a Tuya fan controller:
     [12:39:45][C][tuya:046]:   Product: '{"p":"hqq73kftvzh8c92u","v":"1.0.0","m":0}'
 
 
+Configuration variables:
+------------------------
+
+- **clock** (*Optional*, :ref:`config-id`): Some Tuya devices support obtaining local time from ESPHome. 
+  Specify the ID of the :ref:`Time Component <time>` which will be used.
+
+
 See Also
 --------
 


### PR DESCRIPTION
## Description:
Tuya MCU allows obtaining local time by MCU from esp by 0x1C command.
https://developer.tuya.com/en/docs/iot/device-development/access-mode-mcu/wifi-general-solution/software-reference-wifi/tuya-cloud-universal-serial-port-access-protocol?id=K9hhi0xxtn9cb#title-16-Obtaining%20local%20time


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):
https://github.com/esphome/esphome/pull/1344

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
