### PR TITLE
Update devices documentation

### DIFF
--- a/components/esphome.rst
+++ b/components/esphome.rst
@@ -105,6 +105,8 @@ option you can tell ESPHome which Arduino framework to use for compiling.
 For the ESP8266, you currently can manually pin the Arduino version to these values (see the full
 list of Arduino frameworks `here <https://github.com/esp8266/Arduino/releases>`__):
 
+* `3.0.1 <https://github.com/esp8266/Arduino/releases/tag/3.0.1>`__ (not recommended yet)
+* `3.0.0 <https://github.com/esp8266/Arduino/releases/tag/3.0.0>`__ (not recommended yet)
 * `2.7.4 <https://github.com/esp8266/Arduino/releases/tag/2.7.4>`__ (default)
 * `2.7.3 <https://github.com/esp8266/Arduino/releases/tag/2.7.3>`__
 * `2.7.2 <https://github.com/esp8266/Arduino/releases/tag/2.7.2>`__

--- a/components/esphome.rst
+++ b/components/esphome.rst
@@ -27,14 +27,14 @@ Configuration variables:
 - **name** (**Required**, string): This is the name of the node. It
   should always be unique in your ESPHome network. May only contain lowercase
   characters, digits and hyphens. See :ref:`esphome-changing_node_name`.
-- **platform** (**Required**, string): The platform your board is on,
-  either ``ESP32`` or ``ESP8266``. See :ref:`esphome-arduino_version`.
-- **board** (**Required**, string): The board ESPHome should
-  specify for PlatformIO. For the ESP32, choose the appropriate one
-  from `this list <http://docs.platformio.org/en/latest/platforms/espressif32.html#boards>`__
-  and use `this list <http://docs.platformio.org/en/latest/platforms/espressif8266.html#boards>`__
-  for ESP8266-based boards. *This only affects pin aliases and some internal settings*, if unsure
-  choose the generic board option!
+- **platform** (**Required**, string): The platform your board is using,
+  either ``ESP32`` or ``ESP8266``.
+- **board** (**Required**, string): The PlatformIO board ID that should
+  be used. Choose the appropriate board from
+  `this list <https://platformio.org/boards?count=1000&filter%5Bplatform%5D=espressif8266>` for the ESP8266, and
+  `this list <https://platformio.org/boards?count=1000&filter%5Bplatform%5D=espressif32`> for the ESP32 (the icon
+  next to the name can be used to copy the board ID). *This only affects pin aliases and some internal settings*,
+  if unsure choose a generic board from Espressif.
 
 Advanced options:
 

--- a/devices/esp32.rst
+++ b/devices/esp32.rst
@@ -7,7 +7,7 @@ Generic ESP32
 
 All ESP32-based devices are supported by ESPHome. Simply select ``ESP32`` when
 the ESPHome wizard asks you for your platform and choose a board type
-from `this link <http://docs.platformio.org/en/latest/platforms/espressif32.html>`__ when the wizard
+from `this link <https://platformio.org/boards?count=1000&filter%5Bplatform%5D=espressif32>`__ when the wizard
 asks you for the board type.
 
 .. code-block:: yaml

--- a/devices/esp32.rst
+++ b/devices/esp32.rst
@@ -4,8 +4,9 @@ Generic ESP32
 .. seo::
     :description: Information about how to use generic ESP32 boards in ESPHome.
     :image: esp32.png
+    :keywords: ESP32
 
-All ESP32-based devices are supported by ESPHome. Simply select ``ESP32`` when
+All devices based on the original ESP32 are supported by ESPHome. Simply select ``ESP32`` when
 the ESPHome wizard asks you for your platform and choose a board type
 from `this link <https://platformio.org/boards?count=1000&filter%5Bplatform%5D=espressif32>`__ when the wizard
 asks you for the board type.
@@ -17,6 +18,10 @@ asks you for the board type.
       name: livingroom
       platform: ESP32
       board: <BOARD_TYPE>
+
+.. note::
+
+    Support for the ESP32-S2 and ESP32-C3 is currently in development.
 
 The ESP32 boards often use the internal GPIO pin numbering on the board, this means that
 you don't have to worry about other kinds of pin numberings, yay!

--- a/devices/esp8266.rst
+++ b/devices/esp8266.rst
@@ -8,7 +8,7 @@ Generic ESP8266
 
 All ESP8266-based devices are supported by ESPHome. Simply select ``ESP8266`` when
 the ESPHome wizard asks you for your platform and choose a board type
-from `this link <http://docs.platformio.org/en/latest/platforms/espressif8266.html>`__ when the wizard
+from `this link <https://platformio.org/boards?count=1000&filter%5Bplatform%5D=espressif8266>`__ when the wizard
 asks you for the board type.
 
 

--- a/devices/nodemcu_esp8266.rst
+++ b/devices/nodemcu_esp8266.rst
@@ -43,10 +43,11 @@ In general, it is best to just use the ``D0``, ``D1``, ... pin numbering to avoi
 Note that in certain conditions you *can* use the pins marked as ``INTERNAL`` in above image.
 
 - ``D0`` also can be used to wake the device up from :doc:`deep sleep </components/deep_sleep>` if
-  the pin is connected to the ``RESET`` pin. ``D0`` is additionally connected to the LED
+  the pin is connected to the ``RESET`` pin. On some boards ``D0`` is additionally connected to the LED
   next to the UART chip, but in an inverted mode.
 - ``D3``, ``D4`` and ``D8`` are used on startup to determine the boot mode, therefore these pins should
   not be pulled low on startup. You can, however, still use them as output pins.
+- ``D4`` additionally is connected to the blue LED next to the antenna, but in an inverted mode.
 - ``A0``: This pin can be used as a normal GPIO pin (like ``D1`` etc) but additionally can measure
   voltages from 0 to 1.0V using the :doc:`/components/sensor/adc`.
 - ``VIN``: This board can be powered by an external power supply by using this pin. Supply a voltage depends on the board you use. Some boards support up to 12V, some up to 5V.

--- a/devices/sonoff.rst
+++ b/devices/sonoff.rst
@@ -15,10 +15,6 @@ and shipping from China takes a long time, I've only set up dedicated guides for
       name: <NAME_OF_NODE>
       platform: ESP8266
       board: esp8285
-      arduino_version: 2.4.2
-
-The selected board and arduino_version are required in v1.14.3 (and probably later), see
-https://github.com/esphome/issues/issues/931 for details.
 
 After that use the following list of pin to function mappings to set up your Sonoff device.
 This list has been compiled from the Sonoff Tasmota pin source file which can be found here:

--- a/devices/sonoff_basic.rst
+++ b/devices/sonoff_basic.rst
@@ -55,7 +55,6 @@ exposes all of the basic functions.
       name: <NAME_OF_NODE>
       platform: ESP8266
       board: esp8285
-      arduino_version: 2.4.2
 
     wifi:
       ssid: <YOUR_SSID>


### PR DESCRIPTION
## Description:

* Update links to the PlatformIO boardlist to the new fancy UI
* Clarify what is meant with generic boards
* Add a note that the ESP32-S2 and ESP32-C3 aren't supported yet
* Update the Arduino version list
* Add note about LED connected to `D4` pin on NodeMCU boards, fixes https://github.com/esphome/issues/issues/2313
* Drop recommendation to use `arduino_version: 2.4.2` for Sonoff devices per https://github.com/esphome/issues/issues/2309#issuecomment-896219456

Note that I don't have a Sonoff device so I can't test that, but I've seen multiple reports of dropping `arduino_version` fixing the issue.

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
