### PR TITLE
Fix duplicated "on_ble" in on_ble_service_data_advertise heading

### DIFF
--- a/components/esp32_ble_tracker.rst
+++ b/components/esp32_ble_tracker.rst
@@ -159,8 +159,8 @@ Configuration variables:
 
 .. _esp32_ble_tracker-on_ble_service_data_advertise:
 
-``on_ble_on_ble_service_data_advertise``
-****************************************
+``on_ble_service_data_advertise``
+*********************************
 
 This automation will be triggered when a Bluetooth advertising with service data is received. A
 variable ``x`` of type ``std::vector<uint8_t>`` is passed to the automation for use in lambdas.


### PR DESCRIPTION
## Description:

SSIA.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [X] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
