### PR TITLE
Add on_tag_removed documentation to pn532.rst

### DIFF
--- a/components/binary_sensor/pn532.rst
+++ b/components/binary_sensor/pn532.rst
@@ -54,6 +54,8 @@ Configuration variables:
   If a device is not found within this time window, it will be marked as not present. Defaults to 1s.
 - **on_tag** (*Optional*, :ref:`Automation <automation>`): An automation to perform
   when a tag is read. See :ref:`pn532-on_tag`.
+- **on_tag_removed** (*Optional*, :ref:`Automation <automation>`): An automation to perform
+  when a tag is removed. See :ref:`pn532-on_tag_removed`.
 - **spi_id** (*Optional*, :ref:`config-id`): Manually specify the ID of the :ref:`SPI Component <spi>` if you want
   to use multiple SPI buses.
 - **i2c_id** (*Optional*, :ref:`config-id`): Manually specify the ID of the :ref:`I²C Component <spi>` if you want
@@ -115,6 +117,27 @@ Alternatively you could also send the value directly to Home Assistant via a
       - platform: template
         name: "RFID Tag"
         id: rfid_tag
+
+.. _pn532-on_tag_removed:
+
+``on_tag_removed``
+------------------
+
+This automation will be triggered when the PN532 module responds with no tag. This will only be triggered
+if the tag goes away for one cycle of ``update_interval``.
+
+The parameter ``x`` this trigger provides is of type ``std::string`` and is the removed tag UID in the format
+``74-10-37-94``. The configuration below will for example publish the removed tag ID on the MQTT topic ``pn532/tag_removed``.
+
+.. code-block:: yaml
+
+    pn532:
+      # ...
+      on_tag_removed:
+        then:
+          - mqtt.publish:
+              topic: pn532/tag_removed
+              payload: !lambda 'return x;'
 
 .. _pn532-tag:
 


### PR DESCRIPTION
## Description:

Add on_tag_removed trigger to pn532 to get a notification when tag is removed.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#1436

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
