### PR TITLE
deep-sleep/enter-action-templatable

### DIFF
--- a/components/deep_sleep.rst
+++ b/components/deep_sleep.rst
@@ -87,7 +87,7 @@ This action makes the given deep sleep component enter deep sleep immediately.
 
 Configuration options:
 
-- **sleep_duration** (*Optional*, :ref:`config-time`): The time duration to stay in deep sleep mode.
+- **sleep_duration** (*Optional*, :ref:`templatable <config-templatable>`, :ref:`config-time`): The time duration to stay in deep sleep mode.
 
 
 .. _deep_sleep-prevent_action:


### PR DESCRIPTION
## Description:

Adds templatable keyword to `deep_sleep.enter` action

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#1765

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
