### PR TITLE
Add documentation for deassert_rts_dtr option

### DIFF
--- a/components/logger.rst
+++ b/components/logger.rst
@@ -43,7 +43,7 @@ Advanced settings:
 -  **deassert_rts_dtr** (*Optional*, boolean): Deasserts RTS/DTR when opening
    log over UART. This is useful if RTS/DTR signals are directly connected to
    the reset pin or strapping pins. Note: Deassert typically means high on TTL
-   level since RTS/DTR are usually low active signals.
+   level since RTS/DTR are usually low active signals. Defaults to ``false``.
 
 .. _logger-hardware_uarts:
 

--- a/components/logger.rst
+++ b/components/logger.rst
@@ -40,6 +40,10 @@ Advanced settings:
 -  **on_message** (*Optional*, :ref:`Automation <automation>`): An action to be
    performed when a message is to be looged. The vairables ``int level``, ``const char* tag`` and
    ``const char* message`` are available for lambda processing.
+-  **deassert_rts_dtr** (*Optional*, boolean): Deasserts RTS/DTR when opening
+   log over UART. This is useful if RTS/DTR signals are directly connected to
+   the reset pin or strapping pins. Note: Deassert typically means high on TTL
+   level since RTS/DTR are usually low active signals.
 
 .. _logger-hardware_uarts:
 


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes esphome/issues#1382

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#2089

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
