### PR TITLE
Update ads1115.rst Multiplexer and Gain

### DIFF
--- a/components/sensor/ads1115.rst
+++ b/components/sensor/ads1115.rst
@@ -93,9 +93,15 @@ Configuration variables:
    to check the sensor. Defaults to ``60s``.
 -  **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
 
-Multiplexer And Gain
+Multiplexer and Gain
 --------------------
 
+.. note::
+
+    As per (`datasheet <http://www.ti.com/lit/ds/symlink/ads1115.pdf>`__, `Adafruit`_) Section 7.3 Note 2: 
+    "No more than VDD + 0.3V must be applied to the analog inputs of the device."
+    This means if you power the device with 3.3V, take care not to supply the 4 AIN pins with more than 3.6V.
+    
 The ADS1115 has a multiplexer that can be configured to measure voltage between several pin configurations. These are:
 
  - ``A0_A1`` (between Pin 0 and Pin 1)


### PR DESCRIPTION
Update ads1115.rst notes with gentle warning about over voltage measurement which is not entirely clear at first sight / observation of the sensor.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
