### PR TITLE
Adds differential_sampling optional parameter

### DIFF
--- a/components/sensor/ct_clamp.rst
+++ b/components/sensor/ct_clamp.rst
@@ -39,6 +39,8 @@ Configuration variables:
 - **sensor** (**Required**, :ref:`config-id`): The source sensor to measure voltage values from.
 - **sample_duration** (*Optional*, :ref:`config-time`): The time duration to sample the current clamp
   with. Higher values can increase accuracy. Defaults to ``200ms`` which would be 10 whole cycles on a 50Hz system.
+- **differential_sampling** (*Optional*, boolean): Assumes differential sampling from the source sensor
+  (alternating signal is centered around 0V). Defaults to `false`.
 - **update_interval** (*Optional*, :ref:`config-time`): The interval
   to check the sensor. Defaults to ``60s``.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.


### PR DESCRIPTION
## Description:
differential_sampling parameter instructs the sensor to assume the alternating signal is centerd around 0V.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#2283

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.