### PR TITLE
Make changelog banner dismissable

### DIFF
--- a/_static/custom.css
+++ b/_static/custom.css
@@ -62,15 +62,18 @@ table.docutils {
   z-index: 9999;
   display: none
 }
-#upgrade-footer-changelog {
+.footer-button-container {
+  margin: 0 60px 0 10px;
+  float: right;
+}
+.footer-button {
   background-color: #b3b3b3;
   color: #4e4e4e;
   display: inline-block;
   border-radius: 5px;
   padding: 0 20px;
+  margin-left: 10px;
   cursor: pointer;
-  float: right;
-  margin: 0 60px 0 10px;
   text-decoration: none;
 }
 .not-hidden {

--- a/_templates/layout.html
+++ b/_templates/layout.html
@@ -30,15 +30,20 @@
 {% block footer %}
   <div id="upgrade-footer">
     A new version has been release since you last visited this page: {{ release }} 🎉
-    <a id="upgrade-footer-changelog" href="/changelog/v{{ version }}.0.html">View Changelog</a>
+    <div class="footer-button-container">
+      <div role="button" id="upgrade-footer-dismiss" class="footer-button">Dismiss</div>
+      <a id="upgrade-footer-changelog" class="footer-button" href="/changelog/v{{ version }}.0.html">View Changelog</a>  
+    </div>
   </div>
   <script>
     var old = window.localStorage.getItem("version");
     if (old === null) { window.localStorage.setItem("version", "{{ version }}");
     } else if (old !== "{{ version }}") {
-      document.getElementById("upgrade-footer").classList.add("not-hidden");
-      document.getElementById("upgrade-footer-changelog").addEventListener('click', function () {
+      const footerEl = document.getElementById("upgrade-footer");
+      footerEl.classList.add("not-hidden");
+      footerEl.addEventListener('click', function () {
         window.localStorage.setItem("version", "{{ version }}");
+        footerEl.classList.remove("not-hidden");
       });
     }
   </script>


### PR DESCRIPTION
## Description:
This change adds a "Dismiss" button to the changelog update footer, as not all users might be interested in checking it out. Clicking anywhere on the footer makes it disappear and updates Local Storage so it's permanent until next release.

I used a `<div role="button">` so it's a bit more accessible, and so I don't have to override too many styles, which I would have needed to do if I used a real `<button>`. Moved some styles to classes, as that's industry standard.

Desktop:
![localhost_8000_components_esphome html (2)](https://user-images.githubusercontent.com/2961735/115798392-28d5db00-a3a4-11eb-8ce4-665c15a83098.png)

Mobile:
![localhost_8000_components_esphome html(Pixel 2)](https://user-images.githubusercontent.com/2961735/115798388-270c1780-a3a4-11eb-9c8b-990f2a54ec25.png)


## Checklist:

  - [X] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.