### PR TITLE
Add missing link from Tuya MCU to Tuya Sensor

### DIFF
--- a/components/tuya.rst
+++ b/components/tuya.rst
@@ -68,5 +68,6 @@ See Also
 - :doc:`/components/switch/tuya`
 - :doc:`/components/climate/tuya`
 - :doc:`/components/binary_sensor/tuya`
+- :doc:`/components/sensor/tuya`
 - :apiref:`tuya/tuya.h`
 - :ghedit:`Edit`


### PR DESCRIPTION
## Description:

The docs for Tuya MCU are missing a "see also" link to Tuya Sensor.

I recently wanted to find out which platforms were supported by Tuya MCU, and the existing documentation made it look like there was no support for the `sensor` platform. After looking into the source code of esphome, I found out that the platform is indeed implemented, but just not linked from the Tuya MCU documentatino page. This PR fixes this.

**Related issue (if applicable):** -

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** -

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
