### PR TITLE
Number Template: Clarify how to get value in set_action

### DIFF
--- a/components/number/template.rst
+++ b/components/number/template.rst
@@ -30,7 +30,7 @@ Configuration variables:
   Lambda to be evaluated every update interval to get the new value of the number.
 - **set_action** (*Optional*, :ref:`Action <config-action>`): The action that should
   be performed when the remote (like Home Assistant's frontend) requests to set the
-  number value. The new value is available to lambdas in the `x``` variable.
+  number value. The new value is available to lambdas in the `x`` variable.
 - **update_interval** (*Optional*, :ref:`config-time`): The interval to check the
   number. Defaults to ``60s``.
 - **optimistic** (*Optional*, boolean): Whether to operate in optimistic mode - when in this mode,

--- a/components/number/template.rst
+++ b/components/number/template.rst
@@ -29,7 +29,8 @@ Configuration variables:
 - **lambda** (*Optional*, :ref:`lambda <config-lambda>`):
   Lambda to be evaluated every update interval to get the new value of the number.
 - **set_action** (*Optional*, :ref:`Action <config-action>`): The action that should
-  be performed when the remote (like Home Assistant's frontend) requests to set the number value.
+  be performed when the remote (like Home Assistant's frontend) requests to set the
+  number value. The new value is available to lambdas in the `x variable.
 - **update_interval** (*Optional*, :ref:`config-time`): The interval to check the
   number. Defaults to ``60s``.
 - **optimistic** (*Optional*, boolean): Whether to operate in optimistic mode - when in this mode,

--- a/components/number/template.rst
+++ b/components/number/template.rst
@@ -30,7 +30,7 @@ Configuration variables:
   Lambda to be evaluated every update interval to get the new value of the number.
 - **set_action** (*Optional*, :ref:`Action <config-action>`): The action that should
   be performed when the remote (like Home Assistant's frontend) requests to set the
-  number value. The new value is available to lambdas in the `x` variable.
+  number value. The new value is available to lambdas in the `x``` variable.
 - **update_interval** (*Optional*, :ref:`config-time`): The interval to check the
   number. Defaults to ``60s``.
 - **optimistic** (*Optional*, boolean): Whether to operate in optimistic mode - when in this mode,

--- a/components/number/template.rst
+++ b/components/number/template.rst
@@ -30,7 +30,7 @@ Configuration variables:
   Lambda to be evaluated every update interval to get the new value of the number.
 - **set_action** (*Optional*, :ref:`Action <config-action>`): The action that should
   be performed when the remote (like Home Assistant's frontend) requests to set the
-  number value. The new value is available to lambdas in the `x`` variable.
+  number value. The new value is available to lambdas in the ``x`` variable.
 - **update_interval** (*Optional*, :ref:`config-time`): The interval to check the
   number. Defaults to ``60s``.
 - **optimistic** (*Optional*, boolean): Whether to operate in optimistic mode - when in this mode,

--- a/components/number/template.rst
+++ b/components/number/template.rst
@@ -30,7 +30,7 @@ Configuration variables:
   Lambda to be evaluated every update interval to get the new value of the number.
 - **set_action** (*Optional*, :ref:`Action <config-action>`): The action that should
   be performed when the remote (like Home Assistant's frontend) requests to set the
-  number value. The new value is available to lambdas in the `x variable.
+  number value. The new value is available to lambdas in the `x` variable.
 - **update_interval** (*Optional*, :ref:`config-time`): The interval to check the
   number. Defaults to ``60s``.
 - **optimistic** (*Optional*, boolean): Whether to operate in optimistic mode - when in this mode,


### PR DESCRIPTION
Make it clear in the documentation how to get the new value in the `set_action` automation of the Number Template.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
