### PR TITLE
Updated documentation for the SGP30 sensor improvements.

### DIFF
--- a/components/sensor/sgp30.rst
+++ b/components/sensor/sgp30.rst
@@ -24,8 +24,9 @@ The :ref:`I²C Bus <i2c>` is required to be set up in your configuration for thi
         tvoc:
           name: "Workshop TVOC"
           accuracy_decimals: 1
+        store_baseline: yes
         address: 0x58
-        update_interval: 5s
+        update_interval: 1s
 
 
 Configuration variables:
@@ -43,19 +44,34 @@ Configuration variables:
   - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.
   - All other options from :ref:`Sensor <config-sensor>`.
 
+- **store_baseline** (*Optional*, boolean): Store the sensor baselines persistently when calculated or updated. 
+  Defaults to yes.
+
 - **address** (*Optional*, int): Manually specify the I^2C address of the sensor.
   Defaults to ``0x58``.
 
 - **update_interval** (*Optional*, :ref:`config-time`): The interval to check the
-  sensor. Defaults to ``60s``.
+  sensor. Defaults to ``1s``.
 
 Advanced:
 
 - **baseline** (*Optional*): The block containing baselines for calibration purposes. See :ref:`sgp30-calibrating` for more info.
 
-  - **eco2_baseline** (**Required**, int): The eCO2 baseline for calibration purposes.
+  - **eco2_baseline** (**Required**, int): The eCO2 baseline for calibration purposes. After OTA, this value is used to calibrate the sensor.
 
-  - **tvoc_baseline** (**Required**, int): The TVOC baseline for calibration purposes.
+  - **tvoc_baseline** (**Required**, int): The TVOC baseline for calibration purposes. After OTA, this value is used to calibrate the sensor.
+
+- **eco2_baseline** (*Optional*): The information for the CO₂eq. sensor baseline value. Baseline value is published in decimals.
+
+  - **name** (**Required**, string): The name for the CO₂eq baseline value sensor.
+  - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.
+  - All other options from :ref:`Sensor <config-sensor>`.
+
+- **tvoc_baseline** (*Optional*): The information for the TVOC baseline value sensor. Baseline value is published in in decimals.
+
+  - **name** (**Required**, string): The name for the TVOC baseline value sensor.
+  - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.
+  - All other options from :ref:`Sensor <config-sensor>`.
 
 - **compensation** (*Optional*): The block containing sensors used for compensation.
 
@@ -70,15 +86,21 @@ Advanced:
 Calibrating Baseline
 --------------------
 
-The SGP30 sensor will re-calibrate its baseline each time it is powered on. During the first power-up this can take up to 12 hours.
+The SGP30 sensor will re-calibrate its baseline each time it is powered on. During the first power-up this will take up to 12 hours.
+Exposing to outside air for at least 10 minutes cumulative time is advised during the calibration period.  
 
-For best performance and faster startup times, the current **baseline** needs to be persistently stored on the device before shutting it down and set again accordingly after boot up
-that also means that if the sensor reboots at a time when the air is less clean than normal,
-the values will have a constant offset and cannot be compared to the values before the last
-boot.
+For best performance and faster startup times, the current **baseline** needs to be persistently stored on the device before shutting it down and set again accordingly after boot up.
+It implies that if the sensor reboots at a time when the air is less clean than normal, the values will have a constant offset and cannot be compared to the values before the last boot.
 
-To do this, let the sensor boot up with no baseline set and let the sensor calibrate itself. After around 12 hours you can then view the remote logs on the ESP. The next
-time the sensor is read out, you will see a log message with something like ``Current eCO2 baseline: 0x86C5, TVOC baseline: 0x8B38``.
+Using the **store_baseline** option will automatically store the baseline values after calibration or when it is updated during operation. When booting up, the stored values will then be
+(re)applied in the sensor. Stored baselines are cleared after OTA.
+
+Another method is to manually specify the baseline values in the configuration file. To do this, let the sensor boot up with no baseline set and let the sensor calibrate itself. 
+After around 12 hours you can then view the remote logs on the ESP. The nexttime the sensor is read out, you will see a log message with something like 
+``Current eCO2 baseline: 0x86C5, TVOC baseline: 0x8B38``. 
+
+Another way to obtain the baseline values is to configure the eco2 and TVOC baseline value sensors. Values will be published to your Home Automation system.
+Convert the decimal value to hex value before use (e.g. 37577 --> 0x92C9) 
 
 Now set the baseline property in your configuration file like so with the value you got
 via the logs:
@@ -95,8 +117,7 @@ via the logs:
 
 The next time you upload the code, the SGP30 will be continue its operation with this baseline and you will get consistent values.
 
-Please note that Sensirion recommends that after around 7 days, the baseline will need to be
-re-calibrated because the internal sensor has a slight value drift over time.
+Please note while the sensor is off, baseline values are valid for a maximum of seven days.
 
 See Also
 --------


### PR DESCRIPTION
## Description:

Updated the SGP30 sensor with configuration options to persistently store the eCO2/TVOC baselines so that it survives a power cycle. It removes the need to recompile and OTA the configuration file when the baselines have been determined after the calibration period (of 12 hours).

As a convenience, the baseline values can also be configured as sensors so that they are published to Home assistant.

Last, the update interval default is set to 1 second which is advised by the datasheet.

**Related issue (if applicable):** fixes <link to issue>
#673
#668

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>
#1503

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
