### PR TITLE
Light Component now shows effect: none to cancel effects

### DIFF
--- a/components/light/index.rst
+++ b/components/light/index.rst
@@ -429,6 +429,9 @@ entries with each having a unique name like so:
               transition_length: 4s
               update_interval: 5s
 
+.. note::
+    After setting a light effect, it is possible to reset the in-use effect back to a static light by setting the `effect` to `none` when it is being called through Home Assistant or directly on the device.
+
 Pulse Effect
 ************
 

--- a/components/light/index.rst
+++ b/components/light/index.rst
@@ -431,7 +431,7 @@ entries with each having a unique name like so:
 
 .. note::
 
-    After setting a light effect, it is possible to reset the in-use effect back to a static light by setting the `effect` to `none` when it is being called through Home Assistant or directly on the device.
+    After setting a light effect, it is possible to reset the in-use effect back to a static light by setting the ``effect`` to ``none`` when it is being called through Home Assistant or directly on the device.
 
 Pulse Effect
 ************

--- a/components/light/index.rst
+++ b/components/light/index.rst
@@ -430,6 +430,7 @@ entries with each having a unique name like so:
               update_interval: 5s
 
 .. note::
+
     After setting a light effect, it is possible to reset the in-use effect back to a static light by setting the `effect` to `none` when it is being called through Home Assistant or directly on the device.
 
 Pulse Effect


### PR DESCRIPTION
## Description:
When I was trying to find a way to stop a light effect on a light without turning the light off first, I came across the setting of "effect: none", which can be transmitted through Home Assistant and will stop any lighting effects currently active on the light. 
It wasn't documented anywhere that was easy to see - so I added it as a note within the Light Component page, just into the Light Effects area.

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
