### PR TITLE
Corrected value for "inverted"

### DIFF
--- a/components/switch/gpio.rst
+++ b/components/switch/gpio.rst
@@ -59,7 +59,7 @@ To create an active-low switch (one that is turned off by default), use the :ref
       - platform: gpio
         pin:
           number: 25
-          inverted: yes
+          inverted: True
 
 Momentary Switch
 ----------------

--- a/components/switch/gpio.rst
+++ b/components/switch/gpio.rst
@@ -59,7 +59,7 @@ To create an active-low switch (one that is turned off by default), use the :ref
       - platform: gpio
         pin:
           number: 25
-          inverted: True
+          inverted: true
 
 Momentary Switch
 ----------------


### PR DESCRIPTION


## Description:
According to the pin schema the value for "inverted" should be true or false, but not yes.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
