### PR TITLE
Fix ble_client YAML syntax

### DIFF
--- a/components/ble_client.rst
+++ b/components/ble_client.rst
@@ -72,7 +72,7 @@ This automation is triggered when the client connects to the BLE device.
         on_connect:
           then:
             - lambda: |-
-              ESP_LOGD("ble_client_lambda", "Connected to BLE device");
+                ESP_LOGD("ble_client_lambda", "Connected to BLE device");
 
 .. _ble_client-on_disconnect:
 
@@ -89,7 +89,7 @@ This automation is triggered when the client disconnects from a BLE device.
         on_disconnect:
           then:
             - lambda: |-
-              ESP_LOGD("ble_client_lambda", "Disconnected from BLE device");
+                ESP_LOGD("ble_client_lambda", "Disconnected from BLE device");
 
 BLE Overview
 ------------


### PR DESCRIPTION
While testing this awesome new component, I found a YAML syntax error that this patch fixes.

## Description:

Adding 2 spaces before the C++ code avoids to get the following error:

```
ERROR Error while reading config: Invalid YAML syntax:

while scanning a simple key
  in "/config/esphome/HOSTNAME.yaml", line 31, column 11:
              ESP_LOGD("ble_client_lambda", "C ... 
              ^
could not find expected ':'
  in "/config/esphome/HOSTNAME.yaml", line 32, column 5:
        on_disconnect:
        ^
```