### PR TITLE
Fix teleinfo

### DIFF
--- a/components/sensor/teleinfo.rst
+++ b/components/sensor/teleinfo.rst
@@ -107,7 +107,8 @@ Configuration variables:
     logger:     
       baud_rate: 0   # disable logging via UART, help to avoid numerous crash with ESP_LOGD
       level: INFO   # INFO for less log, put DEBUG to view all the linky's "étiquettes" received  in the logs
-      esp8266_store_log_strings_in_flash: False     # recommanded for ESP8266 https://esphome.io/components/sensor/custom.html
+      esp8266_store_log_strings_in_flash: False     #  :doc:`recommanded for ESP8266 </components/sensor/custom>`
+      
     
 
 See Also

--- a/components/sensor/teleinfo.rst
+++ b/components/sensor/teleinfo.rst
@@ -97,6 +97,18 @@ Configuration variables:
 - **uart_id** (*Optional*, :ref:`config-id`): Manually specify the ID of the :ref:`UART Component <uart>` if you want
   to use multiple UART buses.
 
+.. note::
+
+    On ESP8266, the logging via UART must be disabled to avoid crashes leading to boot loop :
+    
+    .. code-block:: yaml
+    
+    logger:     
+      baud_rate: 0   # disable logging via UART, help to avoid numerous crash with ESP_LOGD
+      level: INFO   # INFO for less log, put DEBUG to view all the linky's "étiquettes" received  in the logs
+      esp8266_store_log_strings_in_flash: False     # recommanded for ESP8266 https://esphome.io/components/sensor/custom.html
+    
+
 See Also
 --------
 

--- a/components/sensor/teleinfo.rst
+++ b/components/sensor/teleinfo.rst
@@ -60,17 +60,17 @@ simply press -/+ buttons on the counter and look for `Standard mode` or
     sensor:
       - platform: teleinfo
         tags:
-         - name: "HCHC"
+         - tag_name: "HCHC"
            sensor:
             name: "hchc"
             unit_of_measurement: "Wh"
             icon: mdi:flash
-         - name: "HCHP"
+         - tag_name: "HCHP"
            sensor:
             name: "hchp"
             unit_of_measurement: "Wh"
             icon: mdi:flash
-         - name: "PAPP"
+         - tag_name: "PAPP"
            sensor:
             name: "papp"
             unit_of_measurement: "VA"

--- a/components/sensor/teleinfo.rst
+++ b/components/sensor/teleinfo.rst
@@ -97,12 +97,13 @@ Configuration variables:
 - **uart_id** (*Optional*, :ref:`config-id`): Manually specify the ID of the :ref:`UART Component <uart>` if you want
   to use multiple UART buses.
 
-.. note::
+
+.. warning::
 
     On ESP8266, the logging via UART must be disabled to avoid crashes leading to boot loop :
     
-    .. code-block:: yaml
-    
+.. code-block:: yaml
+
     logger:     
       baud_rate: 0   # disable logging via UART, help to avoid numerous crash with ESP_LOGD
       level: INFO   # INFO for less log, put DEBUG to view all the linky's "étiquettes" received  in the logs


### PR DESCRIPTION
## Description:
Teleinfo component 
Correct yaml example (according to test1.yaml in esphome repo) and add a warning to disable loggin via UART

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
