### PR TITLE
Remove `NFC` from RDM6300 as it is RFID not NFC

### DIFF
--- a/components/binary_sensor/rdm6300.rst
+++ b/components/binary_sensor/rdm6300.rst
@@ -1,21 +1,21 @@
-RDM6300 NFC/RFID
+RDM6300 RFID
 ================
 
 .. seo::
-    :description: Instructions for setting up RDM6300 NFC/RFID tag readers and tags in ESPHome.
+    :description: Instructions for setting up RDM6300 RFID tag readers and tags in ESPHome.
     :image: rdm6300.jpg
-    :keywords: RDM6300, NFC, RFID
+    :keywords: RDM6300, RFID
 
 .. _rdm6300-component:
 
 Component/Hub
 -------------
 
-The ``rdm6300`` component allows you to use RDM6300 NFC/RFID controllers
+The ``rdm6300`` component allows you to use RDM6300 RFID controllers
 (`datasheet <https://elty.pl/upload/download/RFID/RDM630-Spec.pdf>`__, `iTead <https://www.itead.cc/rdm6300.html>`__)
 with ESPHome. This component is a global hub that establishes the connection to the RDM6300 via :ref:`UART <uart>` and
 translates the received data. Using the :ref:`RDM6300 binary sensors <rdm6300-tag>` you can then
-create individual binary sensors that track if an NFC/RFID tag is currently detected by the RDM6300.
+create individual binary sensors that track if an RFID tag is currently detected by the RDM6300.
 
 .. figure:: images/rdm6300-full.jpg
     :align: center
@@ -39,7 +39,7 @@ with the baud rate set to 9600
     binary_sensor:
       - platform: rdm6300
         uid: 7616525
-        name: "RDM6300 NFC Tag"
+        name: "RDM6300 RFID Tag"
 
 Configuration variables:
 ************************
@@ -86,7 +86,7 @@ using :ref:`api-homeassistant_tag_scanned_action`.
 ``rdm6300`` Binary Sensor
 -------------------------
 
-The ``rdm6300`` binary sensor platform lets you track if an NFC/RFID tag with a given
+The ``rdm6300`` binary sensor platform lets you track if an RFID tag with a given
 unique id (``uid``) is currently being detected by the RDM6300 or not.
 
 .. code-block:: yaml
@@ -101,12 +101,12 @@ unique id (``uid``) is currently being detected by the RDM6300 or not.
     binary_sensor:
       - platform: rdm6300
         uid: 7616525
-        name: "RDM6300 NFC Tag"
+        name: "RDM6300 RFID Tag"
 
 Configuration variables:
 ************************
 
-- **uid** (**Required**, integer): The unique ID of the NFC/RFID tag.
+- **uid** (**Required**, integer): The unique ID of the RFID tag.
 - **name** (**Required**, string): The name of the binary sensor.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
 - All other options from :ref:`Binary Sensor <config-binary_sensor>`.
@@ -116,10 +116,10 @@ Configuration variables:
 Setting Up Tags
 ---------------
 
-To set up binary sensors for specific NFC tags you first have to know their unique IDs. To obtain this
+To set up binary sensors for specific RFID tags you first have to know their unique IDs. To obtain this
 id, first set up a simple RDM6300 configuration without any binary sensors like above.
 
-When your code is running and you approach the RDM6300 with an NFC Tag, you should see a message like this:
+When your code is running and you approach the RDM6300 with an RFID Tag, you should see a message like this:
 
 .. code::
 


### PR DESCRIPTION
## Description:

The RDM6300 is RFID not NFC, these two terms should not be confused.


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
