### PR TITLE
added auto_detach_time and transition_length

### DIFF
--- a/components/servo.rst
+++ b/components/servo.rst
@@ -55,6 +55,9 @@ Advanced Options:
 - **restore** (*Optional*, boolean): Whether to restore the state of the servo motor at startup.
   This is useful if you have an absolute servo motor and it goes back to its 0 position at startup.
   Defaults to ``false``.
+- **keep_on_time** (*Optional*, ms): The time after reaching the target value when the servo will be detached.
+- **run_duration** (*Optional*, ms): The needed for a full movement (-1.0 to 1.0).
+This can slow down the servo to avoid loud noises or just make the movement not jerking.
 
 .. note::
 

--- a/components/servo.rst
+++ b/components/servo.rst
@@ -55,8 +55,8 @@ Advanced Options:
 - **restore** (*Optional*, boolean): Whether to restore the state of the servo motor at startup.
   This is useful if you have an absolute servo motor and it goes back to its 0 position at startup.
   Defaults to ``false``.
-- **keep_on_time** (*Optional*, ms): The time after reaching the target value when the servo will be detached.
-- **run_duration** (*Optional*, ms): The needed for a full movement (-1.0 to 1.0).
+- **auto_detach_time** (*Optional*, ms): The time after reaching the target value when the servo will be detached.
+- **transition_length** (*Optional*, ms): The needed for a full movement (-1.0 to 1.0).
   This can slow down the servo to avoid loud noises or just make the movement not jerking.
 
 .. note::

--- a/components/servo.rst
+++ b/components/servo.rst
@@ -57,7 +57,7 @@ Advanced Options:
   Defaults to ``false``.
 - **keep_on_time** (*Optional*, ms): The time after reaching the target value when the servo will be detached.
 - **run_duration** (*Optional*, ms): The needed for a full movement (-1.0 to 1.0).
-This can slow down the servo to avoid loud noises or just make the movement not jerking.
+  This can slow down the servo to avoid loud noises or just make the movement not jerking.
 
 .. note::
 


### PR DESCRIPTION
## Description:
This pull add the functionality to tell servos a time after reaching there target to detach automaticly.
Additional a transition_length is added to slow the movement down.


**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#1413

## Checklist:

  - [X] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
