### PR TITLE
Add RTSP Server documentation

### DIFF
--- a/components/rtsp_server.rst
+++ b/components/rtsp_server.rst
@@ -5,7 +5,7 @@ RTSP Server Component
     :description: Instructions for setting up an RTSP Server with the ESP32 Camera in ESPHome
     :image: camera.png
 
-The ``rtsp_server`` component allows you to stream vide from ESP32-based camera boards in ESPHome to
+The ``rtsp_server`` component allows you to stream video from ESP32-based camera boards in ESPHome to
 any RTSP-compatible application (VLC Media Player; GStreamer; etc).
 
 An ``esp32_camera`` configuration item is required to use this component.
@@ -20,4 +20,3 @@ Configuration variables:
 
 - **port** (**Required**, number): The port number on which to listen
 - **camera** (**Required**, :ref:`config-id`) The camera from which to stream video
-

--- a/components/rtsp_server.rst
+++ b/components/rtsp_server.rst
@@ -1,0 +1,23 @@
+RTSP Server Component
+======================
+
+.. seo::
+    :description: Instructions for setting up an RTSP Server with the ESP32 Camera in ESPHome
+    :image: camera.png
+
+The ``rtsp_server`` component allows you to stream vide from ESP32-based camera boards in ESPHome to
+any RTSP-compatible application (VLC Media Player; GStreamer; etc).
+
+An ``esp32_camera`` configuration item is required to use this component.
+
+.. code-block:: yaml
+    rtsp_server:
+      port: 8675
+      camera: cam1
+
+Configuration variables:
+------------------------
+
+- **port** (**Required**, number): The port number on which to listen
+- **camera** (**Required**, :ref:`config-id`) The camera from which to stream video
+

--- a/components/rtsp_server.rst
+++ b/components/rtsp_server.rst
@@ -8,7 +8,7 @@ RTSP Server Component
 The ``rtsp_server`` component allows you to stream video from ESP32-based camera boards in ESPHome to
 any RTSP-compatible application (VLC Media Player; GStreamer; etc).
 
-An ``esp32_camera`` configuration item is required to use this component.
+An :ref:`esp32_camera <esp32_camera>` configuration item is required to use this component.
 
 .. code-block:: yaml
     rtsp_server:

--- a/index.rst
+++ b/index.rst
@@ -368,6 +368,7 @@ Misc Components
     ESP32 Ethernet, components/ethernet, ethernet.svg
 
     ESP32 Camera, components/esp32_camera, camera.svg
+    RTSP Server, components/rtsp_server.rst, camera.svg
     Stepper, components/stepper/index, stepper.svg
     Servo, components/servo, servo.svg
 


### PR DESCRIPTION
## Description:

Addsd Documentation for the RTSP server component

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
