### PR TITLE
Update mirabella-genio-bulb.rst to show potential use of GPIO14 instead of GPIO13 for specific monochromatic dimmable globes 

### DIFF
--- a/cookbook/mirabella-genio-bulb.rst
+++ b/cookbook/mirabella-genio-bulb.rst
@@ -120,7 +120,7 @@ Thanks to the `existing work <https://github.com/arendst/Sonoff-tasmota/wiki/Mir
 3.1 Monochromatic Bulbs
 ***********************
 
-So the brightness of the bulb can be controlled we use the ``esp8266_pwm`` output component connected to the light component using the id configuration
+The brightness of the bulb can be controlled using the ``esp8266_pwm`` output component connected to the light component using the id configuration
 variable ``output_component1``.
 
 .. code-block:: yaml
@@ -152,7 +152,9 @@ variable ``output_component1``.
     output:
       - platform: esp8266_pwm
         id: output_component1
+        # May need to use GPIO14 instead for certain globes
         pin: GPIO13
+        
 
 3.2 Cold + Warm White Bulbs
 ***************************


### PR DESCRIPTION
## Description:

Added a tip to use GPIO14 for the PWM brightness component after struggling with why nothing worked using GPIO13 (this is for the monochromatic Mirabella Genio 9W WiFi LED Item # 1002333 - as per https://mirabellagenio.net.au/es-%2F-bc-warm-white-specs).  
Tasmota recommendations don't quite work for this globe (as per <https://tasmota.github.io/docs/devices/Mirabella-Genio-Bulb/> under the heading "Dimmable warm white or cool white bulbs").  

Instead I used:
- Module type => Generic (18)
- D5 GPIO14 => PWM1 (37)

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.