### PR TITLE
Update max frequency

### DIFF
--- a/components/output/pca9685.rst
+++ b/components/output/pca9685.rst
@@ -37,7 +37,7 @@ Configuration variables:
 
 -  **frequency** (**Required**, float): The frequency to let the
    component drive all PWM outputs at. Must be in range from 24Hz to
-   1526Hz.
+   1525.88Hz.
 -  **address** (*Optional*, int): The I²C address of the driver.
    Defaults to ``0x00``.
 -  **id** (*Optional*, :ref:`config-id`): The id to use for


### PR DESCRIPTION
Not sure if this is an issue with the docs, or the linter, but the linter throws an error at 1526: `value must be at most 1525.88`

<img width="315" alt="image" src="https://user-images.githubusercontent.com/1432129/118382852-474b8280-b5ae-11eb-9671-b6ee34355620.png">

[PCA9685 docs](https://www.nxp.com/docs/en/data-sheet/PCA9685.pdf) say 1526, but maybe they are rounding.


## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
