### PR TITLE
Update pzemac.rst due to wrong PIN reference

### DIFF
--- a/components/sensor/pzemac.rst
+++ b/components/sensor/pzemac.rst
@@ -35,8 +35,8 @@ to some pins on your board and the baud rate set to 9600.
 
     # Example configuration entry
     uart:
-      rx_pin: D1
-      tx_pin: D2
+      rx_pin: GPIO3
+      tx_pin: GPIO1
       baud_rate: 9600
 
     sensor:


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
