### PR TITLE
Add restore_mode to rotary_encoder sensor

### DIFF
--- a/components/sensor/rotary_encoder.rst
+++ b/components/sensor/rotary_encoder.rst
@@ -63,6 +63,13 @@ Configuration variables:
   upon start of ESPHome. By default the value is only published when it changes, causing an
   "unknown" value at first. If you set this option to true, the value is published once after
   boot and when it changes. Defaults to ``false``.
+- **restore_mode** (*Optional*): Control how the Rotary Encoder attempts to restore state on bootup.
+  For restoring on ESP8266s, also see ``esp8266_restore_from_flash`` in the
+  :doc:`esphome section </components/esphome>`.
+
+    - ``RESTORE_DEFAULT_ZERO`` (Default) - Attempt to restore state and default to zero (0) if not possible to restore.
+    - ``ALWAYS_ZERO`` - Always initialize the counter with value zero (0).
+
 - **on_clockwise** (*Optional*, :ref:`Automation <automation>`): Actions to be performed when
   the knob is turned clockwise. See :ref:`sensor-rotary_encoder-triggers`.
 - **on_anticlockwise** (*Optional*, :ref:`Automation <automation>`): Actions to be performed when


### PR DESCRIPTION
## Description:

Adds the restore_mode variable and its options to the rotary_encoder sensor documentation.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
