### PR TITLE
hlw8012: add constants by sensor model

### DIFF
--- a/components/sensor/hlw8012.rst
+++ b/components/sensor/hlw8012.rst
@@ -67,6 +67,9 @@ Advanced Options:
   Defaults to the Sonoff POW's value ``0.001 ohm``.
 - **voltage_divider** (*Optional*, float): The value of the voltage divider on the board as ``(R_upstream + R_downstream) / R_downstream``.
   Defaults to the Sonoff POW's value ``2351``.
+- **model** (*Optional*, string): The sensor model on the board, to set internal constant factors to convert pulses to measurements. 
+  Possible values are ``HLW8012``, ``CSE7759``, ``BL0937``. Defaults to ``HLW8012``. 
+  CSE7759 uses same constants and it also works with default. Must be set for BL0937 to be able to calibrate all three measurements at the same time.
 - **change_mode_every** (*Optional*, int): After how many updates to cycle between the current/voltage measurement mode.
   Note that the first value after switching is discarded because it is often inaccurate. Defaults to ``8``.
 - **initial_mode** (*Optional*, string): The initial measurement mode. Defaults to ``VOLTAGE``.


### PR DESCRIPTION
## Description:

Add a configuration option sensor_model to handle constants on per sensor model basis.
Fixes BL0937 sensor readings

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#1973

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
