### PR TITLE
Added docs for parameters on PR#1500

### DIFF
--- a/components/light/rgb.rst
+++ b/components/light/rgb.rst
@@ -69,6 +69,11 @@ Configuration variables:
 - **green** (**Required**, :ref:`config-id`): The id of the float :ref:`output` to use for the green channel.
 - **blue** (**Required**, :ref:`config-id`): The id of the float :ref:`output` to use for the blue channel.
 - **effects** (*Optional*, list): A list of :ref:`light effects <light-effects>` to use for this light.
+- **rgb_temperature_emulation** (*Optional*, : bool): Enables Color Temperature emulation using the RGB LEDs. Defaults to ``False``.
+- **cold_white_color_temperature** (*Optional*, : bool): When Color Temperature emulation enabled, sets the coldest color temperature (in
+  `mireds <https://en.wikipedia.org/wiki/Mired>`__ or Kelvin). Defaults to ``6700 K``.
+- **warm_white_color_temperature** (*Optional*, : bool): When Color Temperature emulation enabled, sets the warmest color temperature (in
+  `mireds <https://en.wikipedia.org/wiki/Mired>`__ or Kelvin). Defaults to ``2700 K``.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
 - All other options from :ref:`Light <config-light>`.
 


### PR DESCRIPTION
## Description:
Added documentation for an RGB Color Temperature Emulation parameter that enables simple RGB lights to Emulate RGBWW lights by converting color temperature to RGB using an adaptation from the implementation on Aircoookie/Espalexa#33.

Parameters to control how far you want to go in the temperature scale were also added to enable controlling the min and max color temperatures along with their docs as well.

Parameters added:

    cold_white_color_temperature: 6700 K
    warm_white_color_temperature: 2700 K
    rgb_temperature_emulation: False


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#1500

## Checklist:

  - [X] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [X] Link added in `/index.rst` when creating new documents for new components or cookbook.
