### PR TITLE
Add information about `esp8266_disable_ssl_support:`

### DIFF
--- a/components/http_request.rst
+++ b/components/http_request.rst
@@ -29,6 +29,21 @@ Configuration variables:
 - **timeout** (*Optional*, :ref:`time <config-time>`): Timeout for request. Defaults to ``5s``.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
 
+ESP8266 Options:
+
+- **esp8266_disable_ssl_support** (*Optional*, boolean): Whether to include SSL support on ESP8266s.
+  Defaults to ``no``. See :ref:`esphome-esp8266_disable_ssl_support` for more info
+
+.. _esphome-esp8266_disable_ssl_support:
+
+``esp8266_disable_ssl_support``
+-------------------------------
+
+This options allows you to disable inclusion of SSL libraries. This is required on a flash
+constrained devices (512k or 1M) which does not have enough space to support
+SSL and OTA concurrently. The flashing will fail with the following error
+``Error: ESP does not have enough space to store OTA file``.
+
 HTTP Request Actions
 --------------------
 


### PR DESCRIPTION
## Description:

Adds information about `esp8266_disable_ssl_support:` option

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** https://github.com/esphome/esphome/pull/2236

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
