### PR TITLE
teleinfo: fix attribute tag_name in example

### DIFF
--- a/components/sensor/teleinfo.rst
+++ b/components/sensor/teleinfo.rst
@@ -84,7 +84,7 @@ Configuration variables:
 
 - **tags** (**Required**): Specify the tag you want to retrieve from the Teleinformation and select with what name to transmit it.
 
-  - **name** (**Required**, string): The name of the tag corresponding to what the electrical counter send.
+  - **tag_name** (**Required**, string): The name of the tag corresponding to what the electrical counter send.
   - **sensor** (**Required**, :ref:`Sensor <config-sensor>`): Associate a sensor with the tag. See options from :ref:`Sensor <config-sensor>`.
 
 - **historical_mode** (*Optional*): Wether to use historical mode or standard mode.

--- a/components/sensor/teleinfo.rst
+++ b/components/sensor/teleinfo.rst
@@ -60,17 +60,17 @@ simply press -/+ buttons on the counter and look for `Standard mode` or
     sensor:
       - platform: teleinfo
         tags:
-         - name: "HCHC"
+         - tag_name: "HCHC"
            sensor:
             name: "hchc"
             unit_of_measurement: "Wh"
             icon: mdi:flash
-         - name: "HCHP"
+         - tag_name: "HCHP"
            sensor:
             name: "hchp"
             unit_of_measurement: "Wh"
             icon: mdi:flash
-         - name: "PAPP"
+         - tag_name: "PAPP"
            sensor:
             name: "papp"
             unit_of_measurement: "VA"


### PR DESCRIPTION
## Description:

Fix wrong attribute name in teleinfo configuration documentation: `name` ➡️ `tag_name`.

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
