### PR TITLE
Support for the DKE screen version of LilyGo-TTGO-T5 V2.3

### DIFF
--- a/components/display/waveshare_epaper.rst
+++ b/components/display/waveshare_epaper.rst
@@ -82,6 +82,7 @@ Configuration variables:
   - ``2.13in-ttgo`` (T5_V2.3 tested. Also works for Wemos D1 Mini ePaper Shield 2.13 1.0.0 "LOLIN")
   - ``2.13in-ttgo-b73`` (T5_V2.3 with B73 display tested)
   - ``2.13in-ttgo-b1`` (T5_V2.3 with B1 display tested)
+  - ``2.13in-ttgo-dke`` (T5_V2.3 with DKE group display (DEPG0213BN) tested)
   - ``2.70in`` (currently not working with the HAT Rev 2.1 version)
   - ``2.90in``
   - ``2.90inv2``


### PR DESCRIPTION
## Description:
Adds the display model for DKE screen version of LilyGo-TTGO-T5 V2.3.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#1969

## Checklist:

  - [X] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
