### PR TITLE
Fixed wrong link in i2c_id

### DIFF
--- a/components/binary_sensor/pn532.rst
+++ b/components/binary_sensor/pn532.rst
@@ -100,7 +100,7 @@ Configuration variables:
   If a device is not found within this time window, it will be marked as not present. Defaults to 1s.
 - **on_tag** (*Optional*, :ref:`Automation <automation>`): An automation to perform
   when a tag is read. See :ref:`pn532-on_tag`.
-- **i2c_id** (*Optional*, :ref:`config-id`): Manually specify the ID of the :ref:`I²C Component <spi>` if you want
+- **i2c_id** (*Optional*, :ref:`config-id`): Manually specify the ID of the :ref:`I²C Component <i2c>` if you want
   to use multiple I²C buses.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID for this component.
 


### PR DESCRIPTION
## Description:
The i2c_id was linking to the SPI component page. Fixed it so that it links to i2c component page.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
