### PR TITLE
Update automations.rst

### DIFF
--- a/guides/automations.rst
+++ b/guides/automations.rst
@@ -436,7 +436,7 @@ time period.
 .. note::
 
     This is a "smart" asynchronous delay - other code will still run in the background while
-    the delay is happening.
+    the delay is happening. When using a lambda call, you should return the delay value in milliseconds.
 
 .. _lambda_action:
 


### PR DESCRIPTION
made it clear that lambda delay is in milliseconds rather than seconds. Ref: https://community.home-assistant.io/t/lambda-value-on-delay/235794

## Description:
The documentation frequently gives delay values in seconds or minutes, but a few people are being tripped up by lambda delays as they don't realise it actually wants milliseconds.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [X] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [X] Link added in `/index.rst` when creating new documents for new components or cookbook.
