### PR TITLE
Improve documentation with information about modbus_id variable

### DIFF
--- a/components/sensor/pzemac.rst
+++ b/components/sensor/pzemac.rst
@@ -27,7 +27,7 @@ for more information.
     This page refers to version V3 of the PZEM004T.
     For using the older V1 variant of this sensor please see :doc:`pzem004t <pzem004t>`.
 
-The communication with this integration is done over a :ref:`UART bus <uart>`.
+The communication with this integration is done over a :ref:`UART bus <uart>` using :ref:`Modbus <modbus>`.
 You must therefore have a ``uart:`` entry in your configuration with both the TX and RX pins set
 to some pins on your board and the baud rate set to 9600.
 
@@ -38,6 +38,8 @@ to some pins on your board and the baud rate set to 9600.
       rx_pin: D1
       tx_pin: D2
       baud_rate: 9600
+      
+    modbus:
 
     sensor:
       - platform: pzemac
@@ -74,6 +76,7 @@ Configuration variables:
   sensor. Defaults to ``60s``.
 - **address** (*Optional*, int): The address of the sensor if multiple sensors are attached to
   the same UART bus. You will need to set the address of each device manually. Defaults to ``1``.
+- **modbus_id** (*Optional*, :ref:`config-id`): Manually specify the ID of the Modbus hub.
 
 See Also
 --------


### PR DESCRIPTION
Improve documentation with information about modbus_id variable

## Description:


**Related issue (if applicable):** [#1896](https://github.com/esphome/issues/issues/1896)

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
