### PR TITLE
Fix typo lambada -> lambda in multiple display compoments

### DIFF
--- a/components/display/ili9341.rst
+++ b/components/display/ili9341.rst
@@ -65,7 +65,7 @@ Configuration examples
 To utilize the color capabilities of this display module, you'll likely want to add a ``color:`` section to your
 YAML configuration; please see :ref:`color <config-color>` for more detail on this configuration section.
 
-To use colors in your lambada:
+To use colors in your lambda:
 
 .. code-block:: yaml
 

--- a/components/display/ssd1325.rst
+++ b/components/display/ssd1325.rst
@@ -71,7 +71,7 @@ To utilize the grayscale capabilities of this display module, add a ``color:`` s
 please see :ref:`color <config-color>` for more details. As this is a grayscale display, it only uses the white color
 element as shown below.
 
-To use grayscale in your lambada:
+To use grayscale in your lambda:
 
 .. code-block:: yaml
 

--- a/components/display/ssd1327.rst
+++ b/components/display/ssd1327.rst
@@ -129,7 +129,7 @@ To utilize the grayscale capabilities of this display module, add a ``color:`` s
 please see :ref:`color <config-color>` for more details. As this is a grayscale display, it only uses the white color
 element as shown below.
 
-To use grayscale in your lambada:
+To use grayscale in your lambda:
 
 .. code-block:: yaml
 

--- a/components/display/st7789v.rst
+++ b/components/display/st7789v.rst
@@ -70,7 +70,7 @@ As of version 1.15, ESPHome supports color displays. To utilize the color capabi
 module, you'll likely want to add a ``color:`` section to your YAML configuration; please see
 :ref:`color <config-color>` for more detail on this configuration section.
 
-To use colors in your lambada:
+To use colors in your lambda:
 
 .. code-block:: yaml
 


### PR DESCRIPTION
## Description:
Fix an typo/autocorrect issue.

**Related issue (if applicable):** fixes n/a

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** n/a

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
