### PR TITLE
Update wifi.rst

### DIFF
--- a/components/wifi.rst
+++ b/components/wifi.rst
@@ -205,6 +205,7 @@ These are advanced settings and you will usually need to consult your enterprise
           password: VerySafePassword
       - ssid: EAP-TLS_EnterpriseNetwork
         eap:
+          identity: bob
           certificate_authority: ca_cert.pem
           certificate: cert.pem
           key: key.pem


### PR DESCRIPTION
Add identity key in EAP-TLS example, as it should be required for EAP-TLS

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
