### PR TITLE
BME680 BSEC: Document per sensor T/P/H sample rate overrides

### DIFF
--- a/components/sensor/bme680_bsec.rst
+++ b/components/sensor/bme680_bsec.rst
@@ -64,8 +64,7 @@ The configuration is made up of three parts: The central hub, individual sensors
 
 Hub Configuration:
 
-- **address** (*Optional*, int): Manually specify the I^2C address of
-  the sensor. Defaults to ``0x76``. Another address can be ``0x77``.
+- **address** (*Optional*, int): Manually specify the I^2C address of the sensor. Defaults to ``0x76``. Another address can be ``0x77``.
 
 - **temperature_offset** (*Optional*, float): Temperature offset if device is in enclosure and reads too high.
   Defaults to ``0``.
@@ -75,6 +74,7 @@ Hub Configuration:
 
 - **sample_rate** (*Optional*, string): Sample rate. Default is ``lp`` for low power consumption, sampling every 3 seconds.
   Can be ``ulp`` for ultra low power, sampling every 5 minutes.
+  This controls the sampling rate for gas-dependant sensors and will govern the interval at which the sensor heater is operated. By default it rate will also be used for temperature, pressure and humidity sensors but these can be overridden on a per-sensor level if required.
 
 - **state_save_interval** (*Optional*, :ref:`config-time`): The minimum interval at which to save calibrated BSEC algorithm state to
   flash so that calibration does have to start from zero on device restart. Defaults to ``6h``.
@@ -85,18 +85,21 @@ Sensor Configuration:
 
   - **name** (**Required**, string): The name for the temperature sensor.
   - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.
+  - **sample_rate** (*Optional*, string): Optional sample rate override for this sensor. Can be ``lp`` for low power consumption, sampling every 3 seconds or ``ulp`` for ultra low power, sampling every 5 minutes.
   - All other options from :ref:`Sensor <config-sensor>`.
 
 - **pressure** (*Optional*): The information for the pressure sensor.
 
   - **name** (**Required**, string): The name for the pressure sensor.
   - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.
+  - **sample_rate** (*Optional*, string): Optional sample rate override for this sensor. Can be ``lp`` for low power consumption, sampling every 3 seconds or ``ulp`` for ultra low power, sampling every 5 minutes.
   - All other options from :ref:`Sensor <config-sensor>`.
 
 - **humidity** (*Optional*): The information for the humidity sensor.
 
   - **name** (**Required**, string): The name for the humidity sensor.
   - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.
+  - **sample_rate** (*Optional*, string): Optional sample rate override for this sensor. Can be ``lp`` for low power consumption, sampling every 3 seconds or ``ulp`` for ultra low power, sampling every 5 minutes.
   - All other options from :ref:`Sensor <config-sensor>`.
 
 - **gas_resistance** (*Optional*): The information for the gas sensor.
@@ -180,7 +183,7 @@ For each sensor all other options from :ref:`Sensor <config-sensor>` and :ref:`T
         # - lp (low power - samples every 3 seconds)
         # - ulp (ultra low power - samples every 5 minutes)
         # Default: lp
-        sample_rate: lp
+        sample_rate: ulp
 
         # Interval at which to save BSEC state
         # ------------------------------------
@@ -192,16 +195,19 @@ For each sensor all other options from :ref:`Sensor <config-sensor>` and :ref:`T
         temperature:
           # Temperature in °C
           name: "BME680 Temperature"
+          sample_rate: lp
           filters:
             - median
         pressure:
           # Pressure in hPa
           name: "BME680 Pressure"
+          sample_rate: lp
           filters:
             - median
         humidity:
           # Relative humidity %
           name: "BME680 Humidity"
+          sample_rate: lp
           filters:
             - median
         gas_resistance:

--- a/components/sensor/bme680_bsec.rst
+++ b/components/sensor/bme680_bsec.rst
@@ -74,7 +74,8 @@ Hub Configuration:
 
 - **sample_rate** (*Optional*, string): Sample rate. Default is ``lp`` for low power consumption, sampling every 3 seconds.
   Can be ``ulp`` for ultra low power, sampling every 5 minutes.
-  This controls the sampling rate for gas-dependant sensors and will govern the interval at which the sensor heater is operated. By default it rate will also be used for temperature, pressure and humidity sensors but these can be overridden on a per-sensor level if required.
+  This controls the sampling rate for gas-dependant sensors and will govern the interval at which the sensor heater is operated.
+  By default this rate will also be used for temperature, pressure and humidity sensors but these can be overridden on a per-sensor level if required.
 
 - **state_save_interval** (*Optional*, :ref:`config-time`): The minimum interval at which to save calibrated BSEC algorithm state to
   flash so that calibration does have to start from zero on device restart. Defaults to ``6h``.


### PR DESCRIPTION
## Description:

Documents per sensor temperature, pressure and humidity sample rate overrides.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#1710

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
