### PR TITLE
Climate component for Ballu air conditioners with remote model YKR-K/002E

### DIFF
--- a/components/climate/ir_climate.rst
+++ b/components/climate/ir_climate.rst
@@ -19,6 +19,8 @@ request so it will be added (see FAQ).
 | Name                                  | Platform name       |  Supports receiver   |
 |                                       |                     |                      |
 +=======================================+=====================+======================+
+| Ballu                                 | ``ballu``           | yes                  |
++---------------------------------------+---------------------+----------------------+
 | Coolix                                | ``coolix``          | yes                  |
 +---------------------------------------+---------------------+----------------------+
 | Daikin                                | ``daikin``          | yes                  |
@@ -157,6 +159,7 @@ See Also
 
 - :doc:`/components/climate/index`
 - :doc:`/components/remote_transmitter`
+- :apiref:`ballu.h <ballu/ballu.h>`,
 - :apiref:`coolix.h <coolix/coolix.h>`,
   :apiref:`daikin.h <daikin/daikin.h>`
   :apiref:`fujitsu_general.h <fujitsu_general/fujitsu_general.h>`,


### PR DESCRIPTION
## Description:

Climate component for Ballu air conditioners with remote model YKR-K/002E

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#1939

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
