### PR TITLE
Add hint for swapped data and clock pin

### DIFF
--- a/components/sensor/zyaura.rst
+++ b/components/sensor/zyaura.rst
@@ -23,7 +23,7 @@ monitors with ESPHome.
     :align: center
     :width: 80.0%
 
-    ZyAura ZGm053U connection diagram (1 - empty, 2 - clock, 3 - data, 4 - GND).
+    ZyAura ZGm053U connection diagram (1 - empty, 2 - clock, 3 - data, 4 - GND). In some other models the clock and data pin are swapped.
 
 .. code-block:: yaml
 

--- a/components/sensor/zyaura.rst
+++ b/components/sensor/zyaura.rst
@@ -23,7 +23,7 @@ monitors with ESPHome.
     :align: center
     :width: 80.0%
 
-    ZyAura ZGm053U connection diagram (1 - empty, 2 - clock, 3 - data, 4 - GND). In some other models the clock and data pin are swapped.
+    ZyAura ZGm053U connection diagram (1 - empty, 2 - clock, 3 - data, 4 - GND). In some other models the clock and data pins are swapped.
 
 .. code-block:: yaml
 


### PR DESCRIPTION
After having the same problem as in #943 it might be worth adding a hint, that some models have swapped data and clock pin.

## Description:


**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/943

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** no
## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
