### PR TITLE
Fix documentation for some st7735 params

### DIFF
--- a/components/display/st7735.rst
+++ b/components/display/st7735.rst
@@ -51,6 +51,7 @@ Configuration variables:
 - **device_height** (**Required**, int): The device height. 160 is default
 - **col_start** (**Required**, int): The starting column offset. Default value depends on **model**.
 - **row_start** (**Required**, int): The starting row offset. Default value depends on **model**.
+- **use_bgr** (*Optional*, "true/false"): Use BGR mode. Default is false.
 - **eight_bit_color** (*Optional*, "true/false" ): 8bit mode. Default is false. This saves 50% of the buffer required for the display.
 - **reset_pin** (*Optional*, :ref:`Pin Schema <config-pin_schema>`): The RESET pin.
 

--- a/components/display/st7735.rst
+++ b/components/display/st7735.rst
@@ -49,8 +49,8 @@ Configuration variables:
 - **dc_pin** (**Required**, :ref:`Pin Schema <config-pin_schema>`): The DC pin.
 - **device_width** (**Required**, int): The device width. 128 is default
 - **device_height** (**Required**, int): The device height. 160 is default
-- **col_start** (**Required**, int): The device height. 160 is default
-- **row_start** (**Required**, int): The device height. 160 is default
+- **col_start** (**Required**, int): The starting column offset. Default value depends on **model**.
+- **row_start** (**Required**, int): The starting row offset. Default value depends on **model**.
 - **eight_bit_color** (*Optional*, "true/false" ): 8bit mode. Default is false. This saves 50% of the buffer required for the display.
 - **reset_pin** (*Optional*, :ref:`Pin Schema <config-pin_schema>`): The RESET pin.
 


### PR DESCRIPTION
## Description:
- Fix wording in st7735 settings
- Add missing parameter for st7735 config

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
