### PR TITLE
Document flash_write_interval

### DIFF
--- a/components/esphome.rst
+++ b/components/esphome.rst
@@ -170,7 +170,7 @@ A safety feature has thus been implemented to mitigate issues resulting from the
 the state is first stored in memory before being flushed to flash after the ``flash_write_interval`` has passed. This
 results in fewer flash writes, preserving the flash health.
 
-This behavior can be disabled by setting ``flash_write_interval`` to `0s` to immediately commit the state to flash,
+This behavior can be disabled by setting ``flash_write_interval`` to ``0s`` to immediately commit the state to flash,
 however, be aware that this may lead to increased flash wearing and a shortened device lifespan!
 
 For ESP8266, :ref:`esphome-esp8266_restore_from_flash` must also be set to true for states to be written to flash.

--- a/components/esphome.rst
+++ b/components/esphome.rst
@@ -170,7 +170,7 @@ A safety feature has thus been implemented to mitigate issues resulting from the
 the state is first stored in memory before being flushed to flash after the ``flash_write_interval`` has passed. This
 results in fewer flash writes, preserving the flash health.
 
-This behavior can be disabled by setting ``flash_write_interval`` to immediately commit the state to flash,
+This behavior can be disabled by setting ``flash_write_interval`` to `0s` to immediately commit the state to flash,
 however, be aware that this may lead to increased flash wearing and a shortened device lifespan!
 
 For ESP8266, :ref:`esphome-esp8266_restore_from_flash` must also be set to true for states to be written to flash.

--- a/components/esphome.rst
+++ b/components/esphome.rst
@@ -152,36 +152,6 @@ the flash section will fail. So do not use this option when you have components 
 These include GPIO switches that are used internally (disable restoring with the ``restore_mode`` option),
 certain light effects like ``random`` and the ``on_value_range`` trigger.
 
-.. _preferences-flash_write_interval:
-
-``flash_write_interval``
-------------------------
-
-.. code-block:: yaml
-
-    # Example configuration entry
-    preferences:
-      flash_write_interval: 1min
-
-- **flash_write_interval** (*Optional*, :ref:`config-time`): Customize the frequency in which data is
-  flushed to the flash. This setting helps to prevent rapid changes to a component from being quickly
-  written to the flash and wearing it out. Defaults to ``1min``.
-
-As all devices have a limited number of flash write cycles, this setting helps to reduce the number of flash writes
-due to quickly changing components. In the past, when components such as ``light``, ``switch``, ``fan`` and ``globals``
-were changed, the state was immediately committed to flash. The result of this was that the last state of these
-components would always restore to its last state on power loss, however, this has the cost of potentially quickly
-damaging the flash if these components are quickly changed.
-
-A safety feature has thus been implemented to mitigate issues resulting from the limited number of flash write cycles,
-the state is first stored in memory before being flushed to flash after the ``flash_write_interval`` has passed. This
-results in fewer flash writes, preserving the flash health.
-
-This behavior can be disabled by setting ``flash_write_interval`` to ``0s`` to immediately commit the state to flash,
-however, be aware that this may lead to increased flash wearing and a shortened device lifespan!
-
-For ESP8266, :ref:`esphome-esp8266_restore_from_flash` must also be set to true for states to be written to flash.
-
 .. _esphome-on_boot:
 
 ``on_boot``
@@ -300,6 +270,35 @@ This option behaves differently depending on what the included file is pointing 
  - If the include string is point at a header file (.h, .hpp, .tcc) - it is copied in the src/ folder
    AND included in the main.cpp. This way the lambda code can access it.
 
+.. _preferences-flash_write_interval:
+
+Adjusting flash writes
+------------------------
+
+.. code-block:: yaml
+
+    # Example configuration entry
+    preferences:
+      flash_write_interval: 1min
+
+- **flash_write_interval** (*Optional*, :ref:`config-time`): Customize the frequency in which data is
+  flushed to the flash. This setting helps to prevent rapid changes to a component from being quickly
+  written to the flash and wearing it out. Defaults to ``1min``.
+
+As all devices have a limited number of flash write cycles, this setting helps to reduce the number of flash writes
+due to quickly changing components. In the past, when components such as ``light``, ``switch``, ``fan`` and ``globals``
+were changed, the state was immediately committed to flash. The result of this was that the last state of these
+components would always restore to its last state on power loss, however, this has the cost of potentially quickly
+damaging the flash if these components are quickly changed.
+
+A safety feature has thus been implemented to mitigate issues resulting from the limited number of flash write cycles,
+the state is first stored in memory before being flushed to flash after the ``flash_write_interval`` has passed. This
+results in fewer flash writes, preserving the flash health.
+
+This behavior can be disabled by setting ``flash_write_interval`` to ``0s`` to immediately commit the state to flash,
+however, be aware that this may lead to increased flash wearing and a shortened device lifespan!
+
+For ESP8266, :ref:`esphome-esp8266_restore_from_flash` must also be set to true for states to be written to flash.
 
 .. _esphome-changing_node_name:
 

--- a/components/esphome.rst
+++ b/components/esphome.rst
@@ -43,9 +43,6 @@ Advanced options:
 - **build_path** (*Optional*, string): Customize where ESPHome will store the build files
   for your node. By default, ESPHome puts all PlatformIO project files under a folder ``<NODE_NAME>/``,
   but you can customize this behavior using this option.
-- **flash_write_interval** (*Optional*, :ref:`config-time`): Customize the frequency in which data is
-  flushed to the flash. This setting helps to prevent rapid changes to a component from being quickly
-  written to the flash and wearing it out. Defaults to ``1min``. See :ref:`esphome-flash_write_interval` for more info.
 - **platformio_options** (*Optional*, mapping): Additional options to pass over to PlatformIO in the
   platformio.ini file. See :ref:`esphome-platformio_options`.
 - **includes** (*Optional*, list of files): A list of C[++] files to include in the main (auto-generated) sketch file
@@ -155,10 +152,20 @@ the flash section will fail. So do not use this option when you have components 
 These include GPIO switches that are used internally (disable restoring with the ``restore_mode`` option),
 certain light effects like ``random`` and the ``on_value_range`` trigger.
 
-.. _esphome-flash_write_interval:
+.. _preferences-flash_write_interval:
 
 ``flash_write_interval``
 ------------------------
+
+.. code-block:: yaml
+
+    # Example configuration entry
+    preferences:
+      flash_write_interval: 1min
+
+- **flash_write_interval** (*Optional*, :ref:`config-time`): Customize the frequency in which data is
+  flushed to the flash. This setting helps to prevent rapid changes to a component from being quickly
+  written to the flash and wearing it out. Defaults to ``1min``.
 
 As all devices have a limited number of flash write cycles, this setting helps to reduce the number of flash writes
 due to quickly changing components. In the past, when components such as ``light``, ``switch``, ``fan`` and ``globals``

--- a/components/esphome.rst
+++ b/components/esphome.rst
@@ -43,6 +43,9 @@ Advanced options:
 - **build_path** (*Optional*, string): Customize where ESPHome will store the build files
   for your node. By default, ESPHome puts all PlatformIO project files under a folder ``<NODE_NAME>/``,
   but you can customize this behavior using this option.
+- **flash_write_interval** (*Optional*, :ref:`config-time`): Customize the frequency in which data is
+  flushed to the flash. This setting helps to prevent rapid changes to a component from being quickly
+  written to the flash and wearing it out. Defaults to ``1s``. See :ref:`esphome-flash_write_interval` for more info.
 - **platformio_options** (*Optional*, mapping): Additional options to pass over to PlatformIO in the
   platformio.ini file. See :ref:`esphome-platformio_options`.
 - **includes** (*Optional*, list of files): A list of C[++] files to include in the main (auto-generated) sketch file
@@ -151,6 +154,22 @@ Beware: The flash has a limited number of write cycles (usually around 100 000),
 the flash section will fail. So do not use this option when you have components that update rapidly.
 These include GPIO switches that are used internally (disable restoring with the ``restore_mode`` option),
 certain light effects like ``random`` and the ``on_value_range`` trigger.
+
+.. _esphome-flash_write_interval:
+
+``flash_write_interval``
+------------------------
+
+As all devices have a limited number of flash write cycles, this setting helps to reduce the number of flash writes
+due to quickly changing components. In the past, components such as ``light``, ``switch``, ``fan`` and ``globals``
+were changed, the state was immediately committed to flash. The result of this was that the last state of these
+components would always restore to its last state on power loss, however, this has the cost of potentially quickly
+damaging the flash if these components are quickly changed. 
+
+Now, when a state is changed, the state is first stored in memory before being flushed to flash after
+the ``flash_write_interval`` has passed.
+
+For ESP8266, :ref:`_esphome-esp8266_restore_from_flash` must also be set to true for states to be written to flash.
 
 .. _esphome-on_boot:
 

--- a/components/esphome.rst
+++ b/components/esphome.rst
@@ -169,7 +169,7 @@ damaging the flash if these components are quickly changed.
 Now, when a state is changed, the state is first stored in memory before being flushed to flash after
 the ``flash_write_interval`` has passed.
 
-For ESP8266, :ref:`_esphome-esp8266_restore_from_flash` must also be set to true for states to be written to flash.
+For ESP8266, :ref:`esphome-esp8266_restore_from_flash` must also be set to true for states to be written to flash.
 
 .. _esphome-on_boot:
 

--- a/components/esphome.rst
+++ b/components/esphome.rst
@@ -45,7 +45,7 @@ Advanced options:
   but you can customize this behavior using this option.
 - **flash_write_interval** (*Optional*, :ref:`config-time`): Customize the frequency in which data is
   flushed to the flash. This setting helps to prevent rapid changes to a component from being quickly
-  written to the flash and wearing it out. Defaults to ``1s``. See :ref:`esphome-flash_write_interval` for more info.
+  written to the flash and wearing it out. Defaults to ``1min``. See :ref:`esphome-flash_write_interval` for more info.
 - **platformio_options** (*Optional*, mapping): Additional options to pass over to PlatformIO in the
   platformio.ini file. See :ref:`esphome-platformio_options`.
 - **includes** (*Optional*, list of files): A list of C[++] files to include in the main (auto-generated) sketch file
@@ -161,13 +161,17 @@ certain light effects like ``random`` and the ``on_value_range`` trigger.
 ------------------------
 
 As all devices have a limited number of flash write cycles, this setting helps to reduce the number of flash writes
-due to quickly changing components. In the past, components such as ``light``, ``switch``, ``fan`` and ``globals``
+due to quickly changing components. In the past, when components such as ``light``, ``switch``, ``fan`` and ``globals``
 were changed, the state was immediately committed to flash. The result of this was that the last state of these
 components would always restore to its last state on power loss, however, this has the cost of potentially quickly
-damaging the flash if these components are quickly changed. 
+damaging the flash if these components are quickly changed.
 
-Now, when a state is changed, the state is first stored in memory before being flushed to flash after
-the ``flash_write_interval`` has passed.
+A safety feature has thus been implemented to mitigate issues resulting from the limited number of flash write cycles,
+the state is first stored in memory before being flushed to flash after the ``flash_write_interval`` has passed. This
+results in fewer flash writes, preserving the flash health.
+
+This behavior can be disabled by setting ``flash_write_interval`` to immediately commit the state to flash,
+however, be aware that this may lead to increased flash wearing and a shortened device lifespan!
 
 For ESP8266, :ref:`esphome-esp8266_restore_from_flash` must also be set to true for states to be written to flash.
 


### PR DESCRIPTION
## Description:
Documents flash_write_interval

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#2119

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
