### PR TITLE
Deleted "}" cause it was not necessary

### DIFF
--- a/cookbook/display_time_temp_oled.rst
+++ b/cookbook/display_time_temp_oled.rst
@@ -119,8 +119,7 @@ Note your ``address`` and ``model`` might be different, use the scan option to f
           // Print inside temperature (from homeassistant sensor)
           if (id(inside_temperature).has_state()) {
             it.printf(127, 23, id(font3), TextAlign::TOP_RIGHT , "%.1f°", id(inside_temperature).state);
-          }
-
+          
           // Print outside temperature (from homeassistant sensor)
           if (id(outside_temperature).has_state()) {
             it.printf(127, 60, id(font3), TextAlign::BASELINE_RIGHT , "%.1f°", id(outside_temperature).state);


### PR DESCRIPTION


## Description:
I got an error trying to upload the part with the outside temperatur. I deleted the unnecessry "}" and everything worked fine.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
