### PR TITLE
Bump changelog index to 1.16.0

### DIFF
--- a/changelog/index.rst
+++ b/changelog/index.rst
@@ -2,7 +2,7 @@ Changelog
 =========
 
 .. redirect::
-    :url: /changelog/v1.15.0.html
+    :url: /changelog/v1.16.0.html
 
 .. toctree::
     :glob:


### PR DESCRIPTION
## Description:

Bumping the changelog index to redirect to the new 1.16.0 changelog.

I have updated the release script to prompt this change during `cut-release`