### PR TITLE
Change set_supports_auto_mode for custom climate

### DIFF
--- a/components/climate/custom.rst
+++ b/components/climate/custom.rst
@@ -46,7 +46,7 @@ two methods (:apiclass:`Climate <climate::Climate>`):
         // The capabilities of the climate device
         auto traits = climate::ClimateTraits();
         traits.set_supports_current_temperature(true);
-        traits.set_supports_auto_mode(true);
+        traits.set_supports_heat_cool_mode(true);
         return traits;
       }
     };


### PR DESCRIPTION
## Description:

Change example to set_supports_heat_cool_mode according to https://github.com/esphome/esphome/pull/1933

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
