### PR TITLE
document new panasonic climate component

### DIFF
--- a/components/climate/ir_climate.rst
+++ b/components/climate/ir_climate.rst
@@ -29,6 +29,8 @@ request so it will be added (see FAQ).
 +---------------------------------------+---------------------+----------------------+
 | Mitsubishi                            | ``mitsubishi``      |                      |
 +---------------------------------------+---------------------+----------------------+
+| :ref:`Panasonic<climate_ir_panasonic>`| ``panasonic``       | yes                  |
++---------------------------------------+---------------------+----------------------+
 | TCL112, Fuego                         | ``tcl112``          | yes                  |
 +---------------------------------------+---------------------+----------------------+
 | Toshiba                               | ``toshiba``         | yes                  |
@@ -154,19 +156,44 @@ Configuration variables:
         header_high: 3265us # AC Units from LG in Brazil, for example use these timings
         header_low: 9856us
 
+
+.. _climate_ir_panasonic:
+
+``Panasonic`` Climate
+---------------------------------
+
+Additional configuration is available for this platform
+
+
+Configuration variables:
+
+- **supports_vertical_swing** (*Optional*, boolean): The AC's vanes can move vertically. Defaults to ``false``
+- **supports_horizontal_swing** (*Optional*, boolean): The AC's vanes can move horizontally. Defaults to ``false``
+- **supports_both_swing** (*Optional*, boolean): The AC's vanes can move both vertically and horizontally. Defaults to ``false``
+
+.. code-block:: yaml
+
+    # Example configuration entry
+    climate:
+      - platform: panasonic
+        name: "AC"
+        supports_vertical_swing: true
+
+
 See Also
 --------
 
 - :doc:`/components/climate/index`
 - :doc:`/components/remote_transmitter`
-- :apiref:`ballu.h <ballu/ballu.h>`,
-- :apiref:`coolix.h <coolix/coolix.h>`,
-  :apiref:`daikin.h <daikin/daikin.h>`
-  :apiref:`fujitsu_general.h <fujitsu_general/fujitsu_general.h>`,
-  :apiref:`hitachi_ac344.h <hitachi_ac344/hitachi_ac344.h>`,
-  :apiref:`mitsubishi.h <mitsubishi/mitsubishi.h>`,
-  :apiref:`tcl112.h <tcl112/tcl112.h>`,
-  :apiref:`yashima.h <yashima/yashima.h>`
-  :apiref:`whirlpool.h <whirlpool/whirlpool.h>`
-  :apiref:`climate_ir_lg.h <climate_ir_lg/climate_ir_lg.h>`
+- :apiref:`ballu.h <ballu/ballu.h>`
+- :apiref:`coolix.h <coolix/coolix.h>`
+- :apiref:`daikin.h <daikin/daikin.h>`
+- :apiref:`fujitsu_general.h <fujitsu_general/fujitsu_general.h>`
+- :apiref:`hitachi_ac344.h <hitachi_ac344/hitachi_ac344.h>`
+- :apiref:`mitsubishi.h <mitsubishi/mitsubishi.h>`
+- :apiref:`panasonic.h <panasonic/panasonic.h>`
+- :apiref:`tcl112.h <tcl112/tcl112.h>`
+- :apiref:`yashima.h <yashima/yashima.h>`
+- :apiref:`whirlpool.h <whirlpool/whirlpool.h>`
+- :apiref:`climate_ir_lg.h <climate_ir_lg/climate_ir_lg.h>`
 - :ghedit:`Edit`

--- a/components/climate/ir_climate.rst
+++ b/components/climate/ir_climate.rst
@@ -160,7 +160,7 @@ Configuration variables:
 .. _climate_ir_panasonic:
 
 ``Panasonic`` Climate
----------------------------------
+---------------------
 
 Additional configuration is available for this platform
 


### PR DESCRIPTION
## Description:
Adds documentation for new panasonic ir climate component.
(mangled the last merge request really bad)

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#1998

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
