### PR TITLE
Update pzemac sensor platform

### DIFF
--- a/changelog/2021.11.0.rst
+++ b/changelog/2021.11.0.rst
@@ -90,7 +90,7 @@ and you will need to reverse them in your YAML configuration.
 BH1750
 ------
 
-When using the default resolution of 0.5 for the BH17850, the result is now divided by 2 as per the finidings of the community.
+When using the default resolution of 0.5 for the BH1750, the result is now divided by 2 as per the finidings of the community.
 
 
 Binary sensor device classes

--- a/components/sensor/dsmr.rst
+++ b/components/sensor/dsmr.rst
@@ -224,6 +224,55 @@ Configuration variables:
   - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.
   - All other options from :ref:`Text Sensor <config-text_sensor>`.
 
+- **timestamp** (*Optional*): Timestamp
+
+   - **name** (**Required**, string): The name for the timestamp sensor.
+   - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.
+   - All other options from :ref:`Text Sensor <config-text_sensor>`.
+
+- **electricity_tariff** (*Optional*): The current tariff. According to the specs value
+  '0001' means 'normal tariff' and value '0002' means 'low tariff'. Your meter may report differently.
+
+   - **name** (**Required**, string): The name for the electricity_tariff sensor.
+   - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.
+   - All other options from :ref:`Text Sensor <config-text_sensor>`.
+
+- **electricity_failure_log** (*Optional*): Electricity Failure Log
+
+   - **name** (**Required**, string): The name for the electricity_failure_log sensor.
+   - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.
+   - All other options from :ref:`Text Sensor <config-text_sensor>`.
+
+- **message_short** (*Optional*): Message Short
+
+   - **name** (**Required**, string): The name for the message_short sensor.
+   - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.
+   - All other options from :ref:`Text Sensor <config-text_sensor>`.
+
+- **message_long** (*Optional*): Message Long
+
+   - **name** (**Required**, string): The name for the message_long sensor.
+   - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.
+   - All other options from :ref:`Text Sensor <config-text_sensor>`.
+
+- **gas_equipment_id** (*Optional*): Gas Equipment ID.
+
+   - **name** (**Required**, string): The name for the gas_equipment_id sensor.
+   - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.
+   - All other options from :ref:`Text Sensor <config-text_sensor>`.
+
+- **water_equipment_id** (*Optional*): Water Equipment ID
+
+   - **name** (**Required**, string): The name for the water_equipment_id sensor.
+   - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.
+   - All other options from :ref:`Text Sensor <config-text_sensor>`.
+
+- **sub_equipment_id** (*Optional*): Sub Equipment ID
+
+   - **name** (**Required**, string): The name for the sub_equipment_id sensor.
+   - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.
+   - All other options from :ref:`Text Sensor <config-text_sensor>`.
+
 - **gas_delivered_text** (*Optional*): A text sensor which unformatted gas data. You need to
   apply a custom parsing of this value depending on your meter format.
 

--- a/components/sensor/pzemac.rst
+++ b/components/sensor/pzemac.rst
@@ -36,6 +36,16 @@ The communication with this integration is done over a :ref:`UART bus <uart>` us
 You must therefore have a ``uart:`` entry in your configuration with both the TX and RX pins set
 to some pins on your board and the baud rate set to 9600.
 
+The previous version of the ``pzemac`` sensor platform had two behaviors that could be unwanted:
+
+- Sometimes, when the PZEM was energized, there was spurious data with very high values.
+
+- When the PZEM lacked power and the ESP8266 was still energized, the last values were kept.
+
+To circumvent these behaviors, a logic was created to filter (or rather, disregard the first
+measurements at power-up) and to reset the values when the PZEM is de-energized.
+The configuration variable ``update_filter`` was created to handle this.
+
 .. code-block:: yaml
 
     # Example configuration entry
@@ -43,7 +53,7 @@ to some pins on your board and the baud rate set to 9600.
       rx_pin: D1
       tx_pin: D2
       baud_rate: 9600
-      
+
     modbus:
 
     sensor:
@@ -60,7 +70,9 @@ to some pins on your board and the baud rate set to 9600.
           name: "PZEM-004T V3 Frequency"
         power_factor:
           name: "PZEM-004T V3 Power Factor"
-        update_interval: 60s
+        update_interval: 1s
+        address: 1
+        update_filter: 3
 
 Configuration variables:
 ------------------------
@@ -82,6 +94,10 @@ Configuration variables:
 - **address** (*Optional*, int): The address of the sensor if multiple sensors are attached to
   the same UART bus. You will need to set the address of each device manually. Defaults to ``1``.
 - **modbus_id** (*Optional*, :ref:`config-id`): Manually specify the ID of the Modbus hub.
+- **update_filter** (*Optional*, int): Update filter defines the number of updates to be rejected
+  when the PZEM was energized, and also the number of update feedback failures to set values to zero.
+  Defaults to ``0``. With ``update_filter`` = ``0`` the ``pzemac`` sensor platform operation is the
+  same as the previous version without ``update_filter``.
 
 See Also
 --------


### PR DESCRIPTION
## Description:
The current version of the pzemac sensor platform had two behaviors that could be unwanted:
Sometimes, when the PZEM was energized, there is spurious data with very high values.
When the PZEM lacked power and the ESP8266 was still energized, the last values were kept.
To circumvent these behaviors, a logic was created to filter (or rather, disregard the first measurements at power-up) and to reset the values when the PZEM is de-energized. The configuration variable update_filter was created to handle this.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#2767

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
