### PR TITLE
Added remote samsung36 protocol docs

### DIFF
--- a/components/remote_receiver.rst
+++ b/components/remote_receiver.rst
@@ -36,6 +36,7 @@ Configuration variables:
   - **pioneer**: Decode and dump Pioneer infrared codes.
   - **jvc**: Decode and dump JVC infrared codes.
   - **samsung**: Decode and dump Samsung infrared codes.
+  - **samsung36**: Decode and dump Samsung36 infrared codes.
   - **sony**: Decode and dump Sony infrared codes.
   - **rc_switch**: Decode and dump RCSwitch RF codes.
   - **rc5**: Decode and dump RC5 IR codes.
@@ -80,6 +81,9 @@ Automations:
 - **on_samsung** (*Optional*, :ref:`Automation <automation>`): An automation to perform when a
   Samsung remote code has been decoded. A variable ``x`` of type :apiclass:`remote_base::SamsungData`
   is passed to the automation for use in lambdas.
+- **on_samsung36** (*Optional*, :ref:`Automation <automation>`): An automation to perform when a
+  Samsung36 remote code has been decoded. A variable ``x`` of type :apiclass:`remote_base::Samsung36Data`
+  is passed to the automation for use in lambdas.  
 - **on_panasonic** (*Optional*, :ref:`Automation <automation>`): An automation to perform when a
   Panasonic remote code has been decoded. A variable ``x`` of type :apiclass:`remote_base::PanasonicData`
   is passed to the automation for use in lambdas.
@@ -152,6 +156,11 @@ Remote code selection (exactly one of these has to be included):
 - **samsung**: Trigger on a decoded Samsung remote code with the given data.
 
   - **data** (**Required**, int): The data to trigger on, see dumper output for more info.
+
+- **samsung36**: Trigger on a decoded Samsung36 remote code with the given data.
+
+  - **address** (**Required**, int): The address to trigger on, see dumper output for more info.
+  - **command** (**Required**, int): The command.
 
 - **panasonic**: Trigger on a decoded Panasonic remote code with the given data.
 

--- a/components/remote_transmitter.rst
+++ b/components/remote_transmitter.rst
@@ -210,7 +210,7 @@ Configuration variables:
 - All other options from :ref:`remote_transmitter-transmit_action`.
 
 ``remote_transmitter.transmit_samsung36`` Action
-**********************************************
+************************************************
 
 This :ref:`action <config-action>` sends a Samsung36 infrared remote code to a remote transmitter.
 

--- a/components/remote_transmitter.rst
+++ b/components/remote_transmitter.rst
@@ -209,6 +209,24 @@ Configuration variables:
 - **data** (**Required**, int): The data to send, see dumper output for more details.
 - All other options from :ref:`remote_transmitter-transmit_action`.
 
+``remote_transmitter.transmit_samsung36`` Action
+**********************************************
+
+This :ref:`action <config-action>` sends a Samsung36 infrared remote code to a remote transmitter.
+
+.. code-block:: yaml
+
+    on_...:
+      - remote_transmitter.transmit_samsung36:
+          address: 0x0400
+          command: 0x000E00FF      
+
+Configuration variables:
+
+- **address** (**Required**, int): The address to send, see dumper output for more details.
+- **command** (**Required**, int): The Samsung36 command to send, see dumper output for more details.
+- All other options from :ref:`remote_transmitter-transmit_action`.
+
 ``remote_transmitter.transmit_panasonic`` Action
 ************************************************
 


### PR DESCRIPTION
## Description:


**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#1438

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
