### PR TITLE
Add docs for git packages

### DIFF
--- a/guides/configuration-types.rst
+++ b/guides/configuration-types.rst
@@ -357,6 +357,7 @@ Packages can also be loaded from a git repository by utilizing the correct confi
 
 .. code-block:: yaml
 
+    packages:
       # Git repo examples
       remote_package:
         url: https://github.com/esphome/non-existant-repo

--- a/guides/configuration-types.rst
+++ b/guides/configuration-types.rst
@@ -270,6 +270,9 @@ config in the main yaml file. All definitions from packages will be merged with 
 config in non-destructive way so you could always override some bits and pieces of package
 configuration.
 
+Local packages
+**************
+
 Consider the following example where the author put common pieces of configuration like WiFi and
 I²C into base files and extends it with some device specific configurations in the main config.
 
@@ -345,6 +348,31 @@ merged with the services definitions from main config file.
 
     switch:
       - !include common/switch/restart_switch.config.yaml
+
+
+Remote/git Packages
+*******************
+
+Packages can also be loaded from a git repository by utilizing the correct config syntax.
+
+.. code-block:: yaml
+
+      # Git repo examples
+      remote_package:
+        url: https://github.com/esphome/non-existant-repo
+        ref: main # optional
+        files: [file1.yml, file2.yml]
+        refresh: 1d # optional
+
+      # A single file can be expressed using `file` or `files` as a string
+      remote_package_two:
+        url: https://github.com/esphome/non-existant-repo
+        file: file1.yml # cannot be combined with `files`
+        # files: file1.yml
+
+      # shorthand form github://username/repository/[folder/]file-path.yml[@branch-or-tag]
+      remote_package_three: github://esphome/non-existant-repo/file1.yml@main
+
 
 See Also
 --------


### PR DESCRIPTION
## Description:

Add docs to support git packages

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#2193

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
