### PR TITLE
Note to set ``optimistic`` when using HA to set

### DIFF
--- a/components/number/template.rst
+++ b/components/number/template.rst
@@ -34,7 +34,8 @@ Configuration variables:
 - **update_interval** (*Optional*, :ref:`config-time`): The interval to check the
   number. Defaults to ``60s``.
 - **optimistic** (*Optional*, boolean): Whether to operate in optimistic mode - when in this mode,
-  any command sent to the template number will immediately update the reported state.
+  any command sent to the template number will immediately update the reported state. 
+  This must be set to ``true`` inorder for changes from Home Assistant to be applied.
   Cannot be used with ``lambda``. Defaults to ``false``.
 - **restore_value** (*Optional*, boolean): Saves and loads the state to RTC/Flash.
   Cannot be used with ``lambda``. Defaults to ``false``.


### PR DESCRIPTION
For a while I was trying to use the Number Template and I couldn't figure why changes I made from the HA UI did not apply in my ESP device.
I think adding a note here will help or revising the text that already exists.
It also might be nice to add a note to have ``restore_count`` set also.

This is what I used.

    number:
      - platform: template
        name: Trigger Count
        id: trigger_count
        icon: "mdi:sync"
        restore_value: true
        optimistic: true
        initial_value: 8
        max_value: 10
        min_value: 1
        step: 1

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
