### PR TITLE
Update cli <some_command> --help

### DIFF
--- a/guides/cli.rst
+++ b/guides/cli.rst
@@ -22,6 +22,17 @@ ESPHome's command line interface always has the following format
 
         esphome livingroom.yaml kitchen.yaml run
 
+``--help`` Option
+--------------------
+
+.. option:: -h|--help
+
+    Output possible <commands> and [arguments].
+    Note: you can also use --help for any command to get arguments specific to that command.
+.. code-block:: console
+
+        esphome <some_command> --help
+
 ``--verbose`` Option
 --------------------
 


### PR DESCRIPTION
Added --help and that --help works for esphome commands. i.e. esphome logs --help

## Description:


**Related issue (if applicable):** fixes <link to issue>
I was looking for serial port option for logs and didn't know `esphome logs --help` would have more information than plain `esphome --help`

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
