### PR TITLE
fixed example code in custom light output documentation

### DIFF
--- a/components/light/custom.rst
+++ b/components/light/custom.rst
@@ -26,8 +26,7 @@ The example below is an example of a custom light output.
       LightTraits get_traits() override {
         // return the traits this light supports
         auto traits = LightTraits();
-        traits.set_supports_brightness(true);
-        traits.set_supports_color_modes({ColorMode::RGB});
+        traits.set_supported_color_modes({ColorMode::RGB, ColorMode::BRIGHTNESS});
         return traits;
       }
 


### PR DESCRIPTION
In the override of get_traits() there were calls to deprecated methods.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
