### PR TITLE
Added documentation for a throttle_average filter

### DIFF
--- a/components/sensor/index.rst
+++ b/components/sensor/index.rst
@@ -378,7 +378,9 @@ An average over the ``specified time period``, potentially throttling incoming v
 * no value received: nothing will be pushed - add the ``heartbeat`` filter if periodical pushes are required
 * one value received: the value is pushed out after the ``specified time period`` passed, without calculating an average
 
-In comparison to the ``throttle`` filter it won't discard any values. In comparison to the ``sliding_window_moving_average`` filter it supports variable sensor reporting intervals, allows to receive slow sensor update rates as they are and to throttle fast sensor update rates to the ``specified time period``.
+For example a ``throttle_average: 60s`` will push out a value every 60 seconds, in case at least one sensor value is received within these 60 seconds.
+
+In comparison to the ``throttle`` filter it won't discard any values. In comparison to the ``sliding_window_moving_average`` filter it supports variable sensor reporting rates without influencing the filter reporting interval (except for the first edge case).
 
 ``heartbeat``
 *************

--- a/components/sensor/index.rst
+++ b/components/sensor/index.rst
@@ -373,10 +373,10 @@ If it is not older than the configured value, the value is not passed forward.
 ``throttle_average``
 ********************
 
-An average over the ``specified time period``, potentially throttling incoming values. When this filter gets an incoming value, it checks the passed time since the last outgoing value, compares it to the ``specified time period`` and either executes:
+An average over the ``specified time period``, potentially throttling incoming values. When this filter gets incoming values, it sums up all values and pushes out the average after the ``specified time period`` passed. There are two edge cases to consider within the ``specified time period``:
 
-* more time passed: push out the new value
-* less time passed: collect all incoming values and push out the average after ``specified time period`` has passed
+* no value received: nothing will be pushed - add the ``heartbeat`` filter if periodical pushes are required
+* one value received: the value is pushed out after the ``specified time period`` passed, without calculating an average
 
 In comparison to the ``throttle`` filter it won't discard any values. In comparison to the ``sliding_window_moving_average`` filter it supports variable sensor reporting intervals, allows to receive slow sensor update rates as they are and to throttle fast sensor update rates to the ``specified time period``.
 

--- a/components/sensor/index.rst
+++ b/components/sensor/index.rst
@@ -375,7 +375,7 @@ If it is not older than the configured value, the value is not passed forward.
 
 An average over the ``specified time period``, potentially throttling incoming values. When this filter gets incoming values, it sums up all values and pushes out the average after the ``specified time period`` passed. There are two edge cases to consider within the ``specified time period``:
 
-* no value received: ``NaN`` is returned - add the ``heartbeat`` filter if periodical pushes are required and/or ``filter_out: nan`` if required
+* no value(s) received: ``NaN`` is returned - add the ``heartbeat`` filter if periodical pushes are required and/or ``filter_out: nan`` if required
 * one value received: the value is pushed out after the ``specified time period`` passed, without calculating an average
 
 For example a ``throttle_average: 60s`` will push out a value every 60 seconds, in case at least one sensor value is received within these 60 seconds.

--- a/components/sensor/index.rst
+++ b/components/sensor/index.rst
@@ -375,7 +375,7 @@ If it is not older than the configured value, the value is not passed forward.
 
 An average over the ``specified time period``, potentially throttling incoming values. When this filter gets incoming values, it sums up all values and pushes out the average after the ``specified time period`` passed. There are two edge cases to consider within the ``specified time period``:
 
-* no value received: nothing will be pushed - add the ``heartbeat`` filter if periodical pushes are required
+* no value received: ``NaN`` is returned - add the ``heartbeat`` filter if periodical pushes are required and/or ``filter_out: nan`` if required
 * one value received: the value is pushed out after the ``specified time period`` passed, without calculating an average
 
 For example a ``throttle_average: 60s`` will push out a value every 60 seconds, in case at least one sensor value is received within these 60 seconds.

--- a/components/sensor/index.rst
+++ b/components/sensor/index.rst
@@ -371,7 +371,7 @@ If it is not older than the configured value, the value is not passed forward.
       - lambda: return x * (9.0/5.0) + 32.0;
 
 ``throttle_average``
-**********
+********************
 
 An average over the ``specified time period``, potentially throttling incoming values. When this filter gets an incoming value, it checks the passed time since the last outgoing value, compares it to the ``specified time period`` and either executes:
 

--- a/components/sensor/index.rst
+++ b/components/sensor/index.rst
@@ -132,6 +132,7 @@ Filters are processed in the order they are defined in your configuration.
           alpha: 0.1
           send_every: 15
       - throttle: 1s
+      - throttle_average: 1s
       - heartbeat: 5s
       - debounce: 0.1s
       - delta: 5.0
@@ -369,6 +370,15 @@ If it is not older than the configured value, the value is not passed forward.
       - delta: 5.0
       - lambda: return x * (9.0/5.0) + 32.0;
 
+``throttle_average``
+**********
+
+An average over the ``specified time period``, potentially throttling incoming values. When this filter gets an incoming value, it checks the passed time since the last outgoing value, compares it to the ``specified time period`` and either executes:
+
+* a) more time passed: push out the new value
+* b) less time passed: collect all incoming values and push out the average after ``specified time period`` has passed
+
+In comparison to the ``throttle`` filter it won't discard any values. In comparison to the ``sliding_window_moving_average`` filter it supports variable sensor reporting intervals and allows to receive slow sensor update rates as they are and to throttle fast sensor update rates to the ``specified time period``.
 
 ``heartbeat``
 *************

--- a/components/sensor/index.rst
+++ b/components/sensor/index.rst
@@ -375,10 +375,10 @@ If it is not older than the configured value, the value is not passed forward.
 
 An average over the ``specified time period``, potentially throttling incoming values. When this filter gets an incoming value, it checks the passed time since the last outgoing value, compares it to the ``specified time period`` and either executes:
 
-* a) more time passed: push out the new value
-* b) less time passed: collect all incoming values and push out the average after ``specified time period`` has passed
+* more time passed: push out the new value
+* less time passed: collect all incoming values and push out the average after ``specified time period`` has passed
 
-In comparison to the ``throttle`` filter it won't discard any values. In comparison to the ``sliding_window_moving_average`` filter it supports variable sensor reporting intervals and allows to receive slow sensor update rates as they are and to throttle fast sensor update rates to the ``specified time period``.
+In comparison to the ``throttle`` filter it won't discard any values. In comparison to the ``sliding_window_moving_average`` filter it supports variable sensor reporting intervals, allows to receive slow sensor update rates as they are and to throttle fast sensor update rates to the ``specified time period``.
 
 ``heartbeat``
 *************


### PR DESCRIPTION
## Description:

Adds documentation for a throttle_average filter
Background: There is no filter which throttles sensors with variable sensor update rates without discarding any values

**Related issue (if applicable):** https://github.com/esphome/feature-requests/issues/569

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** https://github.com/esphome/esphome/pull/2485

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
