### PR TITLE
Add publish_initial_value option to rotary_encoder

### DIFF
--- a/components/sensor/rotary_encoder.rst
+++ b/components/sensor/rotary_encoder.rst
@@ -59,6 +59,10 @@ Configuration variables:
   the knob further will not decrease the number. Defaults to no minimum.
 - **max_value** (*Optional*, int): The maximum value this rotary encoder will go to, turning
   the knob further will not increase the number. Defaults to no maximum.
+- **publish_initial_value** (*Optional*, boolean): Controls whether the value is published
+  upon start of ESPHome. By default the value is only published when it changes, causing an
+  "unknown" value at first. If you set this option to true, the value is published once after
+  boot and when it changes. Defaults to ``false``.
 - **on_clockwise** (*Optional*, :ref:`Automation <automation>`): Actions to be performed when
   the knob is turned clockwise. See :ref:`sensor-rotary_encoder-triggers`.
 - **on_anticlockwise** (*Optional*, :ref:`Automation <automation>`): Actions to be performed when


### PR DESCRIPTION
## Description:
Adds a description for the publish_initial_value variable. This is an optional variable and is set to false by default. Some users might need it (see https://github.com/esphome/issues/issues/2535)

**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/2535

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#2503

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
