### PR TITLE
Update sonoff_basic.rst

### DIFF
--- a/devices/sonoff_basic.rst
+++ b/devices/sonoff_basic.rst
@@ -54,7 +54,8 @@ exposes all of the basic functions.
     esphome:
       name: <NAME_OF_NODE>
       platform: ESP8266
-      board: esp01_1m
+      board: esp8285
+      arduino_version: 2.4.2
 
     wifi:
       ssid: <YOUR_SSID>


### PR DESCRIPTION
Use same recommended device config section as the info here - https://esphome.io/devices/sonoff.html

## Description: 

Slight difference/conflict as to what to set as the sonoff basic board type.  Just converted all my sonoff basics to use the same esphome block as the recommendation for the generic sonoff and everything is working well.

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
