### PR TITLE
Split BLE/server docs

### DIFF
--- a/components/esp32_ble.rst
+++ b/components/esp32_ble.rst
@@ -5,30 +5,22 @@ BLE Component
     :description: Instructions for setting up Bluetooth LE in ESPHome.
     :image: bluetooth.svg
 
-The ``esp32_ble`` component in ESPHome sets up a simple BLE GATT server that exposes the device name,
-manufacturer and board. This component allows other components to create their own services to expose
-data and control.
+The ``esp32_ble`` component in ESPHome sets up the Bluetooth LE stack on the device so that a :doc:`esp32_ble_server`
+can run.
 
 .. code-block:: yaml
 
     # Example configuration
 
     esp32_ble:
-      server:
 
 
-Configuration variables:
-------------------------
-
-- **server** (*Optional*): Starts the BLE GATT server
-
-  - **manufacturer** (*Optional*, string): The name of the manufacturer/firmware creator. Defaults to ``ESPHome``.
-  - **model** (*Optional*, string): The model name of the device. Defaults to the friendly name of the ``board`` chosen
-    in the :ref:`core configuration <esphome-configuration_variables>`.
+No configuration variables.
 
 See Also
 --------
 
+- :doc:`esp32_ble_server`
 - :doc:`esp32_improv`
 - :apiref:`esp32_ble/ble.h`
 - :ghedit:`Edit`

--- a/components/esp32_ble_server.rst
+++ b/components/esp32_ble_server.rst
@@ -1,0 +1,32 @@
+BLE Server
+==========
+
+.. seo::
+    :description: Instructions for setting up Bluetooth LE GATT Server in ESPHome.
+    :image: bluetooth.svg
+
+The ``esp32_ble_server`` component in ESPHome sets up a simple BLE GATT server that exposes the device name,
+manufacturer and board. This component allows other components to create their own services to expose
+data and control.
+
+.. code-block:: yaml
+
+    # Example configuration
+
+    esp32_ble_server:
+
+
+Configuration variables:
+------------------------
+
+- **manufacturer** (*Optional*, string): The name of the manufacturer/firmware creator. Defaults to ``ESPHome``.
+- **model** (*Optional*, string): The model name of the device. Defaults to the friendly name of the ``board`` chosen
+  in the :ref:`core configuration <esphome-configuration_variables>`.
+
+See Also
+--------
+
+- :doc:`esp32_ble`
+- :doc:`esp32_improv`
+- :apiref:`esp32_ble/ble.h`
+- :ghedit:`Edit`

--- a/components/esp32_improv.rst
+++ b/components/esp32_improv.rst
@@ -8,7 +8,7 @@ Improv
 The ``esp32_improv`` component in ESPHome implements the open `Improv standard <https://www.improv-wifi.com/>`__
 for configuring Wi-Fi on an ESP32 device by using Bluetooth Low Energy to receive the credentials.
 
-The ``esp32_improv`` component requires the :doc:`BLE Server <esp32_ble>` to be set up.
+The ``esp32_improv`` component will automatically set up the :doc:`BLE Server <esp32_ble>`.
 
 
 .. code-block:: yaml
@@ -16,9 +16,6 @@ The ``esp32_improv`` component requires the :doc:`BLE Server <esp32_ble>` to be 
     # Example configuration entry
     wifi:
       # ...
-
-    esp32_ble:
-      server:  # A BLE server is required
 
     esp32_improv:
       authorizer: binary_sensor_id


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#1898

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
