### PR TITLE
Use lowercase true/false values

### DIFF
--- a/components/binary_sensor/esp32_touch.rst
+++ b/components/binary_sensor/esp32_touch.rst
@@ -17,7 +17,7 @@ the eight touch pads of the ESP32 as :ref:`binary sensors <esp32-touch-binary-se
 
     # Example configuration entry
     esp32_touch:
-      setup_mode: False
+      setup_mode: false
 
     binary_sensor:
       - platform: esp32_touch
@@ -131,7 +131,7 @@ to make the validator happy, we are going to find good thresholds in a moment an
 
     # Example configuration entry for finding threshold values
     esp32_touch:
-      setup_mode: True
+      setup_mode: true
 
     binary_sensor:
       - platform: esp32_touch
@@ -148,7 +148,7 @@ touch/non-touch events.
     :align: center
 
 Finally, put your threshold parameter in the configuration. Do not forget to disable the ``setup_mode``
-option again by setting it to ``False``. Otherwise you will end up spamming the logs and slowing the device
+option again by setting it to ``false``. Otherwise you will end up spamming the logs and slowing the device
 down.
 
 See Also

--- a/components/binary_sensor/gpio.rst
+++ b/components/binary_sensor/gpio.rst
@@ -60,7 +60,7 @@ sensor:
       - platform: gpio
         pin:
           number: D2
-          inverted: True
+          inverted: true
         name: ...
 
 Debouncing Values

--- a/components/binary_sensor/nextion.rst
+++ b/components/binary_sensor/nextion.rst
@@ -7,7 +7,7 @@ Nextion Binary Sensor Component
     :description: Instructions for setting up Nextion binary sensor.
     :image: nextion.jpg
 
-The ``nextion`` binary sensor platform supports the many switched components in the Nextion as well as integer variables (>0 == True). It can be a component or variable in the Nextion display.
+The ``nextion`` binary sensor platform supports the many switched components in the Nextion as well as integer variables (>0 == true). It can be a component or variable in the Nextion display.
 It is best to set the components vscope to global in the Nextion Editor. This way the component will be available if the page is shown or not. 
 
 See :doc:`/components/display/nextion` for setting up the display

--- a/components/binary_sensor/xpt2046.rst
+++ b/components/binary_sensor/xpt2046.rst
@@ -41,7 +41,7 @@ The :ref:`SPI <spi>` is required to be set up in your configuration for this sen
       calibration_x_max: 280
       calibration_y_min: 340
       calibration_y_max: 3860
-      swap_x_y: False
+      swap_x_y: false
 
     binary_sensor:
       - platform: xpt2046
@@ -220,7 +220,7 @@ That means that the minimum raw x is 281, maximum 3848, minimum y 347 and maximu
 Identify which raw value is the display's x direction and what the y one. In our case
 moving right decreases the x raw value and going down increases the y one so the axes
 match and we *don't* need to use ``swap_x_y``. If the raw x is the display's y,
-use ``swap_x_y = True``.
+use ``swap_x_y = true``.
 
 If one of the coordinates goes in the "wrong" direction it needs to be inverted.
 The inversion is performed by swapping the minimum and maximum values. In our

--- a/components/canbus.rst
+++ b/components/canbus.rst
@@ -46,7 +46,7 @@ Each canbus platform extends this configuration schema.
         can_id: 4
         on_frame:
         - can_id: 500
-          use_extended_id: False
+          use_extended_id: false
           then:
           - lambda: |-
               std::string b(x.begin(), x.end());
@@ -56,8 +56,8 @@ Configuration variables:
 
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
 - **can_id** (**Required**, integer): default *can id* used for transmitting frames.
-- **use_extended_id** (*Optional*, boolean): default *False* identifies the type of *can_id*:
-  *False*: Standard 11 bits IDs, *True*: Extended 29 bits ID
+- **use_extended_id** (*Optional*, boolean): default *false* identifies the type of *can_id*:
+  *false*: Standard 11 bits IDs, *true*: Extended 29 bits ID
 - **bit_rate** (*Optional*, enum): One of the supported bitrates. Defaults to ``125KBPS``.
 
     - 5KBPS
@@ -138,8 +138,8 @@ Configuration variables:
   the frame. Not needed if you are using only 1 can bus.
 - **can_id** (*Optional*, int): Allows to override the can id configured in
   the can bus device.
-- **use_extended_id** (*Optional*, boolean): default *False* identifies the type of *can_id*:
-  *False*: Standard 11 Bit IDs, *True*: Extended 29Bit ID
+- **use_extended_id** (*Optional*, boolean): default *false* identifies the type of *can_id*:
+  *false*: Standard 11 Bit IDs, *true*: Extended 29Bit ID
 
 MCP2515 Component
 -----------------
@@ -221,7 +221,7 @@ Standard IDs and Extended IDs can coexist on the same segment.
             then:
               - canbus.send:
                   # Extended ID explicit
-                  use_extended_id: True
+                  use_extended_id: true
                   can_id: 0x100
                   data: [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]
               - canbus.send:
@@ -235,11 +235,11 @@ Standard IDs and Extended IDs can coexist on the same segment.
         spi_id: McpSpi
         cs_pin: GPIO14
         can_id: 0x1fff
-        use_extended_id: True
+        use_extended_id: true
         bit_rate: 125kbps
         on_frame:
         - can_id: 0x123
-          use_extended_id: True
+          use_extended_id: true
           then:
           - lambda: |-
               std::string b(x.begin(), x.end());

--- a/components/climate/ir_climate.rst
+++ b/components/climate/ir_climate.rst
@@ -68,8 +68,8 @@ Configuration variables:
 - **name** (**Required**, string): The name for the climate device.
 - **sensor** (*Optional*, :ref:`config-id`): The sensor that is used to measure the ambient
   temperature. This is only for reporting the current temperature in the frontend.
-- **supports_cool** (*Optional*, boolean): Enables setting cooling mode for this climate device. Defaults to ``True``.
-- **supports_heat** (*Optional*, boolean): Enables setting heating mode for this climate device. Defaults to ``True``.
+- **supports_cool** (*Optional*, boolean): Enables setting cooling mode for this climate device. Defaults to ``true``.
+- **supports_heat** (*Optional*, boolean): Enables setting heating mode for this climate device. Defaults to ``true``.
 - **receiver_id** (*Optional*, :ref:`config-id`): The id of the remote_receiver if this platform supports
   receiver. see: :ref:`ir-receiver_id`.
 - All other options from :ref:`Climate <config-climate>`.
@@ -102,7 +102,7 @@ IR receiver.
       id: rcvr
       pin:
         number: GPIO14
-        inverted: True
+        inverted: true
         mode: INPUT_PULLUP
       # high 55% tolerance is recommended for some remote control units
       tolerance: 55%

--- a/components/climate/midea_ac.rst
+++ b/components/climate/midea_ac.rst
@@ -91,14 +91,14 @@ Configuration variables:
   - **name** (**Required**, string): The name of the sensor.
   - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.
   - All other options from :ref:`Sensor <config-sensor>`.
-- **beeper** (*Optional*, boolean): Beeper feedback on command. Defaults to ``False``.
+- **beeper** (*Optional*, boolean): Beeper feedback on command. Defaults to ``false``.
 - **custom_fan_modes** (*Optional*, list): List of supported custom fan modes. Possible values are: SILENT, TURBO.
-- **preset_eco** (*Optional*, boolean): ECO preset support. Defaults to ``False``.
-- **preset_sleep** (*Optional*, boolean): SLEEP preset support. Defaults to ``False``.
-- **preset_boost** (*Optional*, boolean): BOOST preset support. Defaults to ``False``.
+- **preset_eco** (*Optional*, boolean): ECO preset support. Defaults to ``false``.
+- **preset_sleep** (*Optional*, boolean): SLEEP preset support. Defaults to ``false``.
+- **preset_boost** (*Optional*, boolean): BOOST preset support. Defaults to ``false``.
 - **custom_presets** (*Optional*, list): List of supported custom presets. Possible values are: FREEZE_PROTECTION.
-- **swing_horizontal** (*Optional*, boolean): Enable **swing horizontal** option. Defaults to ``False``.
-- **swing_both** (*Optional*, boolean): Enable **swing both** option. Defaults to ``False``.
+- **swing_horizontal** (*Optional*, boolean): Enable **swing horizontal** option. Defaults to ``false``.
+- **swing_both** (*Optional*, boolean): Enable **swing both** option. Defaults to ``false``.
 - All other options from :ref:`Climate <config-climate>`.
 
 Configuration variables of midea-dongle component:
@@ -108,7 +108,7 @@ Configuration variables of midea-dongle component:
 - **uart_id** (*Optional*, :ref:`config-id`): Manually specify the ID of the :doc:`../uart` if you want
   to use multiple UART buses.
 - **strength_icon** (*Optional*, boolean): Set if your device have signal strength icon
-  and you want to use this feature. By default, on connected state, icon show maximum signal quality. Defaults to ``False``.
+  and you want to use this feature. By default, on connected state, icon show maximum signal quality. Defaults to ``false``.
 
 
 Acknowledgments:

--- a/components/climate/tuya.rst
+++ b/components/climate/tuya.rst
@@ -45,8 +45,8 @@ Configuration variables:
 
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
 - **name** (**Required**, string): The name of the climate device.
-- **supports_heat** (*Optional*, boolean): Specifies if the device has a heating mode. Defaults to ``True``.
-- **supports_cool** (*Optional*, boolean): Specifies if the device has a cooling mode. Defaults to ``False``.
+- **supports_heat** (*Optional*, boolean): Specifies if the device has a heating mode. Defaults to ``true``.
+- **supports_cool** (*Optional*, boolean): Specifies if the device has a cooling mode. Defaults to ``false``.
 - **switch_datapoint** (**Required**, int): The datapoint id number of the climate switch.
 - **active_state_datapoint** (*Optional*, int): The datapoint id number of the active state.
 - **active_state_heating_value** (*Optional*, int): The active state datapoint value the device reports when heating. Defaults to ``1``.

--- a/components/cover/time_based.rst
+++ b/components/cover/time_based.rst
@@ -51,10 +51,10 @@ Configuration variables:
 - **has_built_in_endstop** (*Optional*, boolean): Indicates that the cover has built in end stop
   detectors. In this configuration the ``stop_action`` is not performed when the open or close
   time is completed and if the cover is commanded to open or close the corresponding actions
-  will be performed without checking current state. Defaults to ``False``.
+  will be performed without checking current state. Defaults to ``false``.
 - **assumed_state** (*Optional*, boolean): Whether the true state of the cover is not known.
   This will make the Home Assistant frontend show buttons for both OPEN and CLOSE actions, instead
-  of hiding or disabling one of them. Defaults to ``True``.
+  of hiding or disabling one of them. Defaults to ``true``.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
 - All other options from :ref:`Cover <config-cover>`.
 

--- a/components/dfplayer.rst
+++ b/components/dfplayer.rst
@@ -109,7 +109,7 @@ Configuration options:
 - **file** (*Optional*, int, :ref:`templatable <config-templatable>`): The global track
   number (from all tracks in the device). If not specified plays the first track.
 - **loop** (*Optional*, bool, :ref:`templatable <config-templatable>`): Repeats playing
-  the same track. Defaults to ``False``.
+  the same track. Defaults to ``false``.
 
 ``dfplayer.play_folder`` Action
 -------------------------------
@@ -147,7 +147,7 @@ Configuration options:
 - **file** (*Optional*, int, :ref:`templatable <config-templatable>`): The file number
   inside the folder to play. Optional only if ``loop`` is not set.
 - **loop** (*Optional*, bool, :ref:`templatable <config-templatable>`): Repeats playing
-  all files in the folder. Causes ``file`` to be ignored. Defaults to ``False``.
+  all files in the folder. Causes ``file`` to be ignored. Defaults to ``false``.
 
 
 ``dfplayer.set_device`` Action
@@ -369,7 +369,7 @@ Sample code
         then:
           - dfplayer.play_folder:
               folder: !lambda 'return folder;'
-              loop: True
+              loop: true
 
       - service: dfplayer_set_device_tf
         then:

--- a/components/display/inkplate6.rst
+++ b/components/display/inkplate6.rst
@@ -70,8 +70,8 @@ Configuration variables:
 ************************
 
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
-- **greyscale** (*Optional*, boolean): Makes the screen display 3 bit colors. Defaults to ``False``
-- **partial_updating** (*Optional*, boolean): Makes the screen update partially, which is faster, but leaves burnin. Defaults to ``False``
+- **greyscale** (*Optional*, boolean): Makes the screen display 3 bit colors. Defaults to ``false``
+- **partial_updating** (*Optional*, boolean): Makes the screen update partially, which is faster, but leaves burnin. Defaults to ``false``
 - **full_update_every** (*Optional*, int): When partial updating is enabled, forces a full screen update after chosen number of updates. Defaults to ``10``
 - **lambda** (*Optional*, :ref:`lambda <config-lambda>`): The lambda to use for rendering the content on the display.
   See :ref:`display-engine` for more information.

--- a/components/display/max7219.rst
+++ b/components/display/max7219.rst
@@ -53,7 +53,7 @@ Configuration variables:
 - **spi_id** (*Optional*, :ref:`config-id`): Manually specify the ID of the :ref:`SPI Component <spi>` if you want
   to use multiple SPI buses.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
-- **reverse_enable** (*Optional*, boolean): For some displays the order of the chips is reversed so you'll see "56781234" instead of "12345678". This option will adjust the output to compensate. Defaults to ``False``.
+- **reverse_enable** (*Optional*, boolean): For some displays the order of the chips is reversed so you'll see "56781234" instead of "12345678". This option will adjust the output to compensate. Defaults to ``false``.
 
 
 .. _display-max7219_lambda:

--- a/components/display/max7219digit.rst
+++ b/components/display/max7219digit.rst
@@ -46,7 +46,7 @@ Configuration variables:
   ``4``.
 - **rotate_chip** (*Optional*): Rotates every 8x8 chip. Valid values are ``0``, ``90``, ``180`` and ``270``.
   Defaults to ``0``.
-- **scroll_enable** (*Optional*, boolean): Turn scroll mode on when content does not fit. Defaults to ``True``.
+- **scroll_enable** (*Optional*, boolean): Turn scroll mode on when content does not fit. Defaults to ``true``.
 - **scroll_mode** (*Optional*): Set the scroll mode. One of ``CONTINUOUS`` or ``STOP``. Defaults to ``CONTINUOUS``
 
     - ``CONTINUOUS``: Always scrolls and the text repeats continuously, you might need to add some
@@ -57,7 +57,7 @@ Configuration variables:
 - **scroll_delay** (*Optional*, :ref:`config-time`): Set delay time before scroll starts. Defaults to ``1s``.
 - **scroll_dwell** (*Optional*, :ref:`config-time`): Sets the wait time at the end of the scroll before starting
   over. This is only used in mode ``STOP``. Defaults to ``1s``.
-- **reverse_enable** (*Optional*, boolean): For some displays the order of the displays is reversed ("DCBA"). This option will reverse the display to ("ABCD") again. Defaults to  ``False``.
+- **reverse_enable** (*Optional*, boolean): For some displays the order of the displays is reversed ("DCBA"). This option will reverse the display to ("ABCD") again. Defaults to  ``false``.
 - **intensity** (*Optional*, integer): The intensity with which the MAX7219 should drive the outputs. Range is
   from ``0``, least intense to ``15`` the brightest. Defaults to ``15``.
 - **lambda** (*Optional*, :ref:`lambda <config-lambda>`): The lambda to use for rendering the content on the

--- a/components/display/st7735.rst
+++ b/components/display/st7735.rst
@@ -58,8 +58,8 @@ Memory notes:
 *************
 
 - 8Bit color saves 50% of the buffer required.
-- eightbitcolor: true 160x128 = 20480 *Important for memory constrained devices*
-- eightbitcolor: false 160x128x2 = 40960
+- ``eight_bit_color: true`` 160x128 = 20480 *Important for memory constrained devices*
+- ``eight_bit_color: false`` 160x128x2 = 40960
 
 
 Models:

--- a/components/display/st7735.rst
+++ b/components/display/st7735.rst
@@ -51,15 +51,15 @@ Configuration variables:
 - **device_height** (**Required**, int): The device height. 160 is default
 - **col_start** (**Required**, int): The device height. 160 is default
 - **row_start** (**Required**, int): The device height. 160 is default
-- **eight_bit_color** (*Optional*, "True/False" ): 8bit mode. Default is False. This saves 50% of the buffer required for the display.
+- **eight_bit_color** (*Optional*, "true/false" ): 8bit mode. Default is false. This saves 50% of the buffer required for the display.
 - **reset_pin** (*Optional*, :ref:`Pin Schema <config-pin_schema>`): The RESET pin.
 
 Memory notes:
 *************
 
 - 8Bit color saves 50% of the buffer required.
-- eightbitcolor: True 160x128 = 20480 *Important for memory constrained devices*
-- eightbitcolor: False 160x128x2 = 40960
+- eightbitcolor: true 160x128 = 20480 *Important for memory constrained devices*
+- eightbitcolor: false 160x128x2 = 40960
 
 
 Models:

--- a/components/esphome.rst
+++ b/components/esphome.rst
@@ -52,7 +52,7 @@ Advanced options:
   to include in the project. See `platformio lib install <https://docs.platformio.org/en/latest/userguide/lib/cmd_install.html>`__.
 - **comment** (*Optional*, string): Additional text information about this node. Only for display in UI.
 - **name_add_mac_suffix** (*Optional*, boolean): Appends the last 6 bytes of the mac address of the device to
-  the name in the form ``<name>-aabbcc``. Defaults to ``False``.
+  the name in the form ``<name>-aabbcc``. Defaults to ``false``.
   See :ref:`esphome-mac_suffix`.
 
 - **project** (*Optional*): ESPHome Creator's Project information. See :ref:`esphome-creators_project`.

--- a/components/i2c.rst
+++ b/components/i2c.rst
@@ -22,7 +22,7 @@ connecting the wires from each device back to the two I²C pins on the ESP.
     i2c:
       sda: 21
       scl: 22
-      scan: True
+      scan: true
       id: bus_a
 
 Configuration variables:
@@ -34,7 +34,7 @@ Configuration variables:
   Defaults to the default of your board (usually GPIO22 for ESP32 and
   GPIO5 for ESP8266).
 - **scan** (*Optional*, boolean): If ESPHome should do a search of the I²C address space on startup.
-  Defaults to ``True``.
+  Defaults to ``true``.
 - **frequency** (*Optional*, float): Set the frequency the I²C bus should operate on.
   Defaults to ``50kHz``. Values are ``50kHz``, ``100kHz``, ``200kHz``, ... ``800kHz``
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID for this I²C bus if you need multiple I²C buses.
@@ -50,11 +50,11 @@ Configuration variables:
           - id: bus_a
             sda: 13
             scl: 16
-            scan: True
+            scan: true
           - id: bus_b
             sda: 14
             scl: 15
-            scan: True
+            scan: true
        # Sensors should be specified as follows
        - platform: bme680
          i2c_id: bus_b

--- a/components/light/index.rst
+++ b/components/light/index.rst
@@ -459,15 +459,15 @@ This effect cycles through a list of colors with specific durations.
           - strobe:
               name: Strobe Effect With Custom Values
               colors:
-                - state: True
+                - state: true
                   brightness: 100%
                   red: 100%
                   green: 90%
                   blue: 0%
                   duration: 500ms
-                - state: False
+                - state: false
                   duration: 250ms
-                - state: True
+                - state: true
                   brightness: 100%
                   red: 0%
                   green: 100%
@@ -479,7 +479,7 @@ Configuration variables:
 - **name** (*Optional*, string): The name of the effect. Defaults to ``Strobe``.
 - **colors** (*Optional*, list): A list of colors to cycle through. Defaults to a quick cycle between ON and OFF.
 
-  - **state** (*Optional*, boolean): The ON/OFF state to show. Defaults to ``True``.
+  - **state** (*Optional*, boolean): The ON/OFF state to show. Defaults to ``true``.
   - **brightness** (*Optional*, percentage): The brightness of the light. Defaults to ``100%``.
   - **red** (*Optional*, percentage): The percentage that the red color should be on for RGB lights. Defaults to ``100%``.
   - **green** (*Optional*, percentage): The percentage that the green color should be on for RGB lights. Defaults to ``100%``.
@@ -603,7 +603,7 @@ the strip and shifts them forward every ``add_led_interval``.
                   blue: 0%
                   num_leds: 1
               add_led_interval: 100ms
-              reverse: False
+              reverse: false
 
 Configuration variables:
 
@@ -614,13 +614,13 @@ Configuration variables:
   - **red** (*Optional*, percentage): The percentage the red color channel should be on. Defaults to ``100%``.
   - **green** (*Optional*, percentage): The percentage the green color channel should be on. Defaults to ``100%``.
   - **blue** (*Optional*, percentage): The percentage the blue color channel should be on. Defaults to ``100%``.
-  - **random** (*Optional*, boolean): If set to ``True``, will overwrite the RGB colors by a new, randomly-chosen
-    color each time. Defaults to ``False``.
+  - **random** (*Optional*, boolean): If set to ``true``, will overwrite the RGB colors by a new, randomly-chosen
+    color each time. Defaults to ``false``.
   - **num_leds** (*Optional*, int): The number of leds of this type to have before moving on to the next color.
 
 - **add_led_interval** (*Optional*, :ref:`config-time`): The interval with which to shift in new leds at the
   beginning of the strip. Defaults to ``100ms``.
-- **reverse** (*Optional*, boolean): Whether to reverse the direction of the color wipe. Defaults to ``False``.
+- **reverse** (*Optional*, boolean): Whether to reverse the direction of the color wipe. Defaults to ``false``.
 
 Addressable Scan Effect
 ***********************

--- a/components/light/rgbw.rst
+++ b/components/light/rgbw.rst
@@ -67,7 +67,7 @@ the RGB channels to maximum whilst wanting a white light will have an undesired 
 configuration variable is available that prevents the RGB leds and white leds from being turned on at the same
 time: ``color_interlock``.
 
-Setting this variable to ``True`` will automatically turn off the RGB leds when the white value is non-zero, or
+Setting this variable to ``true`` will automatically turn off the RGB leds when the white value is non-zero, or
 when the color is set to white (equal values for red, green and blue). When a different color is set, or the
 color brightness is raised above 0%, the white leds are automatically turned off.
 

--- a/components/mcp230xx.rst
+++ b/components/mcp230xx.rst
@@ -37,7 +37,7 @@ The MCP23008 component (`datasheet <http://ww1.microchip.com/downloads/en/device
           # Use pin number 0
           number: 0
           mode: OUTPUT
-          inverted: False
+          inverted: false
 
     # Individual inputs
     binary_sensor:
@@ -49,7 +49,7 @@ The MCP23008 component (`datasheet <http://ww1.microchip.com/downloads/en/device
           number: 1
           # One of INPUT or INPUT_PULLUP
           mode: INPUT
-          inverted: False
+          inverted: false
 
 Configuration variables:
 ************************
@@ -68,7 +68,7 @@ Pin configuration variables:
 - **interrupt** (*Optional*): Set this pin to trigger the INT pin on the component. Can be one of ``CHANGE``, ``RISING``, ``FALLING``.
 - **number** (**Required**, integer): The pin number.
 - **inverted** (*Optional*, boolean): If all read and written values
-  should be treated as inverted. Defaults to ``False``.
+  should be treated as inverted. Defaults to ``false``.
 - **mode** (*Optional*, string): A pin mode to set for the pin at. One of ``INPUT`` or ``OUTPUT``.
 
 .. _mcp23016-label:
@@ -99,7 +99,7 @@ has 16 GPIOs and can be configured the same way than the other variants.
           # Use pin number 0
           number: 0
           mode: OUTPUT
-          inverted: False
+          inverted: false
 
     # Individual inputs
     binary_sensor:
@@ -110,7 +110,7 @@ has 16 GPIOs and can be configured the same way than the other variants.
           # Use pin number 1
           number: 1
           mode: INPUT
-          inverted: False
+          inverted: false
 
 
 Configuration variables:
@@ -158,7 +158,7 @@ binary sensor or GPIO switch.
           # Use pin number 0
           number: 0
           mode: OUTPUT
-          inverted: False
+          inverted: false
 
     # Individual inputs
     binary_sensor:
@@ -170,7 +170,7 @@ binary sensor or GPIO switch.
           number: 1
           # One of INPUT or INPUT_PULLUP
           mode: INPUT_PULLUP
-          inverted: False
+          inverted: false
 
 Configuration variables:
 ************************

--- a/components/mcp23Sxx.rst
+++ b/components/mcp23Sxx.rst
@@ -39,7 +39,7 @@ The MCP23S08 component (`datasheet <http://ww1.microchip.com/downloads/en/Device
           number: 0
           # One of INPUT, INPUT_PULLUP or OUTPUT
           mode: OUTPUT
-          inverted: False
+          inverted: false
 
     # Individual inputs
     binary_sensor:
@@ -51,7 +51,7 @@ The MCP23S08 component (`datasheet <http://ww1.microchip.com/downloads/en/Device
           number: 1
           # One of INPUT or INPUT_PULLUP
           mode: INPUT
-          inverted: False
+          inverted: false
 
 Configuration variables:
 ************************
@@ -104,7 +104,7 @@ binary sensor or GPIO switch.
           # Use pin number 0
           number: 0
           mode: OUTPUT
-          inverted: False
+          inverted: false
 
     # Individual inputs
     binary_sensor:
@@ -116,7 +116,7 @@ binary sensor or GPIO switch.
           number: 1
           # One of INPUT or INPUT_PULLUP
           mode: INPUT_PULLUP
-          inverted: False
+          inverted: false
 
 Configuration variables:
 ************************

--- a/components/mqtt.rst
+++ b/components/mqtt.rst
@@ -38,10 +38,10 @@ Configuration variables:
 - **client_id** (*Optional*, string): The client id to use for opening
   connections. See :ref:`mqtt-defaults` for more information.
 - **discovery** (*Optional*, boolean): If Home Assistant automatic
-  discovery should be enabled. Defaults to ``True``.
+  discovery should be enabled. Defaults to ``true``.
 - **discovery_retain** (*Optional*, boolean): Whether to retain MQTT
   discovery messages so that entities are added automatically on Home
-  Assistant restart. Defaults to ``True``.
+  Assistant restart. Defaults to ``true``.
 - **discovery_prefix** (*Optional*, string): The prefix to use for Home
   Assistant’s MQTT discovery. Should not contain trailing slash.
   Defaults to ``homeassistant``.
@@ -91,7 +91,7 @@ It is used in several places like last will and birth messages or MQTT log optio
       topic: topic/to/send/to
       payload: online
       qos: 0
-      retain: True
+      retain: true
 
 
 Configuration options:
@@ -103,7 +103,7 @@ Configuration options:
    Service <https://www.hivemq.com/blog/mqtt-essentials-part-6-mqtt-quality-of-service-levels>`__
    level of the topic. Defaults to 0.
 -  **retain** (*Optional*, boolean): If the published message should
-   have a retain flag on or not. Defaults to ``True``.
+   have a retain flag on or not. Defaults to ``true``.
 
 
 The ``log_topic`` has an additional configuration option:
@@ -126,7 +126,7 @@ discovery in your Home Assistant configuration with the following:
     # Example Home Assistant configuration.yaml entry
     mqtt:
       broker: ...
-      discovery: True
+      discovery: true
 
 And that should already be it 🎉 All devices defined through ESPHome should show up automatically
 in the entities section of Home Assistant.
@@ -253,8 +253,8 @@ MQTT can have some overrides for specific options.
 
     name: "Component Name"
     # Optional variables:
-    retain: True
-    discovery: True
+    retain: true
+    discovery: true
     availability:
       topic: livingroom/status
       payload_available: online
@@ -267,7 +267,7 @@ Configuration variables:
 -  **name** (**Required**, string): The name to use for the MQTT
    Component.
 -  **retain** (*Optional*, boolean): If all MQTT state messages should
-   be retained. Defaults to ``True``.
+   be retained. Defaults to ``true``.
 -  **discovery** (*Optional*, boolean): Manually enable/disable
    discovery for a component. Defaults to the global default.
 -  **availability** (*Optional*): Manually set what should be sent to
@@ -447,7 +447,7 @@ Configuration options:
    Service <https://www.hivemq.com/blog/mqtt-essentials-part-6-mqtt-quality-of-service-levels>`__
    level of the topic. Defaults to 0.
 -  **retain** (*Optional*, boolean, :ref:`templatable <config-templatable>`): If the published message should
-   have a retain flag on or not. Defaults to ``False``.
+   have a retain flag on or not. Defaults to ``false``.
 
 
 .. note::
@@ -498,7 +498,7 @@ Configuration options:
    Service <https://www.hivemq.com/blog/mqtt-essentials-part-6-mqtt-quality-of-service-levels>`__
    level of the topic. Defaults to 0.
 -  **retain** (*Optional*, boolean): If the published message should
-   have a retain flag on or not. Defaults to ``False``.
+   have a retain flag on or not. Defaults to ``false``.
 
 
 .. note::

--- a/components/ota.rst
+++ b/components/ota.rst
@@ -21,14 +21,14 @@ Logging+WiFi+OTA are initialized, so that you can upload a new binary.
 
     # Example configuration entry
     ota:
-      safe_mode: True
+      safe_mode: true
       password: VERYSECURE
 
 Configuration variables:
 ------------------------
 
 -  **safe_mode** (*Optional*, boolean): Whether to enable safe mode.
-   Defaults to ``True``.
+   Defaults to ``true``.
 -  **password** (*Optional*, string): The password to use for updates.
 -  **port** (*Optional*, int): The port to use for OTA updates. Defaults
    to ``3232`` for the ESP32 and ``8266`` for the ESP8266.

--- a/components/output/ac_dimmer.rst
+++ b/components/output/ac_dimmer.rst
@@ -62,7 +62,7 @@ Configuration variables:
 
 - **init_with_half_cycle** (*Optional*, boolean): Will send the first full half AC cycle
   Try to use this for dimmable LED lights, it might help turning on at low brightness
-  levels. On Halogen lamps it might show at initial flicker. Defaults to ``False``.
+  levels. On Halogen lamps it might show at initial flicker. Defaults to ``false``.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
 - All other options from :ref:`Output <config-output>`.
 

--- a/components/output/index.rst
+++ b/components/output/index.rst
@@ -26,7 +26,7 @@ Each output platform extends this configuration schema.
       - platform: ...
         id: my_output_id
         power_supply: power_supply_id
-        inverted: False
+        inverted: false
         min_power: 0.01
         max_power: 0.75
 
@@ -38,7 +38,7 @@ Configuration variables:
   this output. When the output is enabled, the power supply will
   automatically be switched on too.
 - **inverted** (*Optional*, boolean): If the output should be treated
-  as inverted. Defaults to ``False``.
+  as inverted. Defaults to ``false``.
 
 Float outputs only:
 

--- a/components/output/mcp4725.rst
+++ b/components/output/mcp4725.rst
@@ -18,7 +18,7 @@ and configurable alternative is ``0x61``.
     i2c:
       sda: 21
       scl: 22
-      scan: True
+      scan: true
 
     # Set the output with default (address: 0x60 / global i2c)
     output:

--- a/components/pcf8574.rst
+++ b/components/pcf8574.rst
@@ -32,7 +32,7 @@ not work.
     pcf8574:
       - id: 'pcf8574_hub'
         address: 0x21
-        pcf8575: False
+        pcf8575: false
 
     # Individual outputs
     switch:
@@ -44,7 +44,7 @@ not work.
           number: 0
           # One of INPUT or OUTPUT
           mode: OUTPUT
-          inverted: False
+          inverted: false
 
 Configuration variables:
 ************************
@@ -52,7 +52,7 @@ Configuration variables:
 - **id** (**Required**, :ref:`config-id`): The id to use for this PCF8574 component.
 - **address** (*Optional*, int): The I²C address of the driver.
   Defaults to ``0x21``.
-- **pcf8575** (*Optional*, boolean): Whether this is a 16-pin PCF8575. Defaults to ``False``.
+- **pcf8575** (*Optional*, boolean): Whether this is a 16-pin PCF8575. Defaults to ``false``.
 
 
 Pin configuration variables:
@@ -61,7 +61,7 @@ Pin configuration variables:
 - **pcf8574** (**Required**, :ref:`config-id`): The id of the PCF8574 component of the pin.
 - **number** (**Required**, integer): The pin number.
 - **inverted** (*Optional*, boolean): If all read and written values
-  should be treated as inverted. Defaults to ``False``.
+  should be treated as inverted. Defaults to ``false``.
 - **mode** (*Optional*, string): A pin mode to set for the pin at. One of ``INPUT`` or ``OUTPUT``.
 
 

--- a/components/remote_receiver.rst
+++ b/components/remote_receiver.rst
@@ -231,7 +231,7 @@ Remote code selection (exactly one of these has to be included):
         remote_receiver:
           pin:
             number: D4
-            inverted: True
+            inverted: true
             mode: INPUT_PULLUP
           dump: all
 

--- a/components/sensor/sgp40.rst
+++ b/components/sensor/sgp40.rst
@@ -26,7 +26,7 @@ Configuration variables:
 - **name** (**Required**, string): The name for the CO₂eq sensor.
 - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.
 - **update_interval** (*Optional*, :ref:`config-time`): The interval to check the sensor. Defaults to ``60s``
-- **store_baseline** (*Optional*, boolean ): Stores and retrieves the baseline information for quicker startups. Defaults to ``True``
+- **store_baseline** (*Optional*, boolean ): Stores and retrieves the baseline information for quicker startups. Defaults to ``true``
 
 - **compensation** (*Optional*): The block containing sensors used for compensation. If not set defaults will be used.
 

--- a/components/sensor/teleinfo.rst
+++ b/components/sensor/teleinfo.rst
@@ -96,7 +96,7 @@ In teleinfo platform:
 
 - **historical_mode** (*Optional*): Whether to use historical mode or standard mode.
   With historical mode, baudrate of 1200 must be used whereas 9600 must be used in
-  standard mode. Defaults to ``False``.
+  standard mode. Defaults to ``false``.
 
 - **update_interval** (*Optional*, :ref:`config-time`): The interval to check the
   sensor. Defaults to ``60s``.

--- a/components/sensor/vl53l0x.rst
+++ b/components/sensor/vl53l0x.rst
@@ -51,7 +51,7 @@ The :ref:`I²C Bus <i2c>` is required to be set up in your configuration for thi
         name: "VL53L0x Distance"
         address: 0x29
         update_interval: 60s
-        long_range: True
+        long_range: true
 
 Configuration variables:
 ------------------------

--- a/components/sn74hc595.rst
+++ b/components/sn74hc595.rst
@@ -40,7 +40,7 @@ Use of the OE pin is optional. If used, the pin should be pulled up externally.
           sn74hc595: sn74hc595_hub
           # Use pin number 0
           number: 0
-          inverted: False
+          inverted: false
 
 Configuration variables:
 ************************
@@ -59,7 +59,7 @@ Pin configuration variables:
 - **sn74hc595** (**Required**, :ref:`config-id`): The id of the SN74HC595 component of the pin.
 - **number** (**Required**, integer): The pin number.
 - **inverted** (*Optional*, boolean): If all written values should be treated as inverted.
-  Defaults to ``False``.
+  Defaults to ``false``.
 
 
 See Also

--- a/components/status_led.rst
+++ b/components/status_led.rst
@@ -38,7 +38,7 @@ Configuration variables:
         status_led:
           pin:
             number: D0
-            inverted: True
+            inverted: true
 
 See Also
 --------

--- a/components/stepper/index.rst
+++ b/components/stepper/index.rst
@@ -79,7 +79,7 @@ Configuration variables:
             # ...
             dir_pin:
               number: D1
-              inverted: True
+              inverted: true
 
 ULN2003 Component
 -----------------

--- a/components/switch/index.rst
+++ b/components/switch/index.rst
@@ -27,7 +27,7 @@ Configuration variables:
   sensor in the frontend.
 - **inverted** (*Optional*, boolean): Whether to invert the binary
   state, i.e. report ON states as OFF and vice versa. Defaults
-  to ``False``.
+  to ``false``.
 - **internal** (*Optional*, boolean): Mark this component as internal. Internal components will
   not be exposed to the frontend (like Home Assistant). Only specifying an ``id`` without
   a ``name`` will implicitly set this to true.

--- a/components/sx1509.rst
+++ b/components/sx1509.rst
@@ -152,7 +152,7 @@ The outputs can in turn be used to add PWM-enabled lights like the monochromatic
           # Use pin number 0 on the SX1509
           number: 0
           mode: INPUT_PULLUP
-          inverted: True
+          inverted: true
 
     # Individual binary outputs
     switch:
@@ -164,7 +164,7 @@ The outputs can in turn be used to add PWM-enabled lights like the monochromatic
           number: 1
           # use as output for switch
           mode: OUTPUT
-          inverted: False
+          inverted: false
 
     # Individual outputs
     output:
@@ -185,7 +185,7 @@ The outputs can in turn be used to add PWM-enabled lights like the monochromatic
 - **sx1509** (**Required**, :ref:`config-id`): The id of the SX1509 component of the pin.
 - **number** (**Required**, integer): The pin number.
 - **inverted** (*Optional*, boolean): If all read and written values
-  should be treated as inverted. Defaults to ``False``.
+  should be treated as inverted. Defaults to ``false``.
 - **mode** (*Optional*, string): A pin mode to set for the pin at. One of ``INPUT``,
   ``INPUT_PULLUP`` or ``OUTPUT``.
 

--- a/components/tca9548a.rst
+++ b/components/tca9548a.rst
@@ -27,7 +27,7 @@ Once configured, you can use any of the 8 channels (TCA9548A) as separated chann
       - address: 0x70
         id: multiplex0
         i2c_id: i2c0
-        scan: True
+        scan: true
 
     # Individual I2C Devices
     sensor:

--- a/components/text_sensor/version.rst
+++ b/components/text_sensor/version.rst
@@ -23,7 +23,7 @@ Configuration variables:
 ------------------------
 
 - **name** (**Required**, string): The name of the text sensor.
-- **hide_timestamp** (*Optional*, boolean): Allows you to hide the compilation timestamp from the version string. Defaults to ``False``.
+- **hide_timestamp** (*Optional*, boolean): Allows you to hide the compilation timestamp from the version string. Defaults to ``false``.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
 - All other options from :ref:`Text Sensor <config-text_sensor>`.
 
@@ -36,7 +36,7 @@ Disabling the compilation timestamp:
     text_sensor:
       - platform: version
         name: "ESPHome Version"
-        hide_timestamp: True
+        hide_timestamp: true
 
 This will, for example, change the output of the senser from:
 

--- a/components/uart.rst
+++ b/components/uart.rst
@@ -54,7 +54,7 @@ Configuration variables:
 
 ESP32 options:
 
-- **invert** (*Optional*, boolean): Invert the logic levels of the RX and TX pins. Options: ``True`` or ``False``. Defaults to ``False``.
+- **invert** (*Optional*, boolean): Invert the logic levels of the RX and TX pins. Options: ``true`` or ``false``. Defaults to ``false``.
 
 .. _uart-hardware_uarts:
 

--- a/cookbook/brilliant-mirabella-genio-smart-plugs.rst
+++ b/cookbook/brilliant-mirabella-genio-smart-plugs.rst
@@ -254,7 +254,7 @@ which these adaptions created by `@cryptelli <https://community.home-assistant.i
       - platform: gpio
         pin:
           number: GPIO3
-          inverted: True
+          inverted: true
         name: "Power Button"
         on_press:
           - switch.toggle: relay
@@ -277,7 +277,7 @@ which these adaptions created by `@cryptelli <https://community.home-assistant.i
       - platform: hlw8012
         sel_pin:
           number: GPIO12
-          inverted: True
+          inverted: true
         cf_pin: GPIO04
         cf1_pin: GPIO05
         current_resistor: 0.00221
@@ -381,7 +381,7 @@ Check the following page for calibrating the measurements: :ref:`sensor-filter-c
       - platform: gpio
         pin:
           number: GPIO0
-          inverted: True
+          inverted: true
         name: "${plug_name}_button"
         on_press:
           - switch.toggle: relay
@@ -390,7 +390,7 @@ Check the following page for calibrating the measurements: :ref:`sensor-filter-c
       - platform: gpio
         name: "${plug_name}_LED_Red"
         pin: GPIO13
-        inverted: True
+        inverted: true
         restore_mode: ALWAYS_OFF
         id: red_led
 
@@ -410,7 +410,7 @@ Check the following page for calibrating the measurements: :ref:`sensor-filter-c
       - platform: hlw8012
         sel_pin:
           number: GPIO12
-          inverted: True
+          inverted: true
         cf_pin: GPIO04
         cf1_pin: GPIO05
         current_resistor: ${current_res}

--- a/cookbook/display_time_temp_oled.rst
+++ b/cookbook/display_time_temp_oled.rst
@@ -102,7 +102,7 @@ Note your ``address`` and ``model`` might be different, use the scan option to f
     i2c:
       sda: D1
       scl: D2
-      scan: False
+      scan: false
 
     display:
       - platform: ssd1306_i2c

--- a/cookbook/ifan02.rst
+++ b/cookbook/ifan02.rst
@@ -79,7 +79,7 @@ Then you need to set it up with yaml.
         id: vbutton_light
         pin:
           number: GPIO0
-          inverted: True
+          inverted: true
         on_press:
           then:
             - light.toggle: ifan02_light
@@ -88,7 +88,7 @@ Then you need to set it up with yaml.
         id: vbutton_relay_1
         pin:
           number: GPIO9
-          inverted: True
+          inverted: true
         on_press:
           then:
             - switch.toggle: fan_relay1
@@ -98,7 +98,7 @@ Then you need to set it up with yaml.
         id: vbutton_relay_2
         pin:
           number: GPIO10
-          inverted: True
+          inverted: true
         on_press:
           then:
             - switch.toggle: fan_relay2
@@ -108,7 +108,7 @@ Then you need to set it up with yaml.
         id: vbutton_relay_3
         pin:
           number: GPIO14
-          inverted: True
+          inverted: true
         on_press:
           then:
             - switch.toggle: fan_relay3
@@ -137,7 +137,7 @@ Then you need to set it up with yaml.
     switch:
       - platform: template
         id: update_fan_speed
-        optimistic: True
+        optimistic: true
         turn_on_action:
           then:
             - delay: 200ms

--- a/cookbook/leak-detector-m5stickC.rst
+++ b/cookbook/leak-detector-m5stickC.rst
@@ -89,7 +89,7 @@ I also needed this procedure to flash M5Stack ATOM Lite and ATOM Matrix modules,
 Calibration & Testing
 =====================
 
-Once everything is hooked up and flashed, enable ``esp32_touch:`` ``setup_mode: True`` and proceed to adjust the threshold setting on the touch-sensitive binary sensor (GPIO33) to find the proper value for your particular moisture sensor and cabling situation.  Grab a glass of water for testing, another for yourself, and dip away while watching the logs.  Your goal is to find a threshold value that is sufficient to trigger the binary sensor in water, but not otherwise.  See :ref:`ESP32 Touch Pad <esp32-touch-binary-sensor>` for more information.
+Once everything is hooked up and flashed, enable ``esp32_touch:`` ``setup_mode: true`` and proceed to adjust the threshold setting on the touch-sensitive binary sensor (GPIO33) to find the proper value for your particular moisture sensor and cabling situation.  Grab a glass of water for testing, another for yourself, and dip away while watching the logs.  Your goal is to find a threshold value that is sufficient to trigger the binary sensor in water, but not otherwise.  See :ref:`ESP32 Touch Pad <esp32-touch-binary-sensor>` for more information.
 
 ------------
 
@@ -161,7 +161,7 @@ ESPHome configuration
     status_led:
       pin:
         number: GPIO10
-        inverted: True
+        inverted: true
 
     spi:
       clk_pin: GPIO13
@@ -171,10 +171,10 @@ ESPHome configuration
        - id: bus_a
          sda: GPIO21
          scl: GPIO22
-         scan: True
+         scan: true
 
     esp32_touch:
-      #setup_mode: True
+      #setup_mode: true
       iir_filter: 10ms
 
     binary_sensor:

--- a/cookbook/sonoff-basic-light-switch.rst
+++ b/cookbook/sonoff-basic-light-switch.rst
@@ -118,7 +118,7 @@ Now you have a pair of wires from the GPIO and 0V to your retractive switch lets
         pin:
           number: GPIO14
           mode: INPUT_PULLUP
-          inverted: True
+          inverted: true
         id: button_1
         on_press:
           then:

--- a/cookbook/sonoff-dual-light-switch.rst
+++ b/cookbook/sonoff-dual-light-switch.rst
@@ -98,7 +98,7 @@ The R1 version of the Dual controls the relays via the UART, so the code gets a 
         pin:
           number: GPIO4
           mode: INPUT_PULLUP
-          inverted: True
+          inverted: true
         id: button_1
         on_press:
           then:
@@ -108,7 +108,7 @@ The R1 version of the Dual controls the relays via the UART, so the code gets a 
         pin:
           number: GPIO14
           mode: INPUT_PULLUP
-          inverted: True
+          inverted: true
         id: button_2
         on_press:
           then:
@@ -197,7 +197,7 @@ It's basically the same as the :doc:`T2 </cookbook/sonoff-t1-3>`
         pin:
           number: GPIO0
           mode: INPUT_PULLUP
-          inverted: True
+          inverted: true
         id: button
         on_press:
           then:
@@ -207,7 +207,7 @@ It's basically the same as the :doc:`T2 </cookbook/sonoff-t1-3>`
         pin:
           number: GPIO14
           mode: INPUT_PULLUP
-          inverted: True
+          inverted: true
         id: button
         on_press:
           then:

--- a/cookbook/sonoff-t1-3.rst
+++ b/cookbook/sonoff-t1-3.rst
@@ -37,7 +37,7 @@ T1
         pin:
           number: GPIO0
           mode: INPUT_PULLUP
-          inverted: True
+          inverted: true
         id: button_1
         on_press:
           then:
@@ -100,7 +100,7 @@ T2
         pin:
           number: GPIO0
           mode: INPUT_PULLUP
-          inverted: True
+          inverted: true
         id: button_1
         on_press:
           then:
@@ -110,7 +110,7 @@ T2
         pin:
           number: GPIO9
           mode: INPUT_PULLUP
-          inverted: True
+          inverted: true
         id: button_2
         on_press:
           then:
@@ -171,7 +171,7 @@ T3
         pin:
           number: GPIO0
           mode: INPUT_PULLUP
-          inverted: True
+          inverted: true
         id: button_1
         on_press:
           then:
@@ -181,7 +181,7 @@ T3
         pin:
           number: GPIO9
           mode: INPUT_PULLUP
-          inverted: True
+          inverted: true
         id: button_2
         on_press:
           then:
@@ -191,7 +191,7 @@ T3
         pin:
           number: GPIO10
           mode: INPUT_PULLUP
-          inverted: True
+          inverted: true
         id: button_3
         on_press:
           then:

--- a/devices/sonoff_4ch.rst
+++ b/devices/sonoff_4ch.rst
@@ -244,25 +244,25 @@ of the basic functions.
         pin:
           number: GPIO0
           mode: INPUT_PULLUP
-          inverted: True
+          inverted: true
         name: "Sonoff 4CH Button 1"
       - platform: gpio
         pin:
           number: GPIO9
           mode: INPUT_PULLUP
-          inverted: True
+          inverted: true
         name: "Sonoff 4CH Button 2"
       - platform: gpio
         pin:
           number: GPIO10
           mode: INPUT_PULLUP
-          inverted: True
+          inverted: true
         name: "Sonoff 4CH Button 3"
       - platform: gpio
         pin:
           number: GPIO14
           mode: INPUT_PULLUP
-          inverted: True
+          inverted: true
         name: "Sonoff 4CH Button 4"
       - platform: status
         name: "Sonoff 4CH Status"
@@ -286,7 +286,7 @@ of the basic functions.
       - platform: esp8266_pwm
         id: blue_led
         pin: GPIO13
-        inverted: True
+        inverted: true
 
     light:
       # ... and then make a light out of it.

--- a/devices/sonoff_4ch.yaml
+++ b/devices/sonoff_4ch.yaml
@@ -18,7 +18,7 @@ binary_sensor:
   pin:
     number: GPIO0
     mode: INPUT_PULLUP
-    inverted: True
+    inverted: true
   name: "Sonoff 4CH Button 1"
   on_press:
     - switch.toggle: relay_1
@@ -26,7 +26,7 @@ binary_sensor:
   pin:
     number: GPIO9
     mode: INPUT_PULLUP
-    inverted: True
+    inverted: true
   name: "Sonoff 4CH Button 2"
   on_press:
     - switch.toggle: relay_2
@@ -34,7 +34,7 @@ binary_sensor:
   pin:
     number: GPIO10
     mode: INPUT_PULLUP
-    inverted: True
+    inverted: true
   name: "Sonoff 4CH Button 3"
   on_press:
     - switch.toggle: relay_3
@@ -42,7 +42,7 @@ binary_sensor:
   pin:
     number: GPIO14
     mode: INPUT_PULLUP
-    inverted: True
+    inverted: true
   name: "Sonoff 4CH Button 4"
   on_press:
     - switch.toggle: relay_4
@@ -71,7 +71,7 @@ output:
 - platform: esp8266_pwm
   id: blue_led
   pin: GPIO13
-  inverted: True
+  inverted: true
 
 light:
 - platform: monochromatic

--- a/devices/sonoff_basic.rst
+++ b/devices/sonoff_basic.rst
@@ -72,7 +72,7 @@ exposes all of the basic functions.
         pin:
           number: GPIO0
           mode: INPUT_PULLUP
-          inverted: True
+          inverted: true
         name: "Sonoff Basic Button"
         on_press:
           - switch.toggle: relay

--- a/devices/sonoff_s20.rst
+++ b/devices/sonoff_s20.rst
@@ -226,7 +226,7 @@ of the basic functions.
         pin:
           number: GPIO0
           mode: INPUT_PULLUP
-          inverted: True
+          inverted: true
         name: "Sonoff S20 Button"
       - platform: status
         name: "Sonoff S20 Status"
@@ -246,7 +246,7 @@ of the basic functions.
         id: s20_green_led
         pin:
           number: GPIO13
-          inverted: True
+          inverted: true
 
     light:
       # ... and then make a light out of it.
@@ -275,7 +275,7 @@ in Home Assistant, replace the last part with this:
         id: s20_green_led
         pin:
           number: GPIO13
-          inverted: True
+          inverted: true
       # Note: do *not* make the relay a dimmable (PWM) signal, relays cannot handle that
       - platform: gpio
         id: s20_relay

--- a/devices/sonoff_s20.yaml
+++ b/devices/sonoff_s20.yaml
@@ -19,7 +19,7 @@ binary_sensor:
   pin:
     number: GPIO0
     mode: INPUT_PULLUP
-    inverted: True
+    inverted: true
   name: "Sonoff S20 Button"
   on_press:
     - switch.toggle: relay
@@ -37,7 +37,7 @@ output:
 - platform: esp8266_pwm
   id: s20_green_led
   pin: GPIO13
-  inverted: True
+  inverted: true
 
 light:
 - platform: monochromatic

--- a/devices/sonoff_t1_uk_3gang_v1.1.rst
+++ b/devices/sonoff_t1_uk_3gang_v1.1.rst
@@ -247,19 +247,19 @@ of the basic functions.
         pin:
           number: GPIO0
           mode: INPUT_PULLUP
-          inverted: True
+          inverted: true
         name: "Sonoff T1 UK 3 Gang Touchpad 1"
       - platform: gpio
         pin:
           number: GPIO9
           mode: INPUT_PULLUP
-          inverted: True
+          inverted: true
         name: "Sonoff T1 UK 3 Gang Touchpad 2"
       - platform: gpio
         pin:
           number: GPIO10
           mode: INPUT_PULLUP
-          inverted: True
+          inverted: true
         name: "Sonoff T1 UK 3 Gang Touchpad 3"
       - platform: status
         name: "Sonoff T1 UK 3 Gang Status"
@@ -280,7 +280,7 @@ of the basic functions.
       - platform: esp8266_pwm
         id: blue_led
         pin: GPIO13
-        inverted: True
+        inverted: true
 
     light:
       # ... and then make a light out of it.

--- a/devices/sonoff_t1_uk_3gang_v1.1.yaml
+++ b/devices/sonoff_t1_uk_3gang_v1.1.yaml
@@ -25,7 +25,7 @@ binary_sensor:
     pin:
       number: GPIO0
       mode: INPUT_PULLUP
-      inverted: True
+      inverted: true
     name: "Sonoff T1 UK 3 Gang Touchpad 1"
     on_press:
       - switch.toggle: relay_1
@@ -33,7 +33,7 @@ binary_sensor:
     pin:
       number: GPIO9
       mode: INPUT_PULLUP
-      inverted: True
+      inverted: true
     name: "Sonoff T1 UK 3 Gang Touchpad 2"
     on_press:
       - switch.toggle: relay_2
@@ -41,7 +41,7 @@ binary_sensor:
     pin:
       number: GPIO10
       mode: INPUT_PULLUP
-      inverted: True
+      inverted: true
     name: "Sonoff T1 UK 3 Gang Touchpad 3"
     on_press:
       - switch.toggle: relay_3
@@ -67,7 +67,7 @@ output:
   - platform: esp8266_pwm
     id: blue_led
     pin: GPIO13
-    inverted: True
+    inverted: true
 
 light:
   # ... and then make a light out of it.

--- a/devices/sonoff_t3_eu_3gang_v1.0.rst
+++ b/devices/sonoff_t3_eu_3gang_v1.0.rst
@@ -251,19 +251,19 @@ of the basic functions.
         pin:
           number: GPIO0
           mode: INPUT_PULLUP
-          inverted: True
+          inverted: true
         name: "Sonoff T3 EU 3 Gang Touchpad 1"
       - platform: gpio
         pin:
           number: GPIO9
           mode: INPUT_PULLUP
-          inverted: True
+          inverted: true
         name: "Sonoff T3 EU 3 Gang Touchpad 2"
       - platform: gpio
         pin:
           number: GPIO10
           mode: INPUT_PULLUP
-          inverted: True
+          inverted: true
         name: "Sonoff T3 EU 3 Gang Touchpad 3"
       - platform: status
         name: "Sonoff T3 EU 3 Gang Status"
@@ -284,7 +284,7 @@ of the basic functions.
       - platform: esp8266_pwm
         id: blue_led
         pin: GPIO13
-        inverted: True
+        inverted: true
 
     light:
       # ... and then make a light out of it.

--- a/devices/sonoff_t3_eu_3gang_v1.0.yaml
+++ b/devices/sonoff_t3_eu_3gang_v1.0.yaml
@@ -25,7 +25,7 @@ binary_sensor:
     pin:
       number: GPIO0
       mode: INPUT_PULLUP
-      inverted: True
+      inverted: true
     name: "Sonoff T3 EU 3 Gang Touchpad 1"
     on_press:
       - switch.toggle: relay_1
@@ -33,7 +33,7 @@ binary_sensor:
     pin:
       number: GPIO9
       mode: INPUT_PULLUP
-      inverted: True
+      inverted: true
     name: "Sonoff T3 EU 3 Gang Touchpad 2"
     on_press:
       - switch.toggle: relay_2
@@ -41,7 +41,7 @@ binary_sensor:
     pin:
       number: GPIO10
       mode: INPUT_PULLUP
-      inverted: True
+      inverted: true
     name: "Sonoff T3 EU 3 Gang Touchpad 3"
     on_press:
       - switch.toggle: relay_3
@@ -67,7 +67,7 @@ output:
   - platform: esp8266_pwm
     id: blue_led
     pin: GPIO13
-    inverted: True
+    inverted: true
 
 light:
   # ... and then make a light out of it.

--- a/devices/teckin.yaml
+++ b/devices/teckin.yaml
@@ -22,7 +22,7 @@ binary_sensor:
     pin:
       number: GPIO1
       mode: INPUT_PULLUP
-      inverted: True
+      inverted: true
     on_press:
       - switch.toggle: relay
 
@@ -31,7 +31,7 @@ switch:
   id: blue_led
   pin:
     number: GPIO13
-    inverted: True
+    inverted: true
 - platform: gpio
   name: "Teckin Relay"
   pin: GPIO14
@@ -45,13 +45,13 @@ switch:
 status_led:
   pin:
     number: GPIO3
-    inverted: True
+    inverted: true
 
 sensor:
   - platform: hlw8012
     sel_pin:
       number: GPIO12
-      inverted: True
+      inverted: true
     cf_pin: GPIO04
     cf1_pin: GPIO05
     # Higher value gives lower watt readout

--- a/devices/teckin_sp20_us.yaml
+++ b/devices/teckin_sp20_us.yaml
@@ -30,7 +30,7 @@ sensor:
   - platform: hlw8012
     sel_pin:
       number: GPIO12
-      inverted: True
+      inverted: true
     cf_pin: GPIO5
     cf1_pin: GPIO14
     current:
@@ -64,7 +64,7 @@ time:
 status_led:
   pin:
     number: GPIO0   # Red LED
-    inverted: True
+    inverted: true
 
 binary_sensor:
   - platform: gpio
@@ -73,14 +73,14 @@ binary_sensor:
     name: ${friendly_name} Button
     on_press:
       - switch.toggle: relay
-    internal: True
+    internal: true
 
 switch:
   - platform: gpio
     id: blue_led
     pin:
       number: GPIO2
-      inverted: True
+      inverted: true
     
   - platform: gpio
     pin: GPIO4

--- a/guides/configuration-types.rst
+++ b/guides/configuration-types.rst
@@ -74,14 +74,14 @@ In some places, ESPHome also supports a more advanced “pin schema”.
       # Advanced:
       pin:
         number: D0
-        inverted: True
+        inverted: true
         mode: INPUT_PULLUP
 
 Configuration variables:
 
 -  **number** (**Required**, pin): The pin number.
 -  **inverted** (*Optional*, boolean): If all read and written values
-   should be treated as inverted. Defaults to ``False``.
+   should be treated as inverted. Defaults to ``false``.
 -  **mode** (*Optional*, string): A pin mode to set for the pin at
    startup, corresponds to Arduino’s ``pinMode`` call.
 
@@ -326,7 +326,7 @@ merged with the services definitions from main config file.
     i2c:
       sda: GPIO21
       scl: GPIO22
-      scan: True
+      scan: true
       frequency: 100kHz
 
     # Enable logging

--- a/guides/getting_started_command_line.rst
+++ b/guides/getting_started_command_line.rst
@@ -126,7 +126,7 @@ Sensor </components/binary_sensor/gpio>`.
         name: "Living Room Window"
         pin:
           number: 16
-          inverted: True
+          inverted: true
           mode: INPUT_PULLUP
 
 This is an advanced feature of ESPHome. Almost all pins can

--- a/guides/getting_started_hassio.rst
+++ b/guides/getting_started_hassio.rst
@@ -132,7 +132,7 @@ Sensor </components/binary_sensor/gpio>`.
         name: "Living Room Window"
         pin:
           number: 16
-          inverted: True
+          inverted: true
           mode: INPUT_PULLUP
 
 This time when installing, you don’t need to have the device plugged in


### PR DESCRIPTION
## Description:

Consequently use lowercase true/false instead of True/False for YAML fragments.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
