### PR TITLE
Add the documentation for the on_page_change display trigger

### DIFF
--- a/components/display/index.rst
+++ b/components/display/index.rst
@@ -580,14 +580,14 @@ You can then switch between these with three different actions:
 .. code-block:: yaml
 
     display:
-    - platform: ...
-      # ...
-      on_page_change:
-        - from: page1
-          to: page2
-          then:
-            lambda: |-
-              ESP_LOGD("display", "Page changed from 1 to 2");
+      - platform: ...
+        # ...
+        on_page_change:
+          - from: page1
+            to: page2
+            then:
+              lambda: |-
+                ESP_LOGD("display", "Page changed from 1 to 2");
 
 - **from** (*Optional*, :ref:`config-id`): A page id. If set the automation is only triggered if changing from this page. Defaults to all pages.
 - **to** (*Optional*, :ref:`config-id`): A page id. If set the automation is only triggered if changing to this page. Defaults to all pages.

--- a/components/display/index.rst
+++ b/components/display/index.rst
@@ -573,6 +573,22 @@ You can then switch between these with three different actions:
           then:
             ...
 
+.. _display-on_page_change-trigger:
+
+**on_page_change**: This automation will be triggered when the page that is shown changes.
+The old page will be given as the variable ``from`` and the new one as the variable ``to``.
+
+.. code-block:: yaml
+
+    display:
+    - platform: ...
+      # ...
+      on_page_change:
+        then:
+          lambda: |-
+            if (from == id(page1) && to == id(page2))
+              ESP_LOGD("display", "Page changed from 1 to 2");
+
 
 See Also
 --------

--- a/components/display/index.rst
+++ b/components/display/index.rst
@@ -576,7 +576,6 @@ You can then switch between these with three different actions:
 .. _display-on_page_change-trigger:
 
 **on_page_change**: This automation will be triggered when the page that is shown changes.
-The old page will be given as the variable ``from`` and the new one as the variable ``to``.
 
 .. code-block:: yaml
 
@@ -584,12 +583,17 @@ The old page will be given as the variable ``from`` and the new one as the varia
     - platform: ...
       # ...
       on_page_change:
-        then:
-          lambda: |-
-            if (from == id(page1) && to == id(page2))
+        - from: page1
+          to: page2
+          then:
+            lambda: |-
               ESP_LOGD("display", "Page changed from 1 to 2");
 
+- **from** (*Optional*, :ref:`config-id`): A page id. If set the automation is only triggered if changing from this page. Defaults to all pages.
+- **to** (*Optional*, :ref:`config-id`): A page id. If set the automation is only triggered if changing to this page. Defaults to all pages.
 
+Additionally the old page will be given as the variable ``from`` and the new one as the variable ``to``.
+              
 See Also
 --------
 

--- a/guides/automations.rst
+++ b/guides/automations.rst
@@ -334,6 +334,7 @@ All Triggers
 - :ref:`switch.on_turn_on/off <switch-on_turn_on_off_trigger>`
 - :ref:`sim800l.on_sms_received <sim800l-on_sms_received>`
 - :ref:`rf_bridge.on_code_received <rf_bridge-on_code_received>`
+- :ref:`display.on_page_change <display-on_page_change-trigger>`
 
 All Actions
 -----------


### PR DESCRIPTION
## Description:

This PR adds a documentation for the on_page_change trigger for a multi-page display. The trigger allows the user to hook actions on entering or leaving display pages.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#1687

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
