### PR TITLE
Update custom_component.rst

### DIFF
--- a/custom/custom_component.rst
+++ b/custom/custom_component.rst
@@ -41,6 +41,9 @@ And in YAML:
 .. code-block:: yaml
 
     # Example configuration entry
+    mqtt:
+      broker: localhost
+    
     esphome:
       includes:
         - my_custom_component.h


### PR DESCRIPTION
There must be mqtt: component configured to compile the example.

## Description:

Improve documentation of CustomMQTTDevice, make implicit, that you have to configure the mqtt broker to use the component.

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
