### PR TITLE
[b-parasite] Fix doc typo on "battery"

### DIFF
--- a/components/sensor/b_parasite.rst
+++ b/components/sensor/b_parasite.rst
@@ -9,7 +9,7 @@ b-parasite
 
 `b-parasite <https://github.com/rbaron/b-parasite>`__ is an open source soil moisture and ambient temperature/humidity sensor.
 
-The ``b_parasite`` sensor platform tracks b-parasite's Bluetooth Low Energy (BLE) advertisement packets. These packets contains soil moisture, air temperature/humidity and baterry voltage data.
+The ``b_parasite`` sensor platform tracks b-parasite's Bluetooth Low Energy (BLE) advertisement packets. These packets contains soil moisture, air temperature/humidity and battery voltage data.
 
 .. figure:: images/b_parasite.jpg
     :align: center


### PR DESCRIPTION
## Description:
[b-parasite] Fix doc typo on "battery"

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
