### PR TITLE
Update CGG1 documentation around bindkey

### DIFF
--- a/components/sensor/xiaomi_ble.rst
+++ b/components/sensor/xiaomi_ble.rst
@@ -140,7 +140,9 @@ Configuration example:
 CGG1
 ****
 
-Hygro thermometer, round body, e-ink display
+Cleargrass (Qingping): hygro thermometer, round body, e-ink display.
+
+New firmware requires a bindkey in order to decrypt the received data (see :ref:`obtaining_the_bindkey`), and stopped broadcasting battery level.
 
 .. figure:: images/xiaomi_cgg1.jpg
     :align: center
@@ -159,6 +161,13 @@ Configuration example:
           name: "CGG1 Humidity"
         battery_level:
           name: "CGG1 Battery Level"
+      - platform: xiaomi_cgg1
+        mac_address: "7A:80:8E:28:39:CD"
+        bindkey: "00112233445566778899aabbccddeeff"
+        temperature:
+          name: "CGG1 (New) Temperature"
+        humidity:
+          name: "CGG1 (New) Humidity"
 
 LYWSD03MMC
 **********


### PR DESCRIPTION
## Description:

Update the xiaomi_ble documentation to include a notice that a bindkey may be needed with newer CGG1 devices.

**Related issue (if applicable):** (possibly) fixes https://github.com/esphome/issues/issues/1659

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#1407

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
