### PR TITLE
Update uart.rst example to read all available characters

### DIFF
--- a/components/text_sensor/uart.rst
+++ b/components/text_sensor/uart.rst
@@ -49,8 +49,10 @@ With this you can use automations or lambda to set switch or sensor states.
       void loop() override {
         const int max_line_length = 80;
         static char buffer[max_line_length];
-        if (available() && readline(read(), buffer, max_line_length) > 0) {
-          publish_state(buffer);
+        while (available()) {
+          if(readline(read(), buffer, max_line_length) > 0) {
+            publish_state(buffer);
+          }
         }
       }
     };


### PR DESCRIPTION
Process ALL available data to avoid data loss if the rx_buffer_size would otherwise be overrun.

## Description:
Processing only a single character per `loop()` call runs the risk of overrunning the `rx_buffer_size`. Processing all `available()` data in a single loop invocation helps to avoid this.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
