### PR TITLE
Drop 128x160 ESP-32 camera resolution support

### DIFF
--- a/components/esp32_camera.rst
+++ b/components/esp32_camera.rst
@@ -67,7 +67,6 @@ Frame Settings:
   resolutions require more memory, if there's not enough memory you will see an error during startup.
 
     - ``160x120`` (QQVGA)
-    - ``128x160`` (QQVGA2)
     - ``176x144`` (QCIF)
     - ``240x176`` (HQVGA)
     - ``320x240`` (QVGA)


### PR DESCRIPTION
## Description:
Drop 128x160 resolution as a valid option for the ESP-32 camera.

**Related issue (if applicable):** fixes esphome/issues#1880

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#1813

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
