### PR TITLE
[remote_receiver] Correct actual default for "filter" (50us instead of 10us)

### DIFF
--- a/components/remote_receiver.rst
+++ b/components/remote_receiver.rst
@@ -51,7 +51,7 @@ Configuration variables:
 - **memory_blocks** (*Optional*, int): The number of RMT memory blocks used. Only used on ESP32 platform. Defaults to
   ``3``.
 - **filter** (*Optional*, :ref:`time <config-time>`): Filter any pulses that are shorter than this. Useful for removing
-  glitches from noisy signals. Defaults to ``10us``.
+  glitches from noisy signals. Defaults to ``50us``.
 - **idle** (*Optional*, :ref:`time <config-time>`): The amount of time that a signal should remain stable (i.e. not
   change) for it to be considered complete. Defaults to ``10ms``.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation. Use this if you have


### PR DESCRIPTION
## Description:

The currently implemented default for filter is 50us:
https://github.com/esphome/esphome/blob/ac0d921413c3884752193fe568fa82853f0f99e9/esphome/components/remote_receiver/__init__.py#L37

This PR corrects the documentation for that value.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
