### PR TITLE
Add support for color_temperature_invert on tuya lights

### DIFF
--- a/components/light/tuya.rst
+++ b/components/light/tuya.rst
@@ -87,6 +87,9 @@ Configuration variables:
   maximum of 255, but dimmers with a maximum of 1000 can also be found. Try what works best.
 - **color_temperature_max_value** (*Optional*, int, default 255): The highest color temperature
   value allowed. Some ceiling fans have a value of 100 (also for `max_value`).
+- **color_temperature_invert** (*Optional*, boolean, default false): Control how color temperature
+  values are sent to the MCU. If this is set to true ESPHome will treat 0 as warm white and
+  **color_temperature_max_value** as cool white when setting **color_temperature_datapoint**.
 - **cold_white_color_temperature** (*Optional*, float): The color temperature (in `mireds
   <https://en.wikipedia.org/wiki/Mired>`__ or Kelvin) of the cold white channel.
 - **warm_white_color_temperature** (*Optional*, float): The color temperature (in `mireds


### PR DESCRIPTION
## Description:

Add documentation for new feature

**Related issue (if applicable):** n/a

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#2277

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
