### PR TITLE
waveshare_epaper: Add note about non-working 1.54 V2

### DIFF
--- a/components/display/waveshare_epaper.rst
+++ b/components/display/waveshare_epaper.rst
@@ -76,7 +76,7 @@ Configuration variables:
 - **dc_pin** (**Required**, :ref:`Pin Schema <config-pin_schema>`): The DC pin.
 - **model** (**Required**): The model of the E-Paper display. Options are:
 
-  - ``1.54in``
+  - ``1.54in`` (does not work with V2 of the product, see https://github.com/esphome/issues/issues/1032)
   - ``2.13in`` (not tested)
   - ``2.13in-ttgo`` (T5_V2.3 tested. Also works for Wemos D1 Mini ePaper Shield 2.13 1.0.0 "LOLIN")
   - ``2.13in-ttgo-b73`` (T5_V2.3 with B73 display tested)


### PR DESCRIPTION
## Description:

Link to open Github issue about 1.54" V2 not working.

**Related issue (if applicable):** mentions but does not fix https://github.com/esphome/issues/issues/1032

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** N/A

## Checklist:

  - [+] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [N/A] Link added in `/index.rst` when creating new documents for new components or cookbook.
