### PR TITLE
missing merge symbol before file include

### DIFF
--- a/guides/configuration-types.rst
+++ b/guides/configuration-types.rst
@@ -344,7 +344,7 @@ merged with the services definitions from main config file.
       - <<: !include common/binary_sensor/connection_status.config.yaml
 
     switch:
-      - !include common/switch/restart_switch.config.yaml
+      - <<: !include common/switch/restart_switch.config.yaml
 
 See Also
 --------


### PR DESCRIPTION
Also, some explanation where << is and isn't required would be helpful e.g. for root key whole file include vs parameter include. Home assistants docs don't make this clear either.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
