### PR TITLE
Doc update for variable bit width for Samsung protocol enhancement

### DIFF
--- a/components/remote_receiver.rst
+++ b/components/remote_receiver.rst
@@ -156,6 +156,7 @@ Remote code selection (exactly one of these has to be included):
 - **samsung**: Trigger on a decoded Samsung remote code with the given data.
 
   - **data** (**Required**, int): The data to trigger on, see dumper output for more info.
+  - **nbits** (*Optional*, int): The number of bits of the remote code. Defaults to ``32``.
 
 - **samsung36**: Trigger on a decoded Samsung36 remote code with the given data.
 

--- a/components/remote_transmitter.rst
+++ b/components/remote_transmitter.rst
@@ -200,22 +200,29 @@ Configuration variables:
 **********************************************
 
 This :ref:`action <config-action>` sends a Samsung infrared remote code to a remote transmitter.
+It transmits codes up to 64 bits in length in a single packet.
 
 .. code-block:: yaml
 
     on_...:
       - remote_transmitter.transmit_samsung:
           data: 0x1FEF05E4
+      # additional example for 48-bit codes:
+      - remote_transmitter.transmit_samsung:
+          data: 0xB946F50A09F6
+          nbits: 48
 
 Configuration variables:
 
 - **data** (**Required**, int): The data to send, see dumper output for more details.
+- **nbits** (*Optional*, int): The number of bits to send. Defaults to ``32``.
 - All other options from :ref:`remote_transmitter-transmit_action`.
 
 ``remote_transmitter.transmit_samsung36`` Action
 ************************************************
 
 This :ref:`action <config-action>` sends a Samsung36 infrared remote code to a remote transmitter.
+It transmits the ``address`` and ``command`` in two packets separated by a "space".
 
 .. code-block:: yaml
 


### PR DESCRIPTION
## Description:

Doc update for https://github.com/esphome/esphome/pull/1927

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** https://github.com/esphome/esphome/pull/1927

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook. **N/A**
