### PR TITLE
Add documentation for dsmr max_telegram_length

### DIFF
--- a/components/sensor/dsmr.rst
+++ b/components/sensor/dsmr.rst
@@ -44,8 +44,10 @@ Configuration variables:
 - **decryption_key** (*Optional*, string, :ref:`templatable <config-templatable>`, 32 characters, case insensitive):
   The key to decrypt the telegrams. Used in Lux only.
 - **gas_mbus_id** (*Optional*, integer): The id of the gas meter. Defaults to ``1``.
-- **crc_check** (*Optional*, boolean): Specifies if the CRC check must be done. This is required to be set to false
-  for older DSMR versions as they do not provide a CRC. Defaults to ``true``.
+- **crc_check** (*Optional*, boolean): Specifies if the CRC check must be done. This is required to be set to false for
+  older DSMR versions as they do not provide a CRC. Defaults to ``true``.
+- **max_telegram_length** (*Optional*, integer): The size of the buffer used for reading DSMR telegrams. Increase
+  if you are reading from a smart meter that sends large telegrams. Defaults to ``1500``.
 - **uart_id** (*Optional*, :ref:`config-id`): Manually specify the ID of the UART hub.
 - **request_pin** (*Optional*, :ref:`Pin Schema <config-pin_schema>`): The pin that can be used for controlling
   the P1 port's Data Request pin. Defaults to not using a Data Request pin.
@@ -212,7 +214,6 @@ Luxembourg
   - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.
   - All other options from :ref:`Sensor <config-sensor>`.
 
-
 Text Sensor
 -----------
 
@@ -278,10 +279,11 @@ Version 2.2 is supported with the following configuration:
         gas_delivered_text:
           name: "gas delivered raw"
 
+
 .. _sensor-dsmr-request_pin:                                                                                                  
 
-Using the P1 Data Request pin
------------------------------
+P1 Data Request pin
+-------------------
 
 From the P1 companion guide: The P1 port is activated (start sending data) by setting "Data Request" line high
 (to +5V). While receiving data, the requesting OSM must keep the "Data Request" line activated (set to +5V).
@@ -311,6 +313,57 @@ or a transistor-based circuit are not feasible options. Here's an example circui
 
 .. figure:: images/dsmr-request-pin-circuit-example.png
 
+.. _sensor-dsmr-improving_reader_results:                                                                                                  
+
+Improving reader results
+------------------------
+
+When telegrams are sometimes missed or when you get a lot of CRC errors, then you might have to do some
+changes to get better reader results.
+
+It is recommended to set the ``rx_buffer_size`` option of the UART bus to at least the maximum telegram size,
+which defaults to 1500 bytes. The default UART read buffer is quite small an can easily overflow, causing
+bytes of data getting lost.
+
+.. code-block:: yaml
+
+    # Example configuration
+    uart:
+      pin: D7
+      baud_rate: 115200
+      rx_buffer_size: 1700
+
+    dsmr:
+      max_telegram_length: 1700
+
+It's best when a hardware UART is used for reading the P1 data. Whether or not hardware UART is used can
+be checked in the config dump that you get when connecting to the API logger. Example logging output:
+
+.. code-block:: text
+
+    [02:38:37][C][uart.arduino_esp8266:095]: UART Bus:
+    [02:38:37][C][uart.arduino_esp8266:097]:   RX Pin: GPIO13
+    [02:38:37][C][uart.arduino_esp8266:099]:   RX Buffer Size: 1500
+    [02:38:37][C][uart.arduino_esp8266:101]:   Baud Rate: 115200 baud
+    [02:38:37][C][uart.arduino_esp8266:102]:   Data Bits: 8
+    [02:38:37][C][uart.arduino_esp8266:103]:   Parity: NONE
+    [02:38:37][C][uart.arduino_esp8266:104]:   Stop bits: 1
+    [02:38:37][C][uart.arduino_esp8266:106]:   Using hardware serial interface.
+                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When using an ESP8266, then GPIO13 (e.g. pin D7 on a D1 Mini) can be used for hardware RX. However, to
+actually make it work, serial logging must be disabled to keep the hardware UART available for D7.
+
+.. code-block:: yaml
+
+    # Example configuration for ESP8266
+    logger:
+      baud_rate: 0
+      level: DEBUG
+
+    uart:
+      pin: GPIO13
+      baud_rate: 115200
 
 See Also
 --------


### PR DESCRIPTION
## Description:

This change documents the `max_telegram_length` option for the dsmr component.
Additionally, it adds a few pointers to the DSMR docs about improving readings.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#2674 

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
