### PR TITLE
Fallback to the beta branch if ref is missing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,14 +21,16 @@ help:
 api:
 	mkdir -p _build/html/api
 	@if [ ! -d "$(ESPHOME_PATH)" ]; then \
-	  git clone --branch $(ESPHOME_REF) https://github.com/esphome/esphome.git $(ESPHOME_PATH); \
+	  git clone --branch $(ESPHOME_REF) https://github.com/esphome/esphome.git $(ESPHOME_PATH) || \
+	  git clone --branch beta https://github.com/esphome/esphome.git $(ESPHOME_PATH); \
 	fi
 	ESPHOME_PATH=$(ESPHOME_PATH) doxygen Doxygen
 
 netlify-api: netlify-dependencies
 	mkdir -p _build/html/api
 	@if [ ! -d "$(ESPHOME_PATH)" ]; then \
-	  git clone --branch $(ESPHOME_REF) https://github.com/esphome/esphome.git $(ESPHOME_PATH); \
+	  git clone --branch $(ESPHOME_REF) https://github.com/esphome/esphome.git $(ESPHOME_PATH) || \
+	  git clone --branch beta https://github.com/esphome/esphome.git $(ESPHOME_PATH); \
 	fi
 	ESPHOME_PATH=$(ESPHOME_PATH) ../doxybin/doxygen Doxygen
 


### PR DESCRIPTION
## Description:

Use "beta" as a fallback branch in build scripts if the target branch is missing

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
