### PR TITLE
Add attribute support to Home Assistant sensors

### DIFF
--- a/components/binary_sensor/homeassistant.rst
+++ b/components/binary_sensor/homeassistant.rst
@@ -16,11 +16,24 @@ states from your Home Assistant instance using the :doc:`native API </components
         name: "Input Boolean From Home Assistant"
         entity_id: input_boolean.state_home
 
+With Home Assistant 2021.6 or newer, entity state attributes can also be imported.
+
+.. code-block:: yaml
+    # Example configuration entry
+    binary_sensor:
+      - platform: homeassistant
+        id: muted
+        entity_id: media_player.mega_speakers
+        attribute: is_volume_muted
+
 Configuration variables:
 ------------------------
 
 - **name** (**Required**, string): The name of the binary sensor.
 - **entity_id** (**Required**, string): The entity ID to import from Home Assistant.
+- **attribute** (*Optional*, string): The name of the state attribute to import from the
+  specified entity. The entity state is used when this option is omitted.
+  Requires Home Assistant 2021.6 or newer.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
 - All other options from :ref:`Binary Sensor <config-binary_sensor>`.
 

--- a/components/binary_sensor/homeassistant.rst
+++ b/components/binary_sensor/homeassistant.rst
@@ -19,6 +19,7 @@ states from your Home Assistant instance using the :doc:`native API </components
 With Home Assistant 2021.6 or newer, entity state attributes can also be imported.
 
 .. code-block:: yaml
+
     # Example configuration entry
     binary_sensor:
       - platform: homeassistant

--- a/components/sensor/homeassistant.rst
+++ b/components/sensor/homeassistant.rst
@@ -16,6 +16,16 @@ states from your Home Assistant instance using the :doc:`native API </components
         name: "Temperature Sensor From Home Assistant"
         entity_id: sensor.temperature_sensor
 
+With Home Assistant 2021.6 or newer, entity state attributes can also be imported.
+
+.. code-block:: yaml
+    # Example configuration entry
+    sensor:
+      - platform: homeassistant
+        id: current_temperature
+        entity_id: climate.living_room
+        attribute: current_temperature
+
 .. note::
 
     This component is only for numeral states. If you want to import arbitrary text states
@@ -25,14 +35,14 @@ states from your Home Assistant instance using the :doc:`native API </components
     in Home Assistant, this component still requires you to register the node under Home Assistant. See:
     :doc:`Getting started with Hassio </guides/getting_started_hassio>`
 
-    Importing attributes is currently not supported, but you can create template sensors in Home Assistant
-    that return the attribute of a sensor and then import the template sensor here.
-
 Configuration variables:
 ------------------------
 
 - **name** (**Required**, string): The name of the sensor.
 - **entity_id** (**Required**, string): The entity ID to import from Home Assistant.
+- **attribute** (*Optional*, string): The name of the state attribute to import from the
+  specified entity. The entity state is used when this option is omitted.
+  Requires Home Assistant 2021.6 or newer.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
 - All other options from :ref:`Sensor <config-sensor>`.
 

--- a/components/sensor/homeassistant.rst
+++ b/components/sensor/homeassistant.rst
@@ -19,6 +19,7 @@ states from your Home Assistant instance using the :doc:`native API </components
 With Home Assistant 2021.6 or newer, entity state attributes can also be imported.
 
 .. code-block:: yaml
+
     # Example configuration entry
     sensor:
       - platform: homeassistant

--- a/components/text_sensor/homeassistant.rst
+++ b/components/text_sensor/homeassistant.rst
@@ -19,6 +19,7 @@ states from your Home Assistant instance using the :doc:`native API </components
 With Home Assistant 2021.6 or newer, entity state attributes can also be imported.
 
 .. code-block:: yaml
+
     # Example configuration entry
     text_sensor:
       - platform: homeassistant

--- a/components/text_sensor/homeassistant.rst
+++ b/components/text_sensor/homeassistant.rst
@@ -16,11 +16,24 @@ states from your Home Assistant instance using the :doc:`native API </components
         name: "Weather Forecast From Home Assistant"
         entity_id: sensor.weather_forecast
 
+With Home Assistant 2021.6 or newer, entity state attributes can also be imported.
+
+.. code-block:: yaml
+    # Example configuration entry
+    text_sensor:
+      - platform: homeassistant
+        id: effect
+        entity_id: light.led_strip
+        attribute: effect
+
 Configuration variables:
 ------------------------
 
 - **name** (**Required**, string): The name of the text sensor.
 - **entity_id** (**Required**, string): The entity ID to import from Home Assistant.
+- **attribute** (*Optional*, string): The name of the state attribute to import from the
+  specified entity. The entity state is used when this option is omitted.
+  Requires Home Assistant 2021.6 or newer.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
 - All other options from :ref:`Text Sensor <config-text_sensor>`.
 


### PR DESCRIPTION
## Description:

This PR adds the documentation for specifying the Home Assistant entity attribute on ESPHome `homeassistant` sensors.

**Related issue (if applicable):** https://github.com/esphome/feature-requests/issues/1112

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#1770

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
