### PR TITLE
Add documentation for the display.is_displaying_page condition

### DIFF
--- a/components/display/index.rst
+++ b/components/display/index.rst
@@ -540,6 +540,27 @@ You can then switch between these with three different actions:
               - display.page.show_next: my_display
               - component.update: my_display
 
+.. _display-is_displaying_page-condition:
+
+**display.is_displaying_page**: This condition returns true while the specified page is being shown.
+
+.. code-block:: yaml
+
+    # In some trigger:
+    on_...:
+      - if:
+          condition:
+            display.is_displaying_page: page1
+          then:
+            ...
+      - if:
+          condition:
+            display.is_displaying_page:
+              id: my_display
+              page_id: page2
+          then:
+            ...
+
 
 See Also
 --------

--- a/guides/automations.rst
+++ b/guides/automations.rst
@@ -394,6 +394,7 @@ All Conditions
 - :ref:`sun.is_above_horizon / sun.is_below_horizon <sun-is_above_below_horizon-condition>`
 - :ref:`text_sensor.state <text_sensor-state_condition>`
 - :ref:`light.is_on <light-is_on_condition>` / :ref:`light.is_off <light-is_off_condition>`
+- :ref:`display.is_displaying_page <display-is_displaying_page-condition>`
 
 All Lambda Calls
 ----------------


### PR DESCRIPTION
## Description:

Adds the documentation for the display.is_displaying_page condition implemented in the related PR.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#1646

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
