### PR TITLE
Template sensor publish updates

### DIFF
--- a/components/sensor/template.rst
+++ b/components/sensor/template.rst
@@ -35,8 +35,9 @@ Configuration variables:
 - **name** (**Required**, string): The name of the sensor.
 - **lambda** (*Optional*, :ref:`lambda <config-lambda>`):
   Lambda to be evaluated every update interval to get the new value of the sensor
-- **update_interval** (*Optional*, :ref:`config-time`): The interval to check the
-  sensor. Defaults to ``60s``.
+- **update_interval** (*Optional*, :ref:`config-time`): The interval to publish the value of the
+  sensor, either the result of the lambda function or if no lambda function the last value
+  published using the publish action. Defaults to ``60s``.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
 - All other options from :ref:`Sensor <config-sensor>`.
 

--- a/components/text_sensor/template.rst
+++ b/components/text_sensor/template.rst
@@ -31,6 +31,9 @@ Configuration variables:
 - **name** (**Required**, string): The name of the text sensor.
 - **lambda** (*Optional*, :ref:`lambda <config-lambda>`):
   Lambda to be evaluated every update interval to get the new value of the text sensor
+- **update_interval** (*Optional*, :ref:`config-time`): The interval to publish the value of the
+  text sensor, either the result of the lambda function or if no lambda function the last value
+  published using the publish action. Defaults to ``60s``.
 - **update_interval** (*Optional*, :ref:`config-time`): The interval to check the
   text sensor. Defaults to ``60s``.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.

--- a/components/text_sensor/template.rst
+++ b/components/text_sensor/template.rst
@@ -34,8 +34,6 @@ Configuration variables:
 - **update_interval** (*Optional*, :ref:`config-time`): The interval to publish the value of the
   text sensor, either the result of the lambda function or if no lambda function the last value
   published using the publish action. Defaults to ``60s``.
-- **update_interval** (*Optional*, :ref:`config-time`): The interval to check the
-  text sensor. Defaults to ``60s``.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
 - All other options from :ref:`Text Sensor <config-text_sensor>`.
 


### PR DESCRIPTION
## Description:
This updates the documentation for the publish interval of template sensors to include that the value is now published on this interval for sensors with a lambda function and sensors that only get values from the publish action.

**Related issue (if applicable):** fixes N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#2224

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [N/A] Link added in `/index.rst` when creating new documents for new components or cookbook.
