### PR TITLE
Clarify sensor component "name".

### DIFF
--- a/components/sensor/index.rst
+++ b/components/sensor/index.rst
@@ -37,7 +37,11 @@ override them if you want to.
 
 Configuration variables:
 
-- **name** (**Required**, string): The name for the sensor.
+- **name** (**Required**, string): The name for the sensor.  Caution in setting this name as it forms 
+  the basis for the unique id for the sensor item. It should only be constructed of the following characters
+  "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_" and the space character.  Any other 
+  characters are deleted. For example, the following names are identical and will cause issues
+  in Home Assistant - "Sensor PM25" equals "Sensor PM2.5".
 - **unit_of_measurement** (*Optional*, string): Manually set the unit
   of measurement the sensor should advertise its values with. This does
   not actually do any maths (conversion between units).


### PR DESCRIPTION
## Description:

[Newbie submitter - so please forgive if this is not the appropriate area - let me know and I'll try and do the right thing.]

I didn't think of this as a bug as such, but rather a lack of clarification in the text describing the use of "names" for sensor components.  I had the names shown in the document fix as part of a custom component for the PMB5003 dust sensor (it puts the device to sleep to conserve the mechanical fan).  The "." is the offending character that is silently deleted and then ends up down the track I assume as part of the unique id for the sensor entities in Home Assistant.  Not necessary to change any code; just let us know there are limitations in naming so others don't spend hours figuring it out for themselves.  Very much a corner-case as such.

## Checklist:

  - [ ] Branch: `next` 
