### PR TITLE
Update st7735.rst

### DIFF
--- a/components/display/st7735.rst
+++ b/components/display/st7735.rst
@@ -6,7 +6,7 @@ ST7735 Display
     :keywords: ST7735
     :image: ST7735.png
 
-ST7735 Display Driver. 
+ST7735 Display Driver.
 
 Usage
 -----
@@ -28,47 +28,48 @@ There are numerous board types out there. Some initialize differently as well. T
 
     # Example configuration entry
     display:
-      - platform: st7735
-        model: "INITR_18BLACKTAB"
-        reset_pin: D4
-        cs_pin: D1
-        dc_pin: D2      
-        rotation: 0
-        devicewidth: 128
-        deviceheight: 160
-        colstart: 0
-        rowstart: 0
-        eightbitcolor: true
-        update_interval: 5s
+    - platform: st7735
+      model: "INITR_18BLACKTAB"
+      reset_pin: D4
+      cs_pin: D1
+      dc_pin: D2
+      rotation: 0
+      device_width: 128
+      device_height: 160
+      col_start: 0
+      row_start: 0
+      eight_bit_color: true
+      update_interval: 5s
 
 Configuration variables:
-~~~~~~~~~~~~~~~~~~~~~~~~
+************************
 
 - **model** (**Required**, "See Models Below"): This the model to use. INITR_BLACKTAB is the default
-- **reset_pin** (:ref:`Pin Schema <config-pin_schema>`): The RESET pin.
-- **cs_pin** (:ref:`Pin Schema <config-pin_schema>`): The CS pin.
-- **dc_pin** (:ref:`Pin Schema <config-pin_schema>`): The DC pin.
-- **devicewidth** (**Required**, int): The device width. 128 is default
-- **deviceheight** (**Required**, int): The device height. 160 is default
-- **colstart** (**Required**, int): The device height. 160 is default
-- **rowstart** (**Required**, int): The device height. 160 is default
-- **eightbitcolor** (*Optional*, "True/False" ): 8bit mode. Default is False. This saves 50% of the buffer required for the display. 
+- **cs_pin** (**Required**, :ref:`Pin Schema <config-pin_schema>`): The CS pin.
+- **dc_pin** (**Required**, :ref:`Pin Schema <config-pin_schema>`): The DC pin.
+- **device_width** (**Required**, int): The device width. Use 0 to get a component-specific default value.
+- **device_height** (**Required**, int): The device height. Use 0 to get a component-specific default value.
+- **col_start** (**Required**, int): The starting column for pixels. Use 0 to get a component-specific default value.
+- **row_start** (**Required**, int): The starting row for pixels. Use 0 to get a component-specific default value.
+- **eight_bit_color** (*Optional*, "True/False" ): 8bit mode. Default is False. This saves 50% of the buffer required for the display.
+- **reset_pin** (*Optional*, :ref:`Pin Schema <config-pin_schema>`): The RESET pin.
+- **use_bgr** (*Optional*, "True/False"): Use BGR for the color specification order instead of RGB.
 
 Memory notes:
-~~~~~~~~~~~~~
+*************
 
 - 8Bit color saves 50% of the buffer required.
 - eightbitcolor: True 160x128 = 20480 *Important for memory constrained devices*
-- eightbitcolor: False 160x128x2 = 40960 
+- eightbitcolor: False 160x128x2 = 40960
 
 
 Models:
-~~~~~~~
+*******
 
 - INITR_GREENTAB
 - INITR_REDTAB
 - INITR_BLACKTAB
-- INITR_MINI160X80
+- INITR_MIN_I160X80
 - INITR_18BLACKTAB
 - INITR_18REDTAB
 


### PR DESCRIPTION
Corrects some mis-statements in the component documentation. It didn't make any sense to say a config item is required and then to say it has a default. It would be better to make those config items optional in the first place.

Also adds the implemented but undocumented "use_bgr" config item.

Thanks for your work in bringing this display controller into esphome.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
