### PR TITLE
add stepper accel and decel to docs

### DIFF
--- a/components/stepper/index.rst
+++ b/components/stepper/index.rst
@@ -228,6 +228,46 @@ Configuration variables:
 - **speed** (**Required**, :ref:`templatable <config-templatable>`, float): The speed
   in ``steps/s`` (steps per seconds) to drive the stepper at.
 
+.. _stepper-set_acceleration_action:
+
+``stepper.set_acceleration`` Action
+-----------------------------------
+
+This :ref:`Action <config-action>` allows you to set the acceleration of a stepper at runtime.
+
+.. code-block:: yaml
+
+    on_...:
+      - stepper.set_acceleration:
+          id: my_stepper
+          speed: 250 steps/s^2
+
+Configuration variables:
+
+- **id** (**Required**, :ref:`config-id`): The ID of the stepper.
+- **acceleration** (**Required**, :ref:`templatable <config-templatable>`, float): The acceleration
+  in ``steps/s^2`` (steps per seconds squared) to use when starting to move.
+
+.. _stepper-set_deceleration_action:
+
+``stepper.set_deceleration`` Action
+-----------------------------------
+
+This :ref:`Action <config-action>` allows you to set the deceleration of a stepper at runtime.
+
+.. code-block:: yaml
+
+    on_...:
+      - stepper.set_deceleration:
+          id: my_stepper
+          speed: 250 steps/s^2
+
+Configuration variables:
+
+- **id** (**Required**, :ref:`config-id`): The ID of the stepper.
+- **deceleration** (**Required**, :ref:`templatable <config-templatable>`, float): The same as ``acceleration``,
+  but for when the motor is decelerating shortly before reaching the set position.
+
 .. _stepper-ha-config:
 
 Home Assistant Configuration


### PR DESCRIPTION
## Description:
Add documentation for new stepper actions: set_acceleration and set_deceleration.

**Related issue (if applicable):** fixes [https://github.com/esphome/feature-requests/issues/580](https://github.com/esphome/feature-requests/issues/580)

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#1977

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
