### PR TITLE
switch argument order

### DIFF
--- a/guides/getting_started_command_line.rst
+++ b/guides/getting_started_command_line.rst
@@ -38,7 +38,7 @@ file called ``livingroom.yaml``:
 
 .. code-block:: bash
 
-    esphome livingroom.yaml wizard
+    esphome wizard livingroom.yaml
     # On Docker:
     docker run --rm -v "${PWD}":/config -it esphome/esphome wizard livingroom.yaml
 


### PR DESCRIPTION
## Description:
`esphome` told me:

```
WARNING Calling ESPHome with the configuration before the command is deprecated and will be removed in the future. 
WARNING Please instead use:
WARNING    esphome wizard livingroom.yaml
```



**Related issue (if applicable):** none

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** none

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
