### PR TITLE
Add option to use MQTT abbreviations

### DIFF
--- a/components/mqtt.rst
+++ b/components/mqtt.rst
@@ -43,6 +43,9 @@ Configuration variables:
 - **discovery_prefix** (*Optional*, string): The prefix to use for Home
   Assistant’s MQTT discovery. Should not contain trailing slash.
   Defaults to ``homeassistant``.
+- **use_abbreviations** (*Optional*, boolean): Whether to use
+  `Abbreviations <https://www.home-assistant.io/docs/mqtt/discovery/>`__
+  in discovery messages. Defaults to ``true``.
 - **topic_prefix** (*Optional*, string): The prefix used for all MQTT
   messages. Should not contain trailing slash. Defaults to
   ``<APP_NAME>``.


### PR DESCRIPTION
## Description:

Add `use_abbreviations` to MQTT docs

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#2641

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
