### PR TITLE
Update apds9960.rst

### DIFF
--- a/components/sensor/apds9960.rst
+++ b/components/sensor/apds9960.rst
@@ -76,6 +76,11 @@ Binary Sensor Configuration:
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
 - All other options from :ref:`Binary Sensor <config-binary_sensor>`.
 
+Troubleshooting:
+----------------
+
+With some APDS9960 modules the VL pin needs to be supplied with 3.3V for gesture sensing to work.  The VL pin provides power for the infrared LED that is used to detect gestures.  There may be two pads on the module which, if shorted with a solder joint, cause the main VCC power pin to supply power for the infrared LED as well.  However, providing a separate power supply via the VL pin may help to isolate the rest of the circuit from noise created by pulsing the infrared LED at relatively high power.
+
 See Also
 --------
 


### PR DESCRIPTION
Added a "troubleshooting" section containing an explanation that some modules require power to the VL pin for gesture sensing to work.

## Description:

Some APDS9960 modules, if wired as described on this page, won't detect gestures.  A "troubleshooting" section is added to explain why and what to do.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
