### PR TITLE
Add output part to binary light example

### DIFF
--- a/components/light/binary.rst
+++ b/components/light/binary.rst
@@ -20,6 +20,11 @@ The ``binary`` light platform creates a simple ON/OFF-only light from a
         name: "Desk Lamp"
         output: output_component1
 
+    output:
+      - id: light_output
+        platform: gpio
+        pin: GPIO16
+
 Configuration variables:
 ------------------------
 

--- a/components/light/binary.rst
+++ b/components/light/binary.rst
@@ -18,7 +18,7 @@ The ``binary`` light platform creates a simple ON/OFF-only light from a
     light:
       - platform: binary
         name: "Desk Lamp"
-        output: output_component1
+        output: light_output
 
     output:
       - id: light_output


### PR DESCRIPTION
## Description:

This adds the output part to the binary light example. This would make the example more complete and potentially avoid some frustration.

On request by @balloob 😜 

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
