### PR TITLE
Update Inkplate.rst

### DIFF
--- a/components/display/Inkplate.rst
+++ b/components/display/Inkplate.rst
@@ -25,7 +25,7 @@ Learn more at `Inkplate's website <https://inkplate.io/>`__
         address: 0x20
 
     display:
-    - platform: inkplate
+    - platform: inkplate6
       id: inkplate_display
       greyscale: false
       partial_updating: false
@@ -224,7 +224,7 @@ Wi-Fi, API, and OTA configuration.
 
 
     display:
-    - platform: inkplate
+    - platform: inkplate6
       id: inkplate_display
       greyscale: false
       partial_updating: false


### PR DESCRIPTION
## Description:
The examples failed to compile and it looks like there is a typo in the display platform. Found the solution here https://community.home-assistant.io/t/platform-inkplate-error/279078/2

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
