### PR TITLE
Update fastled.rst

### DIFF
--- a/components/light/fastled.rst
+++ b/components/light/fastled.rst
@@ -50,6 +50,10 @@ Configuration variables:
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
 - All other options from :ref:`Light <config-light>`.
 
+.. Note::
+
+    On ESP8266 you should avoid using GPIO16 (D0 on Wemos D1 Mini Pro) to drive the data line of the LED.
+
 .. _fastled_clockless-chipsets:
 
 Supported Chipsets


### PR DESCRIPTION
I'm sure I submitted this already. A added a note to say that using GPIO16 on the ESP8266 to drive the LED data line. I found this casually referenced in a couple of places online, but only after I had discovered the problem empirically.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
