### PR TITLE
Add support for rgb support on tuya lights

### DIFF
--- a/components/light/tuya.rst
+++ b/components/light/tuya.rst
@@ -81,6 +81,8 @@ Configuration variables:
   change the brightness and would have to toggle the light using the physical buttons.
 - **color_temperature_datapoint** (*Optional*, int): The datapoint id number of the color
   temperature value.
+- **rgb_datapoint** (*Optional*, int): The datapoint id number of the rgb value.  If this is set
+  then ESPHome will set the color using a 6 digit hex RGB value.
 - **min_value** (*Optional*, int, default 0): The lowest dimmer value allowed.  My dimmer had a
   minimum of 25 and wouldn't even accept anything lower, but this option is available if necessary.
 - **max_value** (*Optional*, int, default 255): The highest dimmer value allowed.  Most dimmers have a
@@ -95,7 +97,7 @@ Configuration variables:
 - **warm_white_color_temperature** (*Optional*, float): The color temperature (in `mireds
   <https://en.wikipedia.org/wiki/Mired>`__ or Kelvin) of the warm white channel.
 - All other options from :ref:`Light <config-light>`.
-- At least one of *dimmer_datapoint* or *switch_datapoint* must be provided.
+- At least one of *dimmer_datapoint*, *switch_datapoint*, or *rgb_datapoint* must be provided.
 
 .. note::
 


### PR DESCRIPTION
## Description:

Add document for new RGB support on Tuya lights

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#2278

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
