### PR TITLE
Update allowed characters for node names

### DIFF
--- a/components/esphome.rst
+++ b/components/esphome.rst
@@ -24,7 +24,7 @@ Configuration variables:
 
 - **name** (**Required**, string): This is the name of the node. It
   should always be unique in your ESPhome network. May only contain lowercase
-  characters, digits, underscores and hyphens. See :ref:`esphome-changing_node_name`.
+  characters, digits and hyphens. See :ref:`esphome-changing_node_name`.
 - **platform** (**Required**, string): The platform your board is on,
   either ``ESP32`` or ``ESP8266``. See :ref:`esphome-arduino_version`.
 - **board** (**Required**, string): The board ESPHome should


### PR DESCRIPTION
## Description:

Removes underscore as a valid component of node names.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#1632

## Checklist:

  - [X] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [X] Link added in `/index.rst` when creating new documents for new components or cookbook.
