### PR TITLE
Add an action for pzemac to reset the total energy

### DIFF
--- a/components/sensor/pzemac.rst
+++ b/components/sensor/pzemac.rst
@@ -86,7 +86,7 @@ Configuration variables:
 .. _pzemac-reset_energy_action:
 
 ``pzemac.reset_energy`` Action
-************************
+******************************
 
 This action resets the total energy value of the pzemac device with the given ID when executed.
 

--- a/components/sensor/pzemac.rst
+++ b/components/sensor/pzemac.rst
@@ -83,6 +83,19 @@ Configuration variables:
   the same UART bus. You will need to set the address of each device manually. Defaults to ``1``.
 - **modbus_id** (*Optional*, :ref:`config-id`): Manually specify the ID of the Modbus hub.
 
+.. _pzemac-reset_energy_action:
+
+``pzemac.reset_energy`` Action
+************************
+
+This action resets the total energy value of the pzemac device with the given ID when executed.
+
+.. code-block:: yaml
+
+    on_...:
+      then:
+        - pzemac.reset_energy: pzemac_1
+
 See Also
 --------
 

--- a/guides/automations.rst
+++ b/guides/automations.rst
@@ -380,6 +380,7 @@ All Actions
 - :ref:`rf_bridge.learn <rf_bridge-learn_action>`
 - :ref:`ds1307.read_time <ds1307-read_time_action>` / :ref:`ds1307.write_time <ds1307-write_time_action>`
 - :ref:`cs5460a.restart <cs5460a-restart_action>`
+- :ref:`pzemac.reset_energy <pzemac-reset_energy_action>`
 - :ref:`number.set <number-set_action>`
 
 .. _config-condition:


### PR DESCRIPTION
## Description:
Add documentation for new pzemac.reset_energy action

**Related issue (if applicable):** fixes esphome/feature-requests#1245

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#2480

## Checklist:

  - [X] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [N/A] Link added in `/index.rst` when creating new documents for new components or cookbook.
