### PR TITLE
Safe Mode Brick Option

### DIFF
--- a/components/ota.rst
+++ b/components/ota.rst
@@ -37,6 +37,7 @@ Configuration variables:
      become unusable until the next OTA. This allows you to forcibly induce a safe mode by manually power cycling
      the device. Useful in situations where you are unable to serial flash and the device freezes during run.
      Defaults to ``False``.
+
      Warning: This has the same cavets as :ref:`esphome-esp8266_restore_from_flash`.
 
 -  **password** (*Optional*, string): The password to use for updates.

--- a/components/ota.rst
+++ b/components/ota.rst
@@ -31,13 +31,13 @@ Configuration variables:
    Defaults to ``True``.
 
   -  **num_attempts** (*Optional*, int): The number of attempts to wait before entering safe mode.
-    Defaults to ``10``.
+     Defaults to ``10``.
   -  **store_bootloops_in_flash_and_brick** (*Optional*, boolean): Whether to store unhandled bootloops in flash
-    and become bricked in safe mode once the `num_attempts` have been reached. Once in safe mode, the device will
-    become unusable until the next OTA. This allows you to forcibly induce a safe mode by manually power cycling
-    the device. Useful in situations where you are unable to serial flash and the device freezes during run.
-    Defaults to ``False``.
-    Warning: This has the same cavets as :ref:`esphome-esp8266_restore_from_flash`.
+     and become bricked in safe mode once the `num_attempts` have been reached. Once in safe mode, the device will
+     become unusable until the next OTA. This allows you to forcibly induce a safe mode by manually power cycling
+     the device. Useful in situations where you are unable to serial flash and the device freezes during run.
+     Defaults to ``False``.
+     Warning: This has the same cavets as :ref:`esphome-esp8266_restore_from_flash`.
 
 -  **password** (*Optional*, string): The password to use for updates.
 -  **port** (*Optional*, int): The port to use for OTA updates. Defaults

--- a/components/ota.rst
+++ b/components/ota.rst
@@ -30,6 +30,8 @@ Configuration variables:
 -  **safe_mode** (*Optional*, boolean): Whether to enable safe mode.
    Defaults to ``True``.
 
+  -  **reboot_timeout** (*Optional*, :ref:`time <config-time>`): The amount of time to wait before rebooting when in
+     safe mode. Defaults to ``5min``.
   -  **num_attempts** (*Optional*, int): The number of attempts to wait before entering safe mode.
      Defaults to ``10``.
   -  **store_bootloops_in_flash_and_brick** (*Optional*, boolean): Whether to store unhandled bootloops in flash
@@ -44,8 +46,6 @@ Configuration variables:
 -  **port** (*Optional*, int): The port to use for OTA updates. Defaults
    to ``3232`` for the ESP32 and ``8266`` for the ESP8266.
 -  **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
--  **reboot_timeout** (*Optional*, :ref:`time <config-time>`): The amount of time to wait before rebooting when in
-   safe mode. Defaults to ``5min``.
 
 .. note::
 

--- a/components/ota.rst
+++ b/components/ota.rst
@@ -29,13 +29,20 @@ Configuration variables:
 
 -  **safe_mode** (*Optional*, boolean): Whether to enable safe mode.
    Defaults to ``True``.
+  -  **num_attempts** (*Optional*, int): The number of attempts to wait before entering safe mode.
+    Defaults to ``10``.
+  -  **store_bootloops_in_flash_and_brick** (*Optional*, boolean): Whether to store unhandled bootloops in flash
+    and become bricked in safe mode once the `num_attempts` have been reached. Once in safe mode, the device will
+    become unusable until the next OTA. This allows you to forcibly induce a safe mode by manually power cycling
+    the device. Useful in situations where you are unable to serial flash and the device freezes during run.
+    Defaults to ``False``.
+    Warning: This has the same cavets as :ref:`_esphome-esp8266_restore_from_flash`.
 -  **password** (*Optional*, string): The password to use for updates.
 -  **port** (*Optional*, int): The port to use for OTA updates. Defaults
    to ``3232`` for the ESP32 and ``8266`` for the ESP8266.
 -  **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
 -  **reboot_timeout** (*Optional*, :ref:`time <config-time>`): The amount of time to wait before rebooting when in
    safe mode. Defaults to ``5min``.
--  **num_attempts** (*Optional*, int): The number of attempts to wait before entering safe mode. Defaults to ``10``.
 
 .. note::
 

--- a/components/ota.rst
+++ b/components/ota.rst
@@ -37,7 +37,7 @@ Configuration variables:
     become unusable until the next OTA. This allows you to forcibly induce a safe mode by manually power cycling
     the device. Useful in situations where you are unable to serial flash and the device freezes during run.
     Defaults to ``False``.
-    Warning: This has the same cavets as :ref:`_esphome-esp8266_restore_from_flash`.
+    Warning: This has the same cavets as :ref:`esphome-esp8266_restore_from_flash`.
 
 -  **password** (*Optional*, string): The password to use for updates.
 -  **port** (*Optional*, int): The port to use for OTA updates. Defaults

--- a/components/ota.rst
+++ b/components/ota.rst
@@ -33,7 +33,7 @@ Configuration variables:
   -  **num_attempts** (*Optional*, int): The number of attempts to wait before entering safe mode.
      Defaults to ``10``.
   -  **store_bootloops_in_flash_and_brick** (*Optional*, boolean): Whether to store unhandled bootloops in flash
-     and become bricked in safe mode once the `num_attempts` have been reached. Once in safe mode, the device will
+     and become bricked in safe mode once the ``num_attempts`` have been reached. Once in safe mode, the device will
      become unusable until the next OTA. This allows you to forcibly induce a safe mode by manually power cycling
      the device. Useful in situations where you are unable to serial flash and the device freezes during run.
      Defaults to ``False``.

--- a/components/ota.rst
+++ b/components/ota.rst
@@ -29,6 +29,7 @@ Configuration variables:
 
 -  **safe_mode** (*Optional*, boolean): Whether to enable safe mode.
    Defaults to ``True``.
+
   -  **num_attempts** (*Optional*, int): The number of attempts to wait before entering safe mode.
     Defaults to ``10``.
   -  **store_bootloops_in_flash_and_brick** (*Optional*, boolean): Whether to store unhandled bootloops in flash
@@ -37,6 +38,7 @@ Configuration variables:
     the device. Useful in situations where you are unable to serial flash and the device freezes during run.
     Defaults to ``False``.
     Warning: This has the same cavets as :ref:`_esphome-esp8266_restore_from_flash`.
+
 -  **password** (*Optional*, string): The password to use for updates.
 -  **port** (*Optional*, int): The port to use for OTA updates. Defaults
    to ``3232`` for the ESP32 and ``8266`` for the ESP8266.


### PR DESCRIPTION
## Description:
Adds safe mode brick option. Useful for Tuya devices.

**Related issue (if applicable):** fixes esphome/feature-requests#1039

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#1420

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
