### PR TITLE
Add docs for http_request on_response trigger

### DIFF
--- a/components/http_request.rst
+++ b/components/http_request.rst
@@ -49,6 +49,12 @@ This :ref:`action <config-action>` sends a GET request.
           headers:
             Content-Type: application/json
           verify_ssl: false
+          on_response:
+            then:
+              - logger.log:
+                  format: 'Response status: %d'
+                  args:
+                    - x
       # Short form
       - http_request.get: https://esphome.io
 
@@ -57,6 +63,7 @@ Configuration variables:
 - **url** (**Required**, string, :ref:`templatable <config-templatable>`): URL to send request.
 - **headers** (*Optional*, mapping): Map of HTTP headers. Values are :ref:`templatable <config-templatable>`.
 - **verify_ssl** (*Optional*, boolean): Verify the SSL certificate of the endpoint. Defaults to ``true``.
+- **on_response** (*Optional*, :ref:`Automation <automation>`): An automation to perform when the request is finished.
 
 .. note::
 
@@ -111,6 +118,29 @@ Configuration variables:
 
 - **method** (**Required**, string): HTTP method to use (``GET``, ``POST``, ``PUT``, ``DELETE``, ``PATCH``).
 - All other options from :ref:`http_request-post_action`.
+
+.. _http_request-on_response:
+
+``on_response`` Trigger
+-----------------------
+
+This automation will be triggered when the HTTP request is finished and will supply the
+http response code in parameter ``x`` as an ``int``.
+
+.. code-block:: yaml
+...
+  on_
+    then:
+      - http_request.get:
+          url: https://esphome.io
+          verify_ssl: false
+          on_response:
+            then:
+              - logger.log:
+                  format: "Response status: %d"
+                  args:
+                    - x
+
 
 .. _http_request-examples:
 

--- a/components/http_request.rst
+++ b/components/http_request.rst
@@ -54,7 +54,7 @@ This :ref:`action <config-action>` sends a GET request.
               - logger.log:
                   format: 'Response status: %d'
                   args:
-                    - x
+                    - status_code
       # Short form
       - http_request.get: https://esphome.io
 
@@ -125,7 +125,7 @@ Configuration variables:
 -----------------------
 
 This automation will be triggered when the HTTP request is finished and will supply the
-http response code in parameter ``x`` as an ``int``.
+http response code in parameter ``status_code`` as an ``int``.
 
 .. code-block:: yaml
 
@@ -139,7 +139,7 @@ http response code in parameter ``x`` as an ``int``.
                 - logger.log:
                     format: "Response status: %d"
                     args:
-                      - x
+                      - status_code
 
 
 .. _http_request-examples:

--- a/components/http_request.rst
+++ b/components/http_request.rst
@@ -129,17 +129,17 @@ http response code in parameter ``x`` as an ``int``.
 
 .. code-block:: yaml
 
-  on_...
-    then:
-      - http_request.get:
-          url: https://esphome.io
-          verify_ssl: false
-          on_response:
-            then:
-              - logger.log:
-                  format: "Response status: %d"
-                  args:
-                    - x
+    on_...
+      then:
+        - http_request.get:
+            url: https://esphome.io
+            verify_ssl: false
+            on_response:
+              then:
+                - logger.log:
+                    format: "Response status: %d"
+                    args:
+                      - x
 
 
 .. _http_request-examples:

--- a/components/http_request.rst
+++ b/components/http_request.rst
@@ -128,8 +128,8 @@ This automation will be triggered when the HTTP request is finished and will sup
 http response code in parameter ``x`` as an ``int``.
 
 .. code-block:: yaml
-...
-  on_
+
+  on_...
     then:
       - http_request.get:
           url: https://esphome.io


### PR DESCRIPTION
## Description:

Adds docs for `on_repsonse` trigger for the `http_request` action.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#1599

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
