### PR TITLE
Add reference to MHO-C401 custom firmware

### DIFF
--- a/components/sensor/xiaomi_ble.rst
+++ b/components/sensor/xiaomi_ble.rst
@@ -236,7 +236,7 @@ Configuration example for PVVX MiThermometer firmware set to "Custom" advertisem
           name: "PVVX Battery-Voltage"
 
 MHO-C401
-**********
+********
 
 Hygro thermometer, square body, e-ink display, encrypted, broadcasts temperature, humidity and battery status. Requires a bindkey in order to decrypt the received data (see :ref:`obtaining_the_bindkey`).
 
@@ -501,7 +501,7 @@ Obtaining The Bindkey
 To set up an encrypted device such as the LYWSD03MMC (with Xiaomi stock firmware) and CGD1, you first need to obtain the bind key. The ``xiaomi_ble`` sensor component is not able to automatically generate a bind key so other workarounds are necessary.
 
 LYWSD03MMC/MHO-C401
-**********
+*******************
 
 If the LYWSD03MMC or MHO-C401 sensor is operated with the Xiaomi stock firmware, you can use the `TeLink flasher application <https://atc1441.github.io/TelinkFlasher.html>`__ to easily generate a new bind key and upload the key to the device without the need to flash a new firmware (see figure). For this, you load the flasher `webpage <https://atc1441.github.io/TelinkFlasher.html>`__ with a `supported browser <https://github.com/WebBluetoothCG/web-bluetooth/blob/master/implementation-status.md>`__ and connect the device by pressing "Connect". After the connection is established, you press the "Do Activation" button and the new key will be shown in the "Mi Bind Key" field. The key can be copied directly into the sensor YAML configuration.
 

--- a/components/sensor/xiaomi_ble.rst
+++ b/components/sensor/xiaomi_ble.rst
@@ -246,7 +246,15 @@ Hygro thermometer, square body, e-ink display, encrypted, broadcasts temperature
 
 ( MHO-C201 doesn't have BT )
 
-Configuration example:
+Similar to the LYWSD03MMC, there is custom firmware available for this device, so there are the following possibilities to operate this sensor:
+
+1. Xiaomi stock firmware (requires a bindkey in order to decrypt the received data, see :ref:`obtaining_the_bindkey`)
+2. Device flashed with `PVVX MiThermometer <https://github.com/pvvx/ATC_MiThermometer>`__ custom firmware
+
+   - "Mi Like" advertisement (dummy bindkey required)
+   - "pvvx" custom advertisement (no bindkey required, only PVVX firmware)
+
+Configuration example for Xiaomi stock firmware:
 
 .. code-block:: yaml
 
@@ -260,6 +268,23 @@ Configuration example:
           name: "MHOC401 Humidity"
         battery_level:
           name: "MHOC401 Battery Level"
+
+Configuration example for PVVX MiThermometer firmware set to "Custom" advertisement:
+
+.. code-block:: yaml
+
+    sensor:
+      - platform: pvvx_mithermometer
+        mac_address: "A4:C1:38:B1:CD:7F"
+        temperature:
+          name: "PVVX Temperature"
+        humidity:
+          name: "PVVX Humidity"
+        battery_level:
+          name: "PVVX Battery-Level"
+        battery_voltage:
+          name: "PVVX Battery-Voltage"
+
 
 CGD1
 ****
@@ -475,10 +500,10 @@ Obtaining The Bindkey
 
 To set up an encrypted device such as the LYWSD03MMC (with Xiaomi stock firmware) and CGD1, you first need to obtain the bind key. The ``xiaomi_ble`` sensor component is not able to automatically generate a bind key so other workarounds are necessary.
 
-LYWSD03MMC
+LYWSD03MMC/MHO-C401
 **********
 
-If the LYWSD03MMC sensor is operated with the Xiaomi stock firmware, you can use the `TeLink flasher application <https://atc1441.github.io/TelinkFlasher.html>`__ to easily generate a new bind key and upload the key to the device without the need to flash a new firmware (see figure). For this, you load the flasher `webpage <https://atc1441.github.io/TelinkFlasher.html>`__ with a `supported browser <https://github.com/WebBluetoothCG/web-bluetooth/blob/master/implementation-status.md>`__ and connect the device by pressing "Connect". After the connection is established, you press the "Do Activation" button and the new key will be shown in the "Mi Bind Key" field. The key can be copied directly into the sensor YAML configuration.
+If the LYWSD03MMC or MHO-C401 sensor is operated with the Xiaomi stock firmware, you can use the `TeLink flasher application <https://atc1441.github.io/TelinkFlasher.html>`__ to easily generate a new bind key and upload the key to the device without the need to flash a new firmware (see figure). For this, you load the flasher `webpage <https://atc1441.github.io/TelinkFlasher.html>`__ with a `supported browser <https://github.com/WebBluetoothCG/web-bluetooth/blob/master/implementation-status.md>`__ and connect the device by pressing "Connect". After the connection is established, you press the "Do Activation" button and the new key will be shown in the "Mi Bind Key" field. The key can be copied directly into the sensor YAML configuration.
 
 .. figure:: images/telink_flasher.jpg
     :align: center


### PR DESCRIPTION
## Description:
The MHO-C401 can now be flashed with the PVVX MiThermometer custom firmware, and the setup process is similar to the LYWSD03MMC, just without the option of the ATC MiThermometer firmware. After some confusion getting my custom-flashed MHO-C401 into ESPHome, I wanted to clarify the section here.


**Related issue (if applicable):** fixes [2569](https://github.com/esphome/issues/issues/2569)


## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
