### PR TITLE
Replace State with Position for Covers

### DIFF
--- a/components/cover/index.rst
+++ b/components/cover/index.rst
@@ -128,7 +128,6 @@ Configuration variables:
 
 - **id** (**Required**, :ref:`config-id`): The cover to control.
 - **stop** (*Optional*, boolean): Whether to stop the cover.
-- **state** (*Optional*, string): The state to set the cover to - one of ``OPEN`` or ``CLOSE``.
 - **position** (*Optional*, float): The cover position to set.
 
   - ``0.0`` = ``0%`` = ``CLOSED``
@@ -164,11 +163,11 @@ advanced stuff.
       id(my_cover).publish_state(COVER_OPEN);
       id(my_cover).publish_state(COVER_CLOSED);
 
-- ``state``: Retrieve the current state of the cover.
+- ``position``: Retrieve the current position of the cover.
 
   .. code-block:: yaml
 
-      if (id(my_cover).state == COVER_OPEN) {
+      if (id(my_cover).position == COVER_OPEN) {
         // Cover is open
       } else {
         // Cover is closed

--- a/components/cover/index.rst
+++ b/components/cover/index.rst
@@ -128,6 +128,7 @@ Configuration variables:
 
 - **id** (**Required**, :ref:`config-id`): The cover to control.
 - **stop** (*Optional*, boolean): Whether to stop the cover.
+- **state** (*Optional*, string): The state to set the cover to - one of ``OPEN`` or ``CLOSE``.
 - **position** (*Optional*, float): The cover position to set.
 
   - ``0.0`` = ``0%`` = ``CLOSED``

--- a/components/cover/template.rst
+++ b/components/cover/template.rst
@@ -102,8 +102,10 @@ with the ``cover.template.publish`` action.
 Configuration options:
 
 - **id** (**Required**, :ref:`config-id`): The ID of the template cover.
+- **state** (*Optional*, :ref:`templatable <config-templatable>`):
+  The state to publish. One of ``OPEN``, ``CLOSED``. If using a lambda, use ``COVER_OPEN`` or ``COVER_CLOSED``.
 - **position** (*Optional*, :ref:`templatable <config-templatable>`, float):
-  The position to publish, from 0 (CLOSED) to 1.0 (OPEN). If using a lambda, use ``COVER_OPEN`` or ``COVER_CLOSED``.
+  The position to publish, from 0 (CLOSED) to 1.0 (OPEN)
 - **tilt** (*Optional*, :ref:`templatable <config-templatable>`, float):
   The tilt position to publish, from 0 (CLOSED) to 1.0 (OPEN)
 - **current_operation** (*Optional*, :ref:`templatable <config-templatable>`, string):

--- a/components/cover/template.rst
+++ b/components/cover/template.rst
@@ -92,12 +92,12 @@ with the ``cover.template.publish`` action.
     on_...:
       - cover.template.publish:
           id: template_cov
-          position: OPEN
+          state: OPEN
 
       # Templated
       - cover.template.publish:
           id: template_cov
-          position: !lambda 'return COVER_OPEN;'
+          state: !lambda 'return COVER_OPEN;'
 
 Configuration options:
 

--- a/components/cover/template.rst
+++ b/components/cover/template.rst
@@ -92,20 +92,18 @@ with the ``cover.template.publish`` action.
     on_...:
       - cover.template.publish:
           id: template_cov
-          state: OPEN
+          position: OPEN
 
       # Templated
       - cover.template.publish:
           id: template_cov
-          state: !lambda 'return COVER_OPEN;'
+          position: !lambda 'return COVER_OPEN;'
 
 Configuration options:
 
 - **id** (**Required**, :ref:`config-id`): The ID of the template cover.
-- **state** (*Optional*, :ref:`templatable <config-templatable>`):
-  The state to publish. One of ``OPEN``, ``CLOSED``. If using a lambda, use ``COVER_OPEN`` or ``COVER_CLOSED``.
 - **position** (*Optional*, :ref:`templatable <config-templatable>`, float):
-  The position to publish, from 0 (CLOSED) to 1.0 (OPEN)
+  The position to publish, from 0 (CLOSED) to 1.0 (OPEN). If using a lambda, use ``COVER_OPEN`` or ``COVER_CLOSED``.
 - **tilt** (*Optional*, :ref:`templatable <config-templatable>`, float):
   The tilt position to publish, from 0 (CLOSED) to 1.0 (OPEN)
 - **current_operation** (*Optional*, :ref:`templatable <config-templatable>`, string):


### PR DESCRIPTION
## Description:
The use of state for covers was deprecated and has now been remove in v1.20.0. This updates the documentation to align with that change.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [X] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
