### PR TITLE
Added links to example for Waveshare Driver Boards

### DIFF
--- a/components/display/waveshare_epaper.rst
+++ b/components/display/waveshare_epaper.rst
@@ -110,4 +110,6 @@ See Also
 - :doc:`index`
 - :apiref:`waveshare_epaper/waveshare_epaper.h`
 - `Arduino Waveshare E-Paper library <https://github.com/soonuse/epd-library-arduino>`__ by `Yehui (@soonuse) <https://github.com/soonuse>`__
+- `Waveshare ESP32 driver board example <https://gist.github.com/jamesfed/ee7df967e5ab7a77f979bc8226a1f0e2>`__ by `James Preston (@jamesfed) <https://gist.github.com/jamesfed>`__
+- `Waveshare ESP8266 driver board example <https://gist.github.com/jamesfed/cb9092b2108d794d75cabdbc24cd1cc7>`__ by `James Preston (@jamesfed) <https://gist.github.com/jamesfed>`__
 - :ghedit:`Edit`


### PR DESCRIPTION
Links added for ESP32 and ESP8266 Waveshare E-Paper Driver Boards (useful for the pinouts and board names).

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
