### PR TITLE
Fix mcp23sXX id config

### DIFF
--- a/components/mcp23Sxx.rst
+++ b/components/mcp23Sxx.rst
@@ -34,7 +34,7 @@ The MCP23S08 component (`datasheet <http://ww1.microchip.com/downloads/en/Device
       - platform: gpio
         name: "MCP23S08 Pin #0"
         pin:
-          mcp23s08_id: mcp23s08_hub
+          mcp23s08: mcp23s08_hub
           # Use pin number 0
           number: 0
           # One of INPUT, INPUT_PULLUP or OUTPUT
@@ -46,7 +46,7 @@ The MCP23S08 component (`datasheet <http://ww1.microchip.com/downloads/en/Device
       - platform: gpio
         name: "MCP23S08 Pin #1"
         pin:
-          mcp23s08_id: mcp23s08_hub
+          mcp23s08: mcp23s08_hub
           # Use pin number 1
           number: 1
           # One of INPUT or INPUT_PULLUP
@@ -90,7 +90,7 @@ binary sensor or GPIO switch.
       - platform: gpio
         name: "MCP23S17 Pin #0"
         pin:
-          mcp23s17_id: mcp23s17_hub
+          mcp23s17: mcp23s17_hub
           # Use pin number 0
           number: 0
           mode: OUTPUT
@@ -101,7 +101,7 @@ binary sensor or GPIO switch.
       - platform: gpio
         name: "MCP23S17 Pin #1"
         pin:
-          mcp23s17_id: mcp23s17_hub
+          mcp23s17: mcp23s17_hub
           # Use pin number 1
           number: 1
           # One of INPUT or INPUT_PULLUP


### PR DESCRIPTION
## Description:
Fix incorrect id config for mcp23sxx pin schemas

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
