### PR TITLE
Link to esp32_ble_controller added

### DIFF
--- a/components/ble_client.rst
+++ b/components/ble_client.rst
@@ -211,4 +211,5 @@ See Also
 - :doc:`/components/sensor/ble_sensor`
 - :ref:`Automation <automation>`
 - :apiref:`ble_client/ble_client.h`
+- Counter part: `Custom BLE controller (server) component <https://github.com/wifwucite/esphome-ble-controller>`__
 - :ghedit:`Edit`


### PR DESCRIPTION
## Description:

Added a link to the custom [BLE controller (server)](https://github.com/wifwucite/esphome-ble-controller), which can act as a counter-part to the BLE client. E.g., the BLE controller can expose hardware sensors over BLE characteristics, which could be picked up by the BLE client and then forwarded over MQTT. This is useful if the ESP32 with the actual sensors is located outdoor w/o wifi connection and runs on battery.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** N/A

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
