### PR TITLE
ST7789V: Document that backlight_pin is now optional

### DIFF
--- a/components/display/st7789v.rst
+++ b/components/display/st7789v.rst
@@ -53,10 +53,10 @@ hardwired programming. (OTA updates are of course possible after ESPHome is init
 Configuration variables:
 ************************
 
-- **backlight_pin** (**Required**, :ref:`Pin Schema <config-pin_schema>`): The display's backlight pin.
 - **cs_pin** (**Required**, :ref:`Pin Schema <config-pin_schema>`): The CS pin.
 - **dc_pin** (**Required**, :ref:`Pin Schema <config-pin_schema>`): The DC pin.
 - **reset_pin** (**Required**, :ref:`Pin Schema <config-pin_schema>`): The RESET pin.
+- **backlight_pin** (*Optional*, :ref:`Pin Schema <config-pin_schema>`): The display's backlight pin.
 - **lambda** (*Optional*, :ref:`lambda <config-lambda>`): The lambda to use for rendering the content on the display.
   See :ref:`display-engine` for more information.
 - **update_interval** (*Optional*, :ref:`config-time`): The interval to re-draw the screen. Defaults to ``5s``.


### PR DESCRIPTION
## Description:

This MR documents that the ST7789V backlight_pin setting is now optional.

**Related issue (if applicable):** none

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#2180

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
