### PR TITLE
Update ethernet.rst

### DIFF
--- a/components/ethernet.rst
+++ b/components/ethernet.rst
@@ -91,7 +91,19 @@ Configuration for Olimex ESP32-POE
       clk_mode: GPIO17_OUT
       phy_addr: 0
       power_pin: GPIO12
-      
+
+Configuration for LILYGO TTGO T-Internet-POE ESP32-WROOM LAN8270A Chip
+----------------------------------------------------------------------
+
+.. code-block:: yaml
+
+    ethernet:
+      type: LAN8720
+      mdc_pin: GPIO23
+      mdio_pin: GPIO18
+      clk_mode: GPIO17_OUT
+      phy_addr: 0
+
 Configuration for OpenHacks LAN8720
 -----------------------------------
 


### PR DESCRIPTION
Added configuration for LilyGO-T-ETH-POE board

## Description:
Added configuration for LilyGO-T-ETH-POE board, as tested

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
