### PR TITLE
Fix docker build failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM ubuntu:xenial
+FROM ubuntu:focal
+ENV TZ=UTC
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         curl \
@@ -17,6 +19,7 @@ RUN pip3 install --no-cache-dir --no-binary :all: \
         sphinx
 
 EXPOSE 8000
-WORKDIR /data/esphome-docs
+WORKDIR /data/esphomedocs
 
 CMD ["make", "webserver"]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,13 @@
-FROM ubuntu:focal
-ENV TZ=UTC
-RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+FROM python:slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         curl \
-        python3 \
-        python3-pip \
-        python3-setuptools \
-        python3-pygments \
         git \
         make \
         doxygen \
         openssh-client \
         software-properties-common \
-    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/*
+        && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/*
 
 RUN pip3 install --no-cache-dir --no-binary :all: \
         sphinx
@@ -22,4 +16,3 @@ EXPOSE 8000
 WORKDIR /data/esphomedocs
 
 CMD ["make", "webserver"]
-


### PR DESCRIPTION
Fix the docker build error from https://github.com/esphome/issues/issues/2041

## Description:

````docker run --rm -v c:\esphomedev\esphome-docs\:/data/esphomedocs -p 8000:8000 -it esphome/esphome-docs```` fails with 
````
Running Sphinx v1.8.4
loading translations [en]... done

Exception occurred:
  File "/usr/local/lib/python3.5/dist-packages/sphinx/registry.py", line 472, in load_extension
    mod = __import__(extname, None, None, ['setup'])
  File "/data/esphomedocs/schema_doc.py", line 26
    logger.info(f"{SCHEMA_PATH} not found. Not documenting schema.")
                                                                  ^
SyntaxError: invalid syntax
````

The reason for this error is python 3.5 used in xenial. 
Switching to ubuntu focal resolves the error 


**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/2041

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
