### PR TITLE
scd30: Add missing configuration variables

### DIFF
--- a/components/sensor/scd30.rst
+++ b/components/sensor/scd30.rst
@@ -53,6 +53,17 @@ Configuration variables:
   - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.
   - All other options from :ref:`Sensor <config-sensor>`.
 
+- **automatic_self_calibration** (*Optional*, bool): Whether to enable
+  automatic self calibration (ASC). Defaults to ``true``.
+
+- **ambient_pressure_compensation** (*Optional*, int): Enable compensation
+  of measured CO₂ values based on given ambient pressure in mBar.
+
+- **altitude_compensation** (*Optional*, int): Enable compensating
+  deviations due to current altitude (in metres). Notice: setting
+  *altitude_compensation* is ignored if *ambient_pressure_compensation*
+  is set.
+
 - **address** (*Optional*, int): Manually specify the I²C address of the sensor.
   Defaults to ``0x61``.
 


### PR DESCRIPTION
Add documentation for automatic self calibration, ambient pressure and altitude compensation settings.


**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#1365

## Checklist:

  - [x ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
