### PR TITLE
Add support for IBS-TH1 External Sensor

### DIFF
--- a/components/sensor/inkbird_ibsth1_mini.rst
+++ b/components/sensor/inkbird_ibsth1_mini.rst
@@ -1,16 +1,20 @@
-Inkbird IBS-TH1 Mini BLE Sensor
+Inkbird IBS-TH1 and IBS-TH1 Mini BLE Sensor
 ===============================
 
 .. seo::
-    :description: Instructions for setting up Inkbird IBS-TH1 Mini Bluetooth-based temperature and humidity sensors in ESPHome.
+    :description: Instructions for setting up Inkbird IBS-TH1 Bluetooth-based temperature and humidity sensors in ESPHome.
     :image: inkbird_isbth1_mini.jpg
     :keywords: Inkbird, BLE, Bluetooth, IBS-TH1
 
-The ``inkbird_ibsth1_mini`` sensor platform lets you track the output of Inkbird IBS-TH1 Mini Bluetooth
+The ``inkbird_ibsth1_mini`` sensor platform lets you track the output of Inkbird IBS-TH1 and IBS-TH1 Mini Bluetooth
 Low Energy devices using the :doc:`/components/esp32_ble_tracker`. This component will track the
-temperature, humidity and the battery level of the IBS-TH1 Mini device every time the
+temperature, external temperature (non mini only), humidity and the battery level of the IBS-TH1 device every time the
 sensor sends out a BLE broadcast. Note that contrary to other implementations, ESPHome can track as
-many IBS-TH1 Mini devices at once as you want.
+many IBS-TH1 devices at once as you want.
+
+.. note::
+    If an external temperature sensor is connected to the IBS-TH1, measurement from the internal sensor is not sent.
+    Only one sensor will work at a time.
 
 .. figure:: images/inkbird_isbth1_mini-full.jpg
     :align: center
@@ -31,19 +35,27 @@ many IBS-TH1 Mini devices at once as you want.
       - platform: inkbird_ibsth1_mini
         mac_address: 38:81:D7:0A:9C:11
         temperature:
-          name: "Inkbird IBS-TH1 Mini Temperature"
+          name: "Inkbird IBS-TH1 Temperature"
+        ext_temperature:
+          name: "Inkburd IBS-TH1 External Temperature"
         humidity:
-          name: "Inkbird IBS-TH1 Mini Humidity"
+          name: "Inkbird IBS-TH1 Humidity"
         battery_level:
-          name: "Inkbird IBS-TH1 Mini Battery Level"
+          name: "Inkbird IBS-TH1 Battery Level"
 
 Configuration variables:
 ------------------------
 
-- **mac_address** (**Required**, MAC Address): The MAC address of the Inkbird IBS-TH1 Mini device.
+- **mac_address** (**Required**, MAC Address): The MAC address of the Inkbird IBS-TH1 device.
 - **temperature** (*Optional*): The information for the temperature sensor.
 
   - **name** (**Required**, string): The name for the temperature sensor.
+  - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.
+  - All other options from :ref:`Sensor <config-sensor>`.
+
+- **ext_temperature** (*Optional*): The information for the external temperature sensor.
+
+  - **name** (**Required**, string): The name for the external temperature sensor.
   - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.
   - All other options from :ref:`Sensor <config-sensor>`.
 
@@ -63,7 +75,7 @@ Configuration variables:
 Setting Up Devices
 ------------------
 
-To set up Inkbird IBS-TH1 Mini devices you first need to find their MAC Address so that ESPHome can
+To set up Inkbird IBS-TH1 devices you first need to find their MAC Address so that ESPHome can
 identify them. So first, create a simple configuration without any ``inkbird_ibsth1_mini`` entries
 like so:
 
@@ -71,7 +83,7 @@ like so:
 
     esp32_ble_tracker:
 
-After uploading the ESP32 will immediately try to scan for BLE devices such as the Inkbird IBS-TH1 Mini. 
+After uploading the ESP32 will immediately try to scan for BLE devices such as the Inkbird IBS-TH1. 
 When it detects these sensors, it will automatically parse the BLE message print a
 message like this one:
 
@@ -82,7 +94,7 @@ message like this one:
     [13:36:43][D][esp32_ble_tracker:567]:   Name: 'sps'
 
 Note that it can sometimes take some time for the first BLE broadcast to be received. Please note that address type
-should say 'PUBLIC' and the device name should be 'sps', this is how you find the Inkbird IBS-TH1 Mini among all the 
+should say 'PUBLIC' and the device name should be 'sps', this is how you find the Inkbird IBS-TH1 among all the 
 other devices.
 
 Then just copy the address (``38:81:D7:0A:9C:11``) into a new ``sensor.inkbird_ibsth1_mini`` platform
@@ -90,7 +102,7 @@ entry like in the configuration example at the top.
 
 .. note::
 
-    The ESPHome Inkbird IBS-TH1 Mini integration listens passively to packets the device sends by itself.
+    The ESPHome Inkbird IBS-TH1 integration listens passively to packets the device sends by itself.
     ESPHome therefore has no impact on the battery life of the device.
 
 See Also

--- a/components/sensor/inkbird_ibsth1_mini.rst
+++ b/components/sensor/inkbird_ibsth1_mini.rst
@@ -1,5 +1,5 @@
 Inkbird IBS-TH1 and IBS-TH1 Mini BLE Sensor
-===============================
+===========================================
 
 .. seo::
     :description: Instructions for setting up Inkbird IBS-TH1 Bluetooth-based temperature and humidity sensors in ESPHome.

--- a/components/sensor/inkbird_ibsth1_mini.rst
+++ b/components/sensor/inkbird_ibsth1_mini.rst
@@ -13,6 +13,7 @@ sensor sends out a BLE broadcast. Note that contrary to other implementations, E
 many IBS-TH1 devices at once as you want.
 
 .. note::
+
     If an external temperature sensor is connected to the IBS-TH1, measurement from the internal sensor is not sent.
     Only one sensor will work at a time.
 

--- a/components/sensor/inkbird_ibsth1_mini.rst
+++ b/components/sensor/inkbird_ibsth1_mini.rst
@@ -37,7 +37,7 @@ many IBS-TH1 devices at once as you want.
         mac_address: 38:81:D7:0A:9C:11
         temperature:
           name: "Inkbird IBS-TH1 Temperature"
-        ext_temperature:
+        external_temperature:
           name: "Inkburd IBS-TH1 External Temperature"
         humidity:
           name: "Inkbird IBS-TH1 Humidity"
@@ -54,7 +54,7 @@ Configuration variables:
   - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.
   - All other options from :ref:`Sensor <config-sensor>`.
 
-- **ext_temperature** (*Optional*): The information for the external temperature sensor.
+- **external_temperature** (*Optional*): The information for the external temperature sensor.
 
   - **name** (**Required**, string): The name for the external temperature sensor.
   - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.


### PR DESCRIPTION
## Description:

Add documentation for the IBS-TH1 External Sensor.
IBS-TH1 Mini was already implemented. This update will add support for non mini models and external sensor with full backwards combability.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#1983

## Checklist:

  - [X] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [X] Link added in `/index.rst` when creating new documents for new components or cookbook.
