### PR TITLE
Correct yaml indentation for dfplayer.play

### DIFF
--- a/components/dfplayer.rst
+++ b/components/dfplayer.rst
@@ -99,8 +99,8 @@ Plays a track.
     on_...:
       then:
         - dfplayer.play:
-          file: 23
-          loop: false
+            file: 23
+            loop: false
         # Shorthand
         - dfplayer.play: 23
 


### PR DESCRIPTION
## Description:

Fixed indentation of `dfplayer.play:` as it would lead to errors in the current format

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
