### PR TITLE
Update teckin sb50 entry as they cannot be flashed anymore

### DIFF
--- a/cookbook/teckin_sb50.rst
+++ b/cookbook/teckin_sb50.rst
@@ -10,10 +10,13 @@ TECKIN SB50 LED Bulb
     :align: center
     :width: 50.0%
 
-**WARNING**: It is not currently possible to flash these bulbs with tuya-convert due to shipping with an updated/patched firmware.  Please see https://github.com/ct-Open-Source/tuya-convert/issues/483 for details and progress on a workaround.
+.. waring::
+
+    It is not currently possible to flash these bulbs with ``tuya-convert`` due to shipping with an updated/patched firmware.
+    Please check `this issue <https://github.com/ct-Open-Source/tuya-convert/issues/483>`__ for details and progress on a workaround.
 
 The Teckin SB50 Bulb's are a great option for lighting that could previously be flashed with tuya-convert. More details can be found at tuya-convert `github page <https://github.com/ct-Open-Source/tuya-convert>`__.
-Below is the ESPHome configuration file that will get you up and running. This assumes you have a secret.yaml with ssid, password, api_password and ota_password keys.
+Below is the ESPHome configuration file that will get you up and running. This assumes you have a ``secret.yaml`` with ssid, password, api_password and ota_password keys.
 
 .. code-block:: yaml
 

--- a/cookbook/teckin_sb50.rst
+++ b/cookbook/teckin_sb50.rst
@@ -10,7 +10,9 @@ TECKIN SB50 LED Bulb
     :align: center
     :width: 50.0%
 
-The Teckin SB50 Bulb's are a great option for lighting that can be flashed with tuya-convert. More details can be found at tuya-convert `github page <https://github.com/ct-Open-Source/tuya-convert>`__.
+**WARNING**: It is not currently possible to flash these bulbs with tuya-convert due to shipping with an updated/patched firmware.  Please see https://github.com/ct-Open-Source/tuya-convert/issues/483 for details and progress on a workaround.
+
+The Teckin SB50 Bulb's are a great option for lighting that could previously be flashed with tuya-convert. More details can be found at tuya-convert `github page <https://github.com/ct-Open-Source/tuya-convert>`__.
 Below is the ESPHome configuration file that will get you up and running. This assumes you have a secret.yaml with ssid, password, api_password and ota_password keys.
 
 .. code-block:: yaml

--- a/cookbook/teckin_sb50.rst
+++ b/cookbook/teckin_sb50.rst
@@ -10,7 +10,7 @@ TECKIN SB50 LED Bulb
     :align: center
     :width: 50.0%
 
-.. waring::
+.. warning::
 
     It is not currently possible to flash these bulbs with ``tuya-convert`` due to shipping with an updated/patched firmware.
     Please check `this issue <https://github.com/ct-Open-Source/tuya-convert/issues/483>`__ for details and progress on a workaround.


### PR DESCRIPTION
Unfortunately these bulbs are now shipping with a newer firmware that can no longer be flashed by tuya-convert.  I am not sure if the page should have any more details than this (or if it should be deleted instead), but I'm mostly just hoping to prevent people from buying them if they expect to be able to use tuya-convert with them.

Related issues:

- https://github.com/esphome/issues/issues/1289
- https://github.com/ct-Open-Source/tuya-convert/issues/483
- https://github.com/ct-Open-Source/tuya-convert/issues/586