### PR TITLE
Add CLI logs section

### DIFF
--- a/guides/cli.rst
+++ b/guides/cli.rst
@@ -218,4 +218,30 @@ through a graphical user interface.
 
     If set, opens the dashboard UI in a browser once the server is up and running.
 
+``logs`` Command
+---------------------
+
+.. program:: esphome logs
+
+The ``esphome <CONFIG> logs`` command validates the configuration and shows all logs.
+
+.. option:: --topic TOPIC
+
+    Manually set the topic to subscribe to.
+
+.. option:: --username USERNAME
+
+    Manually set the username.
+
+.. option:: --password PASSWORD
+
+    Manually set the password.
+
+.. option:: --client-id CLIENT_ID
+
+    Manually set the client id.
+
+.. option:: --serial-port SERIAL_PORT
+
+    Manually specify a serial port to use. For example ``/dev/cu.SLAB_USBtoUART``.
 


### PR DESCRIPTION
## Description:

Added logs section to CLI page.

Also found two more "hidden" options `vscode` and `update-all` but they have no descriptions in --help.

**Related issue (if applicable):** nope

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** nope, just docs change

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
