### PR TITLE
feat: ESP32-EVB ethernet configuration example

### DIFF
--- a/components/ethernet.rst
+++ b/components/ethernet.rst
@@ -92,6 +92,18 @@ Configuration for Olimex ESP32-POE
       phy_addr: 0
       power_pin: GPIO12
 
+Configuration for Olimex ESP32-EVB
+----------------------------------
+
+.. code-block:: yaml
+
+    ethernet:
+      type: LAN8720
+      mdc_pin: GPIO23
+      mdio_pin: GPIO18
+      clk_mode: GPIO0_IN
+      phy_addr: 0
+
 Configuration for LILYGO TTGO T-Internet-POE ESP32-WROOM LAN8270A Chip
 ----------------------------------------------------------------------
 


### PR DESCRIPTION
## Description:

Hello, 
I used the attached configuration to setup the built-in ethernet on my ESP32-EVB.

I tested it and it's working correctly:
```
[18:00:52][C][ethernet:025]: Setting up Ethernet...
[18:01:07][W][ethernet:041]: Connecting via ethernet failed! Re-connecting...
[18:01:12][I][ethernet:052]: Connected via Ethernet!
[18:01:12][C][ethernet:220]:   IP Address: 192.168.1.237
[18:01:12][C][ethernet:221]:   Hostname: 'xxxxxxxxx'
[18:01:12][C][ethernet:222]:   Subnet: 255.255.255.0
[18:01:12][C][ethernet:223]:   Gateway: 192.168.1.1
[18:01:12][C][ethernet:226]:   DNS1: 192.168.1.41
[18:01:12][C][ethernet:228]:   DNS2: 8.8.4.4
[18:01:12][C][ethernet:231]:   MAC Address: 98:F4:AB:24:57:D7
[18:01:12][C][ethernet:232]:   Is Full Duplex: YES
[18:01:12][C][ethernet:233]:   Link Up: YES
[18:01:12][C][ethernet:234]:   Link Speed: 100

```

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
