### PR TITLE
SPI: fix Example

### DIFF
--- a/components/spi.rst
+++ b/components/spi.rst
@@ -31,9 +31,9 @@ rarely be necessary, as the SPI bus can be shared by the devices).
 
     # Example configuration entry
     spi:
-      clk_pin: GPIO21
-      mosi_pin: GPIO22
-      miso_pin: GPIO23
+      clk_pin: GPIO14
+      mosi_pin: GPIO13
+      miso_pin: GPIO12
 
 Configuration variables:
 ------------------------


### PR DESCRIPTION
## Description:

The right pins for ESP8266 and ESP32 would be GPIO12-GPIO14.
GPIO21-23 is not available on an ESP8266, on an ESP32 it is I2C, maybe it was copy&paste from I2C?


## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
