### PR TITLE
Add note about uart parity on 1.21.0 and above

### DIFF
--- a/components/uart.rst
+++ b/components/uart.rst
@@ -32,12 +32,18 @@ In some cases only **TX** or **RX** exists as the device at the other end only a
     ones used for logging. Therefore the UART data on the ESP8266 can have occasional data glitches especially with
     higher baud rates..
 
+.. note::
+
+    From ESPHome 1.21.0 the ``ESP8266SoftwareSerial`` UART ``write_byte`` function had the parity bit fixed to be correct
+    for the data being sent. This could cause unexpected issue if you have built your own devices that do parity checking.
+
+
 .. code-block:: yaml
 
     # Example configuration entry
     uart:
-      tx_pin: D0
-      rx_pin: D1
+      tx_pin: 1
+      rx_pin: 3
       baud_rate: 9600
 
 Configuration variables:

--- a/components/uart.rst
+++ b/components/uart.rst
@@ -35,7 +35,8 @@ In some cases only **TX** or **RX** exists as the device at the other end only a
 .. note::
 
     From ESPHome 1.21.0 the ``ESP8266SoftwareSerial`` UART ``write_byte`` function had the parity bit fixed to be correct
-    for the data being sent. This could cause unexpected issue if you have built your own devices that do parity checking.
+    for the data being sent. This could cause unexpected issues if you are using the Software Serial and have devices that 
+    explicity check the parity. Most likely you will need to flip the ``parity`` flag in YAML.
 
 
 .. code-block:: yaml


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#1873

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
