### PR TITLE
Update name_add_mac_suffix use dash

### DIFF
--- a/components/esphome.rst
+++ b/components/esphome.rst
@@ -49,8 +49,8 @@ Advanced options:
 - **libraries** (*Optional*, list of libraries): A list of `platformio libraries <https://platformio.org/lib>`__
   to include in the project. See `platformio lib install <https://docs.platformio.org/en/latest/userguide/lib/cmd_install.html>`__.
 - **comment** (*Optional*, string): Additional text information about this node. Only for display in UI.
-- **name_add_mac_suffix** (*Optional*, boolean): Appends the last 6 bytes of the mac address of the device to 
-  the name in the form `<name>_aabbcc`. Defaults to ``False``.
+- **name_add_mac_suffix** (*Optional*, boolean): Appends the last 6 bytes of the mac address of the device to
+  the name in the form `<name>-aabbcc`. Defaults to ``False``.
   See :ref:`esphome-mac_suffix`.
 
 ESP8266 Options:


### PR DESCRIPTION
## Description:

`name_add_mac_suffix` change separator `_` to `-`

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#1702

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
