### PR TITLE
Recommending input_boolean

### DIFF
--- a/components/binary_sensor/homeassistant.rst
+++ b/components/binary_sensor/homeassistant.rst
@@ -6,7 +6,11 @@ Home Assistant Binary Sensor
     :image: home-assistant.png
 
 The ``homeassistant`` binary sensor platform allows you to create binary sensors that **import**
-states from your Home Assistant instance using the :doc:`native API </components/api>`.
+states from your Home Assistant instance using the :doc:`native API </components/api>`. 
+
+.. note::
+
+    It is recommended that you use the [Input Boolean](https://www.home-assistant.io/integrations/input_boolean/) entity (and not Home Assistant's [Binary Sensor](https://www.home-assistant.io/integrations/binary_sensor/), manipulating the values only with "off" and "on". 
 
 .. code-block:: yaml
 


### PR DESCRIPTION
I've tried every combination of binary_sensor values from on/off, true/false, 1/0 and each time i get a 

[17:00:14][W][homeassistant.sensor:014]: Can't convert 'False' to number!

(substitute anything for false there)

input_boolean on/off works like a charm, so let's save people some time.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
