### PR TITLE
Fix off to on

### DIFF
--- a/components/fan/index.rst
+++ b/components/fan/index.rst
@@ -76,7 +76,7 @@ Turns the fan with the given ID off when executed.
 ``fan.turn_on`` Action
 ----------------------
 
-Turns the fan with the given ID off when executed.
+Turns the fan with the given ID on when executed.
 
 .. code-block:: yaml
 


### PR DESCRIPTION
## Description:
just a small typo fix

**Related issue (if applicable):**

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

## Checklist:

  - [X] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
