### PR TITLE
Minor uptime docs fixes

### DIFF
--- a/components/sensor/uptime.rst
+++ b/components/sensor/uptime.rst
@@ -41,14 +41,14 @@ with human readable output.
     sensor:
       - platform: uptime
         name: Uptime Sensor
-        id: uptime
+        id: uptime_sensor
         update_interval: 60s
         on_raw_value:
           then:
             - text_sensor.template.publish:
                 id: uptime_human
                 state: !lambda |-
-                  int seconds = round(id(uptime).raw_state);
+                  int seconds = round(id(uptime_sensor).raw_state);
                   int days = seconds / (24 * 3600);
                   seconds = seconds % (24 * 3600);
                   int hours = seconds / 3600;
@@ -58,7 +58,7 @@ with human readable output.
                   return (
                     (days ? String(days) + "d " : "") +
                     (hours ? String(hours) + "h " : "") +
-                    (minutes ? String(minutes + "m " : "") +
+                    (minutes ? String(minutes) + "m " : "") +
                     (String(seconds) + "s") 
                   ).c_str();
 


### PR DESCRIPTION
Compile was not completing because minutes was missing a round bracket `)` And vsc was complaining because id of uptime was uptime which is the name of a component.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
