### PR TITLE
Add note about default settings in remote transmitter

### DIFF
--- a/components/remote_transmitter.rst
+++ b/components/remote_transmitter.rst
@@ -75,10 +75,8 @@ Configuration variables:
 - **transmitter_id** (*Optional*, :ref:`config-id`): The remote transmitter to send the
   remote code with. Defaults to the first one defined in the configuration.
   
-.. note::
-
-    If you're looking for the same functionality as is default in the rpi-rf component in
-    Home Assistant, you'll want to set the **times** to 10 and the **wait_time** to 0s.
+If you're looking for the same functionality as is default in the ``rpi_rf`` integration in
+Home Assistant, you'll want to set the **times** to 10 and the **wait_time** to 0s.
 
 .. _remote_transmitter-transmit_raw:
 

--- a/components/remote_transmitter.rst
+++ b/components/remote_transmitter.rst
@@ -74,6 +74,11 @@ Configuration variables:
 
 - **transmitter_id** (*Optional*, :ref:`config-id`): The remote transmitter to send the
   remote code with. Defaults to the first one defined in the configuration.
+  
+.. note::
+
+    If you're looking for the same functionality as is default in the rpi-rf component in
+    Home Assistant, you'll want to set the **times** to 10 and the **wait_time** to 0s.
 
 .. _remote_transmitter-transmit_raw:
 


### PR DESCRIPTION
## Description:
Update documentation helpful for anyone using the remote transmitter to control rf outlets. The default settings for 433Mhz Rf in ESPHome aren’t the same as Home Assistant and that was very difficult to discover and get working. 

This note would have helped make that a lot easier. 

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ current] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
