### PR TITLE
pmsx003: add config options for extra sensor data points

### DIFF
--- a/components/sensor/pmsx003.rst
+++ b/components/sensor/pmsx003.rst
@@ -40,11 +40,29 @@ value:
 Configuration variables:
 ------------------------
 
-- **pm_1_0** (*Optional*): Use the concentration of particulates of size less than 1.0µm in µg per cubic meter.
+- **pm_1_0_std** (*Optional*): Use the concentration of particulates of size less than 1.0µm in µg per cubic meter at standard particle
   All options from :ref:`Sensor <config-sensor>`.
-- **pm_2_5** (*Optional*): Use the concentration of particulates of size less than 2.5µm in µg per cubic meter.
+- **pm_2_5_std** (*Optional*): Use the concentration of particulates of size less than 2.5µm in µg per cubic meter at standard particle
   All options from :ref:`Sensor <config-sensor>`.
-- **pm_10_0** (*Optional*): Use the concentration of particulates of size less than 10.0µm in µg per cubic meter.
+- **pm_10_0_std** (*Optional*): Use the concentration of particulates of size less than 10.0µm in µg per cubic meter at standard particle
+  All options from :ref:`Sensor <config-sensor>`.
+- **pm_1_0** (*Optional*): Use the concentration of particulates of size less than 1.0µm in µg per cubic meter under atmospheric environment
+  All options from :ref:`Sensor <config-sensor>`.
+- **pm_2_5** (*Optional*): Use the concentration of particulates of size less than 2.5µm in µg per cubic meter under atmospheric environment
+  All options from :ref:`Sensor <config-sensor>`.
+- **pm_10_0** (*Optional*): Use the concentration of particulates of size less than 10.0µm in µg per cubic meter under atmospheric environment
+  All options from :ref:`Sensor <config-sensor>`.
+- **pm_0_3um** (*Optional*): Use the number of particles with diameter beyond 0.3um in 0.1L of air
+  All options from :ref:`Sensor <config-sensor>`.
+- **pm_0_5um** (*Optional*): Use the number of particles with diameter beyond 0.5um in 0.1L of air
+  All options from :ref:`Sensor <config-sensor>`.
+- **pm_1_0um** (*Optional*): Use the number of particles with diameter beyond 1.0um in 0.1L of air
+  All options from :ref:`Sensor <config-sensor>`.
+- **pm_2_5um** (*Optional*): Use the number of particles with diameter beyond 2.5um in 0.1L of air
+  All options from :ref:`Sensor <config-sensor>`.
+- **pm_5_0um** (*Optional*): Use the number of particles with diameter beyond 5.0um in 0.1L of air
+  All options from :ref:`Sensor <config-sensor>`.
+- **pm_10_0um** (*Optional*): Use the number of particles with diameter beyond 10.0um in 0.1L of air
   All options from :ref:`Sensor <config-sensor>`.
 - **temperature** (*Optional*): Use the temperature value in °C for the ``PMS5003T`` and ``PMS5003ST``.
   All options from :ref:`Sensor <config-sensor>`.


### PR DESCRIPTION
## Description:

This adds in the config options for pm1.0, pm2.5, pm10 under standard
particles, as well as the partcile counts beyond 0.3um, 0.5um, 1.0um,
2.5um, 5.0um, and 10.0um

**Related issue (if applicable):**

none

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

esphome/esphome#1694

## Checklist:

  - [X] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [N/A] Link added in `/index.rst` when creating new documents for new components or cookbook.
