### PR TITLE
Midea climate: added IR support for commands unsupported via UART

### DIFF
--- a/components/climate/midea_ac.rst
+++ b/components/climate/midea_ac.rst
@@ -139,7 +139,7 @@ component, as well as control the light of the LED display.
               beeper: false   # may beep on every FM command (or not?)
               temperature: !lambda "return x;"
 
-    # template momentary switch for sending display control command
+    # template momentary switch for sending display control command and swing step actions
     switch:
       - platform: template
         name: "Toggle Display"
@@ -148,6 +148,13 @@ component, as well as control the light of the LED display.
         turn_on_action:
           - remote_transmitter.transmit_midea_toggle_light:
           - switch.turn_off: mlight
+      - platform: template
+        name: "Swing Step"
+        icon: "mdi:tailwind"
+        id: swing_step
+        turn_on_action:
+          - remote_transmitter.transmit_midea_swing_step:
+          - switch.turn_off: swing_step
 
 
 Acknowledgments:

--- a/components/climate/midea_ac.rst
+++ b/components/climate/midea_ac.rst
@@ -142,11 +142,11 @@ component, as well as control the light of the LED display.
     # template momentary switch for sending display control command and swing step actions
     switch:
       - platform: template
-        name: "Toggle Display"
+        name: "Display Toggle"
         icon: "mdi:theme-light-dark"
         id: mlight
         turn_on_action:
-          - remote_transmitter.transmit_midea_toggle_light:
+          - remote_transmitter.transmit_midea_display_toggle:
           - switch.turn_off: mlight
       - platform: template
         name: "Swing Step"

--- a/components/climate/midea_ac.rst
+++ b/components/climate/midea_ac.rst
@@ -39,7 +39,7 @@ This component requires a auto-loaded ``midea-dongle`` component, that use hardw
 
     # Optional (if you want modify settings)
     midea_dongle:
-      strength_icon: true   # for devices supporting indication of several levels of signal quality
+      strength_icon: true   # for devices that supporting indication of several levels of signal quality
     
     # Main settings
     climate:
@@ -122,6 +122,10 @@ component, as well as control the light of the LED display.
 
     # Example configuration entry
 
+    remote_transmitter:
+      pin: GPIO13                 # for midea-open-dongle hardware stick
+      carrier_duty_percent: 100%  # 50% for IR LED, 100% for direct connect to TSOP IR receiver output
+
     sensor:
       - platform: homeassistant
         id: fm_sensor
@@ -135,6 +139,16 @@ component, as well as control the light of the LED display.
               beeper: false   # may beep on every FM command (or not?)
               temperature: !lambda "return x;"
 
+    switch:
+      - platform: template
+        name: "Toggle Display"
+        icon: "mdi:theme-light-dark"
+        id: mlight
+        turn_on_action:
+          - remote_transmitter.transmit_midea_toggle_light:
+          - switch.turn_off: mlight
+
+
 Acknowledgments:
 ----------------
 
@@ -143,6 +157,8 @@ Thanks to the following people for their contributions to reverse engineering th
 * `Mac Zhou <https://github.com/mac-zhou/midea-msmart>`_
 * `NeoAcheron <https://github.com/NeoAcheron/midea-ac-py>`_
 * `Rene Klootwijk <https://github.com/reneklootwijk/node-mideahvac>`_
+
+Special thanks to the project `IRremoteESP8266 <https://github.com/crankyoldgit/IRremoteESP8266>`_ for describing the IR protocol.
 
 See Also
 --------

--- a/components/climate/midea_ac.rst
+++ b/components/climate/midea_ac.rst
@@ -132,7 +132,7 @@ component, as well as control the light of the LED display.
         entity_id: sensor.room_sensor # sensor from HASS
         filters:
           - throttle: 10s
-          - heartbeat: 2min # minimum interval of FM commands
+          - heartbeat: 2min # maximum interval of FM commands
           - debounce: 1s
         on_value:
           - remote_transmitter.transmit_midea_follow_me:

--- a/components/climate/midea_ac.rst
+++ b/components/climate/midea_ac.rst
@@ -33,23 +33,23 @@ This component requires a auto-loaded ``midea-dongle`` component, that use hardw
 
     # UART settings for Midea dongle (required)
     uart:
-      tx_pin: 1
-      rx_pin: 3
+      tx_pin: 1   # hardware dependant
+      rx_pin: 3   # hardware dependant
       baud_rate: 9600
 
     # Optional (if you want modify settings)
     midea_dongle:
-      strength_icon: true
+      strength_icon: true   # for devices supporting indication of several levels of signal quality
     
     # Main settings
     climate:
       - platform: midea_ac
-        name: "My Midea AC"
+        name: "Midea AC #1"   # use a unique name
         visual:
-          min_temperature: 18 °C
-          max_temperature: 25 °C
-          temperature_step: 0.1 °C
-        beeper: true
+          min_temperature: 17 °C    # min: 17
+          max_temperature: 30 °C    # max: 30
+          temperature_step: 0.5 °C  # min: 0.5
+        beeper: true  # beep on commands
         custom_fan_modes:
           - SILENT
           - TURBO
@@ -60,12 +60,12 @@ This component requires a auto-loaded ``midea-dongle`` component, that use hardw
           - FREEZE_PROTECTION
         swing_horizontal: true
         swing_both: true
-        outdoor_temperature:
-          name: "Temp"
-        power_usage:
-          name: "Power"
-        humidity_setpoint:
-          name: "Hum"
+        outdoor_temperature:  # create outdoor unit temperature sensor (may display incorrect values after long inactivity)
+          name: "Temp"        # sensor unique name
+        power_usage:          # create power usage sensor (only for devices that support this feature)
+          name: "Power"       # sensor unique name
+        humidity_setpoint:    # create indoor humidity sensor
+          name: "Hum"         # sensor unique name
 
 Configuration variables:
 ------------------------

--- a/components/climate/midea_ac.rst
+++ b/components/climate/midea_ac.rst
@@ -139,6 +139,7 @@ component, as well as control the light of the LED display.
               beeper: false   # may beep on every FM command (or not?)
               temperature: !lambda "return x;"
 
+    # template momentary switch for sending display control command
     switch:
       - platform: template
         name: "Toggle Display"

--- a/components/climate/midea_ac.rst
+++ b/components/climate/midea_ac.rst
@@ -111,6 +111,30 @@ Configuration variables of midea-dongle component:
   and you want to use this feature. By default, on connected state, icon show maximum signal quality. Defaults to ``False``.
 
 
+Additional control options using IR commands
+--------------------------------------------
+
+It is possible to use the FollowMe function and some other features available only through IR commands.
+Below is an example of how to send FollowMe commands with the values of your sensor using the :doc:`../remote_transmitter`
+component, as well as control the light of the LED display.
+
+.. code-block:: yaml
+
+    # Example configuration entry
+
+    sensor:
+      - platform: homeassistant
+        id: fm_sensor
+        entity_id: sensor.room_sensor # sensor from HASS
+        filters:
+          - throttle: 10s
+          - heartbeat: 2min # minimum interval of FM commands
+          - debounce: 1s
+        on_value:
+          - remote_transmitter.transmit_midea_follow_me:
+              beeper: false   # may beep on every FM command (or not?)
+              temperature: !lambda "return x;"
+
 Acknowledgments:
 ----------------
 


### PR DESCRIPTION
## Description:
Added IR support for commands unsupported via UART.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#1975

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
