### PR TITLE
Update Sonoff 4CH docs

### DIFF
--- a/devices/sonoff_4ch.rst
+++ b/devices/sonoff_4ch.rst
@@ -211,12 +211,16 @@ of the basic functions.
 ---------------------------------------- -----------------------------------------
 ``GPIO13``                               Blue LED (inverted)
 ---------------------------------------- -----------------------------------------
-``GPIO1``                                ``RX`` pin (for external sensors)
+``GPIO1``                                ``TX`` pin (for external sensors)
 ---------------------------------------- -----------------------------------------
-``GPIO3``                                ``TX`` pin (for external sensors)
+``GPIO3``                                ``RX`` pin (for external sensors)
 ---------------------------------------- -----------------------------------------
 ``GPIO2``                                ``IO2`` pin (for external sensors)
 ======================================== =========================================
+
+.. warning::
+
+    The ESP8266 will be prevented from booting if the following pins are pulled LOW (connected to GND) on cold startup: ``GPIO0``, ``GPIO1``, ``GPIO2``. Be prepared if you want to use them for input sensors.
 
 .. code-block:: yaml
 

--- a/devices/sonoff_4ch.rst
+++ b/devices/sonoff_4ch.rst
@@ -218,7 +218,7 @@ of the basic functions.
 ``GPIO2``                                ``IO2`` pin (for external sensors)
 ======================================== =========================================
 
-.. warning::
+.. note::
 
     The ESP8266 will be prevented from booting if the following pins are pulled LOW (connected to GND) on cold startup: ``GPIO0``, ``GPIO1``, ``GPIO2``. Be prepared if you want to use them for input sensors.
 


### PR DESCRIPTION
## Description:

Swap RX/TX in pin list and add a warning about connecting some pins to GND on boot
Tested with `SONOFF 4CH R3 V1.1 2020-04-13`

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
