### PR TITLE
add font to usage example

### DIFF
--- a/components/display/waveshare_epaper.rst
+++ b/components/display/waveshare_epaper.rst
@@ -49,6 +49,11 @@ configuration.
 .. code-block:: yaml
 
     # Example configuration entry
+    font:
+      - file: 'some_font_file.ttf' # place the "some_font_file.ttf" in /config/esphome
+        id: font1
+        size: 8
+    
     spi:
       clk_pin: D0
       mosi_pin: D1
@@ -62,7 +67,7 @@ configuration.
         model: 2.90in
         full_update_every: 30
         lambda: |-
-          it.print(0, 0, id(font), "Hello World!");
+          it.print(0, 0, id(font1), "Hello World!");
 
 Configuration variables:
 ------------------------

--- a/components/display/waveshare_epaper.rst
+++ b/components/display/waveshare_epaper.rst
@@ -50,7 +50,7 @@ configuration.
 
     # Example configuration entry
     font:
-      - file: 'some_font_file.ttf' # place the "some_font_file.ttf" in /config/esphome
+      - file: 'fonts/Comic Sans MS.ttf'
         id: font1
         size: 8
     


### PR DESCRIPTION
## Description:
Added the font part, because without this part I could not upload to sample configuration to the ESP8266. As a beginner it was not directly clear for me what to add due to the error message I got in the UI. 

![2021-03-10](https://user-images.githubusercontent.com/44697375/110703829-8814cd00-81f4-11eb-8177-1ed1bb3a76ba.png)

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.

