### PR TITLE
Fix grammar in uart.rst

### DIFF
--- a/components/uart.rst
+++ b/components/uart.rst
@@ -15,8 +15,8 @@ consists of 2 pins:
 - **TX**: This line is used to send data to the device at the other end.
 - **RX**: This line is used to receive data from the device at the other end.
 
-Please note that these the naming of these two pins depends on the chosen perspective and can be ambiguous. For example,
-while the ESP might send (``TX``) on pin A and receive (``RX``) data on pin B, from the other devices
+Please note that the naming of these two pins depends on the chosen perspective and can be ambiguous. For example,
+while the ESP might send (``TX``) on pin A and receive (``RX``) data on pin B, from the other device's
 perspective these two pins are switched (i.e. *it* sends on pin B and receives on pin A). So you might
 need to try with the two pins switched if it doesn't work immediately.
 
@@ -53,7 +53,7 @@ Configuration variables:
 - **baud_rate** (**Required**, int): The baud rate of the UART bus.
 - **tx_pin** (*Optional*, :ref:`config-pin`): The pin to send data to from the ESP's perspective.
 - **rx_pin** (*Optional*, :ref:`config-pin`): The pin to receive data on from the ESP's perspective.
-- **rx_buffer_size** (*Optional*, int): The size of the buffer used for receiving UART messages. Increase if you use integration that needs to read big payloads from UART. Defaults to ``256``.
+- **rx_buffer_size** (*Optional*, int): The size of the buffer used for receiving UART messages. Increase if you use an integration that needs to read big payloads from UART. Defaults to ``256``.
 - **data_bits** (*Optional*, int): The number of data bits used on the UART bus. Options: 5 to 8. Defaults to 8.
 - **parity** (*Optional*): The parity used on the UART bus. Options: ``NONE``, ``EVEN``, ``ODD``. Defaults to ``NONE``.
 - **stop_bits** (*Optional*, int): The number of stop bits to send. Options: 1, 2. Defaults to 1.


### PR DESCRIPTION
## Description:
Fix grammar in uart.rst, which I am studying to integrate my heating's main control unit with ESPHome.


**Related issue (if applicable):** _none_

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** _none_

## Checklist:

  - [X] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [X] Link added in `/index.rst` when creating new documents for new components or cookbook.
