### PR TITLE
Add new on_state trigger info

### DIFF
--- a/components/climate/index.rst
+++ b/components/climate/index.rst
@@ -184,6 +184,20 @@ advanced stuff.
       // etc. see API reference
       call.perform();
 
+.. _climate-on_state_trigger:
+
+``climate.on_state`` Trigger
+******************************************************
+
+This trigger is activated each time the climate device is updated (using publish_state).
+
+.. code-block:: yaml
+
+    climate:
+      - platform: midea  # or any other platform
+        # ...
+        on_state:
+        - logger.log: "State updated!"
 
 See Also
 --------

--- a/components/climate/index.rst
+++ b/components/climate/index.rst
@@ -189,7 +189,8 @@ advanced stuff.
 ``climate.on_state`` Trigger
 ******************************************************
 
-This trigger is activated each time the climate device is updated (using publish_state).
+This trigger is activated each time the state of the climate device is updated 
+(for example, if the current temperature measurement or the mode set by the users changes).
 
 .. code-block:: yaml
 


### PR DESCRIPTION
## Description:

Add some info about new ``on_state`` trigger for climate components.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#2707

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
