### PR TITLE
Update Web address link for Nextion Editor

### DIFF
--- a/components/display/nextion.rst
+++ b/components/display/nextion.rst
@@ -54,7 +54,7 @@ Rendering Lambda
 With Nextion displays, a dedicated chip on the display itself does the whole rendering. ESPHome can only
 send *instructions* to the display to tell it *how* to render something and *what* to render.
 
-First, you need to use the `Nextion Editor <https://nextion.itead.cc/resources/download/nextion-editor/>`__ to
+First, you need to use the `Nextion Editor <https://nextion.tech/nextion-editor/>`__ to
 create a display file and insert it using the SD card slot. Then, in the rendering ``lambda``, you have 3 main methods
 you can call to populate data on the display:
 


### PR DESCRIPTION
## Description:
Swapped out broken "Nextion Editor" link for new one

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
