### PR TITLE
Fix CO2 spelling inconsistency

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -175,7 +175,7 @@ Air Quality
     SGP40, components/sensor/sgp40, sgp40.jpg, Volatile organics
     SM300D2, components/sensor/sm300d2, sm300d2.jpg, Air quality
     SPS30, components/sensor/sps30, sps30.jpg, Particulate
-    T6613/15, components/sensor/t6615, t6615.png, C02
+    T6613/15, components/sensor/t6615, t6615.png, CO2
     ZyAura, components/sensor/zyaura, zgm053.jpg, CO2 & Temperature & Humidity
 
 


### PR DESCRIPTION
## Description:

Minor typo in docs. C02 should be CO2.

## Checklist:

  - [X] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [X] Link added in `/index.rst` when creating new documents for new components or cookbook.
