### PR TITLE
Update cookbook for ESP32 Water Leak Detector

### DIFF
--- a/cookbook/leak-detector-m5stickC.rst
+++ b/cookbook/leak-detector-m5stickC.rst
@@ -15,11 +15,11 @@ Using the ESP32's capacitive touch GPIOs, it's relatively easy to build a water 
 Things you'll need
 ==================
 
-- M5Stick esphome components
-    https://github.com/airy10/esphome-m5stickC/issues/4
+-  `M5Stick axp192 custom component <https://github.com/airy10/esphome-m5stickC>`__
+    This is needed to power up the display.  You don't need the st7735 display driver, as it is already included with ESPHome >1.16.0
 
 - M5StickC ESP32 development kit
-    `M5Stack Link <https://m5stack.com/collections/m5-core/products/stick-c>`__
+   `M5Stack Link <https://m5stack.com/collections/m5-core/products/stick-c>`__
 
 .. figure:: images/leak-detector-m5stickC-m5stickC.png
     :align: center
@@ -74,7 +74,7 @@ Flashing
 
 I initially had trouble flashing the M5StickC; this is the procedure that I've found to work well with these devices.
 
-You must provide the ESP32 bootloader during the initial flash over USB.  Compile your ESPHome binary, and flash it along with the required bootloader (bootloader_dio_80m.bin), `available here <https://github.com/espressif/arduino-esp32/tree/master/tools/sdk/bin>`__, from the commandline (example under macos):
+You must provide the ESP32 bootloader during the initial flash over USB.  Compile your ESPHome binary, and flash it along with the required bootloader (bootloader_dio_80m.bin), `available here <https://github.com/espressif/arduino-esp32/tree/master/tools/sdk/esp32/bin>`__, from the commandline (example under macos):
 
 ``cd /Applications/ESPHome-Flasher-1.2.0-macOS.app/Contents/MacOS``
 
@@ -252,23 +252,42 @@ ESPHome configuration
         id: font1
         size: 66
 
+    # wonky color fix, in lieu of finding a way to invert the display
+    color:
+        - id: color_wet
+          red: 100%
+          green: 100%
+          blue: 0%
+        - id: color_dry
+          red: 100%
+          green: 0%
+          blue: 100%
+
     # built-in 80x160 TFT
     display:
       - platform: st7735
+        model: "INITR_MINI160X80"
+        device_height: 160
+        device_width: 82
+        col_start: 0
+        row_start: 0
+        eight_bit_color: false
         cs_pin: GPIO5
         dc_pin: GPIO23
         reset_pin: GPIO18
-        rotation: 180
         lambda: |-
           if (id(leak).state) {
-            it.print(38, -24, id(font1), ST77XX_RED, TextAlign::TOP_CENTER, "W");
-            it.print(38, 32, id(font1), ST77XX_RED, TextAlign::TOP_CENTER, "E");
-            it.print(38, 85, id(font1), ST77XX_RED, TextAlign::TOP_CENTER, "T");
+            it.fill(COLOR_ON);
+            it.print(42, -24, id(font1), id(color_wet), TextAlign::TOP_CENTER, "W");
+            it.print(42, 32, id(font1), id(color_wet), TextAlign::TOP_CENTER, "E");
+            it.print(42, 85, id(font1), id(color_wet), TextAlign::TOP_CENTER, "T");
           } else {
-            it.print(38, -24, id(font1), ST77XX_GREEN, TextAlign::TOP_CENTER, "D");
-            it.print(38, 32, id(font1), ST77XX_GREEN, TextAlign::TOP_CENTER, "R");
-            it.print(38, 85, id(font1), ST77XX_GREEN, TextAlign::TOP_CENTER, "Y");
+            it.fill(COLOR_ON);
+            it.print(42, -24, id(font1), id(color_dry), TextAlign::TOP_CENTER, "D");
+            it.print(42, 32, id(font1), id(color_dry), TextAlign::TOP_CENTER, "R");
+            it.print(42, 85, id(font1), id(color_dry), TextAlign::TOP_CENTER, "Y");
           }
+
 
 
 HomeAssistant configuration
@@ -314,5 +333,6 @@ See Also
 ========
 
 - :doc:`/components/display/index`
+- :doc:`/components/display/st7735`
 - :doc:`/components/binary_sensor/esp32_touch`
 - :ghedit:`Edit`

--- a/cookbook/leak-detector-m5stickC.rst
+++ b/cookbook/leak-detector-m5stickC.rst
@@ -16,7 +16,7 @@ Things you'll need
 ==================
 
 -  `M5Stick axp192 custom component <https://github.com/airy10/esphome-m5stickC>`__
-    This is needed to power up the display.  You don't need the st7735 display driver, as it is already included with ESPHome >1.16.0
+    This is needed to power up the display.  You don't need the st7735 display driver, as it is already included with ESPHome >1.16.0.
 
 - M5StickC ESP32 development kit
    `M5Stack Link <https://m5stack.com/collections/m5-core/products/stick-c>`__


### PR DESCRIPTION
The current cookbook yaml no longer compiles with ESPhome >1.16.0.
The following changes rectify the situation.

1) The ST7735 display is now natively supported in ESPHome >1.16.0.  Therefore the custom component is no longer needed. Also, ESPHome color handling seems to have changed, so that has been accounted for. (Without a way to invert the display during initialization, colors had to be adjusted manually to get the proper result). Code and instructions updated accordingly.

2) Updated URL of esp32 bootloader

3) Added st7735 display docs link to footer

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
