### PR TITLE
Edited / added accuracy_decimals

### DIFF
--- a/components/sensor/pulse_meter.rst
+++ b/components/sensor/pulse_meter.rst
@@ -64,6 +64,7 @@ measure the total consumed energy in kWh.
         pin: 12
         unit_of_measurement: 'kW'
         name: 'Electricity Usage'
+        internal_filter: 100ms
         accuracy_decimals: 5
         filters:
           - multiply: 0.06

--- a/components/sensor/pulse_meter.rst
+++ b/components/sensor/pulse_meter.rst
@@ -71,7 +71,7 @@ measure the total consumed energy in kWh.
         total:
           name: "Electricity Total"
           unit_of_measurement: "kWh"
-          accuracy_decimals: 5
+          accuracy_decimals: 3
           filters:
             - multiply: 0.001
 

--- a/components/sensor/pulse_meter.rst
+++ b/components/sensor/pulse_meter.rst
@@ -65,7 +65,7 @@ measure the total consumed energy in kWh.
         unit_of_measurement: 'kW'
         name: 'Electricity Usage'
         internal_filter: 100ms
-        accuracy_decimals: 5
+        accuracy_decimals: 3
         filters:
           - multiply: 0.06
         total:

--- a/components/sensor/pulse_meter.rst
+++ b/components/sensor/pulse_meter.rst
@@ -64,12 +64,13 @@ measure the total consumed energy in kWh.
         pin: 12
         unit_of_measurement: 'kW'
         name: 'Electricity Usage'
+        accuracy_decimals: 5
         filters:
           - multiply: 0.06
         total:
           name: "Electricity Total"
           unit_of_measurement: "kWh"
-          accuracy_decimals: 0
+          accuracy_decimals: 5
           filters:
             - multiply: 0.001
 


### PR DESCRIPTION
## Description:
Current "accuracy_decimals: 0" only returns values in 1kWh amounts, so usage below 1KWh will not be logged - (0kWh vs 0.736 kWh). Similar is true for the "kW" sensor, more accuracy is being measured that what is being returned if using the example "as-is". 

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ x] Link added in `/index.rst` when creating new documents for new components or cookbook.
