### PR TITLE
Add triggers fan.on_turn_on / fan.on_turn_off

### DIFF
--- a/components/fan/index.rst
+++ b/components/fan/index.rst
@@ -45,6 +45,13 @@ MQTT options:
   speed commands on.
 - All other options from :ref:`MQTT Component <config-mqtt-component>`.
 
+Automation triggers:
+
+- **on_turn_on** (*Optional*, :ref:`Action <config-action>`): An automation to perform
+  when the fan is turned on. See :ref:`fan-on_turn_on_off_trigger`.
+- **on_turn_off** (*Optional*, :ref:`Action <config-action>`): An automation to perform
+  when the fan is turned off. See :ref:`fan-on_turn_on_off_trigger`.
+
 .. _fan-toggle_action:
 
 ``fan.toggle`` Action
@@ -94,6 +101,24 @@ Configuration options:
   Set the oscillation state of the fan. Defaults to not affecting oscillation.
 - **speed** (*Optional*, int, :ref:`templatable <config-templatable>`):
   Set the speed level of the fan. Can be a number between 1 and the maximum speed level of the fan.
+
+.. _fan-on_turn_on_off_trigger:
+
+``fan.on_turn_on`` / ``fan.on_turn_off`` Trigger
+****************************************************
+
+This trigger is activated each time the fan is turned on or off. It does not fire
+if a command to turn the fan on or off already matches the current state.
+
+.. code-block:: yaml
+
+    fan:
+      - platform: speed # or any other platform
+        # ...
+        on_turn_on:
+        - logger.log: "Fan Turned On!"
+        on_turn_off:
+        - logger.log: "Fan Turned Off!"
 
 Full Fan Index
 --------------


### PR DESCRIPTION
## Description:

Documentation for the new triggers fan.on_turn_on / on_turn_off per https://github.com/esphome/esphome/pull/1726

**Related issue (if applicable):** n/a (new feature)

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#1726

## Checklist:

  - [X] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [-] Link added in `/index.rst` when creating new documents for new components or cookbook.
