### PR TITLE
esp32_ble_beacon: Allow updating advertisement UUID

### DIFF
--- a/components/esp32_ble_beacon.rst
+++ b/components/esp32_ble_beacon.rst
@@ -70,6 +70,30 @@ It can work with multiple beacons simultaneously.
     :align: center
     :width: 75.0%
 
+Changing advertisement UUID
+---------------------------
+
+You can change the beacon UUID by using ``update_advertisement(std::array<uint8_t, 16>)`` lambda
+call on the beacon component. This can be used for real-time reporting of sensor values via BLE
+advertisement.
+
+Example lambda expression that updates advertisement UUID of a beacon when a sensor value
+changes in the sensor's ``on_value`` automation rule:
+
+.. code-block:: yaml
+
+    on_value:
+      - lambda: |-
+          // round sensor value to the nearest 32-bit integer
+          auto val = lroundf(x);
+
+          // embed sensor value into the first 4 bytes of the new UUID (big endian)
+          std::array<unsigned char, 16> uuid = {(uint8_t) (val >> 24), (uint8_t) (val >> 16), (uint8_t) (val >> 8), (uint8_t) val, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+
+          // update the advertisement UUID of beacon 'id: beacon'
+          id(beacon)->update_advertisement(uuid);
+
+
 See Also
 --------
 


### PR DESCRIPTION
## Description:

This pull request enhances ESP32 BLE beacon component with an API method update_advertisement for changing BLE advertisement UUID after the initial value has been specified in YAML. Beacon can now be used for broadcasting sensor values to other nearby devices without wi-fi capabilities (e.g. battery powered e-paper screen, etc.).

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#2398

## Checklist:

  - [X] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
