### PR TITLE
Add extra margin at the bottom to avoid overlap with Changelog banner

### DIFF
--- a/_static/custom.css
+++ b/_static/custom.css
@@ -5,6 +5,10 @@
   text-align: center;
 }
 
+div.document {
+  margin-bottom: 50px;
+}
+
 img.component-image {
   border: none;
   vertical-align: middle;


### PR DESCRIPTION
## Description:
This is an infrastructure change that adds some margin at the bottom of the document, so the changelog banner doesn't overlap with the content. The only way of getting to the content is by hitting "View changelog" button which opens a new page, and isn't a great experience if all you want to do is read the docs.

I tried to find the best spot to add it, and use a sensible px number.

Before: 
![localhost_8000_components_esphome html (1)](https://user-images.githubusercontent.com/2961735/115796312-a2b79580-a39f-11eb-9651-67a2c16674b3.png)

After: 
![localhost_8000_components_esphome html](https://user-images.githubusercontent.com/2961735/115796320-a77c4980-a39f-11eb-8bfe-b706220e33e6.png)

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
