### PR TITLE
Adding supported midea AC vendor

### DIFF
--- a/components/climate/midea.rst
+++ b/components/climate/midea.rst
@@ -17,6 +17,7 @@ The ``midea`` component creates a Midea air conditioner climate device.
         - `Carrier <https://www.carrier.com/>`_
         - `Comfee <http://www.comfee-russia.ru/>`_
         - `Inventor <https://www.inventorairconditioner.com/>`_
+        - `Senville <https://senville.com/>`_
         - and maybe others
 
     Control is possible with a custom dongle. Example of hardware implementation is `IoT Uni Dongle <https://github.com/dudanov/iot-uni-dongle>`_.


### PR DESCRIPTION
## Description:
New validated vendor

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
