### PR TITLE
remove note about logging on ESP8266

### DIFF
--- a/components/sensor/custom.rst
+++ b/components/sensor/custom.rst
@@ -433,16 +433,6 @@ functions for this.
 
 See :ref:`display-printf` for learning about how to use formatting in log strings.
 
-.. note::
-
-    On ESP8266s you need to disable storing strings in flash to use logging in custom code.
-
-    .. code-block:: yaml
-
-        logger:
-          level: DEBUG
-          esp8266_store_log_strings_in_flash: False
-
 See Also
 --------
 


### PR DESCRIPTION
## Description:

I missed this note yesterday, and thus, in my ignorance, used `ESP_LOGD` on an ESP8266 (Wemos D1 Mini, but I suspect that does not matter). It worked fine. I asked on Discord and got 'I think if you're using the ESP_LOG functions, you should be fine.' and 'I think that note is outdated.. judging from a quick look at the code it seems like the regular logging is always available'. So, I am PRing this so someone can perhaps check more carefully if there's any detail missing here.


**Related issue (if applicable):** none
**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** none

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
