### PR TITLE
Add example for human readable uptime sensor

### DIFF
--- a/components/sensor/uptime.rst
+++ b/components/sensor/uptime.rst
@@ -23,6 +23,48 @@ Configuration variables:
 - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.
 - All other options from :ref:`Sensor <config-sensor>`.
 
+Human readable sensor
+----------------
+
+The sensor reports uptime in seconds which is good for automations
+but is hard to read for humans, this example creates a text sensor
+with human readable output.
+
+.. code-block:: yaml
+
+    # Example configuration entry
+    text_sensor:
+      - platform: template
+        name: Uptime Human Readable
+        id: uptime_human
+        icon: mdi:clock-start
+    sensor:
+      - platform: uptime
+        name: Uptime Sensor
+        id: uptime
+        update_interval: 60s
+        on_raw_value:
+          then:
+            - text_sensor.template.publish:
+                id: uptime_human
+                state: !lambda |-
+                  int seconds = round(id(uptime).raw_state);
+                  int days = seconds / (24 * 3600);
+                  seconds = seconds % (24 * 3600);
+                  int hours = seconds / 3600;
+                  seconds = seconds % 3600;
+                  int minutes = seconds /  60;
+                  seconds = seconds % 60;
+                  if ( days ) {
+                    return { (String(days) +"d " + String(hours) +"h " + String(minutes) +"m "+ String(seconds) +"s").c_str() };
+                  } else if ( hours ) {
+                    return { (String(hours) +"h " + String(minutes) +"m "+ String(seconds) +"s").c_str() };
+                  } else if ( minutes ) {
+                    return { (String(minutes) +"m "+ String(seconds) +"s").c_str() };
+                  } else {
+                    return { (String(seconds) +"s").c_str() };
+                  }
+
 See Also
 --------
 

--- a/components/sensor/uptime.rst
+++ b/components/sensor/uptime.rst
@@ -55,15 +55,12 @@ with human readable output.
                   seconds = seconds % 3600;
                   int minutes = seconds /  60;
                   seconds = seconds % 60;
-                  if ( days ) {
-                    return { (String(days) +"d " + String(hours) +"h " + String(minutes) +"m "+ String(seconds) +"s").c_str() };
-                  } else if ( hours ) {
-                    return { (String(hours) +"h " + String(minutes) +"m "+ String(seconds) +"s").c_str() };
-                  } else if ( minutes ) {
-                    return { (String(minutes) +"m "+ String(seconds) +"s").c_str() };
-                  } else {
-                    return { (String(seconds) +"s").c_str() };
-                  }
+                  return (
+                    (days ? String(days) + "d " : "") +
+                    (hours ? String(hours) + "h " : "") +
+                    (minutes ? String(minutes + "m " : "") +
+                    (String(seconds) + "s") 
+                  ).c_str();
 
 See Also
 --------

--- a/components/sensor/uptime.rst
+++ b/components/sensor/uptime.rst
@@ -24,7 +24,7 @@ Configuration variables:
 - All other options from :ref:`Sensor <config-sensor>`.
 
 Human readable sensor
-----------------
+---------------------
 
 The sensor reports uptime in seconds which is good for automations
 but is hard to read for humans, this example creates a text sensor


### PR DESCRIPTION
## Description:

Adds example of a human readable uptime sensor.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
