### PR TITLE
I2c text update

### DIFF
--- a/components/binary_sensor/mpr121.rst
+++ b/components/binary_sensor/mpr121.rst
@@ -45,7 +45,7 @@ The configuration is made up of two parts: The central component, and individual
 
 Base Configuration:
 
-- **address** (*Optional*, integer): The I^2C address of the sensor. Defaults to ``0x5A``.
+- **address** (*Optional*, integer): The I²C address of the sensor. Defaults to ``0x5A``.
 - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor.
 - **touch_debounce** (*Optional*, integer): The minimum length before a touch is recognized. Range is from 0 to 7.
   Defaults to 0.

--- a/components/binary_sensor/pn532.rst
+++ b/components/binary_sensor/pn532.rst
@@ -13,7 +13,7 @@ Component/Hub
 
 The ``pn532`` component allows you to use PN532 NFC/RFID controllers
 (`datasheet <https://cdn-shop.adafruit.com/datasheets/pn532ds.pdf>`__, `Adafruit <https://www.adafruit.com/product/364>`__)
-with ESPHome. This component is a global hub that establishes the connection to the PN532 via :ref:`SPI <spi>` or :ref:`I^2C <i2c>` and
+with ESPHome. This component is a global hub that establishes the connection to the PN532 via :ref:`SPI <spi>` or :ref:`I²C <i2c>` and
 outputs its data. Using the :ref:`PN532 binary sensors <pn532-tag>` you can then
 create individual binary sensors that track if an NFC/RFID tag is currently detected by the PN532.
 
@@ -23,10 +23,10 @@ create individual binary sensors that track if an NFC/RFID tag is currently dete
 
 See :ref:`pn532-setting_up_tags` for information on how to setup individual binary sensors for this component.
 
-The PN532 can be configured to use either the SPI **or** I^2C protocol for data communication.
+The PN532 can be configured to use either the SPI **or** I²C protocol for data communication.
 You will need to switch the dip switches located on the module according to the table printed on the board.
-SPI is usually switch 1 OFF and switch 2 ON and I^2C is usually switch 1 ON and switch 2 OFF.
-You will need to have the :ref:`SPI Bus <spi>` or the :ref:`I^2C Bus <i2c>` configured depending on your choice.
+SPI is usually switch 1 OFF and switch 2 ON and I²C is usually switch 1 ON and switch 2 OFF.
+You will need to have the :ref:`SPI Bus <spi>` or the :ref:`I²C Bus <i2c>` configured depending on your choice.
 
 .. code-block:: yaml
 
@@ -56,8 +56,8 @@ Configuration variables:
   when a tag is read. See :ref:`pn532-on_tag`.
 - **spi_id** (*Optional*, :ref:`config-id`): Manually specify the ID of the :ref:`SPI Component <spi>` if you want
   to use multiple SPI buses.
-- **i2c_id** (*Optional*, :ref:`config-id`): Manually specify the ID of the :ref:`I^2C Component <spi>` if you want
-  to use multiple I^2C buses.
+- **i2c_id** (*Optional*, :ref:`config-id`): Manually specify the ID of the :ref:`I²C Component <spi>` if you want
+  to use multiple I²C buses.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID for this component.
 
 .. figure:: images/pn532-spi.jpg

--- a/components/binary_sensor/pn532.rst
+++ b/components/binary_sensor/pn532.rst
@@ -35,7 +35,7 @@ You will need to have the :ref:`SPI Bus <spi>` or the :ref:`I²C Bus <i2c>` conf
       cs_pin: D3
       update_interval: 1s
 
-    # Example configuration for I2C (choose which one!)
+    # Example configuration for I²C (choose which one!)
     pn532_i2c:
       update_interval: 1s
 

--- a/components/esp32_camera.rst
+++ b/components/esp32_camera.rst
@@ -45,10 +45,10 @@ Connection Options:
   - **frequency** (*Optional*, float): The frequency of the external clock, must be either 20MHz
     or 10MHz. Defaults to ``20MHz``.
 
-- **i2c_pins** (**Required**): The I^2C control pins of the camera.
+- **i2c_pins** (**Required**): The I²C control pins of the camera.
 
-  - **sda** (**Required**, pin): The SDA pin of the I^2C interface. Also called ``SIOD``.
-  - **scl** (**Required**, pin): The SCL pin of the I^2C interface. Also called ``SIOC``.
+  - **sda** (**Required**, pin): The SDA pin of the I²C interface. Also called ``SIOD``.
+  - **scl** (**Required**, pin): The SCL pin of the I²C interface. Also called ``SIOC``.
 
 - **reset_pin** (*Optional*, pin): The ESP pin the reset pin of the camera is connected to.
   If set, this will reset the camera before the ESP boots.
@@ -261,8 +261,8 @@ Configuration for TTGO T-Journal
       # Image settings
       name: My Camera
       # ...
-      
-      
+
+
 Configuration for TTGO-Camera Plus
 ----------------------------------
 

--- a/components/logger.rst
+++ b/components/logger.rst
@@ -94,7 +94,7 @@ Possible log levels are (sorted by severity):
 -  ``VERY_VERBOSE``
 
   - All internal messages are logged. Including all the data flowing through data buses like
-    I2C, SPI or UART. Warning: May cause the device to slow down and have trouble staying
+    I²C, SPI or UART. Warning: May cause the device to slow down and have trouble staying
     connecting due to amount of generated messages. Color: white
 
 .. _logger-manual_tag_specific_levels:
@@ -185,7 +185,7 @@ using ``message`` (``const char *``), ``level`` (``int``) and ``tag`` (``const c
 
 .. note::
 
-    Logging will not work in the ``on_message`` trigger. You can't use the :ref:`logger.log <logger-log_action>` action  
+    Logging will not work in the ``on_message`` trigger. You can't use the :ref:`logger.log <logger-log_action>` action
     and the ``ESP_LOGx`` logging macros in this automation.
 
 See Also

--- a/components/sensor/ade7953.rst
+++ b/components/sensor/ade7953.rst
@@ -42,7 +42,7 @@ required to be set up in your configuration for this sensor to work.
 Configuration variables:
 ------------------------
 
-- **address** (*Optional*, int): Manually specify the I^2C address of the sensor. Defaults to ``0x38``.
+- **address** (*Optional*, int): Manually specify the I²C address of the sensor. Defaults to ``0x38``.
 - **voltage** (*Optional*): Use the voltage value of the sensor in volt. All options from
   :ref:`Sensor <config-sensor>`.
 - **current_a** (*Optional*): Use the current value of the A channel in amperes. All options from

--- a/components/sensor/am2320.rst
+++ b/components/sensor/am2320.rst
@@ -7,7 +7,7 @@ AM2320 Temperature+Humidity Sensor
     :keywords: am2320
 
 The ``am2320`` Temperature+Humidity sensor allows you to use your AM2320
-(`datasheet <https://akizukidenshi.com/download/ds/aosong/AM2320.pdf>`__) I^2C-based sensor with ESPHome.
+(`datasheet <https://akizukidenshi.com/download/ds/aosong/AM2320.pdf>`__) I²C-based sensor with ESPHome.
 
 .. figure:: images/am2320-full.jpg
     :align: center

--- a/components/sensor/apds9960.rst
+++ b/components/sensor/apds9960.rst
@@ -45,7 +45,7 @@ and direction binary sensors.
 
 Base Configuration:
 
-- **address** (*Optional*, integer): The I2C address of the sensor. Defaults to ``0x39``.
+- **address** (*Optional*, integer): The I²C address of the sensor. Defaults to ``0x39``.
 - **update_interval** (*Optional*, :ref:`config-time`): The interval
   to check the sensor. Defaults to ``60s``.
 

--- a/components/sensor/as3935.rst
+++ b/components/sensor/as3935.rst
@@ -52,7 +52,7 @@ A1            I²C address selection MSB
     as3935_spi:
       cs_pin: GPIO12
       irq_pin: GPIO13
-    # Example configuration for I2C (decide for one!)
+    # Example configuration for I²C (decide for one!)
     as3935_i2c:
       irq_pin: GPIO12
 
@@ -121,7 +121,7 @@ Use this if you want to use your AS3935 in I²C mode.
 
 .. code-block:: yaml
 
-    # Example configuration for I2C (decide for one!)
+    # Example configuration for I²C (decide for one!)
     as3935_i2c:
       irq_pin: GPIO12
     # Example shared configuration

--- a/components/sensor/as3935.rst
+++ b/components/sensor/as3935.rst
@@ -14,7 +14,7 @@ The AS3935 can detect the presence of lightning activity and provide an estimati
 on the distance to the head of the storm. The chip issues a notification through an interrupt
 pin.
 
-The AS3935 can be configured to use either the SPI **or** I^2C protocol for data communication.
+The AS3935 can be configured to use either the SPI **or** I²C protocol for data communication.
 First choose which communication method you want to use for the sensor, set the SI pin for the appropriate
 level and set up the ESPhome integration for the chosen communication method.
 
@@ -114,10 +114,10 @@ Sensor entries:
      the ID used for code generation.
   -  All other options from :ref:`Binary Sensor <config-binary_sensor>`.
 
-Configuration variables (I^2C):
+Configuration variables (I²C):
 -------------------------------
 
-Use this if you want to use your AS3935 in I^2C mode.
+Use this if you want to use your AS3935 in I²C mode.
 
 .. code-block:: yaml
 
@@ -135,7 +135,7 @@ Use this if you want to use your AS3935 in I^2C mode.
       - platform: as3935
         name: "Storm Alert"
 
-- **address** (*Optional*, int): Manually specify the I^2C address of
+- **address** (*Optional*, int): Manually specify the I²C address of
   the sensor. Defaults to ``0x03`` (``A0` and ``A1`` pins pulled low).
   Another address can be ``0x02``.
 

--- a/components/sensor/bh1750.rst
+++ b/components/sensor/bh1750.rst
@@ -41,7 +41,7 @@ Configuration variables:
 ------------------------
 
 - **name** (**Required**, string): The name for the sensor.
-- **address** (*Optional*, int): Manually specify the I^2C address of the sensor.
+- **address** (*Optional*, int): Manually specify the I²C address of the sensor.
   Defaults to ``0x23`` (address if address pin is pulled low). If the address pin is pulled high,
   the address is ``0x5C``.
 - **measurement_time** (*Optional*, int): Manually specifiy the measurement time between ``31``

--- a/components/sensor/bme280.rst
+++ b/components/sensor/bme280.rst
@@ -63,7 +63,7 @@ Configuration variables:
   - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.
   - All other options from :ref:`Sensor <config-sensor>`.
 
-- **address** (*Optional*, int): Manually specify the I^2C address of
+- **address** (*Optional*, int): Manually specify the I²C address of
   the sensor. Defaults to ``0x77``. Another address can be ``0x76``.
 - **iir_filter** (*Optional*): Set up an Infinite Impulse Response filter to increase accuracy. One of
   ``OFF``, ``2x``, ``4x``, ``16x``. Defaults to ``OFF``.

--- a/components/sensor/bme680.rst
+++ b/components/sensor/bme680.rst
@@ -69,7 +69,7 @@ Configuration variables:
   - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.
   - All other options from :ref:`Sensor <config-sensor>`.
 
-- **address** (*Optional*, int): Manually specify the I^2C address of
+- **address** (*Optional*, int): Manually specify the I²C address of
   the sensor. Defaults to ``0x77``. Another address can be ``0x76``.
 - **iir_filter** (*Optional*): Set up an Infinite Impulse Response filter to increase accuracy. One of
   ``OFF``, ``1x``, ``3x``, ``7x``, ``15x``, ``31x``, ``63x`` and ``127x``. Defaults to ``OFF``.

--- a/components/sensor/bmp280.rst
+++ b/components/sensor/bmp280.rst
@@ -53,7 +53,7 @@ Configuration variables:
   - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.
   - All other options from :ref:`Sensor <config-sensor>`.
 
-- **address** (*Optional*, int): Manually specify the I^2C address of
+- **address** (*Optional*, int): Manually specify the I²C address of
   the sensor. Defaults to ``0x77``. Another address can be ``0x76``.
 - **iir_filter** (*Optional*): Set up an Infinite Impulse Response filter to increase accuracy. One of
   ``OFF``, ``2x``, ``4x``, ``16x``. Defaults to ``OFF``.

--- a/components/sensor/dht12.rst
+++ b/components/sensor/dht12.rst
@@ -8,7 +8,7 @@ DHT12 Temperature+Humidity Sensor
 
 The ``dht12`` Temperature+Humidity sensor allows you to use your DHT12
 (`datasheet <http://www.robototehnika.ru/file/DHT12.pdf>`__,
-`electrodragon`_) I^2C-based sensor with ESPHome. This sensor is also called AM2320 by some sellers.
+`electrodragon`_) I²C-based sensor with ESPHome. This sensor is also called AM2320 by some sellers.
 
 .. figure:: images/dht12-full.jpg
     :align: center

--- a/components/sensor/hm3301.rst
+++ b/components/sensor/hm3301.rst
@@ -9,7 +9,7 @@ The ``HM3301`` sensor platform allows you to use your HM3301 particulate matter 
 (`more info <http://wiki.seeedstudio.com/Grove-Laser_PM2.5_Sensor-HM3301>`__)
 sensors with ESPHome.
 
-The sensor communicate with board by ``I2C`` protocol, and requires 3.3v.
+The sensor communicate with board by :ref:`I²C <i2c>` protocol, and requires 3.3v.
 
 .. code-block:: yaml
 

--- a/components/sensor/hmc5883l.rst
+++ b/components/sensor/hmc5883l.rst
@@ -42,7 +42,7 @@ for this sensor to work.
 Configuration variables:
 ------------------------
 
-- **address** (*Optional*, int): Manually specify the I^2C address of the sensor. Defaults to ``0x1E``.
+- **address** (*Optional*, int): Manually specify the I²C address of the sensor. Defaults to ``0x1E``.
 - **field_strength_x** (*Optional*): The field strength in microtesla along the X-Axis. All options from
   :ref:`Sensor <config-sensor>`.
 - **field_strength_y** (*Optional*): The field strength in microtesla along the Y-Axis. All options from

--- a/components/sensor/ina219.rst
+++ b/components/sensor/ina219.rst
@@ -47,7 +47,7 @@ required to be set up in your configuration for this sensor to work.
 Configuration variables:
 ------------------------
 
-- **address** (*Optional*, int): Manually specify the I^2C address of the sensor. Defaults to ``0x40``.
+- **address** (*Optional*, int): Manually specify the I²C address of the sensor. Defaults to ``0x40``.
 - **shunt_resistance** (*Optional*, float): The value of the shunt resistor on the board for current calculation.
   Defaults to ``0.1 ohm``.
 - **max_voltage** (*Optional*, float): The maximum bus voltage you are expecting. ESPHome will use this to

--- a/components/sensor/ina226.rst
+++ b/components/sensor/ina226.rst
@@ -42,7 +42,7 @@ required to be set up in your configuration for this sensor to work.
 Configuration variables:
 ------------------------
 
-- **address** (*Optional*, int): Manually specify the i^2c address of the sensor. Defaults to ``0x40``.
+- **address** (*Optional*, int): Manually specify the I²C address of the sensor. Defaults to ``0x40``.
 - **shunt_resistance** (*Optional*, float): The value of the shunt resistor on the board for current calculation.
   Defaults to ``0.1 ohm``.
 - **max_current** (*Optional*, float): The maximum current you are expecting. ESPHome will use this to

--- a/components/sensor/ina3221.rst
+++ b/components/sensor/ina3221.rst
@@ -50,7 +50,7 @@ required to be set up in your configuration for this sensor to work.
 Configuration variables:
 ------------------------
 
-- **address** (*Optional*, int): Manually specify the I^2C address of the sensor. Defaults to ``0x40``.
+- **address** (*Optional*, int): Manually specify the I²C address of the sensor. Defaults to ``0x40``.
 - **channel_1** (*Optional*): The configuration options for the 1st channel.
 
   - **shunt_resistance** (*Optional*, float): The value of the shunt resistor on this channel for current calculation.

--- a/components/sensor/mpu6050.rst
+++ b/components/sensor/mpu6050.rst
@@ -53,7 +53,7 @@ new feature. Supporting all possible use-cases would be quite hard.
 Configuration variables:
 ------------------------
 
-- **address** (*Optional*, int): Manually specify the I^2C address of the sensor. Defaults to ``0x68``.
+- **address** (*Optional*, int): Manually specify the I²C address of the sensor. Defaults to ``0x68``.
 - **accel_x** (*Optional*): Use the X-Axis of the Accelerometer. All options from
   :ref:`Sensor <config-sensor>`.
 - **accel_y** (*Optional*): Use the Y-Axis of the Accelerometer. All options from

--- a/components/sensor/ms5611.rst
+++ b/components/sensor/ms5611.rst
@@ -51,7 +51,7 @@ Configuration variables:
   - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.
   - All other options from :ref:`Sensor <config-sensor>`.
 
-- **address** (*Optional*, int): Manually specify the I^2C address of
+- **address** (*Optional*, int): Manually specify the I²C address of
   the sensor. Defaults to ``0x77``.
 - **update_interval** (*Optional*, :ref:`config-time`): The interval to check the
   sensor. Defaults to ``60s``.

--- a/components/sensor/scd30.rst
+++ b/components/sensor/scd30.rst
@@ -53,7 +53,7 @@ Configuration variables:
   - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.
   - All other options from :ref:`Sensor <config-sensor>`.
 
-- **address** (*Optional*, int): Manually specify the I^2C address of the sensor.
+- **address** (*Optional*, int): Manually specify the I²C address of the sensor.
   Defaults to ``0x61``.
 
 - **update_interval** (*Optional*, :ref:`config-time`): The interval to check the

--- a/components/sensor/sgp30.rst
+++ b/components/sensor/sgp30.rst
@@ -43,7 +43,7 @@ Configuration variables:
   - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.
   - All other options from :ref:`Sensor <config-sensor>`.
 
-- **address** (*Optional*, int): Manually specify the I^2C address of the sensor.
+- **address** (*Optional*, int): Manually specify the I²C address of the sensor.
   Defaults to ``0x58``.
 
 - **update_interval** (*Optional*, :ref:`config-time`): The interval to check the

--- a/components/sensor/sht3xd.rst
+++ b/components/sensor/sht3xd.rst
@@ -44,7 +44,7 @@ Configuration variables:
   - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.
   - All other options from :ref:`Sensor <config-sensor>`.
 
-- **address** (*Optional*, int): Manually specify the I^2C address of the sensor.
+- **address** (*Optional*, int): Manually specify the I²C address of the sensor.
   Defaults to ``0x44``.
 - **update_interval** (*Optional*, :ref:`config-time`): The interval to check the
   sensor. Defaults to ``60s``.

--- a/components/sensor/shtcx.rst
+++ b/components/sensor/shtcx.rst
@@ -47,7 +47,7 @@ Configuration variables:
   - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.
   - All other options from :ref:`Sensor <config-sensor>`.
 
-- **address** (*Optional*, int): Manually specify the I^2C address of the sensor.
+- **address** (*Optional*, int): Manually specify the I²C address of the sensor.
   Defaults to ``0x70``.
 - **update_interval** (*Optional*, :ref:`config-time`): The interval to check the
   sensor. Defaults to ``60s``.

--- a/components/sensor/sps30.rst
+++ b/components/sensor/sps30.rst
@@ -109,7 +109,7 @@ Configuration variables:
   - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.
   - All other options from :ref:`Sensor <config-sensor>`.
 
-- **address** (*Optional*, int): Manually specify the i^2c address of the sensor.
+- **address** (*Optional*, int): Manually specify the I²C address of the sensor.
   Defaults to ``0x69``.
 - **update_interval** (*Optional*, :ref:`config-time`): The interval to check the
   sensor. Defaults to ``60s``.

--- a/components/sensor/sts3x.rst
+++ b/components/sensor/sts3x.rst
@@ -28,7 +28,7 @@ Configuration variables:
 ------------------------
 
 - **name** (**Required**, string): The name for the temperature sensor.
-- **address** (*Optional*, int): Manually specify the I^2C address of the sensor.
+- **address** (*Optional*, int): Manually specify the I²C address of the sensor.
   Defaults to ``0x4A``.
 - **update_interval** (*Optional*, :ref:`config-time`): The interval to check the
   sensor. Defaults to ``60s``.

--- a/components/sensor/tcs34725.rst
+++ b/components/sensor/tcs34725.rst
@@ -64,7 +64,7 @@ Configuration variables:
   values are ``1x`` (default), ``4x``, ``16x``, ``60x`` (highest gain).
 - **integration_time** (*Optional*): The amount of time the light sensor is exposed. Valid values are
   ``2.4ms`` (default), ``24ms``, ``50ms``, ``101ms``, ``154ms``, ``700ms``.
-- **address** (*Optional*, int): Manually specify the I^2C address of the sensor. Defaults to ``0x29``.
+- **address** (*Optional*, int): Manually specify the I²C address of the sensor. Defaults to ``0x29``.
 - **update_interval** (*Optional*, :ref:`config-time`): The interval to check the
   sensor. Defaults to ``60s``.
 

--- a/components/sensor/tmp117.rst
+++ b/components/sensor/tmp117.rst
@@ -20,7 +20,7 @@ sensors with ESPHome.
 
 .. _Sparkfun: https://www.sparkfun.com/products/15805
 
-The TMP117 is a high precision temperature sensor that communicates over I2C. Each sensor is tested on a NIST tracable test setup during Texas Instruments' production process. Accuracy should be at worst 0.1C across the -20C to +50C temperature range.
+The TMP117 is a high precision temperature sensor that communicates over I²C. Each sensor is tested on a NIST tracable test setup during Texas Instruments' production process. Accuracy should be at worst 0.1C across the -20C to +50C temperature range.
 
 To use the sensor, first set up an :ref:`I²C Bus <i2c>` and connect the sensor to the specified pins.
 

--- a/components/sensor/tsl2561.rst
+++ b/components/sensor/tsl2561.rst
@@ -37,7 +37,7 @@ Configuration variables:
 ------------------------
 
 - **name** (**Required**, string): The name for the sensor.
-- **address** (*Optional*, int): Manually specify the I^2C address of the sensor. Defaults to ``0x39``.
+- **address** (*Optional*, int): Manually specify the I²C address of the sensor. Defaults to ``0x39``.
 - **integration_time** (*Optional*, :ref:`config-time`):
   The time the sensor will take for each measurement. Longer means more accurate values. One of
   ``14ms``, ``101ms``, ``402ms``. Defaults to ``402ms``.

--- a/components/sensor/vl53l0x.rst
+++ b/components/sensor/vl53l0x.rst
@@ -53,7 +53,7 @@ Configuration variables:
 - All other options from :ref:`Sensor <config-sensor>`.
 - **long_range** (*Optional*, bool): Set the sensor in long range mode. The signal_rate_limit is overruled
   to ``0.1``. Defaults to false.
-- **address** (*Optional*, int): Manually specify the I^2C address of the sensor. Defaults to ``0x29``.
+- **address** (*Optional*, int): Manually specify the I²C address of the sensor. Defaults to ``0x29``.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
 
 See Also

--- a/components/sx1509.rst
+++ b/components/sx1509.rst
@@ -17,7 +17,7 @@ The SX1509 can do much more than just simple digital pin control. It can produce
 And, with a built-in keypad engine, it can interface with up to 64 buttons set up in an 8x8 matrix.
 
 Any option accepting a :ref:`Pin Schema <config-pin_schema>` can theoretically be used, but some more
-complicated components that use the pin schema will not work. For example the I2C or SPI pins.
+complicated components that use the pin schema will not work. For example the I²C or SPI pins.
 
 .. figure:: images/sx1509-full.jpg
     :align: center

--- a/cookbook/bme280_environment.rst
+++ b/cookbook/bme280_environment.rst
@@ -6,7 +6,7 @@ BME280 Environment
     :image: bme280.jpg
     :keywords: BME280
 
-The :doc:`/components/sensor/bme280` is a simple temperature, humidity, and pressure sensor with communication over I2C.
+The :doc:`/components/sensor/bme280` is a simple temperature, humidity, and pressure sensor with communication over :ref:`I²C <i2c>`.
 With some simple math it is possible to either determine the height of the sensor, or the current pressure at sea level.
 This guide can be applied to any sensor measuring temperature and pressure at the same time, like the
 :doc:`/components/sensor/bmp280`, or :doc:`/components/sensor/bme680`.

--- a/guides/configuration-types.rst
+++ b/guides/configuration-types.rst
@@ -291,7 +291,7 @@ config in non-destructive way so you could always override some bits and pieces 
 configuration.
 
 Consider the following example where author put common pieces of configuration like WiFi,
-I2C into base files and extends it with some devices specific configurations in the main config.
+I²C into base files and extends it with some devices specific configurations in the main config.
 
 Note how the piece of configuration describing ``api`` component in ``device_base.yaml`` gets
 merged with the services definitions from main config file.
@@ -342,7 +342,7 @@ merged with the services definitions from main config file.
       board: wemos_d1_mini32
       build_path: ./build/${node_name}
 
-    # I2C Bus
+    # I²C Bus
     i2c:
       sda: GPIO21
       scl: GPIO22

--- a/guides/contributing.rst
+++ b/guides/contributing.rst
@@ -577,7 +577,7 @@ Standard for the esphome-core codebase:
   communication interface, please consider implementing the library natively in ESPHome.
 
   - This depends on the communication interface of course - if the library is directly working
-    with pins or doesn't do any I/O itself, it's ok. However if it's something like I^2C, then ESPHome's
+    with pins or doesn't do any I/O itself, it's ok. However if it's something like I²C, then ESPHome's
     own communication abstractions should be used. Especially if the library accesses a global variable/state
     like ``Wire`` there's a problem because then the component may not modular (i.e. not possible
     to create two instances of a component on one ESP)

--- a/guides/faq.rst
+++ b/guides/faq.rst
@@ -107,7 +107,7 @@ For me to fix the issue quickly, there are some things that would be really help
     help given just that information?
 2.  A snippet of the code/configuration file used is always great to reproduce this issue.
     Please read `How to create a Minimal, Complete, and Verifiable example <https://stackoverflow.com/help/mcve>`__.
-3.  If it's an I^2C or hardware communication issue please also try setting the
+3.  If it's an I²C or hardware communication issue please also try setting the
     :ref:`log level <logger-log_levels>` to ``VERY_VERBOSE`` as it provides helpful information
     about what is going on.
 4.  Please also include what you've already tried and didn't work as that can help us track down the issue.


### PR DESCRIPTION
## Description:

For some consistency in the docs, replacing `I^2C` and `I2C` with the nicer looking `I²C`

I have put this to next as there are occurrences there and this can wait for the next release.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
