### PR TITLE
Adding that mpr121_id is a valid option for binary_sensor

### DIFF
--- a/components/binary_sensor/mpr121.rst
+++ b/components/binary_sensor/mpr121.rst
@@ -32,7 +32,6 @@ required to be set up in your configuration for this sensor to work.
 
     binary_sensor:
       - platform: mpr121
-        mpr121_id: mpr121_component
         id: touch_key0
         channel: 0
         name: "Touch Key 0"

--- a/components/binary_sensor/mpr121.rst
+++ b/components/binary_sensor/mpr121.rst
@@ -32,6 +32,7 @@ required to be set up in your configuration for this sensor to work.
 
     binary_sensor:
       - platform: mpr121
+        mpr121_id: mpr121_component
         id: touch_key0
         channel: 0
         name: "Touch Key 0"
@@ -58,6 +59,7 @@ Base Configuration:
 Binary Sensor Configuration:
 
 - **name** (**Optional**, string): The name for the binary sensor.
+- **mpr121_id** (*Optional*, :ref:`config-id`): The ID of the MPR121 defined above. Useful for multiple MPR121's on the I²C bus
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
 - **channel** (*Required*, integer): The channel number at the MPR121 the touchkey is connected to.
 - **touch_threshold** (*Optional*, integer): A per-channel override of the global touch_threshold value. If not specified, uses the global value.


### PR DESCRIPTION
## Description:

I had to figure out how to have multiple MPR121's defined, figured I would document the fix so it would be easier for the next guy. Let me know if I did something wrong, this is my first contribution to the docs.

**Related issue (if applicable):** fixes N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** N/A

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
