### PR TITLE
Document set direction on fan.turn_on action

### DIFF
--- a/components/fan/index.rst
+++ b/components/fan/index.rst
@@ -104,6 +104,8 @@ Configuration options:
   Set the oscillation state of the fan. Defaults to not affecting oscillation.
 - **speed** (*Optional*, int, :ref:`templatable <config-templatable>`):
   Set the speed level of the fan. Can be a number between 1 and the maximum speed level of the fan.
+- **direction** (*Optional*, string, :ref:`templatable <config-templatable>`):
+  Set the diretion of the fan. Can be either ``forward`` or ``reverse``. Defaults to not changing the direction.
 
 .. _fan-on_turn_on_off_trigger:
 


### PR DESCRIPTION
## Description:
Document addition of ``direction`` option in fan.turn_on action

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#2171

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
