### PR TITLE
Adding docs to new scan results text sensor.

### DIFF
--- a/components/text_sensor/wifi_info.rst
+++ b/components/text_sensor/wifi_info.rst
@@ -21,6 +21,8 @@ via text sensors.
           name: ESP Connected BSSID
         mac_address:
           name: ESP Mac Wifi Address
+        scan_results:
+          name: ESP Latest Scan Results
 
 Configuration variables:
 ------------------------
@@ -32,6 +34,8 @@ Configuration variables:
 - **bssid** (*Optional*): Expose the BSSID of the currently connected WiFi network as a text sensor. All options from
   :ref:`Text Sensor <config-text_sensor>`.
 - **mac_address** (*Optional*): Expose the Mac Address of the WiFi card. All options from
+  :ref:`Text Sensor <config-text_sensor>`.
+- **scan_results** (*Optional*): Expose the latest networks found during the latest scan. All options from
   :ref:`Text Sensor <config-text_sensor>`.
 
 See Also


### PR DESCRIPTION
## Description:

Adds documentation to the new text sensor that adds the latest wifi can results.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#1605

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
