### PR TITLE
Add troubleshooting help with light partition

### DIFF
--- a/components/light/partition.rst
+++ b/components/light/partition.rst
@@ -11,6 +11,9 @@ This platform also allows splitting up an addressable lights into multiple segme
 segments can be individually controlled.
 
 Similarly, a single light strip can be partitioned into multiple partitions with this integration.
+If you want to do this, you may run into strange behavior - the original light entity (f.e. ``fastled_clockless``)
+may be conflicting with the partition. For better control over which fragments of the strip will overlap each other,
+mark the original ``light`` as ``internal: true``.
 
 .. code-block:: yaml
 
@@ -31,6 +34,8 @@ Similarly, a single light strip can be partitioned into multiple partitions with
       # Example for light segment source
       - platform: fastled_clockless
         id: light2
+        # You may want (but don't need) to do this:
+        internal: true
         # Other settings
 
 Configuration variables:

--- a/components/light/partition.rst
+++ b/components/light/partition.rst
@@ -11,8 +11,9 @@ This platform also allows splitting up an addressable lights into multiple segme
 segments can be individually controlled.
 
 Similarly, a single light strip can be partitioned into multiple partitions with this integration.
-If you want to do this, you may run into strange behavior - the original light entity (f.e. ``fastled_clockless``)
-may be conflicting with the partition. For better control over which fragments of the strip will overlap each other,
+
+If you want to do this, you may run into strange behavior like that the original light entity (e.g., ``fastled_clockless``)
+may be conflicting with the partition. For better control over which segments of the strip will overlap each other,
 mark the original ``light`` as ``internal: true``.
 
 .. code-block:: yaml
@@ -34,7 +35,7 @@ mark the original ``light`` as ``internal: true``.
       # Example for light segment source
       - platform: fastled_clockless
         id: light2
-        # You may want (but don't need) to do this:
+        # You may want (but don't need) this
         internal: true
         # Other settings
 


### PR DESCRIPTION
## Description:
When I wanted to divide my single strip into multiple parts to use as separate HA entities, I've ran into some issues: original light component kept conflicting with the new partition.

I figured out that the best solution is to just mark original light as internal, and control all segments myself - not to be forced to have single entity that will turn on/off whole strip

So I added this in documentation of partition :smile: :+1: 

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
