### PR TITLE
Remove deprecated board_flash_mode from configuration example

### DIFF
--- a/guides/configuration-types.rst
+++ b/guides/configuration-types.rst
@@ -248,7 +248,6 @@ added ``board``, and overridden ``name`` substitutions):
       platform: ESP8266
       board: esp01_1m
       includes: []
-      board_flash_mode: dout
       libraries: []
       esp8266_restore_from_flash: false
       build_path: device01


### PR DESCRIPTION
## Description:

This PR removes an occurrence of `board_flash_mode`, which has been deprecated/removed for quite some time now.

**Related issue (if applicable):** n/a

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** n/a

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
