### PR TITLE
Fix typo in dsmr docs 

### DIFF
--- a/components/sensor/dsmr.rst
+++ b/components/sensor/dsmr.rst
@@ -223,7 +223,7 @@ Configuration variables:
 
 Belgium
 
-- **p1_version_be** (*Optional*): DSMR Version Beligum
+- **p1_version_be** (*Optional*): DSMR Version Belgium
 
   - **name** (**Required**, string): The name for the p1_version_be text sensor.
   - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.


### PR DESCRIPTION
## Description:

Fixes a typo. `Beligum` -> `Belgium`.

## Checklist:

  - [X] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
