### PR TITLE
Mark required fields for endstop cover as required

### DIFF
--- a/components/cover/endstop.rst
+++ b/components/cover/endstop.rst
@@ -15,7 +15,7 @@ controlling the cover. The user just needs to enter what to do when the platform
 cover in either direction, or stop it, as well as information about open and close information so that
 the current position can be approximated.
 
-Additionally, open and close durations can be specified to allow ESPHome to approximate the
+Additionally, open and close durations must be specified to allow ESPHome to approximate the
 current position of the cover.
 
 .. figure:: images/more-info-ui.png
@@ -55,7 +55,7 @@ Configuration variables:
 - **open_endstop** (**Required**, :ref:`config-id`): The ID of the
   :ref:`Binary Sensor <config-binary_sensor>` that turns on when the open position is reached.
 
-- **close_action** (*Optional*, :ref:`Action <config-action>`): The action that should
+- **close_action** (**Required**, :ref:`Action <config-action>`): The action that should
   be performed when the remote requests the cover to be closed.
 - **close_duration** (**Required**, :ref:`config-time`): The amount of time it takes the cover
   to close from the fully-open state.


### PR DESCRIPTION
## Description:

These fields are actually required: https://github.com/esphome/esphome/blob/dev/esphome/components/endstop/cover.py#L22

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
