### PR TITLE
Add the documentation for the autorepeat filter

### DIFF
--- a/components/binary_sensor/index.rst
+++ b/components/binary_sensor/index.rst
@@ -78,13 +78,20 @@ of these entries matters!)
           - delayed_on: 100ms
           - delayed_off: 100ms
           - delayed_on_off: 100ms
+          - autorepeat:
+            - delay: 1s
+              time_off: 100ms
+              time_on: 900ms
+            - delay: 5s
+              time_off: 100ms
+              time_on: 400ms
           - lambda: |-
               if (id(other_binary_sensor).state) {
                 return x;
               } else {
                 return {};
               }
-
+      
 ``invert``
 **********
 
@@ -112,6 +119,25 @@ Only send an OFF value if the binary sensor has stayed OFF for at least the spec
 (**Required**, :ref:`config-time`): Only send an ON or OFF value if the binary sensor has stayed in the same state
 for at least the specified time period.
 **Useful for debouncing binary switches**.
+
+``autorepeat``
+**************
+
+A filter implementing the autorepeat behavior. The filter is parametrized by a list of timing descriptions.
+When a signal ON is received it is passed to the output and the first ``delay`` is started. When this
+interval expires the output is turned OFF and toggles using the ``time_off`` and ``time_on`` durations
+for the OFF and ON state respectively. At the same time the ``delay`` of the second timing description
+is started and the process is repeated until the list is exhausted, in which case the timing of the
+last description remains in use. Receiving an OFF signal stops the whole process and immediately outputs OFF.
+
+The example thus waits one second with the output being ON, toggles it once per second for five seconds,
+then toggles twice per second until OFF is received.
+
+Configuration variables:
+
+- **delay** (*Optional*, :ref:`config-time`): Delay to proceed to the next timing. Defaults to ``1s``.
+- **time_off** (*Optional*, :ref:`config-time`): Interval to hold the output at OFF. Defaults to ``100ms``.
+- **time_on** (*Optional*, :ref:`config-time`): Interval to hold the output at ON. Defaults to ``900ms``.
 
 ``lambda``
 **********

--- a/components/binary_sensor/index.rst
+++ b/components/binary_sensor/index.rst
@@ -91,7 +91,7 @@ of these entries matters!)
               } else {
                 return {};
               }
-      
+
 ``invert``
 **********
 
@@ -132,6 +132,9 @@ last description remains in use. Receiving an OFF signal stops the whole process
 
 The example thus waits one second with the output being ON, toggles it once per second for five seconds,
 then toggles twice per second until OFF is received.
+
+An ``autorepeat`` filter with no timing description is equivalent to one timing with all the parameters
+set to default values.
 
 Configuration variables:
 


### PR DESCRIPTION
## Description:

A documentation for a common autorepeat filter able to produce binary sensor changes according to a timing description

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#1681

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
