### PR TITLE
Add map filter for text sensors

### DIFF
--- a/components/text_sensor/index.rst
+++ b/components/text_sensor/index.rst
@@ -142,6 +142,25 @@ Search the current value of the text sensor for a string, and replace it with an
 
 The arguments are a list of substitutions, each in the form ``TO_FIND -> REPLACEMENT``.
 
+``map``
+*******
+
+Lookup the current value of the text sensor in a list, and return the matching item if found. 
+Does not change the value of the text sensor if the current value wasn't found.
+
+
+.. code-block:: yaml
+
+    # Example configuration entry
+    - platform: template
+      # ...
+      filters:
+        - map:
+          - high -> On
+          - low -> Off
+
+The arguments are a list of substitutions, each in the form ``LOOKUP -> REPLACEMENT``.
+
 ``lambda``
 **********
 


### PR DESCRIPTION
## Description:

Add map filter for text sensors

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#2761

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
