### PR TITLE
Document support for Waveshare 7.5in "version C" bichromatic e-paper display

### DIFF
--- a/components/display/waveshare_epaper.rst
+++ b/components/display/waveshare_epaper.rst
@@ -88,6 +88,7 @@ Configuration variables:
   - ``4.20in``
   - ``5.83in``
   - ``7.50in``
+  - ``7.50in-bc`` (display with version sticker '(C)' on the back, B/W rendering only)
   - ``7.50inV2`` (Can't use with an ESP8266 as it runs out of RAM)
 
 - **busy_pin** (*Optional*, :ref:`Pin Schema <config-pin_schema>`): The BUSY pin. Defaults to not connected.


### PR DESCRIPTION
## Description:

Document support for Waveshare 7.5in "version C" bichromatic e-paper display

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#1844

## Checklist:

  - [X] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
Not necessary.