### PR TITLE
Update image type for st7789 display

### DIFF
--- a/components/display/st7789v.rst
+++ b/components/display/st7789v.rst
@@ -120,7 +120,7 @@ Wi-Fi, API, and OTA configuration. It defines:
 - time, for display...on the display
 - the SPI configuration for communicating with the display
 - the display component itself, for use on the TTGO module
-- a lambada which paints the screen as shown in the picture above:
+- a lambda which paints the screen as shown in the picture above:
 
   - blue borders, with a sort of "title bar" along the top
   - "ESPHome" in yellow in the top left corner
@@ -130,7 +130,7 @@ Wi-Fi, API, and OTA configuration. It defines:
 To use this example, you need only to provide the font file, "Helvetica.ttf" (or update it to
 a font of your choosing) and an image file, "image.png" (it may also be a ".jpg"). Place these
 into the same directory as the YAML configuration file itself. Comment/Uncomment/Modify the
-appropriate lines of C code in the lambada to hide or show the image or text as you wish.
+appropriate lines of C code in the lambda to hide or show the image or text as you wish.
 
 .. code-block:: yaml
 
@@ -222,7 +222,7 @@ appropriate lines of C code in the lambada to hide or show the image or text as 
       - file: "image.png"
         id: my_image
         resize: 200x200
-        type: RGB565
+        type: RGB24
 
     time:
       - platform: homeassistant


### PR DESCRIPTION
## Description:
Using `RGB565` gave the following error
```
Unknown value 'RGB565', valid options are 'BINARY', 'GRAYSCALE', 'RGB24'.
    type: RGB565 [source /config/esphome/esp_tdisplay.yaml:111]
```

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
