### PR TITLE
added slow mode and detach time to servo

### DIFF
--- a/components/servo.rst
+++ b/components/servo.rst
@@ -55,7 +55,7 @@ Advanced Options:
 - **restore** (*Optional*, boolean): Whether to restore the state of the servo motor at startup.
   This is useful if you have an absolute servo motor and it goes back to its 0 position at startup.
   Defaults to ``false``.
-- **auto_detach_time** (*Optional*, :ref:`config-time`): The time after reaching the target value when the servo will be detached`, if set to zero, servo will not be detached. Defaults to ``0s`.
+- **auto_detach_time** (*Optional*, :ref:`config-time`): The time after reaching the target value when the servo will be detached`, if set to zero, servo will not be detached. Defaults to ``0s``.
 - **transition_length** (*Optional*, :ref:`config-time`): The time needed for a full movement (-1.0 to 1.0). This will effectively limit the speed of the servo, the larger the value, the slowest the servo will move. Defaults to `` 0s``
   This can slow down the servo to avoid loud noises or just make the movement not jerking.
 

--- a/components/servo.rst
+++ b/components/servo.rst
@@ -55,6 +55,9 @@ Advanced Options:
 - **restore** (*Optional*, boolean): Whether to restore the state of the servo motor at startup.
   This is useful if you have an absolute servo motor and it goes back to its 0 position at startup.
   Defaults to ``false``.
+- **auto_detach_time** (*Optional*, ms): The time after reaching the target value when the servo will be detached.
+- **transition_length** (*Optional*, ms): The needed for a full movement (-1.0 to 1.0).
+  This can slow down the servo to avoid loud noises or just make the movement not jerking.
 
 .. note::
 

--- a/components/servo.rst
+++ b/components/servo.rst
@@ -56,7 +56,7 @@ Advanced Options:
   This is useful if you have an absolute servo motor and it goes back to its 0 position at startup.
   Defaults to ``false``.
 - **auto_detach_time** (*Optional*, :ref:`config-time`): The time after reaching the target value when the servo will be detached`, if set to zero, servo will not be detached. Defaults to ``0s`.
-- **transition_length** (*Optional*, ms): The needed for a full movement (-1.0 to 1.0).
+- **transition_length** (*Optional*, :ref:`config-time`): The time needed for a full movement (-1.0 to 1.0). This will effectively limit the speed of the servo, the larger the value, the slowest the servo will move. Defaults to `` 0s``
   This can slow down the servo to avoid loud noises or just make the movement not jerking.
 
 .. note::

--- a/components/servo.rst
+++ b/components/servo.rst
@@ -55,7 +55,7 @@ Advanced Options:
 - **restore** (*Optional*, boolean): Whether to restore the state of the servo motor at startup.
   This is useful if you have an absolute servo motor and it goes back to its 0 position at startup.
   Defaults to ``false``.
-- **auto_detach_time** (*Optional*, ms): The time after reaching the target value when the servo will be detached.
+- **auto_detach_time** (*Optional*, :ref:`config-time`): The time after reaching the target value when the servo will be detached`, if set to zero, servo will not be detached. Defaults to ``0s`.
 - **transition_length** (*Optional*, ms): The needed for a full movement (-1.0 to 1.0).
   This can slow down the servo to avoid loud noises or just make the movement not jerking.
 


### PR DESCRIPTION
## Description:
This pull add the functionality to tell servos a time after reaching there target to detach automaticly.
Additional a transition_length is added to slow the movement down.


**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#1413

## Checklist:

  - [X] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
