### PR TITLE
Update ssd1351.rst

### DIFF
--- a/components/display/ssd1351.rst
+++ b/components/display/ssd1351.rst
@@ -90,7 +90,7 @@ To bring in color images:
       - file: "image.jpg"
         id: my_image
         resize: 120x120
-        type: RGB
+        type: RGB24
 
     ...
 


### PR DESCRIPTION
Change RGB to RGB24 for image color type

## Description:

Following recent changes to ESPHome display core component, RGB24 is used to declare images with 24 bits (3 bytes per pixel)

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [current ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
