### PR TITLE
Add `esp32_camera_web_server:` usage docs

### DIFF
--- a/components/esp32_camera_web_server.rst
+++ b/components/esp32_camera_web_server.rst
@@ -1,0 +1,38 @@
+ESP32 Camera Web Server Component
+=================================
+
+.. seo::
+    :description: Instructions for setting up the ESP32 Camera Web Server in ESPHome
+    :image: camera.png
+
+The ``esp32_camera_web_server`` component allows you to use expose web server of
+ESP32-based camera boards in ESPHome that directly can be integrated into external
+surveillance or PVR software.
+
+At a given time only one stream can be served, but multiple snapshots. The stream
+or snapshot can be accessed via `http://<ip>:<port>/`.
+
+.. code-block:: yaml
+
+    # Example configuration entry
+    esp32_camera_web_server:
+      - port: 8080
+        mode: stream
+      - port: 8081
+        mode: snapshot
+
+Configuration variables:
+------------------------
+
+- **port** (**Required**, string): The serving port.
+- **mode** (**Required**, string): The operation mode.
+  One of these values:
+
+  - ``snapshot``
+  - ``stream``
+
+See Also
+--------
+
+- :apiref:`esp32_camera_web_server/esp32_camera_web_server.h`
+- :ghedit:`Edit`

--- a/index.rst
+++ b/index.rst
@@ -578,6 +578,7 @@ Misc Components
     ESP32 Ethernet, components/ethernet, ethernet.svg
 
     ESP32 Camera, components/esp32_camera, camera.svg
+    ESP32 Camera Web Server, components/esp32_camera_web_server, camera.svg
     Stepper, components/stepper/index, stepper.svg
     Servo, components/servo, servo.svg
 


### PR DESCRIPTION
## Description:

Describes in brief words how to configure esp32 camera web server.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** https://github.com/esphome/esphome/pull/2237

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
