### PR TITLE
CAP1188 - Correction - allow_multiple_touches to boolean value

### DIFF
--- a/components/binary_sensor/cap1188.rst
+++ b/components/binary_sensor/cap1188.rst
@@ -32,7 +32,7 @@ required to be set up in your configuration for this sensor to work.
       address: 0x29
       reset_pin: 14
       touch_threshold: 0x40
-      allow_multiple_touches: 0x80
+      allow_multiple_touches: true
 
     binary_sensor:
       - platform: cap1188

--- a/components/binary_sensor/cap1188.rst
+++ b/components/binary_sensor/cap1188.rst
@@ -49,7 +49,7 @@ The configuration is made up of two parts: The central component, and individual
 - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor.
 - **reset_pin** (*Optional*, :ref:`config-pin`): Set the pin that is used to reset the CAP1188 board on boot.
 - **touch_threshold** (*Optional*, integer): The touch threshold for all channels. This defines the sensitivity for touch detection.
-   - ``0x00``: Maximum sensitivity - Most sensitive to touch
+   - ``0x01``: Maximum sensitivity - Most sensitive to touch
    - ``0x20``: Default sensitivity
    - ``0x40``: Medium sensitivity (I used this sensitivity when being used through a 3mm sheet of plastic)
    - ``0x80``: Minimum sensitivity - Least sensitive to touch


### PR DESCRIPTION
## Description:
Changed old value to the new updated Boolean value as is required.

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
