### PR TITLE
Add M5Stack Timer Camera X/F

### DIFF
--- a/components/esp32_camera.rst
+++ b/components/esp32_camera.rst
@@ -149,6 +149,28 @@ Configuration for M5Stack Camera
       name: My Camera
       # ...
 
+Configuration for M5Stack Timer Camera X/F
+--------------------------------
+
+.. code-block:: yaml
+
+    # Example configuration entry
+    esp32_camera:
+      external_clock:
+        pin: GPIO27
+        frequency: 20MHz
+      i2c_pins:
+        sda: GPIO25
+        scl: GPIO23
+      data_pins: [GPIO32, GPIO35, GPIO34, GPIO5, GPIO39, GPIO18, GPIO36, GPIO19]
+      vsync_pin: GPIO22
+      href_pin: GPIO26
+      pixel_clock_pin: GPIO21
+      reset_pin: GPIO15
+
+      # Image settings
+      name: My Camera
+      # ...
 
 Configuration for Wrover Kit Boards
 -----------------------------------

--- a/components/esp32_camera.rst
+++ b/components/esp32_camera.rst
@@ -150,7 +150,7 @@ Configuration for M5Stack Camera
       # ...
 
 Configuration for M5Stack Timer Camera X/F
---------------------------------
+------------------------------------------
 
 .. code-block:: yaml
 


### PR DESCRIPTION
## Description:

Pinouts taken from https://docs.m5stack.com/en/unit/timercam_f (identical to the X model) and verified on real hardware.

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
