### PR TITLE
Add separate current/target Tuya Climate multipliers

### DIFF
--- a/components/climate/tuya.rst
+++ b/components/climate/tuya.rst
@@ -49,7 +49,7 @@ Configuration variables:
 - **target_temperature_datapoint** (**Required**, int): The datapoint id number of the target temperature.
 - **current_temperature_datapoint** (**Required**, int): The datapoint id number of the current temperature.
 - **temperature_multiplier** (**Optional**, float): A multiplier to modify the incoming and outgoing temperature values - :ref:`see below <temperature-multiplier>`.
-  If the device has different multipliers for current and target temperatures, **temperature_multiplier** can be replaced with either or both of:
+  If the device has different multipliers for current and target temperatures, **temperature_multiplier** can be replaced with both of:
 
     - **current_temperature_multiplier** (**Optional**, float): A multiplier to modify the current temperature value.
     - **target_temperature_multiplier** (**Optional**, float): A multiplier to modify the target temperature value.

--- a/components/climate/tuya.rst
+++ b/components/climate/tuya.rst
@@ -49,8 +49,10 @@ Configuration variables:
 - **target_temperature_datapoint** (**Required**, int): The datapoint id number of the target temperature.
 - **current_temperature_datapoint** (**Required**, int): The datapoint id number of the current temperature.
 - **temperature_multiplier** (**Optional**, float): A multiplier to modify the incoming and outgoing temperature values - :ref:`see below <temperature-multiplier>`.
-- **current_temperature_multiplier** (**Optional**, float): A multiplier to modify the current temperature value - :ref:`see below <temperature-multiplier>`.
-- **target_temperature_multiplier** (**Optional**, float): A multiplier to modify the target temperature value - :ref:`see below <temperature-multiplier>`.
+  If the device has different multipliers for current and target temperatures, **temperature_multiplier** can be replaced with either or both of:
+
+    - **current_temperature_multiplier** (**Optional**, float): A multiplier to modify the current temperature value.
+    - **target_temperature_multiplier** (**Optional**, float): A multiplier to modify the target temperature value.
 - All other options from :ref:`Climate <config-climate>`.
 
 .. _temperature-multiplier:

--- a/components/climate/tuya.rst
+++ b/components/climate/tuya.rst
@@ -48,6 +48,7 @@ Configuration variables:
 - **switch_datapoint** (**Required**, int): The datapoint id number of the climate switch.
 - **target_temperature_datapoint** (**Required**, int): The datapoint id number of the target temperature.
 - **current_temperature_datapoint** (**Required**, int): The datapoint id number of the current temperature.
+- **temperature_multiplier** (**Optional**, float): A multiplier to modify the incoming and outgoing temperature values - :ref:`see below <temperature-multiplier>`.
 - **current_temperature_multiplier** (**Optional**, float): A multiplier to modify the current temperature value - :ref:`see below <temperature-multiplier>`.
 - **target_temperature_multiplier** (**Optional**, float): A multiplier to modify the target temperature value - :ref:`see below <temperature-multiplier>`.
 - All other options from :ref:`Climate <config-climate>`.

--- a/components/climate/tuya.rst
+++ b/components/climate/tuya.rst
@@ -48,7 +48,8 @@ Configuration variables:
 - **switch_datapoint** (**Required**, int): The datapoint id number of the climate switch.
 - **target_temperature_datapoint** (**Required**, int): The datapoint id number of the target temperature.
 - **current_temperature_datapoint** (**Required**, int): The datapoint id number of the current temperature.
-- **temperature_multiplier** (**Optional**, float): A multiplier to modify the incoming and outgoing temperature values - :ref:`see below <temperature-multiplier>`.
+- **current_temperature_multiplier** (**Optional**, float): A multiplier to modify the current temperature value - :ref:`see below <temperature-multiplier>`.
+- **target_temperature_multiplier** (**Optional**, float): A multiplier to modify the target temperature value - :ref:`see below <temperature-multiplier>`.
 - All other options from :ref:`Climate <config-climate>`.
 
 .. _temperature-multiplier:


### PR DESCRIPTION
## Description:
Some Tuya thermostats have different multipliers for current and target temperatures.
So the current approach (having a single `temperature_multiplier`) cannot handle both cases.

This is breaking change, it introduces separate multipliers for both values


**Related issue (if applicable):

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):
https://github.com/esphome/esphome/pull/1345

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
