### PR TITLE
Fan is on is off conditions

### DIFF
--- a/components/fan/index.rst
+++ b/components/fan/index.rst
@@ -107,6 +107,25 @@ Configuration options:
 - **direction** (*Optional*, string, :ref:`templatable <config-templatable>`):
   Set the diretion of the fan. Can be either ``forward`` or ``reverse``. Defaults to not changing the direction.
 
+.. _fan-is_on_condition:
+.. _fan-is_off_condition:
+
+``fan.is_on`` / ``fan.is_off`` Condition
+**********************************************
+
+This :ref:`condition <config-condition>` passes if the given fan is on/off.
+
+.. code-block:: yaml
+
+    # in a trigger:
+    on_...:
+      if:
+        condition:
+          fan.is_on: my_fan
+          # same goes for is_off
+        then:
+        - script.execute: my_script
+
 .. _fan-on_turn_on_off_trigger:
 
 ``fan.on_turn_on`` / ``fan.on_turn_off`` Trigger

--- a/guides/automations.rst
+++ b/guides/automations.rst
@@ -402,6 +402,7 @@ All Conditions
 - :ref:`light.is_on <light-is_on_condition>` / :ref:`light.is_off <light-is_off_condition>`
 - :ref:`display.is_displaying_page <display-is_displaying_page-condition>`
 - :ref:`number.in_range <number-in_range_condition>`
+- :ref:`fan.is_on <fan-is_on_condition>` / :ref:`fan.is_off <fan-is_off_condition>`
 
 All Lambda Calls
 ----------------


### PR DESCRIPTION
## Description:
This PR adds documentation for the new fan.is_on and fan.is_off conditions

**Related issue (if applicable):** fixes esphome/feature-requests#1382

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#2225

## Checklist:

  - [X] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [N/A] Link added in `/index.rst` when creating new documents for new components or cookbook.
