### PR TITLE
cli.rst add --help

### DIFF
--- a/guides/cli.rst
+++ b/guides/cli.rst
@@ -31,7 +31,7 @@ ESPHome's command line interface always has the following format
     Note: you can also use --help for any command to get arguments specific to that command.
 .. code-block:: console
 
-        esphome <some_command> --help
+    esphome <some_command> --help
 
 ``--verbose`` Option
 --------------------

--- a/guides/cli.rst
+++ b/guides/cli.rst
@@ -28,7 +28,7 @@ ESPHome's command line interface always has the following format
 .. option:: -h|--help
 
     Output possible <commands> and [arguments].
-    Note: you can also use --help for any command to get arguments specific to that command.
+    Note: you can also use ``--help`` for any command to get arguments specific to that command.
 .. code-block:: console
 
     esphome <some_command> --help
@@ -217,6 +217,5 @@ through a graphical user interface.
 .. option:: --open-ui
 
     If set, opens the dashboard UI in a browser once the server is up and running.
-
 
 

--- a/guides/cli.rst
+++ b/guides/cli.rst
@@ -20,7 +20,18 @@ ESPHome's command line interface always has the following format
 
     .. code-block:: console
 
-        esphome livingroom.yaml kitchen.yaml run
+    esphome livingroom.yaml kitchen.yaml run
+
+``--help`` Option
+--------------------
+
+.. option:: -h|--help
+
+    Output possible <commands> and [arguments].
+    Note: you can also use --help for any command to get arguments specific to that command.
+.. code-block:: console
+
+        esphome <some_command> --help
 
 ``--verbose`` Option
 --------------------


### PR DESCRIPTION
Added --help and that --help works for esphome commands. i.e. esphome logs --help

## Description:


**Related issue (if applicable):** fixes <link to issue>
I was looking for serial port option for logs and didn't know `esphome logs --help` would have more information than plain `esphome --help`

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
