### PR TITLE
Add past changelogs to current

### DIFF
--- a/changelog/v1.16.0.rst
+++ b/changelog/v1.16.0.rst
@@ -387,3 +387,19 @@ All changes
 - docs: Update scd30 docs to show sensors are optional :docspr:`970` by :ghuser:`jesserockz` (cherry-picked)
 - esphome: fix esp8266 remote_transmitter using incorrect timings :esphomepr:`1465` by :ghuser:`hcoohb` (cherry-picked)
 - esphome: rc522 increased retry loop count :esphomepr:`1506` by :ghuser:`glmnet` (cherry-picked)
+
+Past Changelogs
+---------------
+
+.. toctree::
+    :maxdepth: 1
+
+    v1.15.0
+    v1.14.0
+    v1.13.0
+    v1.12.0
+    v1.11.0
+    v1.10.0
+    v1.9.0
+    v1.8.0
+    v1.7.0

--- a/changelog/v1.17.0.rst
+++ b/changelog/v1.17.0.rst
@@ -221,3 +221,20 @@ All changes
 - docs: Update canbus.rst :docspr:`1115` by :ghuser:`meijerwynand`
 - docs: Update diy.rst :docspr:`1114` by :ghuser:`murilobaliego`
 - docs: Update email addresses :docspr:`1122` by :ghuser:`jesserockz`
+
+Past Changelogs
+---------------
+
+.. toctree::
+    :maxdepth: 1
+
+    v1.16.0
+    v1.15.0
+    v1.14.0
+    v1.13.0
+    v1.12.0
+    v1.11.0
+    v1.10.0
+    v1.9.0
+    v1.8.0
+    v1.7.0


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
