### PR TITLE
Add Toshiba AC doc

### DIFF
--- a/components/remote_receiver.rst
+++ b/components/remote_receiver.rst
@@ -38,6 +38,7 @@ Configuration variables:
   - **samsung**: Decode and dump Samsung infrared codes.
   - **samsung36**: Decode and dump Samsung36 infrared codes.
   - **sony**: Decode and dump Sony infrared codes.
+  - **toshiba_ac**: Decode and dump Toshiba AC infrared codes.
   - **rc_switch**: Decode and dump RCSwitch RF codes.
   - **rc5**: Decode and dump RC5 IR codes.
   - **raw**: Print all remote codes in their raw form. Useful for using arbitrary protocols.
@@ -68,6 +69,9 @@ Automations:
   is passed to the automation for use in lambdas.
 - **on_sony** (*Optional*, :ref:`Automation <automation>`): An automation to perform when a
   Sony remote code has been decoded. A variable ``x`` of type :apiclass:`remote_base::SonyData`
+  is passed to the automation for use in lambdas.
+- **on_toshiba_ac** (*Optional*, :ref:`Automation <automation>`): An automation to perform when a
+  Toshiba AC remote code has been decoded. A variable ``x`` of type :apiclass:`remote_base::ToshibaAcData`
   is passed to the automation for use in lambdas.
 - **on_raw** (*Optional*, :ref:`Automation <automation>`): An automation to perform when a
   raw remote code has been decoded. A variable ``x`` of type ``std::vector<int>``
@@ -147,6 +151,11 @@ Remote code selection (exactly one of these has to be included):
   - **data** (**Required**, int): The Sony code to trigger on, see dumper output for more info.
   - **nbits** (*Optional*, int): The number of bits of the remote code. Defaults to ``12``.
 
+- **toshiba_ac**: Trigger on a decoded Toshiba AC remote code with the given data.
+
+  - **rc_code_1** (**Required**, int): The remote control code to trigger on, see dumper output for more details.
+  - **rc_code_2** (*Optional*, int): The second part of the remote control code to trigger on, see dumper output for more details.
+
 - **raw**: Trigger on a raw remote code with the given code.
 
   - **code** (**Required**, list): The code to listen for, see :ref:`remote_transmitter-transmit_raw`
@@ -174,7 +183,7 @@ Remote code selection (exactly one of these has to be included):
 
 - **pioneer**: Trigger on a decoded Pioneer remote code with the given data.
 
-  - **rc_code_1** (**Required**, int): The remote control code trigger on, see dumper output for more details.
+  - **rc_code_1** (**Required**, int): The remote control code to trigger on, see dumper output for more details.
 
 - **dish**: Trigger on a decoded Dish Network remote code with the given data.
   Beware that Dish remotes use a different carrier frequency (57.6kHz) that many receiver hardware don't decode.

--- a/components/remote_transmitter.rst
+++ b/components/remote_transmitter.rst
@@ -302,6 +302,26 @@ At the time this action was created, Pioneer maintained listings of IR codes use
 If unable to find your specific device in the documentation, find a device in the same class; the codes
 are largely shared among devices within a given class.
 
+``remote_transmitter.transmit_toshiba_ac`` Action
+*************************************************
+
+This :ref:`action <config-action>` sends a Toshiba AC infrared remote code to a remote transmitter.
+
+.. code-block:: yaml
+
+    on_...:
+      - remote_transmitter.transmit_toshiba_ac:
+          rc_code_1: 0xB24DBF4040BF
+          rc_code_2: 0xD5660001003C
+
+Configuration variables:
+
+- **rc_code_1** (**Required**, int): The remote control code to send, see dumper output for more details.
+- **rc_code_2** (*Optional*, int): The secondary remote control code to send; some codes are sent in
+  two parts.
+- **Note:** this action transmits codes using the new(er) Toshiba AC protocol and likely will not work with older units.
+- All other options from :ref:`remote_transmitter-transmit_action`.
+
 ``remote_transmitter.transmit_rc_switch_raw`` Action
 ****************************************************
 


### PR DESCRIPTION
## Description:

Docs for https://github.com/esphome/esphome/pull/2019

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** https://github.com/esphome/esphome/pull/2019

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook. **N/A**