### PR TITLE
Update for ruuvi and xiaomi ble to require yaml

### DIFF
--- a/components/sensor/ruuvitag.rst
+++ b/components/sensor/ruuvitag.rst
@@ -153,11 +153,13 @@ Setting Up Devices
 
 To set up RuuviTag devices you first need to find their MAC Address so that
 ESPHome can identify them. So first, create a simple configuration without any
-``ruuvitag`` entries like so:
+``ruuvitag`` entries but with ``ruuvi_ble`` enabled like so:
 
 .. code-block:: yaml
 
     esp32_ble_tracker:
+
+    ruuvi_ble:
 
 After uploading the ESP32 will immediately try to scan for BLE devices.
 When it detects these sensors, it will automatically parse the BLE message

--- a/components/sensor/xiaomi_ble.rst
+++ b/components/sensor/xiaomi_ble.rst
@@ -458,6 +458,8 @@ To find the MAC Address so that ESPHome can identify the device, you can create 
 
     esp32_ble_tracker:
 
+    xiaomi_ble:
+
 After uploading, the ESP32 will immediately try to scan for BLE devices. When it detects a new sensor, it will automatically parse the BLE message print a message like this one:
 
 .. code::


### PR DESCRIPTION
## Description: 

There is a PR for esphome to remove the auto_loading of Ruuvi and Xiaomi BLE components by the generic esp32_ble_tracker component.  This forced this code to load anytime esp32_ble_tracker was loaded and is unnecessary when not using ruuvi or xiaomi components.  Given there are now many BLE components it doesn't make sense to use an autoload pattern.  Just wastes flash/ram and compute cycles if the user doesn't have any sensors.  


**Related issue (if applicable):** fixes <https://github.com/esphome/issues/issues/2503>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#2617

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
