### PR TITLE
Added example for transmitting IR codes from lambda functions

### DIFF
--- a/components/remote_transmitter.rst
+++ b/components/remote_transmitter.rst
@@ -476,6 +476,26 @@ Configuration variables:
   for more information.
 - All other options from :ref:`remote_transmitter-transmit_action`.
 
+
+lambda calls
+************
+
+Actions may also be called from :ref:`lambdas <config-lambda>`. The ``.transmit()`` call can be populated with
+encoded data for a specific protocol by following the example below.
+See the full `API Reference <https://esphome.io/api/namespaceesphome_1_1remote__base.html>`__ for more info.
+
+- ``.transmit()``: Transmit an IR code using the remote transmitter.
+
+  .. code-block:: cpp
+
+      // Example - transmit using the Pioneer protocol
+      auto call = id(my_transmitter).transmit();
+      esphome::remote_base::PioneerData data = { rc_code_1, rc_code_2 };
+      esphome::remote_base::PioneerProtocol().encode(call.get_data(), data);
+      call.set_send_times(2);
+      call.perform();
+
+
 .. _remote-setting-up-infrared:
 
 Setting up Infrared Devices

--- a/components/remote_transmitter.rst
+++ b/components/remote_transmitter.rst
@@ -482,7 +482,7 @@ lambda calls
 
 Actions may also be called from :ref:`lambdas <config-lambda>`. The ``.transmit()`` call can be populated with
 encoded data for a specific protocol by following the example below.
-See the full `API Reference <https://esphome.io/api/namespaceesphome_1_1remote__base.html>`__ for more info.
+See the full API Reference for more info.
 
 - ``.transmit()``: Transmit an IR code using the remote transmitter.
 


### PR DESCRIPTION
## Description:
Added an example of how to transmit IR codes from lambdas.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
