### PR TITLE
Add documentation for deep-sleep wakeup from esp32 touch sensor event

### DIFF
--- a/components/binary_sensor/esp32_touch.rst
+++ b/components/binary_sensor/esp32_touch.rst
@@ -95,6 +95,10 @@ Configuration variables:
 -  **id** (*Optional*,
    :ref:`config-id`): Manually specify
    the ID used for code generation.
+-  **wakeup_threshold** (*Optional*, int): The threshold to use to detect touch events to wakeup from deep
+   sleep. Smaller values mean a higher probability that the pad is being touched. All touch pad sensors that
+   should trigger a wakeup from deep sleep must specify this value. The :ref:`deep_sleep-component` must also
+   be configured to enable a wakeup from a touch event. Note that no filter is active during deep sleep.
 -  All other options from :ref:`Binary Sensor <config-binary_sensor>`.
 
 Touch Pad Pins

--- a/components/deep_sleep.rst
+++ b/components/deep_sleep.rst
@@ -1,3 +1,5 @@
+.. _deep_sleep-component:
+
 Deep Sleep Component
 ====================
 
@@ -33,6 +35,8 @@ Configuration variables:
 
 - **run_duration** (*Optional*, :ref:`config-time`): The time duration the node should be active, i.e. run code.
 - **sleep_duration** (*Optional*, :ref:`config-time`): The time duration to stay in deep sleep mode.
+- **touch_wakeup** (*Optional*, boolean): Only on ESP32. Use a touch event to wakeup from deep sleep. To be able
+  to wakeup from a touch event, :ref:`esp32-touch-binary-sensor` must be configured properly.
 - **wakeup_pin** (*Optional*, :ref:`Pin Schema <config-pin_schema>`): Only on ESP32. A pin to wake up to once
   in deep sleep mode. Use the inverted property to wake up to LOW signals.
 - **wakeup_pin_mode** (*Optional*): Only on ESP32. Specify how to handle waking up from a ``wakeup_pin`` if


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#2281

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
