### PR TITLE
Update sonof_basic.rst - incorrect example

### DIFF
--- a/devices/sonoff_basic.rst
+++ b/devices/sonoff_basic.rst
@@ -54,18 +54,19 @@ exposes all of the basic functions.
     esphome:
       name: <NAME_OF_NODE>
       platform: ESP8266
-      board: esp8285
-      arduino_version: 2.4.2
+      board: esp01_1m
 
     wifi:
       ssid: <YOUR_SSID>
       password: <YOUR_PASSWORD>
 
-    api:
-
     logger:
 
+    api:
+      password: "<YOUR_PASSWORD>"
+
     ota:
+      password: "<YOUR_PASSWORD>"
 
     binary_sensor:
       - platform: gpio

--- a/devices/sonoff_basic.rst
+++ b/devices/sonoff_basic.rst
@@ -61,7 +61,7 @@ exposes all of the basic functions.
       password: <YOUR_PASSWORD>
 
     api:
-    
+
     logger:
 
     ota:

--- a/devices/sonoff_basic.rst
+++ b/devices/sonoff_basic.rst
@@ -60,13 +60,11 @@ exposes all of the basic functions.
       ssid: <YOUR_SSID>
       password: <YOUR_PASSWORD>
 
+    api:
+    
     logger:
 
-    api:
-      password: "<YOUR_PASSWORD>"
-
     ota:
-      password: "<YOUR_PASSWORD>"
 
     binary_sensor:
       - platform: gpio


### PR DESCRIPTION
Board not correct and arduino version not necessary

## Description: The example uses incorrect board type. Got it from the cookbook which gives a good example with light: https://esphome.io/cookbook/sonoff-basic-light-switch.html


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
