### PR TITLE
added E-LOG pin on PCB version 2.1

### DIFF
--- a/devices/sonoff_s20.rst
+++ b/devices/sonoff_s20.rst
@@ -200,6 +200,8 @@ of the basic functions.
 ``GPIO1``                                ``RX`` pin (for external sensors)
 ---------------------------------------- ----------------------------------------
 ``GPIO3``                                ``TX`` pin (for external sensors)
+---------------------------------------- ----------------------------------------
+``GPIO2``                                ``E-LOG`` pin (From PCB V2.1; for external sensors)
 ======================================== ========================================
 
 .. code-block:: yaml
@@ -207,8 +209,7 @@ of the basic functions.
     esphome:
       name: <NAME_OF_NODE>
       platform: ESP8266
-      board: esp8285
-      arduino_version: 2.4.2
+      board: esp01_1m
 
     wifi:
       ssid: <YOUR_SSID>
@@ -229,6 +230,9 @@ of the basic functions.
         name: "Sonoff S20 Button"
       - platform: status
         name: "Sonoff S20 Status"
+      - platform: gpio
+        pin: GPIO2
+        name: "Sonoff S20 Sensor"
 
 
     switch:


### PR DESCRIPTION
Using it with PIR myself, but it is possible to add any type of sensor. The information of the E-LOG pin being GPIO 2, was a guess based on other type of Sonoff devices. I was unable to find information about the pinout of the Sonoff S20 E-LOG pin. This seems like a usefull place to store this information to help others.

## Description: I furthermore changed the board type and android type as that is no longer needed.


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
