### PR TITLE
Add SM16703 to list of supported FastLED chipsets

### DIFF
--- a/components/light/fastled.rst
+++ b/components/light/fastled.rst
@@ -79,6 +79,7 @@ Supported Chipsets
 - ``UCS1903``
 - ``UCS1904``
 - ``UCS2903``
+- ``SM16703``
 
 .. _fastled-spi:
 


### PR DESCRIPTION
## Description:

Add SM16703 to list of supported FastLED chipsets.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#1751

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
