### PR TITLE
Update docs for Configurable OTA Safe Mode

### DIFF
--- a/components/ota.rst
+++ b/components/ota.rst
@@ -23,8 +23,6 @@ Logging+WiFi+OTA are initialized, so that you can upload a new binary.
     ota:
       safe_mode: True
       password: VERYSECURE
-      reboot_timeout: 5min
-      num_attempts: 10
 
 Configuration variables:
 ------------------------

--- a/components/ota.rst
+++ b/components/ota.rst
@@ -23,7 +23,7 @@ Logging+WiFi+OTA are initialized, so that you can upload a new binary.
     ota:
       safe_mode: True
       password: VERYSECURE
-      reboot_timeout: 2min
+      reboot_timeout: 5min
       num_attempts: 10
 
 Configuration variables:

--- a/components/ota.rst
+++ b/components/ota.rst
@@ -13,8 +13,8 @@ uploads. ESPHome natively supports this through its ``run`` and
 
 ESPHome also has an "OTA safe mode". If for some reason your
 node gets into a boot loop, ESPHome will automatically try to detect
-this and will go over into a safe mode after 10 unsuccessful boot
-attempts. In that mode, all components are disabled and only Serial
+this and will go over into a safe mode after the configured unsuccessful boot
+attempts (Defaults to ``10``). In that mode, all components are disabled and only Serial
 Logging+WiFi+OTA are initialized, so that you can upload a new binary.
 
 .. code-block:: yaml
@@ -23,6 +23,8 @@ Logging+WiFi+OTA are initialized, so that you can upload a new binary.
     ota:
       safe_mode: True
       password: VERYSECURE
+      reboot_timeout: 2min
+      num_attempts: 10
 
 Configuration variables:
 ------------------------
@@ -33,6 +35,9 @@ Configuration variables:
 -  **port** (*Optional*, int): The port to use for OTA updates. Defaults
    to ``3232`` for the ESP32 and ``8266`` for the ESP8266.
 -  **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
+-  **reboot_timeout** (*Optional*, :ref:`time <config-time>`): The amount of time to wait before rebooting when in
+   safe mode. Defaults to ``5min``.
+-  **num_attempts** (*Optional*, int): The number of attempts to wait before entering safe mode. Defaults to ``10``.
 
 .. note::
 


### PR DESCRIPTION
## Description:
Documents configurable OTA safe mode options.

**Related issue (if applicable):** fixes esphome/issues#1629

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#1393

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
