### PR TITLE
Document recurring data in uart switch

### DIFF
--- a/components/switch/uart.rst
+++ b/components/switch/uart.rst
@@ -22,6 +22,10 @@ The ``uart`` switch platform allows you to send a pre-defined sequence of bytes 
       - platform: uart
         name: "UART Bytes Output"
         data: [0xDE, 0xAD, 0xBE, 0xEF]
+      - platform: uart
+        name: "UART Recurring Output"
+        data: [0xDE, 0xAD, 0xBE, 0xEF]
+        send_every: 1s
 
 Configuration variables:
 ------------------------
@@ -31,6 +35,7 @@ Configuration variables:
 - **name** (**Required**, string): The name for the switch.
 - **uart_id** (*Optional*, :ref:`config-id`): Manually specify the ID of the UART hub.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
+- **send_every** (*Optional*, :ref:`config-time`): Sends recurring data instead of sending once.
 - All other options from :ref:`Switch <config-switch>`.
 
 See Also


### PR DESCRIPTION
## Description:

Adds documentation for new `send_every` key on UART switches.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#1514

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
