### PR TITLE
Update remote_transmitter.rst

### DIFF
--- a/components/remote_transmitter.rst
+++ b/components/remote_transmitter.rst
@@ -432,9 +432,11 @@ remote_receiver instance:
 .. code-block:: yaml
 
     remote_receiver:
-      pin: D0
+      pin: 
+        number: D0
+        inverted: True
+        mode: INPUT_PULLUP
       dump: all
-
 Compile and upload the code. While viewing the log output from the ESP,
 press a button on an infrared remote you want to capture (one at a time).
 


### PR DESCRIPTION
changed remote receiver code block to inverted mode, because that is usually needed..

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
