### PR TITLE
Override document title for index

### DIFF
--- a/_templates/layout.html
+++ b/_templates/layout.html
@@ -36,6 +36,9 @@
     </div>
   </div>
   <script>
+    if (window.location.pathname === "/") {
+      window.document.title = "ESPHome"
+    }
     var old = window.localStorage.getItem("version");
     if (old === null) { window.localStorage.setItem("version", "{{ version }}");
     } else if (old !== "{{ version }}") {


### PR DESCRIPTION
## Description:

Override the document title (used in tabs) on page load for the index

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
