### PR TITLE
Fix RF Bridge link to Portisch Repo

### DIFF
--- a/components/rf_bridge.rst
+++ b/components/rf_bridge.rst
@@ -159,7 +159,7 @@ Configuration options:
 Portisch firmware
 -----------------
 
-If you have flashed the secondary MCU with the `Portisch firmware <https://github.com/Portisch/RF-Bridge-EFM8BB1>`,
+If you have flashed the secondary MCU with the `Portisch firmware <https://github.com/Portisch/RF-Bridge-EFM8BB1>`__,
 ESPHome is able to receive the extra protocols that can be decoded as well as activate the other modes supported.
 
 

--- a/components/rf_bridge.rst
+++ b/components/rf_bridge.rst
@@ -159,7 +159,7 @@ Configuration options:
 Portisch firmware
 -----------------
 
-If you have flashed the secondary MCU with the `"Portisch firmware" <https://github.com/Portisch/RF-Bridge-EFM8BB1>`,
+If you have flashed the secondary MCU with the `Portisch firmware <https://github.com/Portisch/RF-Bridge-EFM8BB1>`,
 ESPHome is able to receive the extra protocols that can be decoded as well as activate the other modes supported.
 
 


### PR DESCRIPTION
## Description:

Fixing a link

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
