### PR TITLE
Clarify that includes option does not only accept headers

### DIFF
--- a/components/esphome.rst
+++ b/components/esphome.rst
@@ -43,9 +43,9 @@ Advanced options:
   but you can customize this behavior using this option.
 - **platformio_options** (*Optional*, mapping): Additional options to pass over to PlatformIO in the
   platformio.ini file. See :ref:`esphome-platformio_options`.
-- **includes** (*Optional*, list of files): A list of C[++] files to include in the main (auto-generated) sketch file
+- **includes** (*Optional*, list of files): A list of C/C++ files to include in the main (auto-generated) sketch file
   for custom components. The paths in this list are relative to the directory where the YAML configuration file
-  is in. Should have file extension ``.h`` - See :ref:`esphome-includes` for more info.
+  is in. See :ref:`esphome-includes` for more info.
 - **libraries** (*Optional*, list of libraries): A list of `platformio libraries <https://platformio.org/lib>`__
   to include in the project. See `platformio lib install <https://docs.platformio.org/en/latest/userguide/lib/cmd_install.html>`__.
 - **comment** (*Optional*, string): Additional text information about this node. Only for display in UI.
@@ -254,10 +254,13 @@ The ``includes`` option is only a helper option that does that for you.
 
 This option behaves differently depending on what the included file is pointing at:
 
- - If the include string is pointing at a directory, the entire directory tree is copied over
-   to the src/ folder.
- - If the include string is point at a header file (.h, .hpp, .tcc) - it is copied in the src/ folder
-   AND included in the main.cpp. This way the lambda code can access it.
+ - If the include string is pointing at a directory, the entire directory tree is copied into the
+   src/ folder.
+ - If the include string points to a header file (.h, .hpp, .tcc), it is copied in the src/ folder
+   AND included in the ``main.cpp`` file. This way the lambda code can access it.
+ - If the include string points to a regular source file (.c, .cpp), it is copied in the src/ folder
+   AND compiled into the binary. This way implementation of classes and functions in header files can
+   be provided.
 
 
 .. _esphome-changing_node_name:


### PR DESCRIPTION
## Description:
Clarify that the `includes` option does not only accept headers, but you can also specify .c/.cpp files there. 

**Related issue (if applicable):** fixes N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** N/A

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
