### PR TITLE
Add dashboard_import to sharing page

### DIFF
--- a/guides/creators.rst
+++ b/guides/creators.rst
@@ -4,7 +4,7 @@ Sharing ESPHome devices
 .. seo::
     :description: Information for creating and sharing devices using ESPHome firmware.
 
-We have added configuration options to ESPHome to make it easier for everyone
+We have added configuration options to ESPHome to make it easier
 to create, configure, install and distribute devices running ESPHome.
 
 Example configuration

--- a/guides/creators.rst
+++ b/guides/creators.rst
@@ -55,8 +55,8 @@ Relevant Documentation
   credentials and they must be set by the user via either the ``ap`` + ``captive_portal`` or
   the ``esp32_improv`` components.
 - ``dashboard_import`` -> ``package_import_url`` - This should point to the public repository containing
-  the configuration for the device so that the user's ESPHome dashboard can auto detect this device and
-  create a minimal yaml using :ref:`config-git_packages`.
+  the configuration for the device so that the user's ESPHome dashboard can autodetect this device and
+  create a minimal YAML using :ref:`config-git_packages`.
 
 See Also
 --------

--- a/guides/creators.rst
+++ b/guides/creators.rst
@@ -1,10 +1,10 @@
-Using ESPHome for your Project
-==============================
+Sharing ESPHome devices
+=======================
 
 .. seo::
-    :description: Information for creators when using ESPHome firmware.
+    :description: Information for creating and sharing devices using ESPHome firmware.
 
-We have added configuration options to ESPHome to make it easier for creators
+We have added configuration options to ESPHome to make it easier for everyone
 to create, configure, install and distribute devices running ESPHome.
 
 Example configuration
@@ -23,6 +23,10 @@ Example configuration
       project:
         name: jesse.temperature_monitor
         version: "1.0"
+
+    # This should point to the public location of this yaml file.
+    dashboard_import:
+      package_import_url: github://jesserockz/dummy-esphome-configs@v1/temperature-monitor.yaml
 
     wifi:
       # Set up a wifi access point
@@ -50,6 +54,9 @@ Relevant Documentation
 - ``wifi`` -> ``networks: []`` allows you to flash a device that will not contain any
   credentials and they must be set by the user via either the ``ap`` + ``captive_portal`` or
   the ``esp32_improv`` components.
+- ``dashboard_import`` -> ``package_import_url`` - This should point to the public repository containing
+  the configuration for the device so that the user's ESPHome dashboard can auto detect this device and
+  create a minimal yaml using :ref:`config-git_packages`.
 
 See Also
 --------

--- a/index.rst
+++ b/index.rst
@@ -69,7 +69,7 @@ ESPHome is a system to control your ESP8266/ESP32 by simple yet powerful configu
                 </li>
                 <li>
                     <a class="reference" href="/guides/creators.html">
-                        Creating a Project
+                        Sharing ESPHome devices
                     </a>
                 </li>
                 <li>


### PR DESCRIPTION
## Description:

- Rename creators page to sharing
- Add dashboard_import to sharing page


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
