### PR TITLE
Fix lamba example for uptime.rst 

### DIFF
--- a/components/sensor/uptime.rst
+++ b/components/sensor/uptime.rst
@@ -58,7 +58,7 @@ with human readable output.
                   return (
                     (days ? String(days) + "d " : "") +
                     (hours ? String(hours) + "h " : "") +
-                    (minutes ? String(minutes + "m " : "") +
+                    (minutes ? String(minutes) + "m " : "") +
                     (String(seconds) + "s") 
                   ).c_str();
 


### PR DESCRIPTION
## Description:

Fix documentation for uptime sensor. Fix 'Uptime Human Readable' yaml example.

**Related issue (if applicable):** fixes <link to issue> https://github.com/esphome/issues/issues/1760

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [X] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
