### PR TITLE
document modbus fp32 datatype

### DIFF
--- a/components/binary_sensor/modbus_controller.rst
+++ b/components/binary_sensor/modbus_controller.rst
@@ -24,6 +24,9 @@ Configuration variables:
 - **bitmask** : some values are packed in a response. The bitmask is used to determined if the result is true or false
 - **skip_updates**: (*Optional*, integer): By default all sensors of of a modbus_controller are updated together. For data points that don't change very frequently updates can be skipped. A value of 5 would only update this sensor range in every 5th update cycle
 - **force_new_range**: (*Optional*, boolean): If possible sensors with sequential addresses are grouped together and requested in one range. Setting `foce_new_range: true` enforces the start of a new range at that address.
+- **custom_data** (**Optional**, list of bytes): raw bytes for modbus command. This allows using non-standard commands. If `custom_data` is used `address` and `register_type` can't be used. 
+  custom data must contain all required bytes including the modbus device address. The crc is automatically calculated and appended to the command.
+  See :ref:`modbus_custom_data` how to use `custom_command`
 - **lambda** (*Optional*, :ref:`lambda <config-lambda>`):
   Lambda to be evaluated every update interval to get the new value of the sensor
 - **offset**: (*Optional*, integer): not required for most cases

--- a/components/binary_sensor/modbus_controller.rst
+++ b/components/binary_sensor/modbus_controller.rst
@@ -24,7 +24,7 @@ Configuration variables:
 - **bitmask** : some values are packed in a response. The bitmask is used to determined if the result is true or false
 - **skip_updates**: (*Optional*, integer): By default all sensors of of a modbus_controller are updated together. For data points that don't change very frequently updates can be skipped. A value of 5 would only update this sensor range in every 5th update cycle
 - **force_new_range**: (*Optional*, boolean): If possible sensors with sequential addresses are grouped together and requested in one range. Setting ``force_new_range: true`` enforces the start of a new range at that address.
-- **custom_data** (**Optional**, list of bytes): raw bytes for modbus command. This allows using non-standard commands. If ``custom_data`` is used ``address`` and ``register_type`` can't be used. 
+- **custom_data** (*Optional*, list of bytes): raw bytes for modbus command. This allows using non-standard commands. If ``custom_data`` is used ``address`` and ``register_type`` can't be used. 
   custom data must contain all required bytes including the modbus device address. The crc is automatically calculated and appended to the command.
   See :ref:`modbus_custom_data` how to use ``custom_command``
 - **lambda** (*Optional*, :ref:`lambda <config-lambda>`):

--- a/components/binary_sensor/modbus_controller.rst
+++ b/components/binary_sensor/modbus_controller.rst
@@ -23,10 +23,10 @@ Configuration variables:
 - **address**: (**Required**, integer): start address of the first register in a range
 - **bitmask** : some values are packed in a response. The bitmask is used to determined if the result is true or false
 - **skip_updates**: (*Optional*, integer): By default all sensors of of a modbus_controller are updated together. For data points that don't change very frequently updates can be skipped. A value of 5 would only update this sensor range in every 5th update cycle
-- **force_new_range**: (*Optional*, boolean): If possible sensors with sequential addresses are grouped together and requested in one range. Setting `foce_new_range: true` enforces the start of a new range at that address.
-- **custom_data** (**Optional**, list of bytes): raw bytes for modbus command. This allows using non-standard commands. If `custom_data` is used `address` and `register_type` can't be used. 
+- **force_new_range**: (*Optional*, boolean): If possible sensors with sequential addresses are grouped together and requested in one range. Setting ``force_new_range: true`` enforces the start of a new range at that address.
+- **custom_data** (**Optional**, list of bytes): raw bytes for modbus command. This allows using non-standard commands. If ``custom_data`` is used ``address`` and ``register_type`` can't be used. 
   custom data must contain all required bytes including the modbus device address. The crc is automatically calculated and appended to the command.
-  See :ref:`modbus_custom_data` how to use `custom_command`
+  See :ref:`modbus_custom_data` how to use ``custom_command``
 - **lambda** (*Optional*, :ref:`lambda <config-lambda>`):
   Lambda to be evaluated every update interval to get the new value of the sensor
 - **offset**: (*Optional*, integer): not required for most cases

--- a/components/modbus_controller.rst
+++ b/components/modbus_controller.rst
@@ -7,10 +7,6 @@ Modbus Controller
 
 The ``modbus_controller`` component creates a RS485 connection to control a modbus device
 
-.. warning::
-
-    If you are using the :doc:`logger` uart logging might interfere especially on esp8266. You can disable the uart logging with the ``baud_rate: 0`` option.
-
 .. figure:: /images/modbus.png
     :align: center
     :width: 25%
@@ -29,6 +25,25 @@ See [How is this RS485 Module Working?](https://electronics.stackexchange.com/qu
 
 The controller connects to the UART of the MCU. For ESP32  GPIO PIN 16 to TXD PIN 17 to RXD are the default ports but any other pins can be used as well . 3.3V to VCC and GND to GND.
 
+.. note::
+
+    If your are using an ESP82xx serial logging may cause problems reading from uart. For best results hardware serial is prefered. Software serial may not be able to read all received data if other components spend a lot of time in loop()
+    
+    For hardware serial only a limited set of pins can be used. Either `tx_pin: GPIO1` and `rx_pin: GPIO3`  or `tx_pin: GPIO15` and `rx_pin: GPIO13`.
+    
+    The disadvantage of using the hardware uart is that you can't use serial logging because the serial logs would be sent to the modbus device and cause errors.
+    
+    Serial logging can be disable by setting `baud_rate: 0`.
+    
+    See :doc:`logger` for more details
+
+    .. code-block:: yaml
+
+        logger:
+            level: <level>
+            baud_rate: 0
+
+
 
 Configuration variables:
 ------------------------
@@ -42,8 +57,8 @@ Configuration variables:
   Because some modbus devices limit the rate of requests the interval between sending requests to the device can be modified.
 
 
-Getting started with Home Assistant
------------------------------------
+Example
+-------
 The following code create a modbus_controller hub talking to a modbus device at address 1 with 115200 bps
 
 
@@ -53,73 +68,73 @@ Technically there is no difference between the "inline" and the standard definit
 .. code-block:: yaml
 
     esphome:
-      name: solarstation
-      platform: ESP32
-      board: esp32dev
+        name: solarstation
+        platform: ESP32
+        board: esp32dev
 
     substitutions:
-      updates: 30s
+        updates: 30s
 
     wifi:
-      ssid: !secret wifi_sid
-      password: !secret wifi_password
-      reboot_timeout: 2min
+        ssid: !secret wifi_sid
+        password: !secret wifi_password
+        reboot_timeout: 2min
 
     logger:
-      level: INFO
-      baud_rate: 0
+        level: INFO
+        baud_rate: 0
 
     api:
-      password: !secret api_password
+        password: !secret api_password
 
     uart:
-      id: mod_bus
-      tx_pin: 17
-      rx_pin: 16
-      baud_rate: 115200
-      stop_bits: 1
+        id: mod_bus
+        tx_pin: 17
+        rx_pin: 16
+        baud_rate: 115200
+        stop_bits: 1
 
     modbus:
-      flow_control_pin: 5
-      id: modbus1
+        flow_control_pin: 5
+        id: modbus1
 
     modbus_controller:
-      - id: epever
-        ## the Modbus device addr
-        address: 0x1
-        modbus_id: modbus1
-        setup_priority: -10
+        - id: epever
+          ## the Modbus device addr
+          address: 0x1
+          modbus_id: modbus1
+          setup_priority: -10
 
     text_sensor:
-      - name: "rtc_clock"
-        platform: modbus_controller
-        modbus_controller_id: epever
-        id: rtc_clock
-        internal: true
-        register_type: holding
-        address: 0x9013
-        register_count: 3
-        raw_encode: HEXBYTES
-        response_size: 6
+        - name: "rtc_clock"
+          platform: modbus_controller
+          modbus_controller_id: epever
+          id: rtc_clock
+          internal: true
+          register_type: holding
+          address: 0x9013
+          register_count: 3
+          raw_encode: HEXBYTES
+          response_size: 6
 
     switch:
-      - platform: modbus_controller
-        modbus_controller_id: epever
-        id: reset_to_fabric_default
-        name: "Reset to Factory Default"
-        register_type: coil
-        address: 0x15
-        bitmask: 1
+        - platform: modbus_controller
+          modbus_controller_id: epever
+          id: reset_to_fabric_default
+          name: "Reset to Factory Default"
+          register_type: coil
+          address: 0x15
+          bitmask: 1
 
     sensor:
-      - platform: modbus_controller
-        modbus_controller_id: epever
-        name: "Battery Capacity"
-        id: battery_capacity
-        register_type: holding
-        address: 0x9001
-        unit_of_measurement: "AH"
-        value_type: U_WORD
+        - platform: modbus_controller
+          modbus_controller_id: epever
+          name: "Battery Capacity"
+          id: battery_capacity
+          register_type: holding
+          address: 0x9001
+          unit_of_measurement: "AH"
+          value_type: U_WORD
 
 
 Protocol decoding example

--- a/components/modbus_controller.rst
+++ b/components/modbus_controller.rst
@@ -27,13 +27,13 @@ The controller connects to the UART of the MCU. For ESP32  GPIO PIN 16 to TXD PI
 
 .. note::
 
-    If your are using an ESP82xx serial logging may cause problems reading from uart. For best results hardware serial is prefered. Software serial may not be able to read all received data if other components spend a lot of time in loop()
+    If you are using an ESP8266, serial logging may cause problems reading from UART. For best results, hardware serial is recommended. Software serial may not be able to read all received data if other components spend a lot of time in the ``loop()``.
     
     For hardware serial only a limited set of pins can be used. Either `tx_pin: GPIO1` and `rx_pin: GPIO3`  or `tx_pin: GPIO15` and `rx_pin: GPIO13`.
     
     The disadvantage of using the hardware uart is that you can't use serial logging because the serial logs would be sent to the modbus device and cause errors.
     
-    Serial logging can be disable by setting `baud_rate: 0`.
+    Serial logging can be disabled by setting `baud_rate: 0`.
     
     See :doc:`logger` for more details
 

--- a/components/modbus_controller.rst
+++ b/components/modbus_controller.rst
@@ -68,73 +68,73 @@ Technically there is no difference between the "inline" and the standard definit
 .. code-block:: yaml
 
     esphome:
-        name: solarstation
-        platform: ESP32
-        board: esp32dev
+      name: solarstation
+      platform: ESP32
+      board: esp32dev
 
     substitutions:
-        updates: 30s
+      updates: 30s
 
     wifi:
-        ssid: !secret wifi_sid
-        password: !secret wifi_password
-        reboot_timeout: 2min
+      ssid: !secret wifi_sid
+      password: !secret wifi_password
+      reboot_timeout: 2min
 
     logger:
-        level: INFO
-        baud_rate: 0
+      level: INFO
+      baud_rate: 0
 
     api:
-        password: !secret api_password
+      password: !secret api_password
 
     uart:
-        id: mod_bus
-        tx_pin: 17
-        rx_pin: 16
-        baud_rate: 115200
-        stop_bits: 1
+      id: mod_bus
+      tx_pin: 17
+      rx_pin: 16
+      baud_rate: 115200
+      stop_bits: 1
 
     modbus:
-        flow_control_pin: 5
-        id: modbus1
+      flow_control_pin: 5
+      id: modbus1
 
     modbus_controller:
-        - id: epever
-          ## the Modbus device addr
-          address: 0x1
-          modbus_id: modbus1
-          setup_priority: -10
+      - id: epever
+        ## the Modbus device addr
+        address: 0x1
+        modbus_id: modbus1
+        setup_priority: -10
 
     text_sensor:
-        - name: "rtc_clock"
-          platform: modbus_controller
-          modbus_controller_id: epever
-          id: rtc_clock
-          internal: true
-          register_type: holding
-          address: 0x9013
-          register_count: 3
-          raw_encode: HEXBYTES
-          response_size: 6
+      - name: "rtc_clock"
+        platform: modbus_controller
+        modbus_controller_id: epever
+        id: rtc_clock
+        internal: true
+        register_type: holding
+        address: 0x9013
+        register_count: 3
+        raw_encode: HEXBYTES
+        response_size: 6
 
     switch:
-        - platform: modbus_controller
-          modbus_controller_id: epever
-          id: reset_to_fabric_default
-          name: "Reset to Factory Default"
-          register_type: coil
-          address: 0x15
-          bitmask: 1
+      - platform: modbus_controller
+        modbus_controller_id: epever
+        id: reset_to_fabric_default
+        name: "Reset to Factory Default"
+        register_type: coil
+        address: 0x15
+        bitmask: 1
 
     sensor:
-        - platform: modbus_controller
-          modbus_controller_id: epever
-          name: "Battery Capacity"
-          id: battery_capacity
-          register_type: holding
-          address: 0x9001
-          unit_of_measurement: "AH"
-          value_type: U_WORD
+      - platform: modbus_controller
+        modbus_controller_id: epever
+        name: "Battery Capacity"
+        id: battery_capacity
+        register_type: holding
+        address: 0x9001
+        unit_of_measurement: "AH"
+        value_type: U_WORD
 
 
 Protocol decoding example

--- a/components/modbus_controller.rst
+++ b/components/modbus_controller.rst
@@ -29,11 +29,11 @@ The controller connects to the UART of the MCU. For ESP32  GPIO PIN 16 to TXD PI
 
     If you are using an ESP8266, serial logging may cause problems reading from UART. For best results, hardware serial is recommended. Software serial may not be able to read all received data if other components spend a lot of time in the ``loop()``.
     
-    For hardware serial only a limited set of pins can be used. Either `tx_pin: GPIO1` and `rx_pin: GPIO3`  or `tx_pin: GPIO15` and `rx_pin: GPIO13`.
+    For hardware serial only a limited set of pins can be used. Either ``tx_pin: GPIO1`` and ``rx_pin: GPIO3``  or ``tx_pin: GPIO15`` and ``rx_pin: GPIO13``.
     
     The disadvantage of using the hardware uart is that you can't use serial logging because the serial logs would be sent to the modbus device and cause errors.
     
-    Serial logging can be disabled by setting `baud_rate: 0`.
+    Serial logging can be disabled by setting ``baud_rate: 0``.
     
     See :doc:`logger` for more details
 

--- a/components/number/modbus_controller.rst
+++ b/components/number/modbus_controller.rst
@@ -19,16 +19,16 @@ Configuration variables:
     - read: Read Input Registers - registers are 16-bit registers used for input, and may only be read
 - **address**: (**Required**, int): start address of the first register in a range
 - **value_type**: (**Required**): datatype of the mod_bus register data. The default data type for modbus is a 16 bit integer in big endian format (MSB first)
-    - U_WORD (unsigned 16 bit integer 1 register =16bit
-    - S_WORD (signed 16 bit integer one register)
+    - U_WORD (unsigned 16 bit integer from 1 register = 16bit)
+    - S_WORD (signed 16 bit integer from 1 register = 16bit)
     - U_DWORD (unsigned 32 bit integer from 2 registers = 32bit)
     - S_DWORD (signed 32 bit integer from 2 registers = 32bit)
-    - U_DWORD_R (unsigned 32 bit integer from 2 registers low word first )
-    - S_DWORD_R (signed 32 bit integer from 2 registers low word first )
-    - U_QWORD (unsigned 64 bit integer from 4 registers = 64bit
-    - S_QWORD (unsigned 64 bit integer from 4 registers = 64bit
-    - U_QWORD_R (unsigend float from 4 registers low word first )
-    - S_QWORD_R (sigend float from 4 registers low word first )
+    - U_DWORD_R (unsigned 32 bit integer from 2 registers low word first)
+    - S_DWORD_R (signed 32 bit integer from 2 registers low word first)
+    - U_QWORD (unsigned 64 bit integer from 4 registers = 64bit)
+    - S_QWORD (unsigned 64 bit integer from 4 registers = 64bit)
+    - U_QWORD_R (unsigned 64 bit integer from 4 registers low word first)
+    - U_QWORD_R signed 64 bit integer from 4 registers low word first)
     - FP32 (32 bit IEEE 754 floating point from 2 registers)
     - FP32_R (32 bit IEEE 754 floating point - same as FP32 but low word first)
 
@@ -42,7 +42,7 @@ Configuration variables:
 - **min_value** (*Optional*, float): The minimum value this number can be.
 - **max_value** (*Optional*, float): The maximum value this number can be.
 - **step** (*Optional*, float): The granularity with which the number can be set. Defaults to 1
-- **custom_data** (**Optional**, list of bytes): raw bytes for modbus command. This allows using non-standard commands. If `custom_data` is used `address` and `register_type` can't be used. 
+- **custom_data** (**Optional**, list of bytes): raw bytes for modbus command. This allows using non-standard commands. If `custom_data` is used `address` and `register_type` can't be used.
   custom data must contain all required bytes including the modbus device address. The crc is automatically calculated and appended to the command.
   See :ref:`modbus_custom_data` how to use `custom_command`
 - **lambda** (*Optional*, :ref:`lambda <config-lambda>`):

--- a/components/number/modbus_controller.rst
+++ b/components/number/modbus_controller.rst
@@ -19,14 +19,14 @@ Configuration variables:
     - read: Read Input Registers - registers are 16-bit registers used for input, and may only be read
 - **address**: (**Required**, int): start address of the first register in a range
 - **value_type**: (**Required**): datatype of the mod_bus register data. The default data type for modbus is a 16 bit integer in big endian format (MSB first)
-    - U_WORD (unsigned float from 1 register =16bit
-    - S_WORD (signed float from one register)
-    - U_DWORD (unsigned float from 2 registers = 32bit)
-    - S_DWORD (unsigned float from 2 registers = 32bit)
-    - U_DWORD_R (unsigend float from 2 registers low word first )
-    - S_DWORD_R (sigend float from 2 registers low word first )
-    - U_QWORD (unsigned float from 4 registers = 64bit
-    - S_QWORD (signed float from 4 registers = 64bit
+    - U_WORD (unsigned 16 bit integer 1 register =16bit
+    - S_WORD (signed 16 bit integer one register)
+    - U_DWORD (unsigned 32 bit integer from 2 registers = 32bit)
+    - S_DWORD (signed 32 bit integer from 2 registers = 32bit)
+    - U_DWORD_R (unsigned 32 bit integer from 2 registers low word first )
+    - S_DWORD_R (signed 32 bit integer from 2 registers low word first )
+    - U_QWORD (unsigned 64 bit integer from 4 registers = 64bit
+    - S_QWORD (unsigned 64 bit integer from 4 registers = 64bit
     - U_QWORD_R (unsigend float from 4 registers low word first )
     - S_QWORD_R (sigend float from 4 registers low word first )
     - FP32 (32 bit IEEE 754 floating point from 2 registers)

--- a/components/number/modbus_controller.rst
+++ b/components/number/modbus_controller.rst
@@ -29,17 +29,22 @@ Configuration variables:
     - S_QWORD (signed float from 4 registers = 64bit
     - U_QWORD_R (unsigend float from 4 registers low word first )
     - S_QWORD_R (sigend float from 4 registers low word first )
+    - FP32 (32 bit IEEE 754 floating point from 2 registers)
+    - FP32_R (32 bit IEEE 754 floating point - same as FP32 but low word first)
 
 - **skip_updates**: (*Optional*, integer): By default all sensors of of a modbus_controller are updated together. For data points that don't change very frequently updates can be skipped. A value of 5 would only update this sensor range in every 5th update cycle
   Note: The modbus_controller groups component by address ranges to reduce number of transactions. All compoents with the same address will be updated in one request. skip_updates applies for all components in the same range.
 - **register_count**: (*Optional*): only required for uncommon response encodings
-  The number of registers this data point spans. Default is 1
+  The number of registers this data point spans. Overrides the defaults determined by `value_type`.
 - **force_new_range**: (*Optional*, boolean): If possible sensors with sequential addresses are grouped together and requested in one range. Setting `foce_new_range: true` enforces the start of a new range at that address.
 - **offset**: (*Optional*, int): only required for uncommon response encodings
     offset from start address in bytes. If more than one register is read a modbus read registers command this value is used to find the start of this datapoint relative to start address. The component calculates the size of the range based on offset and size of the value type
 - **min_value** (*Optional*, float): The minimum value this number can be.
 - **max_value** (*Optional*, float): The maximum value this number can be.
 - **step** (*Optional*, float): The granularity with which the number can be set. Defaults to 1
+- **custom_data** (**Optional**, list of bytes): raw bytes for modbus command. This allows using non-standard commands. If `custom_data` is used `address` and `register_type` can't be used. 
+  custom data must contain all required bytes including the modbus device address. The crc is automatically calculated and appended to the command.
+  See :ref:`modbus_custom_data` how to use `custom_command`
 - **lambda** (*Optional*, :ref:`lambda <config-lambda>`):
   Lambda to be evaluated every update interval to get the new value of the sensor.
 - **write_lambda** (*Optional*, :ref:`lambda <config-lambda>`): Lambda called before send.

--- a/components/number/modbus_controller.rst
+++ b/components/number/modbus_controller.rst
@@ -35,16 +35,16 @@ Configuration variables:
 - **skip_updates**: (*Optional*, integer): By default all sensors of of a modbus_controller are updated together. For data points that don't change very frequently updates can be skipped. A value of 5 would only update this sensor range in every 5th update cycle
   Note: The modbus_controller groups component by address ranges to reduce number of transactions. All compoents with the same address will be updated in one request. skip_updates applies for all components in the same range.
 - **register_count**: (*Optional*): only required for uncommon response encodings
-  The number of registers this data point spans. Overrides the defaults determined by `value_type`.
-- **force_new_range**: (*Optional*, boolean): If possible sensors with sequential addresses are grouped together and requested in one range. Setting `foce_new_range: true` enforces the start of a new range at that address.
+  The number of registers this data point spans. Overrides the defaults determined by ``value_type``.
+- **force_new_range**: (*Optional*, boolean): If possible sensors with sequential addresses are grouped together and requested in one range. Setting ``force_new_range: true`` enforces the start of a new range at that address.
 - **offset**: (*Optional*, int): only required for uncommon response encodings
     offset from start address in bytes. If more than one register is read a modbus read registers command this value is used to find the start of this datapoint relative to start address. The component calculates the size of the range based on offset and size of the value type
 - **min_value** (*Optional*, float): The minimum value this number can be.
 - **max_value** (*Optional*, float): The maximum value this number can be.
 - **step** (*Optional*, float): The granularity with which the number can be set. Defaults to 1
-- **custom_data** (**Optional**, list of bytes): raw bytes for modbus command. This allows using non-standard commands. If `custom_data` is used `address` and `register_type` can't be used.
+- **custom_data** (**Optional**, list of bytes): raw bytes for modbus command. This allows using non-standard commands. If ``custom_data`` is used ``address`` and ``register_type`` can't be used.
   custom data must contain all required bytes including the modbus device address. The crc is automatically calculated and appended to the command.
-  See :ref:`modbus_custom_data` how to use `custom_command`
+  See :ref:`modbus_custom_data` how to use ``custom_command``
 - **lambda** (*Optional*, :ref:`lambda <config-lambda>`):
   Lambda to be evaluated every update interval to get the new value of the sensor.
 - **write_lambda** (*Optional*, :ref:`lambda <config-lambda>`): Lambda called before send.
@@ -59,7 +59,7 @@ Parameters passed into the lambda
 - **x** (float): The parsed float value of the modbus data
 
 - **data** (std::vector<uint8_t): vector containing the complete raw modbus response bytes for this sensor
-      note: because the response contains data for all registers in the same range you have to use `data[item->offset]` to get the first response byte for your sensor.
+      note: because the response contains data for all registers in the same range you have to use ``data[item->offset]`` to get the first response byte for your sensor.
 - **item** (const pointer to a SensorItem derived object):  The sensor object itself.
 
 Possible return values for the lambda:
@@ -74,7 +74,7 @@ Possible return values for the lambda:
 - **x** (float): The float value to be sent to the modbus device
 
 - **payload** (`std::vector<uint16_t>&payload`): empty vector for the payload. The lamdba can add 16 bit raw modbus register words.
-      note: because the response contains data for all registers in the same range you have to use `data[item->offset]` to get the first response byte for your sensor.
+      note: because the response contains data for all registers in the same range you have to use ``data[item->offset]`` to get the first response byte for your sensor.
 - **item** (const pointer to a SensorItem derived object):  The sensor object itself.
 
 Possible return values for the lambda:

--- a/components/number/modbus_controller.rst
+++ b/components/number/modbus_controller.rst
@@ -42,7 +42,7 @@ Configuration variables:
 - **min_value** (*Optional*, float): The minimum value this number can be.
 - **max_value** (*Optional*, float): The maximum value this number can be.
 - **step** (*Optional*, float): The granularity with which the number can be set. Defaults to 1
-- **custom_data** (**Optional**, list of bytes): raw bytes for modbus command. This allows using non-standard commands. If ``custom_data`` is used ``address`` and ``register_type`` can't be used.
+- **custom_data** (*Optional*, list of bytes): raw bytes for modbus command. This allows using non-standard commands. If ``custom_data`` is used ``address`` and ``register_type`` can't be used.
   custom data must contain all required bytes including the modbus device address. The crc is automatically calculated and appended to the command.
   See :ref:`modbus_custom_data` how to use ``custom_command``
 - **lambda** (*Optional*, :ref:`lambda <config-lambda>`):

--- a/components/output/modbus_controller.rst
+++ b/components/output/modbus_controller.rst
@@ -14,16 +14,18 @@ Configuration variables:
 - **name** (**Required**, string): The name of the sensor.
 - **address**: (**Required**, int): start address of the first register in a range
 - **value_type**: (**Required**): datatype of the mod_bus register data. The default data type for modbus is a 16 bit integer in big endian format (MSB first)
-    - U_WORD (unsigned float from 1 register =16bit
-    - S_WORD (signed float from one register)
-    - U_DWORD (unsigned float from 2 registers = 32bit)
-    - S_DWORD (unsigned float from 2 registers = 32bit)
-    - U_DWORD_R (unsigend float from 2 registers low word first )
-    - S_DWORD_R (sigend float from 2 registers low word first )
-    - U_QWORD (unsigned float from 4 registers = 64bit
-    - S_QWORD (signed float from 4 registers = 64bit
+    - U_WORD (unsigned 16 bit integer 1 register =16bit
+    - S_WORD (signed 16 bit integer one register)
+    - U_DWORD (unsigned 32 bit integer from 2 registers = 32bit)
+    - S_DWORD (signed 32 bit integer from 2 registers = 32bit)
+    - U_DWORD_R (unsigned 32 bit integer from 2 registers low word first )
+    - S_DWORD_R (signed 32 bit integer from 2 registers low word first )
+    - U_QWORD (unsigned 64 bit integer from 4 registers = 64bit
+    - S_QWORD (unsigned 64 bit integer from 4 registers = 64bit
     - U_QWORD_R (unsigend float from 4 registers low word first )
     - S_QWORD_R (sigend float from 4 registers low word first )
+    - FP32 (32 bit IEEE 754 floating point from 2 registers)
+    - FP32_R (32 bit IEEE 754 floating point - same as FP32 but low word first)
 - **register_count**: (*Optional*): only required for uncommon response encodings
   The number of registers this data point spans. Default is 1
 - **write_lambda** (*Optional*, :ref:`lambda <config-lambda>`):

--- a/components/output/modbus_controller.rst
+++ b/components/output/modbus_controller.rst
@@ -29,7 +29,7 @@ Configuration variables:
 - **register_count**: (*Optional*): only required for uncommon response encodings
   The number of registers this data point spans. Default is 1
 - **write_lambda** (*Optional*, :ref:`lambda <config-lambda>`):
-  Lambda is evaluated before the modbus write command is created. The value is passed in as `float x` and an empty vector is passed in as `std::vector<uint16_t>&payload`
+  Lambda is evaluated before the modbus write command is created. The value is passed in as ``float x`` and an empty vector is passed in as ``std::vector<uint16_t>&payload``
   You can directly define the payload by adding data to payload then the return value is ignored and the content of payload is used.
 - **multiply** (*Optional*, float): multiply the new value with this factor before sending the requests. Ignored if lambda is defined.
 - **offset**: (*Optional*, int): only required for uncommon response encodings
@@ -43,7 +43,7 @@ All other options from :ref:`Output <config-output>`.
 - **x** (float): The float value to be sent to the modbus device
 
 - **payload** (`std::vector<uint16_t>&payload`): empty vector for the payload. The lamdba can add 16 bit raw modbus register words.
-      note: because the response contains data for all registers in the same range you have to use `data[item->offset]` to get the first response byte for your sensor.
+      note: because the response contains data for all registers in the same range you have to use ``data[item->offset]`` to get the first response byte for your sensor.
 - **item** (const pointer to a SensorItem derived object):  The sensor object itself.
 
 Possible return values for the lambda:

--- a/components/output/modbus_controller.rst
+++ b/components/output/modbus_controller.rst
@@ -14,16 +14,16 @@ Configuration variables:
 - **name** (**Required**, string): The name of the sensor.
 - **address**: (**Required**, int): start address of the first register in a range
 - **value_type**: (**Required**): datatype of the mod_bus register data. The default data type for modbus is a 16 bit integer in big endian format (MSB first)
-    - U_WORD (unsigned 16 bit integer 1 register =16bit
-    - S_WORD (signed 16 bit integer one register)
+    - U_WORD (unsigned 16 bit integer from 1 register = 16bit)
+    - S_WORD (signed 16 bit integer from 1 register = 16bit)
     - U_DWORD (unsigned 32 bit integer from 2 registers = 32bit)
     - S_DWORD (signed 32 bit integer from 2 registers = 32bit)
-    - U_DWORD_R (unsigned 32 bit integer from 2 registers low word first )
-    - S_DWORD_R (signed 32 bit integer from 2 registers low word first )
-    - U_QWORD (unsigned 64 bit integer from 4 registers = 64bit
-    - S_QWORD (unsigned 64 bit integer from 4 registers = 64bit
-    - U_QWORD_R (unsigend float from 4 registers low word first )
-    - S_QWORD_R (sigend float from 4 registers low word first )
+    - U_DWORD_R (unsigned 32 bit integer from 2 registers low word first)
+    - S_DWORD_R (signed 32 bit integer from 2 registers low word first)
+    - U_QWORD (unsigned 64 bit integer from 4 registers = 64bit)
+    - S_QWORD (unsigned 64 bit integer from 4 registers = 64bit)
+    - U_QWORD_R (unsigned 64 bit integer from 4 registers low word first)
+    - U_QWORD_R signed 64 bit integer from 4 registers low word first)
     - FP32 (32 bit IEEE 754 floating point from 2 registers)
     - FP32_R (32 bit IEEE 754 floating point - same as FP32 but low word first)
 - **register_count**: (*Optional*): only required for uncommon response encodings

--- a/components/sensor/modbus_controller.rst
+++ b/components/sensor/modbus_controller.rst
@@ -37,15 +37,15 @@ Configuration variables:
 - **skip_updates**: (*Optional*, integer): By default all sensors of of a modbus_controller are updated together. For data points that don't change very frequently updates can be skipped. A value of 5 would only update this sensor range in every 5th update cycle
   Note: The modbus_controller groups component by address ranges to reduce number of transactions. All compoents with the same address will be updated in one request. skip_updates applies for all components in the same range.
 - **register_count**: (*Optional*): only required for uncommon response encodings
-  The number of registers this data point spans. Overrides the defaults determined by `value_type`.
-  If no value for `register_count` is provided, it is calculated based on the register type.
+  The number of registers this data point spans. Overrides the defaults determined by ``value_type``.
+  If no value for ``register_count`` is provided, it is calculated based on the register type.
 
-  The default size for 1 register is 16 bits (1 Word). Some devices are not adhering to this convention and have registers larger than 16 bits.  In this case `register_count` must be set. For example, if your modbus device uses 1 registers for a FP32 value instead the default of two set `register_count: 2`.
+  The default size for 1 register is 16 bits (1 Word). Some devices are not adhering to this convention and have registers larger than 16 bits.  In this case ``register_count`` must be set. For example, if your modbus device uses 1 registers for a FP32 value instead the default of two set ``register_count: 2``.
 
-- **force_new_range**: (*Optional*, boolean): If possible sensors with sequential addresses are grouped together and requested in one range. Setting `foce_new_range: true` enforces the start of a new range at that address.
-- **custom_data** (**Optional**, list of bytes): raw bytes for modbus command. This allows using non-standard commands. If `custom_data` is used `address` and `register_type` can't be used. 
+- **force_new_range**: (*Optional*, boolean): If possible sensors with sequential addresses are grouped together and requested in one range. Setting ``force_new_range: true`` enforces the start of a new range at that address.
+- **custom_data** (**Optional**, list of bytes): raw bytes for modbus command. This allows using non-standard commands. If ``custom_data`` is used ``address`` and ``register_type`` can't be used. 
   custom data must contain all required bytes including the modbus device address. The crc is automatically calculated and appended to the command.
-  See :ref:`modbus_custom_data` how to use `custom_command`
+  See :ref:`modbus_custom_data` how to use ``custom_command``
 - **lambda** (*Optional*, :ref:`lambda <config-lambda>`):
   Lambda to be evaluated every update interval to get the new value of the sensor.
 - **offset**: (*Optional*, int): only required for uncommon response encodings
@@ -128,7 +128,7 @@ Parameters passed into the lambda
 - **x** (float): The parsed float value of the modbus data
 
 - **data** (std::vector<uint8_t): vector containing the complete raw modbus response bytes for this sensor
-      note: because the response contains data for all registers in the same range you have to use `data[item->offset]` to get the first response byte for your sensor.
+      note: because the response contains data for all registers in the same range you have to use ``data[item->offset]`` to get the first response byte for your sensor.
 - **item** (const pointer to a SensorItem derived object):  The sensor object itself.
 
 Possible return values for the lambda:
@@ -237,7 +237,7 @@ SDM-120 returns the values as floats using 32 bits in 2 registers.
 
     Maybe you don’t care about the Voltage value for Phase 2 and Phase 3 (or you have a SDM-120). 
     Of course, you can delete the sensors your don’t care about. But then you have a gap in the addresses. The configuration above will generate one modbus  command `read multiple registers from 0 to 6`. If you remove the registers at address 2 and 4 then 2 commands will be generated `read register 0` and `read register 6`.
-    To avoid the generation of multiple commands and reduce the amount of uart communication `register_count` can be used to fill the gaps 
+    To avoid the generation of multiple commands and reduce the amount of uart communication ``register_count`` can be used to fill the gaps 
 
     .. code-block:: yaml
 
@@ -257,7 +257,7 @@ SDM-120 returns the values as floats using 32 bits in 2 registers.
 
     Because `register_count: 6` is used for the first register the command “read registers from 0 to 6” can still be used but the values in between are ignored. 
     **Calculation:** FP32 is a 32 bit value and uses 2 registers. Therefore, to skip the 2 FP32 registers the size of these 2 registers must be added to the default size for the first register.
-    So we have 2 for address 0, 2 for address 2 and 2 for address 4 then `register_count` must be 6.
+    So we have 2 for address 0, 2 for address 2 and 2 for address 4 then ``register_count`` must be 6.
 
 
 See Also

--- a/components/sensor/modbus_controller.rst
+++ b/components/sensor/modbus_controller.rst
@@ -14,20 +14,20 @@ Configuration variables:
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
 - **name** (**Required**, string): The name of the sensor.
 - **register_type** (**Required**): type of the modbus register.
-    - coil: coils are also called discrete outout. Coils are 1-bit registers (on/off values) that are used to control discrete outputs. Read and Write access
-    - discrete_input: discrete input register (read only coil) are similar to coils but can only be read.
-    - holding: Holding Registers - Holding registers are the most universal 16-bit register. Read and Write access
-    - read: Read Input Registers - registers are 16-bit registers used for input, and may only be read
+    - coil: coils are also called discrete outout. Coils are 1-bit registers (on/off values) that are used to control discrete outputs. Read and Write access. Modbus function code 1 (Read Coil Status) will be used
+    - discrete_input: discrete input register (read only coil) are similar to coils but can only be read. Modbus function code 2 (Read Input Status) will be used.
+    - holding: Holding Registers - Holding registers are the most universal 16-bit register. Read and Write access. Modbus function code 3 (Read Holding Registers) will be used.
+    - read: Read Input Registers - registers are 16-bit registers used for input, and may only be read. Modbus function code 4 (Read Input Registers) will be used.
 - **address**: (**Required**, int): start address of the first register in a range
 - **value_type**: (**Required**): datatype of the mod_bus register data. The default data type for modbus is a 16 bit integer in big endian format (MSB first)
-    - U_WORD (unsigned float from 1 register =16bit
-    - S_WORD (signed float from one register)
-    - U_DWORD (unsigned float from 2 registers = 32bit)
-    - S_DWORD (unsigned float from 2 registers = 32bit)
-    - U_DWORD_R (unsigend float from 2 registers low word first )
-    - S_DWORD_R (sigend float from 2 registers low word first )
-    - U_QWORD (unsigned float from 4 registers = 64bit
-    - S_QWORD (signed float from 4 registers = 64bit
+    - U_WORD (unsigned 16 bit integer 1 register =16bit
+    - S_WORD (signed 16 bit integer one register)
+    - U_DWORD (unsigned 32 bit integer from 2 registers = 32bit)
+    - S_DWORD (signed 32 bit integer from 2 registers = 32bit)
+    - U_DWORD_R (unsigned 32 bit integer from 2 registers low word first )
+    - S_DWORD_R (signed 32 bit integer from 2 registers low word first )
+    - U_QWORD (unsigned 64 bit integer from 4 registers = 64bit
+    - S_QWORD (unsigned 64 bit integer from 4 registers = 64bit
     - U_QWORD_R (unsigend float from 4 registers low word first )
     - S_QWORD_R (sigend float from 4 registers low word first )
     - FP32 (32 bit IEEE 754 floating point from 2 registers)

--- a/components/sensor/modbus_controller.rst
+++ b/components/sensor/modbus_controller.rst
@@ -20,18 +20,18 @@ Configuration variables:
     - read: Read Input Registers - registers are 16-bit registers used for input, and may only be read. Modbus function code 4 (Read Input Registers) will be used.
 - **address**: (**Required**, int): start address of the first register in a range
 - **value_type**: (**Required**): datatype of the mod_bus register data. The default data type for modbus is a 16 bit integer in big endian format (MSB first)
-    - U_WORD (unsigned 16 bit integer 1 register =16bit
-    - S_WORD (signed 16 bit integer one register)
+    - U_WORD (unsigned 16 bit integer from 1 register = 16bit)
+    - S_WORD (signed 16 bit integer from 1 register = 16bit)
     - U_DWORD (unsigned 32 bit integer from 2 registers = 32bit)
     - S_DWORD (signed 32 bit integer from 2 registers = 32bit)
-    - U_DWORD_R (unsigned 32 bit integer from 2 registers low word first )
-    - S_DWORD_R (signed 32 bit integer from 2 registers low word first )
-    - U_QWORD (unsigned 64 bit integer from 4 registers = 64bit
-    - S_QWORD (unsigned 64 bit integer from 4 registers = 64bit
-    - U_QWORD_R (unsigend float from 4 registers low word first )
-    - S_QWORD_R (sigend float from 4 registers low word first )
+    - U_DWORD_R (unsigned 32 bit integer from 2 registers low word first)
+    - S_DWORD_R (signed 32 bit integer from 2 registers low word first)
+    - U_QWORD (unsigned 64 bit integer from 4 registers = 64bit)
+    - S_QWORD (unsigned 64 bit integer from 4 registers = 64bit)
+    - U_QWORD_R (unsigned 64 bit integer from 4 registers low word first)
+    - U_QWORD_R signed 64 bit integer from 4 registers low word first)
     - FP32 (32 bit IEEE 754 floating point from 2 registers)
-    - FP32_R (32 bit IEEE 754 floating point - same as FP32 but low word first)
+    - FP32_R (32 bit IEEE 754 floating point - same as FP32 but low word first)s
 
 - **bitmask**: (*Optional*) some values are packed in a response. The bitmask can be used to extract a value from the response.  For example, if the high byte value register 0x9013 contains the minute value of the current time. To only exctract this value use bitmask: 0xFF00.  The result will be automatically right shifted by the number of 0 before the first 1 in the bitmask.  For 0xFF00 (0b1111111100000000) the result is shifted 8 posistions.  More than one sensor can use the same address/offset if the bitmask is different.
 - **skip_updates**: (*Optional*, integer): By default all sensors of of a modbus_controller are updated together. For data points that don't change very frequently updates can be skipped. A value of 5 would only update this sensor range in every 5th update cycle

--- a/components/sensor/modbus_controller.rst
+++ b/components/sensor/modbus_controller.rst
@@ -43,7 +43,7 @@ Configuration variables:
   The default size for 1 register is 16 bits (1 Word). Some devices are not adhering to this convention and have registers larger than 16 bits.  In this case ``register_count`` must be set. For example, if your modbus device uses 1 registers for a FP32 value instead the default of two set ``register_count: 2``.
 
 - **force_new_range**: (*Optional*, boolean): If possible sensors with sequential addresses are grouped together and requested in one range. Setting ``force_new_range: true`` enforces the start of a new range at that address.
-- **custom_data** (**Optional**, list of bytes): raw bytes for modbus command. This allows using non-standard commands. If ``custom_data`` is used ``address`` and ``register_type`` can't be used. 
+- **custom_data** (*Optional*, list of bytes): raw bytes for modbus command. This allows using non-standard commands. If ``custom_data`` is used ``address`` and ``register_type`` can't be used. 
   custom data must contain all required bytes including the modbus device address. The crc is automatically calculated and appended to the command.
   See :ref:`modbus_custom_data` how to use ``custom_command``
 - **lambda** (*Optional*, :ref:`lambda <config-lambda>`):

--- a/components/sensor/modbus_controller.rst
+++ b/components/sensor/modbus_controller.rst
@@ -14,7 +14,7 @@ Configuration variables:
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
 - **name** (**Required**, string): The name of the sensor.
 - **register_type** (**Required**): type of the modbus register.
-    - coil: coils are also called discrete outout. Coils are 1-bit registers (on/off values) that are used to control discrete outputs. Read and Write access. Modbus function code 1 (Read Coil Status) will be used
+    - coil: coils are also called discrete output. Coils are 1-bit registers (on/off values) that are used to control discrete outputs. Read and Write access. Modbus function code 1 (Read Coil Status) will be used
     - discrete_input: discrete input register (read only coil) are similar to coils but can only be read. Modbus function code 2 (Read Input Status) will be used.
     - holding: Holding Registers - Holding registers are the most universal 16-bit register. Read and Write access. Modbus function code 3 (Read Holding Registers) will be used.
     - read: Read Input Registers - registers are 16-bit registers used for input, and may only be read. Modbus function code 4 (Read Input Registers) will be used.
@@ -141,7 +141,7 @@ Possible return values for the lambda:
 Using custom_data
 -----------------
 
-`custom_data` can be used to create an arbitrary modbus command. Combined with a lambda any response can be handled. 
+``custom_data`` can be used to create an arbitrary modbus command. Combined with a lambda any response can be handled. 
 This example re-implements the command to read the registers 0x156 (Total active energy) and 0x158 Total (reactive energy) from a SDM-120.
 SDM-120 returns the values as floats using 32 bits in 2 registers. 
 
@@ -204,7 +204,7 @@ SDM-120 returns the values as floats using 32 bits in 2 registers.
 
 .. note:: **Optimize modbus communications**
 
-    `register_count` can also be used to skip a register in consecutive range. 
+    ``register_count`` can also be used to skip a register in consecutive range. 
     
     An example is a SDM meter: 
     

--- a/components/switch/modbus_controller.rst
+++ b/components/switch/modbus_controller.rst
@@ -22,10 +22,10 @@ Configuration variables:
   To get the value of the coil register 2 can be retrived using address: 2 / offset: 0 or address: 0 / offset 2
 - **bitmask** : some values are packed in a response. The bitmask is used to determined if the result is true or false
 - **skip_updates**: (*Optional*, integer): By default all sensors of of a modbus_controller are updated together. For data points that don't change very frequently updates can be skipped. A value of 5 would only update this sensor range in every 5th update cycle
-- **use_write_multiple**: (*Optional*, boolean): By default the modbus command `Force Single Coil` (function code 5) is used to send state changes to the device. If your device only supports `Force Multiple Coils` (function code 15) set this option to true.
-- **custom_data** (**Optional**, list of bytes): raw bytes for modbus command. This allows using non-standard commands. If `custom_data` is used `address` and `register_type` can't be used. 
+- **use_write_multiple**: (*Optional*, boolean): By default the modbus command ``Force Single Coil`` (function code 5) is used to send state changes to the device. If your device only supports ``Force Multiple Coils`` (function code 15) set this option to true.
+- **custom_data** (**Optional**, list of bytes): raw bytes for modbus command. This allows using non-standard commands. If ``custom_data`` is used ``address`` and ``register_type`` can't be used. 
   custom data must contain all required bytes including the modbus device address. The crc is automatically calculated and appended to the command.
-  See :ref:`modbus_custom_data` how to use `custom_command`
+  See :ref:`modbus_custom_data` how to use ``custom_command``
 - **lambda** (*Optional*, :ref:`lambda <config-lambda>`):
   Lambda to be evaluated every update interval to read the status of the switch.
 - **write_lambda** (*Optional*, :ref:`lambda <config-lambda>`): Lambda called before send.
@@ -36,7 +36,7 @@ Configuration variables:
 - **x** (float): The float value to be sent to the modbus device
 
 - **payload** (`std::vector<uint8_t>&payload`): empty vector for the payload. If payload is set in the lambda it is sent as a custom command and must include all required bytes for a modbus request
-      note: because the response contains data for all registers in the same range you have to use `data[item->offset]` to get the first response byte for your sensor.
+      note: because the response contains data for all registers in the same range you have to use ``data[item->offset]`` to get the first response byte for your sensor.
 - **item** (const pointer to a Switch derived object):  The sensor object itself.
 
 Possible return values for the lambda:

--- a/components/switch/modbus_controller.rst
+++ b/components/switch/modbus_controller.rst
@@ -22,7 +22,7 @@ Configuration variables:
   To get the value of the coil register 2 can be retrived using address: 2 / offset: 0 or address: 0 / offset 2
 - **bitmask** : some values are packed in a response. The bitmask is used to determined if the result is true or false
 - **skip_updates**: (*Optional*, integer): By default all sensors of of a modbus_controller are updated together. For data points that don't change very frequently updates can be skipped. A value of 5 would only update this sensor range in every 5th update cycle
-- **use_write_multiple**: (*Optional*, boolean): By default the modbus command `Force Single Coil` (function code 5) is used to send state changes to the device. If your device onyl supports `Force Multiple Coils` (function code 15) set this option to true.
+- **use_write_multiple**: (*Optional*, boolean): By default the modbus command `Force Single Coil` (function code 5) is used to send state changes to the device. If your device only supports `Force Multiple Coils` (function code 15) set this option to true.
 - **custom_data** (**Optional**, list of bytes): raw bytes for modbus command. This allows using non-standard commands. If `custom_data` is used `address` and `register_type` can't be used. 
   custom data must contain all required bytes including the modbus device address. The crc is automatically calculated and appended to the command.
   See :ref:`modbus_custom_data` how to use `custom_command`

--- a/components/switch/modbus_controller.rst
+++ b/components/switch/modbus_controller.rst
@@ -23,7 +23,7 @@ Configuration variables:
 - **bitmask** : some values are packed in a response. The bitmask is used to determined if the result is true or false
 - **skip_updates**: (*Optional*, integer): By default all sensors of of a modbus_controller are updated together. For data points that don't change very frequently updates can be skipped. A value of 5 would only update this sensor range in every 5th update cycle
 - **use_write_multiple**: (*Optional*, boolean): By default the modbus command ``Force Single Coil`` (function code 5) is used to send state changes to the device. If your device only supports ``Force Multiple Coils`` (function code 15) set this option to true.
-- **custom_data** (**Optional**, list of bytes): raw bytes for modbus command. This allows using non-standard commands. If ``custom_data`` is used ``address`` and ``register_type`` can't be used. 
+- **custom_data** (*Optional*, list of bytes): raw bytes for modbus command. This allows using non-standard commands. If ``custom_data`` is used ``address`` and ``register_type`` can't be used. 
   custom data must contain all required bytes including the modbus device address. The crc is automatically calculated and appended to the command.
   See :ref:`modbus_custom_data` how to use ``custom_command``
 - **lambda** (*Optional*, :ref:`lambda <config-lambda>`):

--- a/components/switch/modbus_controller.rst
+++ b/components/switch/modbus_controller.rst
@@ -22,7 +22,7 @@ Configuration variables:
   To get the value of the coil register 2 can be retrived using address: 2 / offset: 0 or address: 0 / offset 2
 - **bitmask** : some values are packed in a response. The bitmask is used to determined if the result is true or false
 - **skip_updates**: (*Optional*, integer): By default all sensors of of a modbus_controller are updated together. For data points that don't change very frequently updates can be skipped. A value of 5 would only update this sensor range in every 5th update cycle
-- **use_write_multiple**: (*Optional*, boolean): By default the modbus command `Force Single Coil` (function code 5) is used to send state changes to the device. If your device onyl support `Force Multiple Coils` (function code 15) set this option to true.
+- **use_write_multiple**: (*Optional*, boolean): By default the modbus command `Force Single Coil` (function code 5) is used to send state changes to the device. If your device onyl supports `Force Multiple Coils` (function code 15) set this option to true.
 - **custom_data** (**Optional**, list of bytes): raw bytes for modbus command. This allows using non-standard commands. If `custom_data` is used `address` and `register_type` can't be used. 
   custom data must contain all required bytes including the modbus device address. The crc is automatically calculated and appended to the command.
   See :ref:`modbus_custom_data` how to use `custom_command`

--- a/components/switch/modbus_controller.rst
+++ b/components/switch/modbus_controller.rst
@@ -22,6 +22,7 @@ Configuration variables:
   To get the value of the coil register 2 can be retrived using address: 2 / offset: 0 or address: 0 / offset 2
 - **bitmask** : some values are packed in a response. The bitmask is used to determined if the result is true or false
 - **skip_updates**: (*Optional*, integer): By default all sensors of of a modbus_controller are updated together. For data points that don't change very frequently updates can be skipped. A value of 5 would only update this sensor range in every 5th update cycle
+- **use_write_multiple**: (*Optional*, boolean): By default the modbus command `Force Single Coil` (function code 5) is used to send state changes to the device. If your device onyl support `Force Multiple Coils` (function code 15) set this option to true.
 - **custom_data** (**Optional**, list of bytes): raw bytes for modbus command. This allows using non-standard commands. If `custom_data` is used `address` and `register_type` can't be used. 
   custom data must contain all required bytes including the modbus device address. The crc is automatically calculated and appended to the command.
   See :ref:`modbus_custom_data` how to use `custom_command`

--- a/components/text_sensor/modbus_controller.rst
+++ b/components/text_sensor/modbus_controller.rst
@@ -27,8 +27,11 @@ Configuration variables:
      - HEXBYTES:  2 byte hex string. 0x2011 will be sent as "2011".
      - COMMA: Byte values as integers, delimited by a coma. 0x2011 will be sent as "32,17"
 - **force_new_range**: (*Optional*, boolean): If possible sensors with sequential addresses are grouped together and requested in one range. Setting `foce_new_range: true` enforces the start of a new range at that address.
+- **custom_data** (**Optional**, list of bytes): raw bytes for modbus command. This allows using non-standard commands. If `custom_data` is used `address` and `register_type` can't be used. 
+  custom data must contain all required bytes including the modbus device address. The crc is automatically calculated and appended to the command.
+  See :ref:`modbus_custom_data` how to use `custom_command`
 - **lambda** (*Optional*, :ref:`lambda <config-lambda>`):
-  Lambda to be evaluated every update interval to get the new value of the sensor
+  Lambda to be evaluated every update interval to get the new value of the text_sensor
 - **offset**: (*Optional*, integer): not required in most cases
   offset from start address in bytes. If more than one register is read a modbus read registers command this value is used to find the start of this datapoint relative to start address. The component calculates the size of the range based on offset and size of the value type
 

--- a/components/text_sensor/modbus_controller.rst
+++ b/components/text_sensor/modbus_controller.rst
@@ -27,7 +27,7 @@ Configuration variables:
      - HEXBYTES:  2 byte hex string. 0x2011 will be sent as "2011".
      - COMMA: Byte values as integers, delimited by a coma. 0x2011 will be sent as "32,17"
 - **force_new_range**: (*Optional*, boolean): If possible sensors with sequential addresses are grouped together and requested in one range. Setting ``force_new_range: true`` enforces the start of a new range at that address.
-- **custom_data** (**Optional**, list of bytes): raw bytes for modbus command. This allows using non-standard commands. If ``custom_data`` is used ``address`` and ``register_type`` can't be used. 
+- **custom_data** (*Optional*, list of bytes): raw bytes for modbus command. This allows using non-standard commands. If ``custom_data`` is used ``address`` and ``register_type`` can't be used. 
   custom data must contain all required bytes including the modbus device address. The crc is automatically calculated and appended to the command.
   See :ref:`modbus_custom_data` how to use ``custom_command``
 - **lambda** (*Optional*, :ref:`lambda <config-lambda>`):

--- a/components/text_sensor/modbus_controller.rst
+++ b/components/text_sensor/modbus_controller.rst
@@ -26,10 +26,10 @@ Configuration variables:
 - **raw_encode**: (*Optional*, NONE , HEXBYTES, COMMA) If the response is binary it can't be published directly. Since a text sensor only publishes strings the binary data can encoded
      - HEXBYTES:  2 byte hex string. 0x2011 will be sent as "2011".
      - COMMA: Byte values as integers, delimited by a coma. 0x2011 will be sent as "32,17"
-- **force_new_range**: (*Optional*, boolean): If possible sensors with sequential addresses are grouped together and requested in one range. Setting `foce_new_range: true` enforces the start of a new range at that address.
-- **custom_data** (**Optional**, list of bytes): raw bytes for modbus command. This allows using non-standard commands. If `custom_data` is used `address` and `register_type` can't be used. 
+- **force_new_range**: (*Optional*, boolean): If possible sensors with sequential addresses are grouped together and requested in one range. Setting ``force_new_range: true`` enforces the start of a new range at that address.
+- **custom_data** (**Optional**, list of bytes): raw bytes for modbus command. This allows using non-standard commands. If ``custom_data`` is used ``address`` and ``register_type`` can't be used. 
   custom data must contain all required bytes including the modbus device address. The crc is automatically calculated and appended to the command.
-  See :ref:`modbus_custom_data` how to use `custom_command`
+  See :ref:`modbus_custom_data` how to use ``custom_command``
 - **lambda** (*Optional*, :ref:`lambda <config-lambda>`):
   Lambda to be evaluated every update interval to get the new value of the text_sensor
 - **offset**: (*Optional*, integer): not required in most cases
@@ -41,7 +41,7 @@ Parameters passed into the lambda
 - **x** (std:string): The parsed float value of the modbus data
 
 - **data** (std::vector<uint8_t): vector containing the complete raw modbus response bytes for this sensor
-      note: because the response contains data for all registers in the same range you have to use `data[item->offset]` to get the first response byte for your sensor.
+      note: because the response contains data for all registers in the same range you have to use ``data[item->offset]`` to get the first response byte for your sensor.
 - **item** (const pointer to a SensorItem derived object):  The sensor object itself.
 
 Possible return values for the lambda:


### PR DESCRIPTION
## Description:

Add missing documentation about FP32 data type 
Improve serial logging information
Add usage details for register_count
Add documentation for custom_command

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#2680

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
