### PR TITLE
Clarify some color temperature settings

### DIFF
--- a/components/light/color_temperature.rst
+++ b/components/light/color_temperature.rst
@@ -26,10 +26,12 @@ Configuration variables:
 - **name** (**Required**, string): The name of the light.
 - **color_temperature** (**Required**, :ref:`config-id`): The id of the float :ref:`output` to use for the color temperature.
 - **brightness** (**Required**, :ref:`config-id`): The id of the float :ref:`output` to use for the brightness.
-- **cold_white_color_temperature** (**Required**, float): The color temperate (in `mireds <https://en.wikipedia.org/wiki/Mired>`__ or Kelvin)
-  of the cold white channel.
-- **warm_white_color_temperature** (**Required**, float): The color temperate (in `mireds <https://en.wikipedia.org/wiki/Mired>`__ or Kelvin)
-  of the warm white channel.
+- **cold_white_color_temperature** (**Required**, float): The coldest color temperature supported by this light. This
+  is the lowest value when expressed in `mireds <https://en.wikipedia.org/wiki/Mired>`__, or the highest value when
+  expressed in Kelvin.
+- **warm_white_color_temperature** (**Required**, float): The warmest color temperature supported by this light. This
+  is the highest value when expressed in `mireds <https://en.wikipedia.org/wiki/Mired>`__, or the lowest value when
+  expressed in Kelvin.
 - **effects** (*Optional*, list): A list of :ref:`light effects <light-effects>` to use for this light.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
 - All other options from :ref:`Light <config-light>`.

--- a/components/light/cwww.rst
+++ b/components/light/cwww.rst
@@ -40,9 +40,9 @@ Configuration variables:
 - **cold_white** (**Required**, :ref:`config-id`): The id of the float :ref:`output` to use for the cold white channel.
 - **warm_white** (**Required**, :ref:`config-id`): The id of the float :ref:`output` to use for the warm white channel.
 - **cold_white_color_temperature** (*Optional*, float): The color temperature (in `mireds <https://en.wikipedia.org/wiki/Mired>`__ or Kelvin)
-  of the cold white channel.
+  of the cold white channel. Note that this option is required to control the mixing from Home Assistant.
 - **warm_white_color_temperature** (*Optional*, float): The color temperature (in `mireds <https://en.wikipedia.org/wiki/Mired>`__ or Kelvin)
-  of the warm white channel.
+  of the warm white channel. Note that this option is required to control the mixing from Home Assistant.
 - **constant_brightness** (*Optional*, boolean): When enabled, this will keep the overall brightness of the cold and warm white channels constant by limiting the combined output to 100% of a single channel. This reduces the possible overall brightness but is necessary for some power supplies that are not able to run both channels at full brightness at once. Defaults to ``false``.
 - **effects** (*Optional*, list): A list of :ref:`light effects <light-effects>` to use for this light.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.

--- a/components/light/rgbct.rst
+++ b/components/light/rgbct.rst
@@ -5,7 +5,7 @@ RGBCT Light
     :description: Instructions for setting up RGBCT lights.
     :image: rgbw.png
 
-The ``rgbct`` light platform creates an RGBWT (colour temperature + white brightness)
+The ``rgbct`` light platform creates an RGBWT (color temperature + white brightness)
 light from 5 :ref:`float output components <output>` (one for each channel).
 
 .. code-block:: yaml
@@ -30,13 +30,15 @@ Configuration variables:
 - **green** (**Required**, :ref:`config-id`): The id of the float :ref:`output` to use for the green channel.
 - **blue** (**Required**, :ref:`config-id`): The id of the float :ref:`output` to use for the blue channel.
 - **color_temperature** (**Required**, :ref:`config-id`): The id of the float :ref:`output` to use for the
-  color temperature cannel.
+  color temperature channel.
 - **white_brightness** (**Required**, :ref:`config-id`): The id of the float :ref:`output` to use for the brightness
   of the white leds.
-- **cold_white_color_temperature** (**Required**, float): The color temperate (in
-  `mireds <https://en.wikipedia.org/wiki/Mired>`__ or Kelvin) of the cold white channel.
-- **warm_white_color_temperature** (**Required**, float): The color temperate (in
-  `mireds <https://en.wikipedia.org/wiki/Mired>`__ or Kelvin) of the warm white channel.
+- **cold_white_color_temperature** (**Required**, float): The coldest color temperature supported by this light. This
+  is the lowest value when expressed in `mireds <https://en.wikipedia.org/wiki/Mired>`__, or the highest value when
+  expressed in Kelvin.
+- **warm_white_color_temperature** (**Required**, float): The warmest color temperature supported by this light. This
+  is the highest value when expressed in `mireds <https://en.wikipedia.org/wiki/Mired>`__, or the lowest value when
+  expressed in Kelvin.
 - **color_interlock** (*Optional*, boolean): When enabled, this will prevent white leds being on at the same
   time as RGB leds. See :ref:`rgbw_color_interlock` for more information. Defaults to ``false``.
 - **effects** (*Optional*, list): A list of :ref:`light effects <light-effects>` to use for this light.

--- a/components/light/rgbww.rst
+++ b/components/light/rgbww.rst
@@ -75,9 +75,11 @@ Configuration variables:
 - **warm_white** (**Required**, :ref:`config-id`): The id of the float :ref:`output` to use for the warm
   white channel.
 - **cold_white_color_temperature** (*Optional*, float): The color temperature (in
-  `mireds <https://en.wikipedia.org/wiki/Mired>`__ or Kelvin) of the cold white channel.
+  `mireds <https://en.wikipedia.org/wiki/Mired>`__ or Kelvin) of the cold white channel. Note that when the color interlock
+  is enabled, this option is required to control the light from Home Assistant.
 - **warm_white_color_temperature** (*Optional*, float): The color temperature (in
-  `mireds <https://en.wikipedia.org/wiki/Mired>`__ or Kelvin) of the warm white channel.
+  `mireds <https://en.wikipedia.org/wiki/Mired>`__ or Kelvin) of the warm white channel. Note that when the color interlock
+  is enabled, this option is required to control the light from Home Assistant.
 - **constant_brightness** (*Optional*, boolean): When enabled, this will keep the overall brightness of the
   cold and warm white channels constant by limiting the combined output to 100% of a single channel. This
   reduces the possible overall brightness but is necessary for some power supplies that are not able to run


### PR DESCRIPTION
## Description:

* Clarify meaning of cold/warm_white_color_temperature setting for CT lights.
* Note that setting cold/warm_white_color_temperature is necessary to control color temperature from HA.
* Fix typos :)

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
