### PR TITLE
Update nextion.rst

### DIFF
--- a/components/display/nextion.rst
+++ b/components/display/nextion.rst
@@ -84,6 +84,7 @@ See Also
 --------
 
 - :doc:`index`
+- :doc:`/components/binary_sensor/nextion`
 - :apiref:`nextion/nextion.h`
 - `Simple Nextion Library <https://github.com/bborncr/nextion>`__ by `Bentley Born <https://github.com/bborncr>`__
 - `Official Nextion Library <https://github.com/itead/ITEADLIB_Arduino_Nextion>`__ by `iTead <https://www.itead.cc/>`__


### PR DESCRIPTION
Links to the touch component for the data binding from the touch to ESPHome.

## Description:

Nextion allows 2 way data binding (kind of). This is just a link from one way to the other.

## Checklist:

  - [X] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [X] Link added in `/index.rst` when creating new documents for new components or cookbook.
