### PR TITLE
Add warning about pn532 moved config key

### DIFF
--- a/components/binary_sensor/pn532.rst
+++ b/components/binary_sensor/pn532.rst
@@ -28,6 +28,11 @@ You will need to switch the dip switches located on the module according to the 
 SPI is usually switch 1 OFF and switch 2 ON and I^2C is usually switch 1 ON and switch 2 OFF.
 You will need to have the :ref:`SPI Bus <spi>` or the :ref:`I^2C Bus <i2c>` configured depending on your choice.
 
+.. warning::
+
+    ``pn532`` as a config key has been removed in favour of ``pn532_spi`` and ``pn532_i2c`` depending on the protocol
+    you choose to use.
+
 .. code-block:: yaml
 
     # Example configuration for SPI (choose which one!)

--- a/components/binary_sensor/pn532.rst
+++ b/components/binary_sensor/pn532.rst
@@ -30,7 +30,7 @@ You will need to have the :ref:`SPI Bus <spi>` or the :ref:`I^2C Bus <i2c>` conf
 
 .. warning::
 
-    ``pn532`` as a config key has been removed in favour of ``pn532_spi`` and ``pn532_i2c`` depending on the protocol
+    Starting in 1.16.0 ``pn532`` as a config key has been removed in favour of ``pn532_spi`` and ``pn532_i2c`` depending on the protocol
     you choose to use.
 
 .. code-block:: yaml


### PR DESCRIPTION
## Description:
Adds a warning about the removed `pn532` key to point users to `pn532_spi` or `pn532_i2c`

Related changes #798 / esphome/esphome#1302

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
