### PR TITLE
Variant now a required option

### DIFF
--- a/components/light/neopixelbus.rst
+++ b/components/light/neopixelbus.rst
@@ -38,7 +38,7 @@ Configuration variables:
 - **type** (*Optional*, string): The type of light. This is used to specify
   if it is an RGBW or RGB light and in which order the colors are. Defaults to
   ``GRB``. Change this if you have lights with white value and/or the colors are in the wrong order.
-- **variant** (*Optional*, string): The chipset variant. You can read more about these
+- **variant** (**Required**, string): The chipset variant. You can read more about these
   `here <https://github.com/Makuna/NeoPixelBus/wiki/NeoPixelBus-object#neopixel-led-model-specific-methods>`__
   (some of the info on that page is not entirely correct).
   One of these values:


### PR DESCRIPTION


## Description:

Apparently variant is now a required option for neopixelbus, as per below. Tested with :latest docker image

Failed config

light.neopixelbus: [source esphome/common/sense_gloworb_common.yaml:35]
  
  'variant' is a required option for [light.neopixelbus].
  platform: neopixelbus
  type: GRB

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ current ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
