### PR TITLE
SGP40: Small correction to the example

### DIFF
--- a/components/sensor/sgp40.rst
+++ b/components/sensor/sgp40.rst
@@ -48,8 +48,8 @@ Example With Compensation
         name: "Workshop VOC"
         update_interval: 5s        
         compensation:
-          humidity_source: dht1_temp
-          temperature_source: dht1_hum  
+          humidity_source: dht1_hum
+          temperature_source: dht1_temp 
           
 See Also
 --------


### PR DESCRIPTION
The example configuration, on the conpensation part, lists temperature and humidity, the example has them inverted

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
