### PR TITLE
Convert pin mode examples to new format

### DIFF
--- a/components/binary_sensor/gpio.rst
+++ b/components/binary_sensor/gpio.rst
@@ -44,7 +44,9 @@ you can do so with the :ref:`Pin Schema <config-pin_schema>`.
       - platform: gpio
         pin:
           number: D2
-          mode: INPUT_PULLUP
+          mode:
+            input: true
+            pullup: true
         name: ...
 
 Inverting Values

--- a/components/climate/ir_climate.rst
+++ b/components/climate/ir_climate.rst
@@ -126,7 +126,9 @@ IR receiver.
       pin:
         number: GPIO14
         inverted: true
-        mode: INPUT_PULLUP
+        mode:
+          input: true
+          pullup: true
       # high 55% tolerance is recommended for some remote control units
       tolerance: 55%
 

--- a/components/display/st7789v.rst
+++ b/components/display/st7789v.rst
@@ -201,7 +201,9 @@ appropriate lines of C code in the lambda to hide or show the image or text as y
         pin:
           number: GPIO0
           inverted: true
-          mode: INPUT_PULLUP
+          mode:
+            input: true
+            pullup: true
         name: "T-Display Button Input 0"
         id: tdisplay_button_input_0
       - platform: gpio

--- a/components/mcp230xx.rst
+++ b/components/mcp230xx.rst
@@ -36,7 +36,8 @@ The MCP23008 component (`datasheet <http://ww1.microchip.com/downloads/en/device
           mcp23xxx: mcp23008_hub
           # Use pin number 0
           number: 0
-          mode: OUTPUT
+          mode:
+            output: true
           inverted: false
 
     # Individual inputs
@@ -48,7 +49,8 @@ The MCP23008 component (`datasheet <http://ww1.microchip.com/downloads/en/device
           # Use pin number 1
           number: 1
           # One of INPUT or INPUT_PULLUP
-          mode: INPUT
+          mode:
+            input: true
           inverted: false
 
 Configuration variables:
@@ -98,7 +100,8 @@ has 16 GPIOs and can be configured the same way than the other variants.
           mcp23016: mcp23016_hub
           # Use pin number 0
           number: 0
-          mode: OUTPUT
+          mode:
+            output: true
           inverted: false
 
     # Individual inputs
@@ -109,7 +112,8 @@ has 16 GPIOs and can be configured the same way than the other variants.
           mcp23016: mcp23016_hub
           # Use pin number 1
           number: 1
-          mode: INPUT
+          mode:
+            input: true
           inverted: false
 
 
@@ -157,7 +161,8 @@ binary sensor or GPIO switch.
           mcp23xxx: mcp23017_hub
           # Use pin number 0
           number: 0
-          mode: OUTPUT
+          mode:
+            output: true
           inverted: false
 
     # Individual inputs
@@ -169,7 +174,9 @@ binary sensor or GPIO switch.
           # Use pin number 1
           number: 1
           # One of INPUT or INPUT_PULLUP
-          mode: INPUT_PULLUP
+          mode:
+            input: true
+            pullup: true
           inverted: false
 
 Configuration variables:

--- a/components/mcp23Sxx.rst
+++ b/components/mcp23Sxx.rst
@@ -38,7 +38,8 @@ The MCP23S08 component (`datasheet <http://ww1.microchip.com/downloads/en/Device
           # Use pin number 0
           number: 0
           # One of INPUT, INPUT_PULLUP or OUTPUT
-          mode: OUTPUT
+          mode:
+            output: true
           inverted: false
 
     # Individual inputs
@@ -50,7 +51,8 @@ The MCP23S08 component (`datasheet <http://ww1.microchip.com/downloads/en/Device
           # Use pin number 1
           number: 1
           # One of INPUT or INPUT_PULLUP
-          mode: INPUT
+          mode:
+            input: true
           inverted: false
 
 Configuration variables:
@@ -103,7 +105,8 @@ binary sensor or GPIO switch.
           mcp23xxx: mcp23s17_hub
           # Use pin number 0
           number: 0
-          mode: OUTPUT
+          mode:
+            output: true
           inverted: false
 
     # Individual inputs
@@ -115,7 +118,9 @@ binary sensor or GPIO switch.
           # Use pin number 1
           number: 1
           # One of INPUT or INPUT_PULLUP
-          mode: INPUT_PULLUP
+          mode:
+            input: true
+            pullup: true
           inverted: false
 
 Configuration variables:

--- a/components/output/ac_dimmer.rst
+++ b/components/output/ac_dimmer.rst
@@ -37,7 +37,8 @@ for example the `RobotDyn dimmer
         gate_pin: D7
         zero_cross_pin:
           number: D6
-          mode: INPUT
+          mode:
+            input: true
           inverted: yes
 
     light:

--- a/components/pcf8574.rst
+++ b/components/pcf8574.rst
@@ -43,7 +43,8 @@ not work.
           # Use pin number 0
           number: 0
           # One of INPUT or OUTPUT
-          mode: OUTPUT
+          mode:
+            output: true
           inverted: false
 
 Configuration variables:

--- a/components/remote_receiver.rst
+++ b/components/remote_receiver.rst
@@ -260,7 +260,9 @@ Remote code selection (exactly one of these has to be included):
           pin:
             number: D4
             inverted: true
-            mode: INPUT_PULLUP
+            mode:
+              input: true
+              pullup: true
           dump: all
 
 

--- a/components/sx1509.rst
+++ b/components/sx1509.rst
@@ -151,7 +151,9 @@ The outputs can in turn be used to add PWM-enabled lights like the monochromatic
           sx1509: sx1509_hub1
           # Use pin number 0 on the SX1509
           number: 0
-          mode: INPUT_PULLUP
+          mode:
+            input: true
+            pullup: true
           inverted: true
 
     # Individual binary outputs
@@ -163,7 +165,8 @@ The outputs can in turn be used to add PWM-enabled lights like the monochromatic
           # Use pin number 1 on the SX1509
           number: 1
           # use as output for switch
-          mode: OUTPUT
+          mode:
+            output: true
           inverted: false
 
     # Individual outputs

--- a/cookbook/brilliant-mirabella-genio-smart-plugs.rst
+++ b/cookbook/brilliant-mirabella-genio-smart-plugs.rst
@@ -147,7 +147,9 @@ which these adaptions created by `@cryptelli <https://community.home-assistant.i
       - platform: gpio
         pin:
           number: 14
-          mode: INPUT_PULLUP
+          mode:
+            input: true
+            pullup: true
           inverted: true
         name: "Power Button"
         on_press:
@@ -202,7 +204,9 @@ which these adaptions created by `@cryptelli <https://community.home-assistant.i
       - platform: gpio
         pin:
           number: GPIO13
-          mode: INPUT_PULLUP
+          mode:
+            input: true
+            pullup: true
           inverted: true
         name: "Power Button"
         on_press:
@@ -321,7 +325,9 @@ Check the following page for calibrating the measurements: :ref:`sensor-filter-c
       - platform: gpio
         pin:
           number: 14
-          mode: INPUT_PULLUP
+          mode:
+            input: true
+            pullup: true
           inverted: true
         name: "Power Button"
         on_press:
@@ -398,13 +404,13 @@ Check the following page for calibrating the measurements: :ref:`sensor-filter-c
         name: "${plug_name}_Relay"
         pin: GPIO14
         restore_mode: ALWAYS_ON
-        id: relay    
+        id: relay
 
         on_turn_on:
-          - switch.turn_on: red_led    
+          - switch.turn_on: red_led
 
         on_turn_off:
-          - switch.turn_off: red_led      
+          - switch.turn_off: red_led
 
     sensor:
       - platform: hlw8012
@@ -474,7 +480,9 @@ Check the following page for calibrating the measurements: :ref:`sensor-filter-c
       - platform: gpio
         pin:
           number: 14
-          mode: INPUT_PULLUP
+          mode:
+            input: true
+            pullup: true
           inverted: true
         name: "${item_name}_button"
         on_press:
@@ -513,7 +521,7 @@ Check the following page for calibrating the measurements: :ref:`sensor-filter-c
       - platform: wifi_signal
         name: "${item_name}_wifi_signal"
         update_interval: 60s
-        
+
 
 4. Adding to Home Assistant
 ---------------------------

--- a/cookbook/esw01-eu.rst
+++ b/cookbook/esw01-eu.rst
@@ -57,7 +57,7 @@ and calculating the current with `Ohm's law <https://en.wikipedia.org/wiki/Ohm%2
     # D7 GPIO13 | HLW8012/CF  | cf_pin
 
     status_led:
-      pin: 
+      pin:
         number: GPIO5
 
     output:
@@ -83,7 +83,9 @@ and calculating the current with `Ohm's law <https://en.wikipedia.org/wiki/Ohm%2
         id: button1
         pin:
           number: GPIO14
-          mode: INPUT_PULLUP
+          mode:
+            input: true
+            pullup: true
           inverted: true
         on_press:
           - switch.toggle: switch1

--- a/cookbook/ilonda-wifi-smart-fish-feeder.rst
+++ b/cookbook/ilonda-wifi-smart-fish-feeder.rst
@@ -13,7 +13,7 @@ firmware can be uploaded allowing you to control the Wifi Smart Fish Feeder via 
 Wifi Smart Fish Feeder Configuration
 ------------------------------------
 
-Thanks to the amazing `Tasmota template <https://templates.blakadder.com/ilonda_L88.html>`__, 
+Thanks to the amazing `Tasmota template <https://templates.blakadder.com/ilonda_L88.html>`__,
 managed to build a fully working esphome configuration. This assumes you have a secret.yaml with ssid and password keys.
 
 .. code-block:: yaml
@@ -39,7 +39,9 @@ managed to build a fully working esphome configuration. This assumes you have a 
         id: button
         pin:
           number: GPIO4
-          mode: INPUT_PULLUP
+          mode:
+            input: true
+            pullup: true
           inverted: True
         name: 'Switch feeder'
         on_press:

--- a/cookbook/sonoff-basic-light-switch.rst
+++ b/cookbook/sonoff-basic-light-switch.rst
@@ -117,7 +117,9 @@ Now you have a pair of wires from the GPIO and 0V to your retractive switch lets
       - platform: gpio
         pin:
           number: GPIO14
-          mode: INPUT_PULLUP
+          mode:
+            input: true
+            pullup: true
           inverted: true
         id: button_1
         on_press:

--- a/cookbook/sonoff-dual-light-switch.rst
+++ b/cookbook/sonoff-dual-light-switch.rst
@@ -97,7 +97,9 @@ The R1 version of the Dual controls the relays via the UART, so the code gets a 
       - platform: gpio
         pin:
           number: GPIO4
-          mode: INPUT_PULLUP
+          mode:
+            input: true
+            pullup: true
           inverted: true
         id: button_1
         on_press:
@@ -107,7 +109,9 @@ The R1 version of the Dual controls the relays via the UART, so the code gets a 
       - platform: gpio
         pin:
           number: GPIO14
-          mode: INPUT_PULLUP
+          mode:
+            input: true
+            pullup: true
           inverted: true
         id: button_2
         on_press:
@@ -196,7 +200,9 @@ It's basically the same as the :doc:`T2 </cookbook/sonoff-t1-3>`
       - platform: gpio
         pin:
           number: GPIO0
-          mode: INPUT_PULLUP
+          mode:
+            input: true
+            pullup: true
           inverted: true
         id: button
         on_press:
@@ -206,7 +212,9 @@ It's basically the same as the :doc:`T2 </cookbook/sonoff-t1-3>`
       - platform: gpio
         pin:
           number: GPIO14
-          mode: INPUT_PULLUP
+          mode:
+            input: true
+            pullup: true
           inverted: true
         id: button
         on_press:

--- a/cookbook/sonoff-fishpond-pump.rst
+++ b/cookbook/sonoff-fishpond-pump.rst
@@ -115,7 +115,9 @@ Here is the configuration with the basic operations outlined above.
         name: "esp_fishpond_gpio14"
         pin:
           number: 14
-          mode: INPUT_PULLUP
+          mode:
+            input: true
+            pullup: true
         on_press:
           - switch.turn_off: esp_fishpond_pump
 

--- a/cookbook/sonoff-t1-3.rst
+++ b/cookbook/sonoff-t1-3.rst
@@ -36,7 +36,9 @@ T1
       - platform: gpio
         pin:
           number: GPIO0
-          mode: INPUT_PULLUP
+          mode:
+            input: true
+            pullup: true
           inverted: true
         id: button_1
         on_press:
@@ -99,7 +101,9 @@ T2
       - platform: gpio
         pin:
           number: GPIO0
-          mode: INPUT_PULLUP
+          mode:
+            input: true
+            pullup: true
           inverted: true
         id: button_1
         on_press:
@@ -109,7 +113,9 @@ T2
       - platform: gpio
         pin:
           number: GPIO9
-          mode: INPUT_PULLUP
+          mode:
+            input: true
+            pullup: true
           inverted: true
         id: button_2
         on_press:
@@ -170,7 +176,9 @@ T3
       - platform: gpio
         pin:
           number: GPIO0
-          mode: INPUT_PULLUP
+          mode:
+            input: true
+            pullup: true
           inverted: true
         id: button_1
         on_press:
@@ -180,7 +188,9 @@ T3
       - platform: gpio
         pin:
           number: GPIO9
-          mode: INPUT_PULLUP
+          mode:
+            input: true
+            pullup: true
           inverted: true
         id: button_2
         on_press:
@@ -190,7 +200,9 @@ T3
       - platform: gpio
         pin:
           number: GPIO10
-          mode: INPUT_PULLUP
+          mode:
+            input: true
+            pullup: true
           inverted: true
         id: button_3
         on_press:
@@ -241,4 +253,3 @@ See Also
 - :doc:`/cookbook/sonoff-light-switch`
 - :doc:`/guides/automations`
 - :doc:`/devices/sonoff_t1_uk_3gang_v1.1`
-

--- a/devices/sonoff_4ch.rst
+++ b/devices/sonoff_4ch.rst
@@ -243,25 +243,33 @@ of the basic functions.
       - platform: gpio
         pin:
           number: GPIO0
-          mode: INPUT_PULLUP
+          mode:
+            input: true
+            pullup: true
           inverted: true
         name: "Sonoff 4CH Button 1"
       - platform: gpio
         pin:
           number: GPIO9
-          mode: INPUT_PULLUP
+          mode:
+            input: true
+            pullup: true
           inverted: true
         name: "Sonoff 4CH Button 2"
       - platform: gpio
         pin:
           number: GPIO10
-          mode: INPUT_PULLUP
+          mode:
+            input: true
+            pullup: true
           inverted: true
         name: "Sonoff 4CH Button 3"
       - platform: gpio
         pin:
           number: GPIO14
-          mode: INPUT_PULLUP
+          mode:
+            input: true
+            pullup: true
           inverted: true
         name: "Sonoff 4CH Button 4"
       - platform: status

--- a/devices/sonoff_4ch.yaml
+++ b/devices/sonoff_4ch.yaml
@@ -17,7 +17,9 @@ binary_sensor:
 - platform: gpio
   pin:
     number: GPIO0
-    mode: INPUT_PULLUP
+    mode:
+      input: true
+      pullup: true
     inverted: true
   name: "Sonoff 4CH Button 1"
   on_press:
@@ -25,7 +27,9 @@ binary_sensor:
 - platform: gpio
   pin:
     number: GPIO9
-    mode: INPUT_PULLUP
+    mode:
+      input: true
+      pullup: true
     inverted: true
   name: "Sonoff 4CH Button 2"
   on_press:
@@ -33,7 +37,9 @@ binary_sensor:
 - platform: gpio
   pin:
     number: GPIO10
-    mode: INPUT_PULLUP
+    mode:
+      input: true
+      pullup: true
     inverted: true
   name: "Sonoff 4CH Button 3"
   on_press:
@@ -41,7 +47,9 @@ binary_sensor:
 - platform: gpio
   pin:
     number: GPIO14
-    mode: INPUT_PULLUP
+    mode:
+      input: true
+      pullup: true
     inverted: true
   name: "Sonoff 4CH Button 4"
   on_press:

--- a/devices/sonoff_basic.rst
+++ b/devices/sonoff_basic.rst
@@ -70,7 +70,9 @@ exposes all of the basic functions.
       - platform: gpio
         pin:
           number: GPIO0
-          mode: INPUT_PULLUP
+          mode:
+            input: true
+            pullup: true
           inverted: true
         name: "Sonoff Basic Button"
         on_press:

--- a/devices/sonoff_s20.rst
+++ b/devices/sonoff_s20.rst
@@ -225,7 +225,9 @@ of the basic functions.
       - platform: gpio
         pin:
           number: GPIO0
-          mode: INPUT_PULLUP
+          mode:
+            input: true
+            pullup: true
           inverted: true
         name: "Sonoff S20 Button"
       - platform: status

--- a/devices/sonoff_s20.yaml
+++ b/devices/sonoff_s20.yaml
@@ -18,7 +18,9 @@ binary_sensor:
 - platform: gpio
   pin:
     number: GPIO0
-    mode: INPUT_PULLUP
+    mode:
+      input: true
+      pullup: true
     inverted: true
   name: "Sonoff S20 Button"
   on_press:

--- a/devices/sonoff_t1_uk_3gang_v1.1.rst
+++ b/devices/sonoff_t1_uk_3gang_v1.1.rst
@@ -246,19 +246,25 @@ of the basic functions.
       - platform: gpio
         pin:
           number: GPIO0
-          mode: INPUT_PULLUP
+          mode:
+            input: true
+            pullup: true
           inverted: true
         name: "Sonoff T1 UK 3 Gang Touchpad 1"
       - platform: gpio
         pin:
           number: GPIO9
-          mode: INPUT_PULLUP
+          mode:
+            input: true
+            pullup: true
           inverted: true
         name: "Sonoff T1 UK 3 Gang Touchpad 2"
       - platform: gpio
         pin:
           number: GPIO10
-          mode: INPUT_PULLUP
+          mode:
+            input: true
+            pullup: true
           inverted: true
         name: "Sonoff T1 UK 3 Gang Touchpad 3"
       - platform: status

--- a/devices/sonoff_t1_uk_3gang_v1.1.yaml
+++ b/devices/sonoff_t1_uk_3gang_v1.1.yaml
@@ -24,7 +24,9 @@ binary_sensor:
   - platform: gpio
     pin:
       number: GPIO0
-      mode: INPUT_PULLUP
+      mode:
+        input: true
+        pullup: true
       inverted: true
     name: "Sonoff T1 UK 3 Gang Touchpad 1"
     on_press:
@@ -32,7 +34,9 @@ binary_sensor:
   - platform: gpio
     pin:
       number: GPIO9
-      mode: INPUT_PULLUP
+      mode:
+        input: true
+        pullup: true
       inverted: true
     name: "Sonoff T1 UK 3 Gang Touchpad 2"
     on_press:
@@ -40,7 +44,9 @@ binary_sensor:
   - platform: gpio
     pin:
       number: GPIO10
-      mode: INPUT_PULLUP
+      mode:
+        input: true
+        pullup: true
       inverted: true
     name: "Sonoff T1 UK 3 Gang Touchpad 3"
     on_press:

--- a/devices/sonoff_t3_eu_3gang_v1.0.rst
+++ b/devices/sonoff_t3_eu_3gang_v1.0.rst
@@ -250,19 +250,25 @@ of the basic functions.
       - platform: gpio
         pin:
           number: GPIO0
-          mode: INPUT_PULLUP
+          mode:
+            input: true
+            pullup: true
           inverted: true
         name: "Sonoff T3 EU 3 Gang Touchpad 1"
       - platform: gpio
         pin:
           number: GPIO9
-          mode: INPUT_PULLUP
+          mode:
+            input: true
+            pullup: true
           inverted: true
         name: "Sonoff T3 EU 3 Gang Touchpad 2"
       - platform: gpio
         pin:
           number: GPIO10
-          mode: INPUT_PULLUP
+          mode:
+            input: true
+            pullup: true
           inverted: true
         name: "Sonoff T3 EU 3 Gang Touchpad 3"
       - platform: status

--- a/devices/sonoff_t3_eu_3gang_v1.0.yaml
+++ b/devices/sonoff_t3_eu_3gang_v1.0.yaml
@@ -24,7 +24,9 @@ binary_sensor:
   - platform: gpio
     pin:
       number: GPIO0
-      mode: INPUT_PULLUP
+      mode:
+        input: true
+        pullup: true
       inverted: true
     name: "Sonoff T3 EU 3 Gang Touchpad 1"
     on_press:
@@ -32,7 +34,9 @@ binary_sensor:
   - platform: gpio
     pin:
       number: GPIO9
-      mode: INPUT_PULLUP
+      mode:
+        input: true
+        pullup: true
       inverted: true
     name: "Sonoff T3 EU 3 Gang Touchpad 2"
     on_press:
@@ -40,7 +44,9 @@ binary_sensor:
   - platform: gpio
     pin:
       number: GPIO10
-      mode: INPUT_PULLUP
+      mode:
+        input: true
+        pullup: true
       inverted: true
     name: "Sonoff T3 EU 3 Gang Touchpad 3"
     on_press:

--- a/devices/teckin.yaml
+++ b/devices/teckin.yaml
@@ -21,7 +21,9 @@ binary_sensor:
     name: "Teckin Button"
     pin:
       number: GPIO1
-      mode: INPUT_PULLUP
+      mode:
+        input: true
+        pullup: true
       inverted: true
     on_press:
       - switch.toggle: relay

--- a/guides/getting_started_command_line.rst
+++ b/guides/getting_started_command_line.rst
@@ -19,7 +19,7 @@ Installing ESPHome is very easy. All you need to do is have `Python
 .. note::
 
     Python 3.7 or above is required to install ESPHome 1.18.0 or above.
-    
+
 
 .. code-block:: bash
 
@@ -127,7 +127,9 @@ Sensor </components/binary_sensor/gpio>`.
         pin:
           number: 16
           inverted: true
-          mode: INPUT_PULLUP
+          mode:
+            input: true
+            pullup: true
 
 This is an advanced feature of ESPHome. Almost all pins can
 optionally have a more complicated configuration schema with options for

--- a/guides/getting_started_hassio.rst
+++ b/guides/getting_started_hassio.rst
@@ -133,7 +133,9 @@ Sensor </components/binary_sensor/gpio>`.
         pin:
           number: 16
           inverted: true
-          mode: INPUT_PULLUP
+          mode:
+            input: true
+            pullup: true
 
 This time when installing, you don’t need to have the device plugged in
 through USB again. The upload will happen wirelessly (:doc:`"over the air" </components/ota>`).


### PR DESCRIPTION
## Description:

Convert all pin mode examples to use the newer object format.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
