### PR TITLE
Add devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,27 @@
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.183.0/containers/python-3
+{
+	"name": "ESPHome - docs",
+	"image": "mcr.microsoft.com/vscode/devcontainers/python:0-3.6",
+	"postCreateCommand": "pip3 install -r requirements.txt",
+	"forwardPorts": [8000],
+	"settings": { 
+		"python.pythonPath": "/usr/local/bin/python",
+		"python.languageServer": "Pylance",
+		"python.linting.enabled": true,
+		"python.linting.pylintEnabled": true,
+		"python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
+		"python.formatting.blackPath": "/usr/local/py-utils/bin/black",
+		"python.formatting.yapfPath": "/usr/local/py-utils/bin/yapf",
+		"python.linting.banditPath": "/usr/local/py-utils/bin/bandit",
+		"python.linting.flake8Path": "/usr/local/py-utils/bin/flake8",
+		"python.linting.mypyPath": "/usr/local/py-utils/bin/mypy",
+		"python.linting.pycodestylePath": "/usr/local/py-utils/bin/pycodestyle",
+		"python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",
+		"python.linting.pylintPath": "/usr/local/py-utils/bin/pylint"
+	},
+
+	"extensions": [
+		"ms-python.python",
+		"ms-python.vscode-pylance"
+	]
+}


### PR DESCRIPTION
## Description:

Adds devcontainer that can be used with VSCode (or GitHub workspaces), the definition is the default definition generated by VSCode with 4 adjustments:
- Changed `name`
- Added `8000` in `forwardPorts`
- Added `postCreateCommand` to install requirements needed to run/build the site
- Removed commented parts

3.6 is old, but that is what's defined in the runtime.txt file which Netlify uses, so this makes the devcontainer and Netlify use the same version


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
