### PR TITLE
Update i2c.rst

### DIFF
--- a/components/i2c.rst
+++ b/components/i2c.rst
@@ -18,7 +18,7 @@ connecting the wires from each device back to the two I²C pins on the ESP.
 
 .. code-block:: yaml
 
-    # Example configuration entry
+    # Example configuration entry for ESP32
     i2c:
       sda: 21
       scl: 22


### PR DESCRIPTION
Clarify that example config is for ESP32

## Description:
I felt in the trap to assume the example config would work for ESP8266, hence the little change in the example comment

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
