### PR TITLE
Add options to control pulse duration on Climate_IR_LG Component

### DIFF
--- a/components/climate/ir_climate.rst
+++ b/components/climate/ir_climate.rst
@@ -122,6 +122,26 @@ Additional configuration is available for this model
   * ``MODEL_DG11J1_3A``: Temperature range is from 18 to 32 (default)
   * ``MODEL_DG11J1_91``: Temperature range is from 16 to 30
 
+LG
+---------
+
+Additional configuration is available for this platform
+
+- **header_high** (*Optional*, :ref:`config-time`): time for the high part of the header for the LG protocol. Defaults to ``8000us``
+- **header_low** (*Optional*, :ref:`config-time`): time for the low part of the header for the LG protocol. Defaults to ``4000us``
+- **bit_high** (*Optional*, :ref:`config-time`): time for the high part of any bit in the LG protocol. Defaults to ``600us``
+- **bit_one_low** (*Optional*, :ref:`config-time`): time for the low part of a '1' bit in the LG protocol. Defaults to ``1600us``
+- **bit_zero_low** (*Optional*, :ref:`config-time`): time for the low part of a '0' bit in the LG protocol. Defaults to ``550us``
+
+.. code-block:: yaml
+
+    # Example configuration entry
+    climate:
+      - platform: climate_ir_lg
+        name: "AC"
+        sensor: room_temperature
+        header_high: 3265us # AC Units from LG in Brazil, for example use these timings
+        header_low: 9856us
 
 See Also
 --------


### PR DESCRIPTION
## Description:

Added parameters for the new pull request in esphome main repo

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#1470

closes esphome/esphome-docs#935

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
