### PR TITLE
Update st7789v.rst

### DIFF
--- a/components/display/st7789v.rst
+++ b/components/display/st7789v.rst
@@ -96,7 +96,7 @@ To bring in color images:
       - file: "image.jpg"
         id: my_image
         resize: 200x200
-        type: RGB565
+        type: RGB24
 
     ...
 
@@ -222,7 +222,7 @@ appropriate lines of C code in the lambada to hide or show the image or text as 
       - file: "image.png"
         id: my_image
         resize: 200x200
-        type: RGB565
+        type: RGB24
 
     time:
       - platform: homeassistant


### PR DESCRIPTION
The original ST7786V component work by folks outside of ESPHome included RGB565 (2 byte pixels), however that customization to 'Image' was never merged into ESPHome, so ESPHome Image only supports RGB24 (3 byte pixels); as such the examples on this page fail validation.  This change replaces RGB565 with RGB24.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
