### PR TITLE
Add doc for 'invert_position' variable for am43 cover.

### DIFF
--- a/components/cover/am43.rst
+++ b/components/cover/am43.rst
@@ -58,6 +58,7 @@ Configuration variables:
 - **pin** (*Optional*, int): The pin for the device, as
   set in the app. The default is usually printed on the
   device. Defaults to ``8888``.
+- **invert_position** (*Optional*, boolean): Inverts the position value to and from the device. Set if ESPHome is swapping around the open/close state of the cover.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
 - All other options from :ref:`Cover <config-cover>`.
 


### PR DESCRIPTION
This variable is contained within the cover code, but was never added to the documentation.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [X] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
