### PR TITLE
DIY: Add Blogpost for SP501E as WS2812 LED Controller

### DIFF
--- a/guides/diy.rst
+++ b/guides/diy.rst
@@ -41,6 +41,7 @@ Blog Posts & Videos
 - `Esp32 six shutters controller <https://github.com/Gio-dot/Six-shutters-ESP32-controller>`__ by `Gio-dot <https://github.com/Gio-dot>`__ 
 - `Washing machine phases detector (Sonoff Pow R2) <https://github.com/Gio-dot/Washing-Machine-Sonoff-Pow-R2-Esphome>`__ by `Gio-dot <https://github.com/Gio-dot>`__ 
 - `Sonoff L1 LED Strip <https://emorydunn.com/blog/2020/08/10/sonoff-l1-home-assistant/>`__ by :ghuser:`emorydunn`
+- `ESPHome for SP501E LED Controller <https://margau.net/posts/2020-11-21-2h-led-hack/>`__ by `margau <https://margau.net>`__ 
 
 Custom Components & Code
 ------------------------


### PR DESCRIPTION
## Description:
This PR adds a link to a blog post describing how to run ESPHome on a cheap digital LED Controller.

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
