### PR TITLE
Remove min width from body for mobile

### DIFF
--- a/_static/custom.css
+++ b/_static/custom.css
@@ -9,6 +9,10 @@ div.document {
   margin-bottom: 50px;
 }
 
+div.body {
+  min-width: initial;
+}
+
 img.component-image {
   border: none;
   vertical-align: middle;


### PR DESCRIPTION
## Description:

This fixes the site being too wide on mobile.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
