### PR TITLE
Add Pronto protocol

### DIFF
--- a/components/remote_transmitter.rst
+++ b/components/remote_transmitter.rst
@@ -109,7 +109,7 @@ Configuration variables:
 .. _remote_transmitter-transmit_pronto:
 
 ``remote_transmitter.transmit_pronto`` Action
-******************************************
+*********************************************
 
 This :ref:`action <config-action>` sends a raw code to a remote transmitter specified in Pronto format.
 

--- a/components/remote_transmitter.rst
+++ b/components/remote_transmitter.rst
@@ -106,6 +106,27 @@ Configuration variables:
   with for infrared signals. Defaults to ``0Hz``.
 - All other options from :ref:`remote_transmitter-transmit_action`.
 
+.. _remote_transmitter-transmit_pronto:
+
+``remote_transmitter.transmit_pronto`` Action
+******************************************
+
+This :ref:`action <config-action>` sends a raw code to a remote transmitter specified in Pronto format.
+
+.. code-block:: yaml
+
+    on_...:
+      - remote_transmitter.transmit_pronto:
+          data: "0000 006D 0010 0000 0008 0020 0008 0046 000A 0020 0008 0020 0008 001E 000A 001E 000A 0046 000A 001E 0008 0020 0008 0020 0008 0046 000A 0046 000A 0046 000A 001E 000A 001E 0008 06C3"
+
+Configuration variables:
+
+- **data** (**Required**, string): The raw code to send specified as a string.
+  A lot of remote control Pronto codes can be found on http://remotecentral.com
+- All other options from :ref:`remote_transmitter-transmit_action`.
+
+
+
 ``remote_transmitter.transmit_jvc`` Action
 ******************************************
 


### PR DESCRIPTION
Add documentation for Pronto protocol addition.

## Description:
Add documentation for the Pronto protocol addition to transmit codes using this protocol specification.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#2619

## Checklist:

  - [X] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
