### PR TITLE
Update bme680.rst

### DIFF
--- a/components/sensor/bme680.rst
+++ b/components/sensor/bme680.rst
@@ -111,4 +111,5 @@ See Also
 - :doc:`bmp085`
 - :apiref:`bme680/bme680.h`
 - `BME680 Sensor API <https://github.com/BoschSensortec/BME680_driver>`__ by `Bosch Sensortec <https://www.bosch-sensortec.com/>`__
+- `Custom BME680 component with indoor air quality sensor <https://github.com/trvrnrth/esphome-bsec-bme680>`__
 - :ghedit:`Edit`


### PR DESCRIPTION
Added an additional link to a custom component that does not only provide raw gas resistance but also calculates an indoor air quality index based on it.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
