### PR TITLE
Update max31856.rst

### DIFF
--- a/components/sensor/max31856.rst
+++ b/components/sensor/max31856.rst
@@ -38,7 +38,7 @@ to have an :ref:`spi bus <spi>` in your configuration with both **miso_pin** and
       mosi_pin: GPIO23
 
     sensor:
-      - platform: MAX31856
+      - platform: max31856
         name: "BBQ Temperature"
         icon: "mdi:hamburger"
         cs_pin: GPIO17


### PR DESCRIPTION
When compiling the example code, the compiler returns: 

Platform not found: 'sensor.MAX31856'

changing the platform to "max31856" appears to resolve the issue.

## Description:


**Related issue (if applicable):** fixes N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable): N/A

## Checklist:

  - [ X] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ NA] Link added in `/index.rst` when creating new documents for new components or cookbook.
