### PR TITLE
Improve template number/select documentation

### DIFF
--- a/components/number/template.rst
+++ b/components/number/template.rst
@@ -14,7 +14,7 @@ using :ref:`lambdas <config-lambda>`.
     number:
       - platform: template
         name: "Template number"
-        update_interval: never
+        optimistic: true
         min_value: 0
         max_value: 100
         step: 1
@@ -27,12 +27,12 @@ Configuration variables:
 - **max_value** (**Required**, float): The maximum value this number can be.
 - **step** (**Required**, float): The granularity with which the number can be set.
 - **lambda** (*Optional*, :ref:`lambda <config-lambda>`):
-  Lambda to be evaluated every update interval to get the new value of the number.
+  Lambda to be evaluated every update interval to get the current value of the number.
 - **set_action** (*Optional*, :ref:`Action <config-action>`): The action that should
   be performed when the remote (like Home Assistant's frontend) requests to set the
   number value. The new value is available to lambdas in the ``x`` variable.
-- **update_interval** (*Optional*, :ref:`config-time`): The interval to check the
-  number. Defaults to ``60s``.
+- **update_interval** (*Optional*, :ref:`config-time`): The interval on which to update the number
+  by executing the ``lambda``. Defaults to ``60s``.
 - **optimistic** (*Optional*, boolean): Whether to operate in optimistic mode - when in this mode,
   any command sent to the template number will immediately update the reported state.
   Cannot be used with ``lambda``. Defaults to ``false``.
@@ -45,9 +45,9 @@ Configuration variables:
 - All other options from :ref:`Number <config-number>`.
 
 ``number.set`` Action
-----------------------------------
+---------------------
 
-You can also publish a state to a template number from elsewhere in your YAML file
+You can also set the number for the template number from elsewhere in your YAML file
 with the :ref:`number-set_action`.
 
 See Also

--- a/components/select/template.rst
+++ b/components/select/template.rst
@@ -14,7 +14,7 @@ using :ref:`lambdas <config-lambda>`.
     select:
       - platform: template
         name: "Template select"
-        update_interval: never
+        optimistic: true
         options:
           - one
           - two
@@ -28,11 +28,12 @@ Configuration variables:
 - **name** (**Required**, string): The name of the Select.
 - **options** (**Required**, list): The list of options this Select has.
 - **lambda** (*Optional*, :ref:`lambda <config-lambda>`):
-  Lambda to be evaluated every update interval to get the new option of the Select.
+  Lambda to be evaluated every update interval to get the current option of the select.
 - **set_action** (*Optional*, :ref:`Action <config-action>`): The action that should
   be performed when the remote (like Home Assistant's frontend) requests to set the Select option.
-- **update_interval** (*Optional*, :ref:`config-time`): The interval to check the
-  Select ``lambda``. Defaults to ``60s``.
+  The new option is available to lambdas in the ``x`` variable.
+- **update_interval** (*Optional*, :ref:`config-time`): The interval on which to update the select
+  by executing the ``lambda``. Defaults to ``60s``.
 - **optimistic** (*Optional*, boolean): Whether to operate in optimistic mode - when in this mode,
   any command sent to the Template Select will immediately update the reported state.
   Cannot be used with ``lambda``. Defaults to ``false``.
@@ -45,9 +46,9 @@ Configuration variables:
 - All other options from :ref:`Select <config-select>`.
 
 ``select.set`` Action
-----------------------------------
+---------------------
 
-You can also set an option to a Template Select from elsewhere in your YAML file
+You can also set an option for the template select from elsewhere in your YAML file
 with the :ref:`select-set_action`.
 
 See Also


### PR DESCRIPTION
## Description:

* Enable `optimistic` mode in the examples, so that they make sense and don't just discard all user input.
* Improve wording for `number.set` / `sensor.set` reference to remove impression that they're the same as the `sensor.template.publish`-style actions (they are not).
* Minor clarifications / wording improvements.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
