### PR TITLE
Icon is ignored by HA when device class is set

### DIFF
--- a/components/sensor/index.rst
+++ b/components/sensor/index.rst
@@ -44,7 +44,8 @@ Configuration variables:
 - **device_class** (*Optional*, string): The device class for the
   sensor. See https://www.home-assistant.io/integrations/sensor/#device-class
   for a list of available options. Set to ``""`` to remove the default device class of a sensor.
-- **icon** (*Optional*, icon): Manually set the icon to use for the sensor in the frontend.
+- **icon** (*Optional*, icon): Manually set the icon to use for the sensor in the frontend. The icon set here
+  is ignored by Home Assistant, if a device class is already set.
 - **accuracy_decimals** (*Optional*, int): Manually set the accuracy of decimals to use when reporting values.
 - **filters** (*Optional*): Specify filters to use for some basic
   transforming of values. See :ref:`Sensor Filters <sensor-filters>` for more information.


### PR DESCRIPTION
## Description:

Home Assistant ignores an icon of an entity from an integration if this entity also has a device class set. With the introduction of device classes (https://github.com/esphome/esphome/pull/1525) for all sensor components (https://github.com/esphome/esphome/pull/1533), users might wonder, why icons set in their ESPHome config do not appear in Home Assistant.

**Related issue (if applicable):** fixes https://github.com/esphome/feature-requests/issues/553

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** https://github.com/esphome/esphome/pull/1533

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
