### PR TITLE
Replace Hass.io with Home Assistant

### DIFF
--- a/components/display/index.rst
+++ b/components/display/index.rst
@@ -167,8 +167,9 @@ Configuration variables:
 .. note::
 
     To use fonts you will need to have the python ``pillow`` package installed, as ESPHome uses that package
-    to translate the TrueType files into an internal format. If you're running this as a Hass.io add-on or with
-    the official ESPHome docker image, it should already be installed. Otherwise you need to install it using
+    to translate the TrueType files into an internal format. If you're running this as a Home Assistant
+    add-on or with the official ESPHome docker image, it should already be installed. Otherwise you need
+    to install it using
     ``pip install pillow``.
 
 
@@ -387,7 +388,7 @@ Configuration variables:
 .. note::
 
     To use images you will need to have the python ``pillow`` package installed.
-    If you're running this as a Hass.io add-on or with the official ESPHome docker image, it should already be
+    If you're running this as a Home Assistant add-on or with the official ESPHome docker image, it should already be
     installed. Otherwise you need to install it using ``pip install pillow``.
 
 And then later in code:

--- a/components/sensor/homeassistant.rst
+++ b/components/sensor/homeassistant.rst
@@ -23,7 +23,7 @@ states from your Home Assistant instance using the :doc:`native API </components
     
     Albeit you might not plan to __export__ states from the node and you do not need an entity of the node
     in Home Assistant, this component still requires you to register the node under Home Assistant. See:
-    :doc:`Getting started with Hassio </guides/getting_started_hassio>`
+    :doc:`Getting started with Home Assistant </guides/getting_started_hassio>`
 
     Importing attributes is currently not supported, but you can create template sensors in Home Assistant
     that return the attribute of a sensor and then import the template sensor here.

--- a/cookbook/brilliant-mirabella-genio-smart-plugs.rst
+++ b/cookbook/brilliant-mirabella-genio-smart-plugs.rst
@@ -87,7 +87,7 @@ firmware can be uploaded allowing you to control the smart plugs via Home Assist
    via SSH and ensure your connection type is set to **SFTP**
 #. Browse to ``/root/tuya-convert/files``.
 #. Upload your compiled ``firmware.bin`` file to this directory. For command line based installs you can access the file under
-   ``<CONFIG_DIR>/<NODE_NAME>/.pioenvs/<NODE_NAME>/firmware.bin`` alternatively Hass.io users can download the file directly from the web ui.
+   ``<CONFIG_DIR>/<NODE_NAME>/.pioenvs/<NODE_NAME>/firmware.bin`` alternatively Home Assistant add-on users can download the file directly from the web ui.
 
 2.7 Use tuya-convert to install ESPHome Firmware
 ************************************************

--- a/cookbook/mirabella-genio-bulb.rst
+++ b/cookbook/mirabella-genio-bulb.rst
@@ -92,7 +92,7 @@ firmware can be uploaded allowing you to control the bulbs via Home Assistant.
    via SSH and ensure your connection type is set to **SFTP**
 #. Browse to ``/root/tuya-convert/files``.
 #. Upload your compiled ``firmware.bin`` file to this directory. For command line based installs you can access the file under
-   ``<CONFIG_DIR>/<NODE_NAME>/.pioenvs/<NODE_NAME>/firmware.bin`` alternatively Hass.io users can download the file directly from the web ui.
+   ``<CONFIG_DIR>/<NODE_NAME>/.pioenvs/<NODE_NAME>/firmware.bin`` alternatively Home Assistant add-on users can download the file directly from the web ui.
 
 2.7 Use tuya-convert to install ESPHome Firmware
 ************************************************

--- a/cookbook/zemismart-rgbw-downlights.rst
+++ b/cookbook/zemismart-rgbw-downlights.rst
@@ -87,7 +87,7 @@ firmware can be uploaded allowing you to control the smart plugs via Home Assist
    via SSH and ensure your connection type is set to **SFTP**
 #. Browse to ``/root/tuya-convert/files``.
 #. Upload your compiled ``firmware.bin`` file to this directory. For command line based installs you can access the file under
-   ``<CONFIG_DIR>/<NODE_NAME>/.pioenvs/<NODE_NAME>/firmware.bin`` alternatively Hass.io users can download the file directly from the web UI.
+   ``<CONFIG_DIR>/<NODE_NAME>/.pioenvs/<NODE_NAME>/firmware.bin`` alternatively Home Assistant add-on users can download the file directly from the web UI.
 
 2.7 Use tuya-convert to install ESPHome Firmware
 ************************************************

--- a/devices/sonoff_4ch.rst
+++ b/devices/sonoff_4ch.rst
@@ -47,7 +47,7 @@ For this guide you will need:
 - A USB to UART Bridge for flashing the device. These can be bought on Amazon (or other online stores) for less than 5 dollars.
   Note that the bridge *must* be 3.3V compatible. Otherwise you will destroy your Sonoff.
 - Jumper wires to connect the UART bridge to the header pins.
-- A computer running Home Assistant with the ESPHome Hass.io add-on.
+- A computer running Home Assistant with the ESPHome Home Assistant add-on.
 - A screwdriver to open up the Sonoff 4CH.
 
 Have everything? Great! Then you can start.

--- a/devices/sonoff_s20.rst
+++ b/devices/sonoff_s20.rst
@@ -46,7 +46,7 @@ For this guide you will need:
 -  Sonoff S20 😉.
 -  A USB to UART Bridge for flashing the device. These can be bought on Amazon (or other online stores) for less than 5 dollars.
    Note that the bridge *must* be 3.3V compatible. Otherwise you will destroy your S20.
--  A computer running Home Assistant with the ESPHome Hass.io add-on.
+-  A computer running Home Assistant with the ESPHome Home Assistant add-on.
 -  A screwdriver to open up the S20.
 -  A soldering iron and a few header pins to connect the UART interface.
 

--- a/devices/sonoff_t1_uk_3gang_v1.1.rst
+++ b/devices/sonoff_t1_uk_3gang_v1.1.rst
@@ -51,7 +51,7 @@ For this guide you will need:
 - A USB to UART Bridge for flashing the device. These can be bought on Amazon for less than 5 dollars.
   Note that the bridge *must* be 3.3V compatible. Otherwise you will destroy your Sonoff.
 - Jumper wires to connect the UART bridge to the header pins and to connect GPIO0 to the Ground.
-- Computer running ESPHome or Hass.io add-on.
+- Computer running ESPHome or Home Assistant add-on.
 - Screwdriver to open up the Sonoff T1 UK 3 Gang.
 
 Have everything? Great! Then you can start.

--- a/guides/faq.rst
+++ b/guides/faq.rst
@@ -51,10 +51,10 @@ and did not mount the ESP device into your container using ``--device=/dev/ttyUS
 Starting with ESPHome 1.9.0, the ESPHome suite provides
 `esphome-flasher <https://github.com/esphome/esphome-flasher>`__, a tool to flash ESPs over USB.
 
-First, you need to get the firmware file to flash. For Hass.io add-on based installs you can
-use the ``COMPILE`` button (click the overflow icon with the three dots) and then press
-``Download Binary``. For command line based installs you can access the file under
-``<CONFIG_DIR>/<NODE_NAME>/.pioenvs/<NODE_NAME>/firmware.bin``.
+First, you need to get the firmware file to flash. For the Home Assistant add-on based
+installs you can use the ``COMPILE`` button (click the overflow icon with the three dots)
+and then press ``Download Binary``. For command line based installs you can access the
+file under ``<CONFIG_DIR>/<NODE_NAME>/.pioenvs/<NODE_NAME>/firmware.bin``.
 
 Then, install esphome-flasher by going to the `releases page <https://github.com/esphome/esphome-flasher/releases>`__
 and downloading one of the pre-compiled binaries. Open up the application and select the serial port
@@ -125,7 +125,8 @@ It's simple. Run:
     # From docker:
     docker pull esphome/esphome:latest
 
-And in Hass.io, there's a simple UPDATE button when there's an update available as with all add-ons
+And in Home Assistant, there's a simple UPDATE button when there's an update
+available as with all add-ons.
 
 .. _faq-beta:
 
@@ -159,7 +160,7 @@ If you find some, please do however report them.
 
 To install the dev version of ESPHome:
 
-- In Hass.io: Add the ESPHome repository `https://github.com/esphome/hassio <https://github.com/esphome/hassio>`
+- In Home Assistant: Add the ESPHome repository `https://github.com/esphome/hassio <https://github.com/esphome/hassio>`
   in Add-on store -> Repositories. Then install the add-on  ``ESPHome Dev``
 - From ``pip``: Run ``pip3 install https://github.com/esphome/esphome/archive/dev.zip``
 - From docker, use the `esphome/esphome:dev <https://hub.docker.com/r/esphome/esphome/tags?page=1&name=dev>`__ image
@@ -315,7 +316,8 @@ And a docker compose file looks like this:
     2. Enable UDP traffic from ESPHome node's subnet to 224.0.0.251/32 on port 5353.
 
     Alternatively, you can make esphome use ICMP pings to check the status of the device
-    with the Hass.io Addon ``"status_use_ping": true,`` option or with docker ``-e ESPHOME_DASHBOARD_USE_PING=true``
+    with the Home Assistant add-on ``"status_use_ping": true,`` option or with
+    Docker ``-e ESPHOME_DASHBOARD_USE_PING=true``.
     See also https://github.com/esphome/issues/issues/641#issuecomment-534156628.
     
 .. _faq-notes_on_disabling_mdns:

--- a/guides/getting_started_command_line.rst
+++ b/guides/getting_started_command_line.rst
@@ -160,7 +160,7 @@ Bonus: ESPHome dashboard
 
 ESPHome features a dashboard that you can use to easily manage your nodes
 from a nice web interface. It was primarily designed for
-:doc:`the Hass.io add-on <getting_started_hassio>`, but also works with a simple command on
+:doc:`the Home Assistant add-on <getting_started_hassio>`, but also works with a simple command on
 \*nix machines (sorry, no windows).
 
 To start the ESPHome dashboard, simply start ESPHome with the following command

--- a/guides/migrate_espeasy.rst
+++ b/guides/migrate_espeasy.rst
@@ -14,8 +14,8 @@ Getting Binary
 First follow the guides for the :ref:`different supported devices <devices>` and create a configuration
 file. Then, generate and download the binary:
 
-- **Using the Hass.io add-on/dashboard**: Just click the ``COMPILE`` button, wait for
-  the compilation to end and press the ``DOWNLOAD BINARY`` button.
+- **Using the Home Assistant add-on/dashboard**: Just click the ``COMPILE`` button,
+  wait for the compilation to end and press the ``DOWNLOAD BINARY`` button.
 
   .. figure:: images/download_binary.png
 

--- a/guides/migrate_espurna.rst
+++ b/guides/migrate_espurna.rst
@@ -14,8 +14,9 @@ Getting Binary
 First follow the guides for the :ref:`different supported devices <devices>` and create a configuration
 file. Then, generate and download the binary:
 
-- **Using the Hass.io add-on/dashboard**: Just click the ``COMPILE`` button, wait for
-  the compilation to end and press the ``DOWNLOAD BINARY`` button.
+- **Using the Home Assistant add-on/dashboard**: Just click the ``COMPILE``
+  button, wait for the compilation to end and press the ``DOWNLOAD BINARY``
+  button.
 
   .. figure:: images/download_binary.png
 

--- a/guides/migrate_sonoff_tasmota.rst
+++ b/guides/migrate_sonoff_tasmota.rst
@@ -14,8 +14,9 @@ Getting the Binary
 First follow the guides for the :ref:`different supported devices <devices>` and create a configuration
 file. Then, generate and download the binary:
 
-- **Using the Hass.io add-on/dashboard**: Just click the ``COMPILE`` button, wait for
-  the compilation to end and press the ``DOWNLOAD BINARY`` button.
+- **Using the Home Assistant add-on/dashboard**: Just click the ``COMPILE``
+  button, wait for the compilation to end and press the ``DOWNLOAD BINARY``
+  button.
 
   .. figure:: images/download_binary.png
 


### PR DESCRIPTION
## Description:

Replaces occurrences of "Hass.io" with "Home Assistant". 
We've rebranded quite some time ago, time to clean up a bit 🧹 

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
