### PR TITLE
Updated link to ble_monitor (previous mitemp_bt)

### DIFF
--- a/components/sensor/xiaomi_ble.rst
+++ b/components/sensor/xiaomi_ble.rst
@@ -359,8 +359,8 @@ See Also
 - :doc:`/components/esp32_ble_tracker`
 - :doc:`/components/sensor/index`
 - :apiref:`xiaomi_lywsd03mmc/xiaomi_ble.h`
-- Xiaomi Home Assistant mitemp_bt custom component `<https://github.com/custom-components/sensor.mitemp_bt>`__
-  by `@Magalex2x14 <https://github.com/Magalex2x14>`__
+- Passive BLE monitor integration for Home Assistant (ble_monitor custom component) `<https://github.com/custom-components/ble_monitor>`__
+  by `@Magalex2x14 <https://github.com/Magalex2x14>`__ and `@Ernst79 <https://github.com/Ernst79>`__
 - Xiaomi LYWSD03MMC passive sensor readout `<https://github.com/ahpohl/xiaomi_lywsd03mmc>`__ by `@ahpohl <https://github.com/ahpohl>`__
 - Mi-standardauth `<https://github.com/danielkucera/mi-standardauth>`__
 


### PR DESCRIPTION
## Description:
- Our mitemp_bt custom component for Home Assistant has changed names to ble_monitor. 
- Updated links to repository
- Added myself as second developer of ble_monitor

**Related issue (if applicable):** fixes n/a

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** n/a

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
