### PR TITLE
std::to_string() triggers an error on compile

### DIFF
--- a/components/logger.rst
+++ b/components/logger.rst
@@ -188,7 +188,7 @@ using ``message`` (``const char *``), ``level`` (``int``) and ``tag`` (``const c
           - mqtt.publish:
               topic: some/topic
               payload: !lambda |-
-                return "Triggered on_message with level " + std::to_string(level) + ", tag " + tag + " and message " + message;
+                return "Triggered on_message with level " + esphome::to_string(level) + ", tag " + tag + " and message " + message;
 
 .. note::
 

--- a/components/logger.rst
+++ b/components/logger.rst
@@ -188,7 +188,7 @@ using ``message`` (``const char *``), ``level`` (``int``) and ``tag`` (``const c
           - mqtt.publish:
               topic: some/topic
               payload: !lambda |-
-                return "Triggered on_message with level " + esphome::to_string(level) + ", tag " + tag + " and message " + message;
+                return "Triggered on_message with level " + to_string(level) + ", tag " + tag + " and message " + message;
 
 .. note::
 


### PR DESCRIPTION
Calling ``std::to_string()`` was causing "`to_string is not part of std library`" error. Fixed by using ``esphome::to_string``

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
