### PR TITLE
Update i2c.rst

### DIFF
--- a/custom/i2c.rst
+++ b/custom/i2c.rst
@@ -11,6 +11,7 @@ them publish values.
 .. code-block:: cpp
 
     #include "esphome.h"
+    #include "Wire.h"
 
     class MyCustomComponent : public Component {
      public:


### PR DESCRIPTION
Add #include "Wire.h"

## Description:
Example is not working without `#include "Wire.h"`

`error: 'Wire' was not declared in this scope`

**Related issue (if applicable):**
n/a

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 
n/a

## Checklist:

  - [ x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [n/a ] Link added in `/index.rst` when creating new documents for new components or cookbook.
