### PR TITLE
Fix human-readable uptime example so it compiles

### DIFF
--- a/components/sensor/uptime.rst
+++ b/components/sensor/uptime.rst
@@ -58,7 +58,7 @@ with human readable output.
                   return (
                     (days ? String(days) + "d " : "") +
                     (hours ? String(hours) + "h " : "") +
-                    (minutes ? String(minutes + "m " : "") +
+                    (minutes ? String(minutes) + "m " : "") +
                     (String(seconds) + "s") 
                   ).c_str();
 


### PR DESCRIPTION
## Description: Fixes human-readable uptime example so it successfully compiles. Was just missing a closing ')'.

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
