### PR TITLE
Fix AS3935 I²C address documentation

### DIFF
--- a/components/sensor/as3935.rst
+++ b/components/sensor/as3935.rst
@@ -129,7 +129,7 @@ Configuration variables:
 
 
 - **address** (*Optional*, int): Manually specify the I²C address of
-  the sensor. Defaults to ``0x03`` (``A0`` and ``A1`` pins pulled **high**).
+  the sensor. Defaults to ``0x03`` (``A0`` and ``A1`` pins pulled high).
   The address is made up using the state of ``A0`` as bit 1 and the state of ``A1`` as bit 2, so a total of four addresses is possible.
 - **irq_pin** (**Required**, :ref:`config-pin`): The IRQ pin, which indicates if a lightning strike has been detected.
 - **indoor** (*Optional*, boolean): Indicates if the sensor is used indoor. Defaults to ``true``.

--- a/components/sensor/as3935.rst
+++ b/components/sensor/as3935.rst
@@ -129,8 +129,8 @@ Configuration variables:
 
 
 - **address** (*Optional*, int): Manually specify the I²C address of
-  the sensor. Defaults to ``0x03`` (``A0` and ``A1`` pins pulled low).
-  Another address can be ``0x02``.
+  the sensor. Defaults to ``0x03`` (``A0`` and ``A1`` pins pulled **high**).
+  The address is made up using the state of ``A0`` as bit 1 and the state of ``A1`` as bit 2, so a total of four addresses is possible.
 - **irq_pin** (**Required**, :ref:`config-pin`): The IRQ pin, which indicates if a lightning strike has been detected.
 - **indoor** (*Optional*, boolean): Indicates if the sensor is used indoor. Defaults to ``true``.
 - **noise_level** (*Optional*, integer): Noise floor level is compared to known reference voltage.


### PR DESCRIPTION
## Description:

There is a formatting typo (one backtick is missing) and the direction of pulling `A0`/`A1` is the wrong way around. According to the datasheet page 17, section 8.5:

> The device addresses for the AS3935 in read or write mode are defined by:
> 0-0-0-0-0-a1-a0-0: write mode device address (DW)
> 0-0-0-0-0-a1-a0-1: read mode device address (DR)
> Where a0 and a1 are defined by the pins 5 (ADD0) and 6 (ADD1).

On my GY-AS3935 breakout board `A0` and `A1` are pulled **high** and thus the write address becomes `0b00000110`, the read address `0b00000111`.

**Related issue (if applicable):** not applicable

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** not applicable

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
