### PR TITLE
Switch the words 'prefix' and 'suffix'

### DIFF
--- a/components/text_sensor/index.rst
+++ b/components/text_sensor/index.rst
@@ -62,8 +62,8 @@ Filters are processed in the order they are defined in your configuration.
     filters:
       - to_upper:
       - to_lower:
-      - append: "_prefix"
-      - prepend: "suffix_"
+      - append: "_suffix"
+      - prepend: "prefix_"
       - substitute:
         - "suf -> foo"
         - "pre -> bar"
@@ -106,7 +106,7 @@ Adds a string to the end of the current string.
     - platform: template
       # ...
       filters:
-        - append: "_prefix"
+        - append: "_suffix"
 
 ``prepend``
 ***********
@@ -119,7 +119,7 @@ Adds a string to the start of the current string.
     - platform: template
       # ...
       filters:
-        - prepend: "suffix_"
+        - prepend: "prefix_"
 
 ``substitute``
 **************


### PR DESCRIPTION
## Description:
I could be wrong, but I think the words 'prefix' and 'suffix' are used in the wrong place. 

When you append a string, you add text to the end. So the text you add you call a suffix, right?
When you prepend a string, you add text to the beginning. So the text you add you call a prefix, right?




## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
