### PR TITLE
Update Arduino SDK versions

### DIFF
--- a/components/esphome.rst
+++ b/components/esphome.rst
@@ -98,7 +98,9 @@ option you can tell ESPHome which Arduino framework to use for compiling.
 For the ESP8266, you currently can manually pin the Arduino version to these values (see the full
 list of Arduino frameworks `here <https://github.com/esp8266/Arduino/releases>`__):
 
-* `2.7.2 <https://github.com/esp8266/Arduino/releases/tag/2.7.2>`__ (default)
+* `2.7.4 <https://github.com/esp8266/Arduino/releases/tag/2.7.4>`__ (default)
+* `2.7.3 <https://github.com/esp8266/Arduino/releases/tag/2.7.3>`__
+* `2.7.2 <https://github.com/esp8266/Arduino/releases/tag/2.7.2>`__
 * `2.7.1 <https://github.com/esp8266/Arduino/releases/tag/2.7.1>`__
 * `2.7.0 <https://github.com/esp8266/Arduino/releases/tag/2.7.0>`__
 * `2.6.3 <https://github.com/esp8266/Arduino/releases/tag/2.6.3>`__
@@ -114,7 +116,9 @@ list of Arduino frameworks `here <https://github.com/esp8266/Arduino/releases>`_
 
 For the ESP32, there are these Arduino `framework versions <https://github.com/espressif/arduino-esp32/releases>`__:
 
-- `1.0.4 <https://github.com/espressif/arduino-esp32/releases/tag/1.0.4>`__ (default)
+- `1.0.6 <https://github.com/espressif/arduino-esp32/releases/tag/1.0.6>`__ (default)
+- `1.0.5 <https://github.com/espressif/arduino-esp32/releases/tag/1.0.5>`__
+- `1.0.4 <https://github.com/espressif/arduino-esp32/releases/tag/1.0.4>`__
 - `1.0.3 <https://github.com/espressif/arduino-esp32/releases/tag/1.0.3>`__
 - `1.0.2 <https://github.com/espressif/arduino-esp32/releases/tag/1.0.2>`__
 - `1.0.1 <https://github.com/espressif/arduino-esp32/releases/tag/1.0.1>`__


### PR DESCRIPTION
ESP8266 uses 2.7.4 since quit a while. This also bumps ESP32 to the
latest stable version 1.0.6.

## Description:


**Related issue (if applicable):** 

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#1789

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
