### PR TITLE
Fix compile error for uptime sensor with esp-idf

### DIFF
--- a/components/sensor/uptime.rst
+++ b/components/sensor/uptime.rst
@@ -56,10 +56,10 @@ with human readable output.
                   int minutes = seconds /  60;
                   seconds = seconds % 60;
                   return (
-                    (days ? String(days) + "d " : "") +
-                    (hours ? String(hours) + "h " : "") +
-                    (minutes ? String(minutes) + "m " : "") +
-                    (String(seconds) + "s") 
+                    (days ? to_string(days) + "d " : "") +
+                    (hours ? to_string(hours) + "h " : "") +
+                    (minutes ? to_string(minutes) + "m " : "") +
+                    (to_string(seconds) + "s") 
                   ).c_str();
 
 See Also


### PR DESCRIPTION
## Description:

When compiling with esp-idf, the human readable uptime sensor example yields an error:

```
bedside-lamp-dev-stock-config.yaml: In lambda function:
bedside-lamp-dev-stock-config.yaml:89:17: error: 'String' was not declared in this scope
bedside-lamp-dev-stock-config.yaml:89:17: note: suggested alternative: 'trunc'
```

Fixed by switching to `to_string(...)` instead of using `String(...)`.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
