### PR TITLE
Update docs: Add references to alternative ICs to HLW8012 and CSE7766

### DIFF
--- a/components/sensor/cse7766.rst
+++ b/components/sensor/cse7766.rst
@@ -4,11 +4,12 @@ CSE7766 Power Sensor
 .. seo::
     :description: Instructions for setting up CSE7766 power sensors for the Sonoff Pow R2
     :image: cse7766.png
-    :keywords: cse7766, Sonoff Pow R2
+    :keywords: cse7766, cse7759b, Sonoff Pow R2
 
 The ``cse7766`` sensor platform allows you to use your CSE7766 voltage/current and power sensors
 (`datasheet <http://dl.itead.cc/S31/CSE7766.pdf>`__) sensors with
-ESPHome. This sensor is commonly found in Sonoff POW R2.
+ESPHome. This sensor is commonly found in Sonoff POW R2. CSE7759B is similar to CSE7766
+and works with this integration.
 
 As the communication with the CSE7766 done using UART, you need
 to have an :ref:`UART bus <uart>` in your configuration with the ``rx_pin`` connected to the CSE7766.

--- a/components/sensor/hlw8012.rst
+++ b/components/sensor/hlw8012.rst
@@ -4,11 +4,13 @@ HLW8012 Power Sensor
 .. seo::
     :description: Instructions for setting up HLW8012 power sensors for the Sonoff Pow R1
     :image: hlw8012.png
-    :keywords: HLW8012, Sonoff Pow R1
+    :keywords: HLW8012, CSE7759, BL0937, Sonoff Pow R1
 
 The ``hlw8012`` sensor platform allows you to use your HLW8012 voltage/current and power sensors
 (`datasheet <https://github.com/xoseperez/hlw8012/blob/master/docs/HLW8012.pdf>`__) sensors with
-ESPHome. This sensor is commonly found in Sonoff POWs.
+ESPHome. This sensor is commonly found in Sonoff POWs. CSE7759 and BL0937 are similar to HLW8012
+and work with this integration. Beware that CSE7759B is different and should be used
+with the :doc:`CSE7766 <cse7766>` integration.
 
 This sensor has two data outputs which both encode values using the frequency of a modulated signal: CF and CF1.
 CF's frequency is proportional to the (active) power measured and CF1 is proportional to the current/voltage. Using


### PR DESCRIPTION
## Description:

I have been banging my head for a whole day why my smart plug wasn't working with the CSE7759 (HLW8012) integration. After a while, I have found out that CSE7759 and CSE7759B are drastically different in terms of communication - pulses vs UART, HLW8012 vs CSE7766 integrations.

I think that cross-referencing CSE7766 (CSE7759B) documentation from the HLW8012 (CSE7759) documentation would be a good idea because it is otherwise a little confusing as there were originally
no references to the alternative IC names. I have implemented this documentation change in this pull request.
 
I have added references to power measurement IC sensors which are functionally identical:

- CSE7759 and BL0937 to HLW8012 documentation
- CSE7759B to CSE7766 documentation


**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** N/A

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
