### PR TITLE
Add cover topics configuration

### DIFF
--- a/components/cover/index.rst
+++ b/components/cover/index.rst
@@ -40,7 +40,19 @@ Advanced options:
 - **disabled_by_default** (*Optional*, boolean): If true, then this entity should not be added to any client's frontend,
   (usually Home Assistant) without the user manually enabling it (via the Home Assistant UI).
   Requires Home Assistant 2021.9 or newer. Defaults to ``false``.
-- If MQTT enabled, all other options from :ref:`MQTT Component <config-mqtt-component>`.
+
+MQTT options:
+
+- **position_state_topic** (*Optional*, string): The topic to publish
+  cover position changes to.
+- **position_command_topic** (*Optional*, string): The topic to receive
+  cover position commands on.
+- **tilt_state_topic** (*Optional*, string): The topic to publish cover
+  cover tilt state changes to.
+- **tilt_command_topic** (*Optional*, string): The topic to receive
+  cover tilt commands on.
+- All other options from :ref:`MQTT Component <config-mqtt-component>`.
+
 
 .. _cover-open_action:
 
@@ -195,7 +207,7 @@ fields are read-only, if you want to act on the cover, use the ``make_call()`` m
         } else {
           // Cover is in-between open and closed
         }
-      
+
 - ``tilt``: Retrieve the current tilt position of the cover, as a value between ``0.0`` and ``1.0``.
 
 - ``current_operation``: The operation the cover is currently performing:


### PR DESCRIPTION
## Description:
Add docs for cover topics configuration.

**Related issue (if applicable):** fixes <link to issue>
https://github.com/esphome/feature-requests/issues/321

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>
https://github.com/esphome/esphome/pull/2472

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
