### PR TITLE
Add Dish Network protocol to remote receiver/transmitter

### DIFF
--- a/components/remote_receiver.rst
+++ b/components/remote_receiver.rst
@@ -90,6 +90,10 @@ Automations:
 - **on_pioneer** (*Optional*, :ref:`Automation <automation>`): An automation to perform when a
   pioneer remote code has been decoded. A variable ``x`` of type :apiclass:`remote_base::PioneerData`
   is passed to the automation for use in lambdas.
+  - **on_dish** (*Optional*, :ref:`Automation <automation>`): An automation to perform when a
+  dish network remote code has been decoded. A variable ``x`` of type :apiclass:`remote_base::DishData`
+  is passed to the automation for use in lambdas.
+  Beware that Dish remotes use a different carrier frequency (57.6kHz) that many receiver hardware don't decode.
 
 .. _remote-receiver-binary-sensor:
 
@@ -171,6 +175,12 @@ Remote code selection (exactly one of these has to be included):
 - **pioneer**: Trigger on a decoded Pioneer remote code with the given data.
 
   - **rc_code_1** (**Required**, int): The remote control code trigger on, see dumper output for more details.
+
+- **dish**: Trigger on a decoded Dish Network remote code with the given data.
+  Beware that Dish remotes use a different carrier frequency (57.6kHz) that many receiver hardware don't decode.
+
+  - **address** (*Optional*, int, 1-16): The number of the receiver to target. Defaults to ``1``. 
+  - **command** (**Required**, int, 0-63): The Dish command to listen for. 
 
 - **rc_switch_raw**: Trigger on a decoded RC Switch raw remote code with the given data.
 

--- a/components/remote_transmitter.rst
+++ b/components/remote_transmitter.rst
@@ -252,6 +252,27 @@ Configuration variables:
 - **command** (**Required**, int): The command to send.
 - All other options from :ref:`remote_transmitter-transmit_action`.
 
+``remote_transmitter.transmit_dish`` Action
+************************************************
+
+This :ref:`action <config-action>` sends a Dish Network infrared remote code to a remote transmitter.
+
+.. code-block:: yaml
+
+    on_...:
+      - remote_transmitter.transmit_dish:
+          address: 1
+          command: 16
+
+Configuration variables:
+
+- **address** (*Optional*, int, 1-16): The number of the receiver to target. Defaults to ``1``.
+- **command** (**Required**, int, 0-63): The command to send.
+- All other options from :ref:`remote_transmitter-transmit_action`.
+
+You can find a list of commands in the `LIRC project <https://sourceforge.net/p/lirc-remotes/code/ci/master/tree/remotes/dishnet/Dish_Network.lircd.conf>`__.
+
+
 ``remote_transmitter.transmit_pioneer`` Action
 **********************************************
 


### PR DESCRIPTION
## Description:
Add Dish Network protocol to remote receiver/transmitter

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#2117

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
