### PR TITLE
Fix Template Switch Lamda Example

### DIFF
--- a/components/switch/template.rst
+++ b/components/switch/template.rst
@@ -89,11 +89,12 @@ Configuration options:
 
 .. note::
 
-    This action can also be written in lambdas:
+    This action can also be written in lambdas, the parameter of the `public_state` method denotes if
+    the switch is currently on or off:
 
     .. code-block:: cpp
 
-        id(template_swi).publish_state(42.0);
+        id(template_swi).publish_state(false);
 
 See Also
 --------


### PR DESCRIPTION
A template switch publish_state method does take a boolean and not a float.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
