### PR TITLE
Add status_led light platform

### DIFF
--- a/components/light/status_led.rst
+++ b/components/light/status_led.rst
@@ -1,0 +1,50 @@
+Status Led Light
+================
+
+.. seo::
+    :description: Instructions for setting up a Status Led shared also as binary ON/OFF light in ESPHome.
+    :image: led-on.png
+
+The ``status_led`` light platform allows to share a single led for indicating the status of
+the device (when on error/warning state) or as binary light (when on OK state). 
+This is useful for devices with only one led available.
+
+It provides the combined functionality of :doc:`status_led component </components/status_led>` and a 
+:doc:`binary light component </components/light/binary>` over a single shared GPIO led. 
+
+When the device is on error/warning state, the function of ``status_led`` will take precedence and control the blinking of the led.
+When the device is in OK state, the led will be restored to the state of the ``binary light`` function and can be controlled as such.
+
+.. code-block:: yaml
+
+    # Example configuration entry
+    light:
+      - platform: status_led
+        name: "Switch state"
+        pin: GPIO2
+
+.. note::
+
+    When using this platform the high level ``status_led`` component should not be included (at least over the same pin),
+    as its functionality is directly provided by this platform. 
+
+    The only difference is that the platform won't be loaded in OTA safe mode, while the component would be.
+
+Configuration variables:
+------------------------
+
+- **name** (**Required**, string): The name of the light.
+- **pin** (**Required**, :ref:`Pin Schema <config-pin_schema>`): The GPIO pin to operate the LED on.
+- **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
+- **effects** (*Optional*, list): A list of :ref:`light effects <light-effects>` to use for this light, though binary lights
+  only support very few of them.
+- All other options from :ref:`Light <config-light>`.
+
+See Also
+--------
+
+- :doc:`/components/status_led`
+- :doc:`/components/light/binary`
+- :doc:`/components/light/index`
+- :apiref:`status_led/light/status_led_light.h`
+- :ghedit:`Edit`

--- a/components/status_led.rst
+++ b/components/status_led.rst
@@ -21,6 +21,10 @@ the device. Specifically, it will:
     status_led:
       pin: GPIO2
 
+.. note::
+
+    If your device has a single led that needs to be shared use  :doc:`status_led light platform </components/light/status_led>` instead.
+
 Configuration variables:
 ------------------------
 
@@ -43,5 +47,6 @@ Configuration variables:
 See Also
 --------
 
+- :doc:`/components/light/status_led`
 - :apiref:`status_led/status_led.h`
 - :ghedit:`Edit`

--- a/index.rst
+++ b/index.rst
@@ -302,6 +302,7 @@ Light Components
 
     Light Core, components/light/index, folder-open.svg
     Binary Light, components/light/binary, lightbulb.svg
+    Status Led, components/light/status_led, led-on.svg
     Monochromatic Light, components/light/monochromatic, brightness-medium.svg
 
     Cold+Warm White Light, components/light/cwww, brightness-medium.svg


### PR DESCRIPTION
## Description:
Add documentation for new `status_led` light platform


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#1974

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
