### PR TITLE
Fix waveshare default update_interval to 1s

### DIFF
--- a/components/display/waveshare_epaper.rst
+++ b/components/display/waveshare_epaper.rst
@@ -108,7 +108,7 @@ Configuration variables:
   all other models.
 - **lambda** (*Optional*, :ref:`lambda <config-lambda>`): The lambda to use for rendering the content on the display.
   See :ref:`display-engine` for more information.
-- **update_interval** (*Optional*, :ref:`config-time`): The interval to re-draw the screen. Defaults to ``10s``, use ``never`` to only manually update the screen via ``component.update``.
+- **update_interval** (*Optional*, :ref:`config-time`): The interval to re-draw the screen. Defaults to ``1s``, use ``never`` to only manually update the screen via ``component.update``.
 - **pages** (*Optional*, list): Show pages instead of a single lambda. See :ref:`display-pages`.
 - **spi_id** (*Optional*, :ref:`config-id`): Manually specify the ID of the :ref:`SPI Component <spi>` if you want
   to use multiple SPI buses.


### PR DESCRIPTION
## Description:
Fix wrong default value of 10s to 1s for `update_interval`
Based on esphome component source :`.extend(cv.polling_component_schema("1s"))`, see [waveshare_epaper/display.py](https://github.com/esphome/esphome/blob/b955527f6ce3e6a7d8066112beb03b4b2e1b1e87/esphome/components/waveshare_epaper/display.py#L96)

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
