### PR TITLE
Fix one of the commens in code block

### DIFF
--- a/custom/custom_component.rst
+++ b/custom/custom_component.rst
@@ -87,7 +87,7 @@ Home Assistant, as well as starting services in Home Assistant.
         //     - cycle_duration: integer
         //     - silent: boolean
         //     - string_argument: string
-        //  - The function on_hello_world declared below will attached to the service.
+        //  - The function start_washer_cycle declared below will attached to the service.
         register_service(&MyCustomComponent::on_start_washer_cycle, "start_washer_cycle",
                          {"cycle_duration", "silent", "string_argument"});
 


### PR DESCRIPTION
## Description:
The start_washer_cycle service comment seems to be mistaken. Apparantly the mistake came from copy-pasting comment.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
