### PR TITLE
Removed err. setting from pzem example

### DIFF
--- a/components/sensor/pzemac.rst
+++ b/components/sensor/pzemac.rst
@@ -38,7 +38,6 @@ to some pins on your board and the baud rate set to 9600.
       rx_pin: D1
       tx_pin: D2
       baud_rate: 9600
-      stop_bits: 2
 
     sensor:
       - platform: pzemac


### PR DESCRIPTION
Fixes https://github.com/esphome/issues/issues/827

## Description:
Remove incorrect "stop bits" setting from the example

**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/827

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
