### PR TITLE
Add on_open and on_closed triggers to cover

### DIFF
--- a/components/cover/index.rst
+++ b/components/cover/index.rst
@@ -222,6 +222,36 @@ fields are read-only, if you want to act on the cover, use the ``make_call()`` m
           // Cover is currently closing
         }
 
+.. _cover-on_open_trigger:
+
+``cover.on_open`` Trigger
+*************************
+
+This trigger is activated each time the cover reaches a fully open state.
+
+.. code-block:: yaml
+
+    cover:
+      - platform: template  # or any other platform
+        # ...
+        on_open:
+          - logger.log: "Cover is Open!"
+
+.. _cover-on_open_trigger:
+
+``cover.on_closed`` Trigger
+*************************
+
+This trigger is activated each time the cover reaches a fully closed state.
+
+.. code-block:: yaml
+
+    cover:
+      - platform: template  # or any other platform
+        # ...
+        on_closed:
+          - logger.log: "Cover is Closed!"
+
 See Also
 --------
 

--- a/components/cover/index.rst
+++ b/components/cover/index.rst
@@ -240,7 +240,7 @@ This trigger is activated each time the cover reaches a fully open state.
 .. _cover-on_closed_trigger:
 
 ``cover.on_closed`` Trigger
-*************************
+***************************
 
 This trigger is activated each time the cover reaches a fully closed state.
 

--- a/components/cover/index.rst
+++ b/components/cover/index.rst
@@ -237,7 +237,7 @@ This trigger is activated each time the cover reaches a fully open state.
         on_open:
           - logger.log: "Cover is Open!"
 
-.. _cover-on_open_trigger:
+.. _cover-on_closed_trigger:
 
 ``cover.on_closed`` Trigger
 *************************

--- a/guides/automations.rst
+++ b/guides/automations.rst
@@ -338,6 +338,7 @@ All Triggers
   :ref:`ota.on_end <ota-on_end>` / :ref:`ota.on_error <ota-on_error>` /
   :ref:`ota.on_state_change <ota-on_state_change>`
 - :ref:`display.on_page_change <display-on_page_change-trigger>`
+- :ref:`cover.on_open <cover-on_open>` / :ref:`cover.on_closed <cover-on_closed>`
 
 All Actions
 -----------

--- a/guides/automations.rst
+++ b/guides/automations.rst
@@ -338,7 +338,7 @@ All Triggers
   :ref:`ota.on_end <ota-on_end>` / :ref:`ota.on_error <ota-on_error>` /
   :ref:`ota.on_state_change <ota-on_state_change>`
 - :ref:`display.on_page_change <display-on_page_change-trigger>`
-- :ref:`cover.on_open <cover-on_open>` / :ref:`cover.on_closed <cover-on_closed>`
+- :ref:`cover.on_open <cover-on_open_trigger>` / :ref:`cover.on_closed <cover-on_closed_trigger>`
 
 All Actions
 -----------


### PR DESCRIPTION
## Description:
Adds automation triggers on_open and on_closed to cover components

**Related issue (if applicable):** fixes esphome/feature-requests#1407

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#2488

## Checklist:

  - [X] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [N/A] Link added in `/index.rst` when creating new documents for new components or cookbook.
