### PR TITLE
Sample codeblock has incorrect variables

### DIFF
--- a/components/display/st7735.rst
+++ b/components/display/st7735.rst
@@ -34,10 +34,10 @@ There are numerous board types out there. Some initialize differently as well. T
         cs_pin: D1
         dc_pin: D2
         rotation: 0
-        devicewidth: 128
-        deviceheight: 160
-        colstart: 0
-        rowstart: 0
+        device_width: 128
+        device_height: 160
+        col_start: 0
+        row_start: 0
         eightbitcolor: true
         update_interval: 5s
 


### PR DESCRIPTION
## Description:

Four of the variables in the sample codeblock don't include underscores as defined in the variables section. This throws an error when using this sample code. To avoid others getting these errors I have updated the sample so it uses the right variables.


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
