### PR TITLE
Added more details to where to put the secrets

### DIFF
--- a/guides/faq.rst
+++ b/guides/faq.rst
@@ -11,7 +11,7 @@ Tips for using ESPHome
 1. ESPHome supports (most of) `Home Assistant's YAML configuration directives
    <https://www.home-assistant.io/docs/configuration/splitting_configuration/>`__ like
    ``!include`` and ``!secret``. So you can store all your secret WiFi passwords and so on
-   in a file called ``secrets.yaml`` within the directory where the configuration file is.
+   in a file called ``secrets.yaml`` within the directory where the esphome configuration files are.
 
    For even more configuration templating, take a look at :ref:`config-substitutions`.
 


### PR DESCRIPTION
Secrets.yaml in the Homeassistant folder didnt work within esphome.
Added the information here to be more precise and get less people confused.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
