### PR TITLE
Explain where to upload .ttf font files

### DIFF
--- a/components/display/index.rst
+++ b/components/display/index.rst
@@ -134,12 +134,27 @@ specific sizes, with ESPHome you have the option to use **any** TrueType (``.ttf
 at **any** size! Granted the reason for it is actually not having to worry about the licensing of font files :)
 
 To use fonts you first have to define a font object in your ESPHome configuration file. Just grab
-a ``.ttf`` file from somewhere on the Internet and create a ``font:`` section in your configuration:
+a ``.ttf`` file from somewhere on the internet and upload it to the ``config/esphome`` folder.
+Next, create a ``font:`` section in your configuration:
 
 .. code-block:: yaml
 
     font:
       - file: "Comic Sans MS.ttf"
+        id: my_font
+        size: 20
+
+    display:
+      # ...
+
+
+If you created a ``fonts`` subfolder, reference the font file as follows:
+
+
+.. code-block:: yaml
+
+    font:
+      - file: "fonts/Comic Sans MS.ttf"
         id: my_font
         size: 20
 

--- a/components/display/index.rst
+++ b/components/display/index.rst
@@ -134,7 +134,8 @@ specific sizes, with ESPHome you have the option to use **any** TrueType (``.ttf
 at **any** size! Granted the reason for it is actually not having to worry about the licensing of font files :)
 
 To use fonts you first have to define a font object in your ESPHome configuration file. Just grab
-a ``.ttf`` file from somewhere on the internet and upload it to the ESPHome root folder.
+a ``.ttf`` file from somewhere on the internet and place it, for example,
+inside a `fonts` folder next to your configuration file.
 
 Next, create a ``font:`` section in your configuration:
 

--- a/components/display/index.rst
+++ b/components/display/index.rst
@@ -134,7 +134,7 @@ specific sizes, with ESPHome you have the option to use **any** TrueType (``.ttf
 at **any** size! Granted the reason for it is actually not having to worry about the licensing of font files :)
 
 To use fonts you first have to define a font object in your ESPHome configuration file. Just grab
-a ``.ttf`` file from somewhere on the internet and upload it to the ``config/esphome`` folder.
+a ``.ttf`` file from somewhere on the internet and upload it to the ESPHome root folder.
 Next, create a ``font:`` section in your configuration:
 
 .. code-block:: yaml
@@ -147,14 +147,14 @@ Next, create a ``font:`` section in your configuration:
     display:
       # ...
 
-
-If you created a ``fonts`` subfolder, reference the font file as follows:
+You can organise your fonts by using subfolders.
+I.e., if you created a ``_fonts`` subfolder, reference the font file as follows:
 
 
 .. code-block:: yaml
 
     font:
-      - file: "fonts/Comic Sans MS.ttf"
+      - file: "_fonts/Comic Sans MS.ttf"
         id: my_font
         size: 20
 

--- a/components/display/index.rst
+++ b/components/display/index.rst
@@ -135,7 +135,7 @@ at **any** size! Granted the reason for it is actually not having to worry about
 
 To use fonts you first have to define a font object in your ESPHome configuration file. Just grab
 a ``.ttf`` file from somewhere on the internet and place it, for example,
-inside a `fonts` folder next to your configuration file.
+inside a ``fonts`` folder next to your configuration file.
 
 Next, create a ``font:`` section in your configuration:
 

--- a/components/display/index.rst
+++ b/components/display/index.rst
@@ -135,32 +135,18 @@ at **any** size! Granted the reason for it is actually not having to worry about
 
 To use fonts you first have to define a font object in your ESPHome configuration file. Just grab
 a ``.ttf`` file from somewhere on the internet and upload it to the ESPHome root folder.
+
 Next, create a ``font:`` section in your configuration:
 
 .. code-block:: yaml
 
     font:
-      - file: "Comic Sans MS.ttf"
+      - file: "fonts/Comic Sans MS.ttf"
         id: my_font
         size: 20
 
     display:
       # ...
-
-You can organise your fonts by using subfolders.
-I.e., if you created a ``_fonts`` subfolder, reference the font file as follows:
-
-
-.. code-block:: yaml
-
-    font:
-      - file: "_fonts/Comic Sans MS.ttf"
-        id: my_font
-        size: 20
-
-    display:
-      # ...
-
 
 Configuration variables:
 


### PR DESCRIPTION
## Description:

The documentation didn't mention .ttf font files should be uploaded in the config/esphome folder.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
