### PR TITLE
Fix spelling/capitalizing mistakes in ESPHome

### DIFF
--- a/components/display/pcd8544.rst
+++ b/components/display/pcd8544.rst
@@ -47,7 +47,7 @@ VCC to 3.3V and GND to GND.
 Backlight
 *********
 
-To use a backlight LIGHT pin needs to be connected to ground. If connected to GPIO pin it can be controlled from EPSHome. See :doc:`/components/light/monochromatic`.
+To use a backlight LIGHT pin needs to be connected to ground. If connected to GPIO pin it can be controlled from ESPHome. See :doc:`/components/light/monochromatic`.
 
 
 Configuration variables:

--- a/components/esphome.rst
+++ b/components/esphome.rst
@@ -23,7 +23,7 @@ Configuration variables:
 ------------------------
 
 - **name** (**Required**, string): This is the name of the node. It
-  should always be unique in your ESPhome network. May only contain lowercase
+  should always be unique in your ESPHome network. May only contain lowercase
   characters, digits and hyphens. See :ref:`esphome-changing_node_name`.
 - **platform** (**Required**, string): The platform your board is on,
   either ``ESP32`` or ``ESP8266``. See :ref:`esphome-arduino_version`.
@@ -162,7 +162,7 @@ is already set up. You can however change this using the ``priority`` parameter.
 Configuration variables:
 
 - **priority** (*Optional*, float): The priority to execute your custom initialization code. A higher value
-  means a high priority and thus also your code being executed earlier. Please note this is an ESPhome-internal
+  means a high priority and thus also your code being executed earlier. Please note this is an ESPHome-internal
   value and any change will not be marked as a breaking change. Defaults to ``-10``. Priorities (you can use any value between them too):
 
   - ``800.0``: This is where all hardware initialization of vital components is executed. For example setting switches

--- a/components/sensor/as3935.rst
+++ b/components/sensor/as3935.rst
@@ -19,7 +19,7 @@ Component/Hub
 
 The AS3935 can be configured to use either the SPI **or** I²C protocol for data communication.
 First choose which communication method you want to use for the sensor, set the SI pin for the appropriate
-level and set up the ESPhome integration for the chosen communication method.
+level and set up the ESPHome integration for the chosen communication method.
 
 Module Pins
 -----------

--- a/components/stepper/index.rst
+++ b/components/stepper/index.rst
@@ -38,7 +38,7 @@ Configuration variables:
 A4988 Component
 ---------------
 
-Put this code into the configuration file on ESPhome for this device.
+Put this code into the configuration file on ESPHome for this device.
 
 .. code-block:: yaml
 

--- a/cookbook/display_time_temp_oled.rst
+++ b/cookbook/display_time_temp_oled.rst
@@ -2,7 +2,7 @@ Time & Temperature on OLED Display
 ==================================
 
 .. seo::
-    :description: Instructions for setting up a display in ESPhome to show sensor values from Home Assistant
+    :description: Instructions for setting up a display in ESPHome to show sensor values from Home Assistant
     :image: display_time_temp_oled_1.jpg
     :keywords: Display
 

--- a/cookbook/leak-detector-m5stickC.rst
+++ b/cookbook/leak-detector-m5stickC.rst
@@ -3,11 +3,11 @@ ESP32 Water Leak Detector (with notification)
 =============================================
 
 .. seo::
-    :description: Water leak detector with ESPhome on an M5StickC ESP32
+    :description: Water leak detector with ESPHome on an M5StickC ESP32
     :image: images/leak-detector-m5stickC_dry.jpg
     :keywords: Leak Detector M5StickC M5Stack M5Atom
 
-Using the ESP32's capacitive touch GPIOs, it's relatively easy to build a water leak detector using ESPhome.  M5StickC was chosen as a platform due to the integrated Grove connector for clean connections and the fact it's well housed.  The built-in display is a bonus, but not strictly necessary.  Notifications are performed via HomeAssistant's 'alert' and 'notify' facilities, which send via Pushover to iOS & Android.
+Using the ESP32's capacitive touch GPIOs, it's relatively easy to build a water leak detector using ESPHome.  M5StickC was chosen as a platform due to the integrated Grove connector for clean connections and the fact it's well housed.  The built-in display is a bonus, but not strictly necessary.  Notifications are performed via HomeAssistant's 'alert' and 'notify' facilities, which send via Pushover to iOS & Android.
 
 .. figure:: images/leak-detector-m5stickC_LeakDetected.gif
     :align: center
@@ -67,14 +67,14 @@ Assembled Components
 Display Font
 ============
 
-You'll need to place the `OpenSans-Regular <https://fonts.google.com/specimen/Open+Sans>`__ font (or another of your choosing) alongside your ESPhome yaml file.  See - :doc:`/components/display/index`.
+You'll need to place the `OpenSans-Regular <https://fonts.google.com/specimen/Open+Sans>`__ font (or another of your choosing) alongside your ESPHome yaml file.  See - :doc:`/components/display/index`.
 
 Flashing
 ========
 
 I initially had trouble flashing the M5StickC; this is the procedure that I've found to work well with these devices.
 
-You must provide the ESP32 bootloader during the initial flash over USB.  Compile your ESPhome binary, and flash it along with the required bootloader (bootloader_dio_80m.bin), `available here <https://github.com/espressif/arduino-esp32/tree/master/tools/sdk/bin>`__, from the commandline (example under macos):
+You must provide the ESP32 bootloader during the initial flash over USB.  Compile your ESPHome binary, and flash it along with the required bootloader (bootloader_dio_80m.bin), `available here <https://github.com/espressif/arduino-esp32/tree/master/tools/sdk/bin>`__, from the commandline (example under macos):
 
 ``cd /Applications/ESPHome-Flasher-1.2.0-macOS.app/Contents/MacOS``
 
@@ -115,7 +115,7 @@ Not shown: Probe is placed on the floor in the corner, out of the way, in the lo
 
 ------------
 
-ESPhome configuration
+ESPHome configuration
 =====================
 
 .. code-block:: yaml

--- a/guides/diy.rst
+++ b/guides/diy.rst
@@ -44,7 +44,7 @@ Blog Posts & Videos
 - `Washing machine phases detector (Sonoff Pow R2) <https://github.com/Gio-dot/Washing-Machine-Sonoff-Pow-R2-Esphome>`__ by `Gio-dot <https://github.com/Gio-dot>`__
 - `Sonoff L1 LED Strip <https://emorydunn.com/blog/2020/08/10/sonoff-l1-home-assistant/>`__ by :ghuser:`emorydunn`
 - `ESPHome for SP501E LED Controller <https://margau.net/posts/2020-11-21-2h-led-hack/>`__ by `margau <https://margau.net>`__
-- `4$ Xiaomi mijia thermometer LYWSD03MMC + ESP32 + ESPhome <https://omarghader.github.io/how-to-monitor-your-home-temperature-with-esp32-and-xiaomi-mijia-using-esphome/>`__ by `Omar GHADER <https://omarghader.github.io/post>`__
+- `4$ Xiaomi mijia thermometer LYWSD03MMC + ESP32 + ESPHome <https://omarghader.github.io/how-to-monitor-your-home-temperature-with-esp32-and-xiaomi-mijia-using-esphome/>`__ by `Omar GHADER <https://omarghader.github.io/post>`__
 - `Baseboard (Line Voltage) Thermostat from Smart Switch <https://github.com/rjmurph2241/baseboard-heating-thermostat>`__ by :ghuser:`rjmurph2241`
 - `Office Doorbell <https://github.com/shish/esphome-projects/blob/master/office-doorbell.md>`__ by :ghuser:`shish`
 - `Display TM1637 with ESPHome and MQTT showing Youtube subscribers count and other info <https://youtu.be/27JZEky0h1Q>`__ by :ghuser:`electrofun-smart`


### PR DESCRIPTION
## Description:
I noticed ESPHome was incorrectly capitalized as ESPhome in the docs, so I fixed them all (and a bonus spelling mistake). :)

**Related issue (if applicable):** fixes N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** N/A

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
