### PR TITLE
Add link to generic Display Component

### DIFF
--- a/components/display/st7735.rst
+++ b/components/display/st7735.rst
@@ -77,5 +77,6 @@ See Also
 --------
 
 - :ref:`spi`
+- :ref:`Display Component`
 - :apiref:`st7735/st7735.h`
 - :ghedit:`Edit`

--- a/components/display/st7735.rst
+++ b/components/display/st7735.rst
@@ -77,6 +77,6 @@ See Also
 --------
 
 - :ref:`spi`
-- :ref:`Display Component`
+- :doc:`/components/display/index`
 - :apiref:`st7735/st7735.h`
 - :ghedit:`Edit`


### PR DESCRIPTION
One needs the Display Component page to figure out how to do anything with st7735.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
