### PR TITLE
Fix on-boot

### DIFF
--- a/components/esphome.rst
+++ b/components/esphome.rst
@@ -165,7 +165,7 @@ is already set up. You can however change this using the ``priority`` parameter.
     esphome:
       # ...
       on_boot:
-        priority: -10
+        priority: 600
         # ...
         then:
           - switch.turn_off: switch_1
@@ -174,7 +174,7 @@ Configuration variables:
 
 - **priority** (*Optional*, float): The priority to execute your custom initialization code. A higher value
   means a high priority and thus also your code being executed earlier. Please note this is an ESPHome-internal
-  value and any change will not be marked as a breaking change. Defaults to ``-10``. Priorities (you can use any value between them too):
+  value and any change will not be marked as a breaking change. Defaults to ``600``. Priorities (you can use any value between them too):
 
   - ``800.0``: This is where all hardware initialization of vital components is executed. For example setting switches
     to their initial state.

--- a/components/mqtt.rst
+++ b/components/mqtt.rst
@@ -16,7 +16,7 @@ Assistant configuration.
 
     When enabling MQTT and you do *not* use the "native API" for Home Assistant, you must
     remove the ``api:`` line from your ESPHome configuration, otherwise the ESP will
-    reboot every 5 minutes because no client connected to the native API.
+    reboot every 15 minutes because no client connected to the native API.
 
 .. code-block:: yaml
 


### PR DESCRIPTION
## Description:
On_boot priority in docs and on_boot in code differed.

https://github.com/esphome/esphome/blob/d9f09a7523e4a31b7498fdd63283987f42aff090/esphome/core/config.py#L183

https://esphome.io/components/esphome.html#esphome-on-boot

https://github.com/esphome/esphome/pull/1392#issuecomment-832372750



Also use the correct API reboot timeout in mqtt.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.