### PR TITLE
wifi: remove mdns option

### DIFF
--- a/components/wifi.rst
+++ b/components/wifi.rst
@@ -62,7 +62,6 @@ Configuration variables:
   - **ap_timeout** (*Optional*, :ref:`time <config-time>`): The time after which to enable the
     configured fallback hotspot. Defaults to ``1min``.
 
-- **enable_mdns** (*Optional*, boolean): Controls if your node should advertise its presence and services using mDNS. When set to ``false`` you won't be able to access your node using its hostname which can break certain functionalities. Please see :ref:`notes on disabling mDNS <faq-notes_on_disabling_mdns>`. Defaults to ``true``.
 - **domain** (*Optional*, string): Set the domain of the node hostname used for uploading.
   For example, if it's set to ``.local``, all uploads will be sent to ``<HOSTNAME>.local``.
   Defaults to ``.local``.


### PR DESCRIPTION
"This option has been removed. Please use the [disabled] option under the new mdns component instead.
  enable_mdns: False"

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
