### PR TITLE
Add `web_server` component's `ota` parameter

### DIFF
--- a/components/web_server.rst
+++ b/components/web_server.rst
@@ -50,6 +50,7 @@ Configuration variables:
   - **username** (**Required**, string): The username to use for authentication.
   - **password** (**Required**, string): The password to check for authentication.
 
+- **ota** (*Optional*, boolean): Turn on or off the OTA feature inside webserver. Strongly not suggested without enabled authentication settings. Default: `true`
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
 
 .. note::
@@ -67,12 +68,14 @@ Configuration variables:
 
     Example web_server configuration with CSS and JS included from esphome-docs.
     CSS and JS URL's are set to empty value, so no internet access is needed for this device to show it's web interface.
+    Force to turn off OTA function because the missing authentication.
 
     .. code-block:: yaml
 
         # Example configuration entry
         web_server:
           port: 80
+          ota: false
           css_include: "../../../esphome-docs/_static/webserver-v1.min.css"
           css_url: ""
           js_include: "../../../esphome-docs/_static/webserver-v1.min.js"


### PR DESCRIPTION
## Description:

Add new `ota` parameter for `web_server` component.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#2685

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
