### PR TITLE
Replace Color::BLACK by COLOR_BLACK

### DIFF
--- a/components/light/index.rst
+++ b/components/light/index.rst
@@ -798,7 +798,7 @@ Available variables in the lambda:
               it[0] = Color::random_color();
 
               // Bonus: use .range() and .all() to set many LEDs without having to write a loop.
-              it.range(0, 50) = Color::BLACK;
+              it.range(0, 50) = COLOR_BLACK;
               it.all().fade_to_black(10);
 
 .. code-block:: yaml
@@ -822,7 +822,7 @@ Available variables in the lambda:
               // again you can use the initial_run variables
               if (initial_run) {
                 progress = 0;
-                it.all() = Color::BLACK;
+                it.all() = COLOR_BLACK;
                 // optionally do a return so nothing happens until the next update_interval
                 return;
               }


### PR DESCRIPTION
Color::BLACK does not exist, haven't checked `random_color()`

## Description:

`Color::BLACK` does somehow not exist

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
