### PR TITLE
Document new min/max filters

### DIFF
--- a/components/sensor/index.rst
+++ b/components/sensor/index.rst
@@ -249,6 +249,41 @@ sensor data. A large window size will make the filter slow to react to input cha
       Must be smaller than or equal to ``send_every``
       Defaults to ``1``.
 
+``min`` / ``max``
+*****************
+
+Calculate min/max over the data. A large window size will make the filter slow to
+react to input changes.
+
+.. code-block:: yaml
+
+    # Example configuration entry
+    - platform: wifi_signal
+      # ...
+      filters:
+        - min:
+            window_size: 7
+            send_every: 4
+            send_first_at: 3
+
+-  **min**: A moving minimum over the last few values.
+
+-  **max**: A moving maximum over the last few values.
+
+-  Both accept the following parameters:
+
+   -  **window_size**: The number of values over which to calculate the min/max
+      when pushing out a value.
+      Defaults to ``5``.
+   -  **send_every**: How often a sensor value should be pushed out. For
+      example, in above configuration the min is calculated after every 4th
+      received sensor value, over the last 7 received values.
+      Defaults to ``5``.
+   -  **send_first_at**: By default, the very first raw value on boot is immediately
+      published. With this parameter you can specify when the very first value is to be sent.
+      Must be smaller than or equal to ``send_every``
+      Defaults to ``1``.
+
 ``sliding_window_moving_average`` / ``exponential_moving_average``
 ******************************************************************
 


### PR DESCRIPTION
## Description:

Adds documentation for new `min`/`max` filters.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#1569

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
