### PR TITLE
correct wrong example parameter

### DIFF
--- a/components/display/st7735.rst
+++ b/components/display/st7735.rst
@@ -38,7 +38,7 @@ There are numerous board types out there. Some initialize differently as well. T
         device_height: 160
         col_start: 0
         row_start: 0
-        eightbitcolor: true
+        eight_bit_color: true
         update_interval: 5s
 
 Configuration variables:


### PR DESCRIPTION
## Description:
_eightbitcolor_ is not a valid parameter, should be _eight_bit_color_

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
