### PR TITLE
Updates b-parasite docs with light sensor information

### DIFF
--- a/components/sensor/b_parasite.rst
+++ b/components/sensor/b_parasite.rst
@@ -7,9 +7,9 @@ b-parasite
     :keywords: b-parasite, parasite, BLE, Bluetooth, soil moisture
 
 
-`b-parasite <https://github.com/rbaron/b-parasite>`__ is an open source soil moisture and ambient temperature/humidity sensor.
+`b-parasite <https://github.com/rbaron/b-parasite>`__ is an open source soil moisture and ambient temperature/humidity/light sensor.
 
-The ``b_parasite`` sensor platform tracks b-parasite's Bluetooth Low Energy (BLE) advertisement packets. These packets contains soil moisture, air temperature/humidity and battery voltage data.
+The ``b_parasite`` sensor platform tracks b-parasite's Bluetooth Low Energy (BLE) advertisement packets. These packets contain soil moisture, air temperature/humidity and battery voltage data. Some b-parasite versions have light sensors, in which case the ambient illuminance is also present in the BLE advertisement data.
 
 .. figure:: images/b_parasite.jpg
     :align: center
@@ -33,6 +33,8 @@ The ``b_parasite`` sensor platform tracks b-parasite's Bluetooth Low Energy (BLE
           name: 'b-parasite Soil Moisture'
         battery_voltage:
           name: 'b-parasite Battery Voltage'
+        illuminance:
+          name: 'b-parasite Illuminance'
 
 Configuration variables
 -----------------------
@@ -51,6 +53,10 @@ Configuration variables
   - **name** (**Required**): Sensor name.
   - All other options from :ref:`Sensor <config-sensor>`.
 - **battery_voltage** (*Optional*): Battery voltage in volts.
+
+  - **name** (**Required**): Sensor name.
+  - All other options from :ref:`Sensor <config-sensor>`.
+- **illuminance** (*Optional*): Illuminance in lux.
 
   - **name** (**Required**): Sensor name.
   - All other options from :ref:`Sensor <config-sensor>`.

--- a/index.rst
+++ b/index.rst
@@ -267,7 +267,7 @@ Environmental
     BME680 via BSEC, components/sensor/bme680_bsec, bme680.jpg, Temperature & Humidity & Pressure & Gas
     BMP085, components/sensor/bmp085, bmp180.jpg, Temperature & Pressure
     BMP280, components/sensor/bmp280, bmp280.jpg, Temperature & Pressure
-    b-parasite, components/sensor/b_parasite, b_parasite.jpg, Moisture & Temperature & Humidity
+    b-parasite, components/sensor/b_parasite, b_parasite.jpg, Moisture & Temperature & Humidity & Light
     Dallas DS18B20, components/sensor/dallas, dallas.jpg, Temperature
     DHT, components/sensor/dht, dht.jpg, Temperature & Humidity
     DHT12, components/sensor/dht12, dht12.jpg, Temperature & Humidity
@@ -316,7 +316,7 @@ Miscellaneous
 
     AS3935, components/sensor/as3935, as3935.jpg, Storm lightning
     Binary Sensor Map, components/sensor/binary_sensor_map, binary_sensor_map.jpg, Map binary to value
-    b-parasite, components/sensor/b_parasite, b_parasite.jpg, Moisture & Temperature & Humidity
+    b-parasite, components/sensor/b_parasite, b_parasite.jpg, Moisture & Temperature & Humidity & Light
     EZO sensor circuits, components/sensor/ezo, ezo-ph-circuit.png, (pH)
     Havells Solar, components/sensor/havells_solar, havellsgti5000d_s.jpg, Solar rooftop
     Nextion, components/sensor/nextion, nextion.jpg, Sensors from display


### PR DESCRIPTION
## Description:

Support for light sensors was introduced in b-parasite in rbaron/b-parasite#6. This PR updates the documentation for the `b_parasite` platform.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#2391

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
