### PR TITLE
Add ESP-EYE config for esp32_camera component

### DIFF
--- a/components/esp32_camera.rst
+++ b/components/esp32_camera.rst
@@ -211,6 +211,9 @@ Configuration for TTGO T-Camera V162
       jpeg_quality: 10
       vertical_flip: true
       horizontal_mirror: false
+
+      # Image settings
+      name: My Camera
       # ...
 
 Configuration for TTGO T-Camera V17
@@ -256,7 +259,6 @@ Configuration for TTGO T-Journal
       href_pin: GPIO26
       pixel_clock_pin: GPIO21
 
-
       # Image settings
       name: My Camera
       # ...
@@ -282,7 +284,6 @@ Configuration for TTGO-Camera Plus
       vertical_flip: false
       horizontal_mirror: false
 
-
       # Image settings
       name: My Camera
       # ...
@@ -305,11 +306,32 @@ Configuration for TTGO-Camera Mini
       href_pin: GPIO25
       pixel_clock_pin: GPIO19
 
+      # Image settings
+      name: My Camera
+      # ...
+      
+Configuration for ESP-EYE
+----------------------------------
 
+.. code-block:: yaml
+
+    # Example configuration entry
+    esp32_camera:
+      external_clock:
+        pin: GPIO4
+        frequency: 20MHz
+      i2c_pins:
+        sda: GPIO18
+        scl: GPIO23
+      data_pins: [GPIO34, GPIO13, GPIO14, GPIO35, GPIO39, GPIO38, GPIO37, GPIO36]
+      vsync_pin: GPIO5
+      href_pin: GPIO27
+      pixel_clock_pin: GPIO25
 
       # Image settings
       name: My Camera
       # ...
+
 
 See Also
 --------


### PR DESCRIPTION
## Description:

The ESP-EYE camera board from Espressif can be configured for the ESP32 Camera Component with the following settings.
This has been tested and verified on my personal HA instance.

I have also edited some of the other example configuration entries to be more consistent.

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
