### PR TITLE
Link to Winsen ZE08-CH2O custom component

### DIFF
--- a/guides/diy.rst
+++ b/guides/diy.rst
@@ -69,6 +69,7 @@ Custom Components & Code
 - `Paradox alarm system sensors custom component <https://github.com/Margriko/Paradox-ESPHome>`__ by :ghuser:`Margriko`
 - `DSC POWER832 (PC5010) alarm system custom component <https://github.com/Dilbert66/esphome-dsckeybus>`__ by :ghuser:`Dilbert66`
 - `ADEMCO/VISTA/Honeywell alarm system custom component <https://github.com/Dilbert66/esphome-vistaECP>`__ by :ghuser:`Dilbert66`
+- `Winsen ZE08-CH2O (Formaldehyde sensor) custom component <https://gist.github.com/cretep/f96606dc6a4eae0d85993d6085959220>`__ by :ghuser:`cretep`
 
 Sample Configurations
 ---------------------


### PR DESCRIPTION
Add link to C++ library and example ESPHome YAML config for reading Winsen's Formaldehyde sensor over serial.

Original code; other implementations I found do not switch the component into question-answer mode (to control update frequency) and they read each UART byte individually. Most Winsen sensors communicate over a serial protocol they have developed, but it is not consistent enough throughout their components to become a common 'winsen' library.