### PR TITLE
Fix range parameters for light.addressable_set

### DIFF
--- a/components/light/index.rst
+++ b/components/light/index.rst
@@ -309,10 +309,10 @@ Configuration variables:
 
 - **id** (**Required**, :ref:`config-id`): The ID of the addressable light to control.
 - **range_from** (*Optional*, :ref:`templatable <config-templatable>`, int): The beginning
-  of the range of LEDs to control. 0-based indexing. Defaults to 0 (the beginning of the strip).
+  of the range of LEDs to control, inclusive, using zero-based indexing. Defaults to 0 (the beginning of the strip).
 - **range_to** (*Optional*, :ref:`templatable <config-templatable>`, int): The end of the
-  range of LEDs to control - this is a half-open interval. 0-based indexing.
-  Defaults to the end of the strip (``num_leds``).
+  range of LEDs to control, inclusive, using zero-based indexing.
+  Defaults to the end of the strip (``num_leds`` - 1).
 - **color_brightness** (*Optional*, :ref:`templatable <config-templatable>`, percentage): The brightness to
   set the color channel to.
 - **red** (*Optional*, :ref:`templatable <config-templatable>`, percentage): The value to


### PR DESCRIPTION
Since 521c080989d4 the range parameters are a closed interval, not a half-open interval.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
