### PR TITLE
pm1006: document changes in esphome PR 2214

### DIFF
--- a/components/sensor/pm1006.rst
+++ b/components/sensor/pm1006.rst
@@ -15,10 +15,8 @@ with ESPHome.
 
     IKEA VINDRIKTNING Particulate Matter Sensor with PM1006 inside
 
-As the communication with the PM1006 is done using UART, you need to have an :ref:`UART bus <uart>` in your configuration with the ``rx_pin`` connected to the TX pin of the
-PM1006.
-This component is currently RX-only, as the IKEA VINDRIKTNING already sends commands to the PM1006.
-Additionally, you need to set the baud rate to 9600.
+As the communication with the PM1006 is done using UART, you need to have an :ref:`UART bus <uart>` in your configuration with the ``rx_pin`` connected to the TX pin of the PM1006.
+The baud rate needs to be set to 9600.
 
 .. code-block:: yaml
 
@@ -32,7 +30,7 @@ Additionally, you need to set the baud rate to 9600.
         pm_2_5:
           name: "Particulate Matter 2.5µm Concentration"
 
-Unlike some other sensors, there is no configurable update interval, as this is a 'passive' implementation that picks up whatever the VINDRIKTNING MCU has requested from the sensor.
+In common usage, with the IKEA VINDRIKTNING still controlling the pm1006 sensor, there is no update interval, and this implementation will passively pick up whatever the VINDRIKTNING MCU has requested from the sensor.
 
 The implementation was inspired by https://github.com/Hypfer/esp8266-vindriktning-particle-sensor; you can also see the pinout there.
 However, we recommend mounting your ESP below the fan (which blows out the front) so you do not obstruct the airflow.
@@ -46,6 +44,30 @@ Configuration variables:
 
 - **uart_id** (*Optional*, :ref:`config-id`): Manually specify the ID of the :ref:`UART Component <uart>` if you want
   to use multiple UART buses.
+
+- **update_interval** (*Optional*, defaults to ``never``): If you need to actively request measurements to the sensor, set this to some sensible interval. The IKEA VINDRIKTNING does measurements every 20 seconds.
+
+Using this component standalone
+-------------------------------
+
+If you acquired a pm1006 outside of an IKEA VINDRIKTNING, or if you removed the IKEA MCU or replaced the whole PCB, you will need to actively request measurements.
+In that case, you need a TX pin, and you need to set an update interval.
+
+Example config:
+
+.. code-block:: yaml
+
+    # Example configuration entry
+    uart:
+      rx_pin: D2
+      tx_pin: D1
+      baud_rate: 9600
+
+    sensor:
+      - platform: pm1006
+        pm_2_5:
+          name: "Particulate Matter 2.5µm Concentration"
+        update_interval: 20s
 
 See Also
 --------


### PR DESCRIPTION
## Description:
this documents TX support for the pm 1006

**Related issue (if applicable):** none

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#2214
## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
