### PR TITLE
Document reversed option for light partitions

### DIFF
--- a/components/light/partition.rst
+++ b/components/light/partition.rst
@@ -88,6 +88,7 @@ Configuration variables:
   - **from** (**Required**, int): The first LED to address in the segment. Counting starts with 0,
     so first LED is 0.
   - **to** (**Required**, int): The index of the last LED to address in this segment.
+  - **reversed** (**Required**, int): Whether to reverse the LEDs in this segment.
 
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
 - **effects** (*Optional*, list): A list of :ref:`light effects <light-effects>` to use for this light.


### PR DESCRIPTION
## Description:
Document the `reversed` option for light partitions.

**Related issue (if applicable):** fixes N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#1484 (already merged).

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
