### PR TITLE
Change on_message topics into a yaml list for deep_sleep docs

### DIFF
--- a/components/deep_sleep.rst
+++ b/components/deep_sleep.rst
@@ -123,14 +123,14 @@ Useful for
         mqtt:
           # ...
           on_message:
-            topic: livingroom/ota_mode
-            payload: 'ON'
-            then:
-              - deep_sleep.prevent: deep_sleep_1
-            topic: livingroom/sleep_mode
-            payload: 'ON'
-            then:
-              - deep_sleep.enter: deep_sleep_1
+            - topic: livingroom/ota_mode
+              payload: 'ON'
+              then:
+                - deep_sleep.prevent: deep_sleep_1
+            - topic: livingroom/sleep_mode
+              payload: 'ON'
+              then:
+                - deep_sleep.enter: deep_sleep_1
 
 See Also
 --------


### PR DESCRIPTION
## Description:
mqtt's on_message requires multiple topics to be passed in via a list

**Related issue (if applicable):** None, I can file an issue if needed

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** N/A

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
