### PR TITLE
Change WiFi Signal strength unit to dBm

### DIFF
--- a/components/sensor/wifi_signal.rst
+++ b/components/sensor/wifi_signal.rst
@@ -9,7 +9,7 @@ The ``wifi_signal`` sensor platform allows you to read the signal
 strength of the currently connected :doc:`WiFi Access Point </components/wifi>`.
 
 The sensor value is the `"Received signal strength indication" <https://en.wikipedia.org/wiki/Received_signal_strength_indication>`__
-measured in decibels. These values are always negative and the closer they are to zero, the better the signal is.
+measured in decibel-milliwatts (dBm). These values are always negative and the closer they are to zero, the better the signal is.
 
 .. figure:: images/wifi_signal-ui.png
     :align: center


### PR DESCRIPTION
## Description:

This PR change WiFi signal unit to dBm as Wifi Signal Strength unit should be dBm and not dB

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#1734

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
