### PR TITLE
Update web-api id component

### DIFF
--- a/web-api/index.rst
+++ b/web-api/index.rst
@@ -64,7 +64,7 @@ calls to this API follow the URL schema ``/<domain>/<id>[/<method>?<param>=<valu
 The ``domain`` is the type of the component, for example ``sensor`` or ``light``. ``id`` refers
 to the id of the component - this ID is created by taking the name of the component, stripping out
 all non-alphanumeric characters, making everything lowercase and replacing all spaces by underscores. 
-To confirm the ``<id>`` to use, you can set the :doc:`logger level </components/logger.html#logger-log-levels>` 
+To confirm the ``<id>`` to use, you can set the :doc:`logger level </components/logger.html>` 
 to ``VERY_VERBOSE`` and check the ``object_id:`` in the logs.
 
 

--- a/web-api/index.rst
+++ b/web-api/index.rst
@@ -64,7 +64,7 @@ calls to this API follow the URL schema ``/<domain>/<id>[/<method>?<param>=<valu
 The ``domain`` is the type of the component, for example ``sensor`` or ``light``. ``id`` refers
 to the id of the component - this ID is created by taking the name of the component, stripping out
 all non-alphanumeric characters, making everything lowercase and replacing all spaces by underscores. 
-To confirm the ``<id>`` to use, you can set the :doc:`logger level <../components/logger.html>` 
+To confirm the ``<id>`` to use, you can set the :doc:`logger level <../components/logger.rst#log-levels>` 
 to ``VERY_VERBOSE`` and check the ``object_id:`` in the logs.
 
 

--- a/web-api/index.rst
+++ b/web-api/index.rst
@@ -63,7 +63,10 @@ There's also a simple REST API available which can be used to get and set the cu
 calls to this API follow the URL schema ``/<domain>/<id>[/<method>?<param>=<value>]``.
 The ``domain`` is the type of the component, for example ``sensor`` or ``light``. ``id`` refers
 to the id of the component - this ID is created by taking the name of the component, stripping out
-all non-alphanumeric characters, making everything lowercase and replacing all spaces by underscores.
+all non-alphanumeric characters, making everything lowercase and replacing all spaces by underscores. 
+To confirm the ``<id>`` to use, you can set the :doc:`logger level </components/logger.html#logger-log-levels>` 
+to ``VERY_VERBOSE`` and check the ``object_id:`` in the logs.
+
 
 By creating a simple GET request for a URL of the form ``/<domain>/<id>`` you will get a JSON payload
 describing the current state of the component. This payload is equivalent to the ones sent by the

--- a/web-api/index.rst
+++ b/web-api/index.rst
@@ -64,7 +64,7 @@ calls to this API follow the URL schema ``/<domain>/<id>[/<method>?<param>=<valu
 The ``domain`` is the type of the component, for example ``sensor`` or ``light``. ``id`` refers
 to the id of the component - this ID is created by taking the name of the component, stripping out
 all non-alphanumeric characters, making everything lowercase and replacing all spaces by underscores. 
-To confirm the ``<id>`` to use, you can set the :doc:`logger level </components/logger.html>` 
+To confirm the ``<id>`` to use, you can set the :doc:`logger level <../components/logger.html>` 
 to ``VERY_VERBOSE`` and check the ``object_id:`` in the logs.
 
 

--- a/web-api/index.rst
+++ b/web-api/index.rst
@@ -64,7 +64,7 @@ calls to this API follow the URL schema ``/<domain>/<id>[/<method>?<param>=<valu
 The ``domain`` is the type of the component, for example ``sensor`` or ``light``. ``id`` refers
 to the id of the component - this ID is created by taking the name of the component, stripping out
 all non-alphanumeric characters, making everything lowercase and replacing all spaces by underscores. 
-To confirm the ``<id>`` to use, you can set the :doc:`logger level <../components/logger.rst#log-levels>` 
+To confirm the ``<id>`` to use, you can set the :ref:`log level <logger-log_levels>`
 to ``VERY_VERBOSE`` and check the ``object_id:`` in the logs.
 
 


### PR DESCRIPTION
## Description:
Where to find the `<id>` component in the logger when using a `name: "String with spaces"` generated ID. This is in the hope it can help someone to see how it is registered / displayed in the logs.

**Related issue (if applicable):** fixes <link to issue>
https://github.com/esphome/issues/issues/2024

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
