### PR TITLE
Add sdp800 to sdp3x documentation

### DIFF
--- a/components/sensor/sdp3x.rst
+++ b/components/sensor/sdp3x.rst
@@ -1,14 +1,14 @@
-SDP3x Differential Pressure Sensor
-==================================
+SDP3x / SDP800 Series Differential Pressure Sensor
+===================================================
 
 .. seo::
-    :description: Instructions for setting up the SDP3x Differential Pressure sensor.
+    :description: Instructions for setting up the SDP3x or SDP800 Series Differential Pressure sensor.
     :image: sdp31.jpg
-    :keywords: SDP3x, SDP31, SDP32
+    :keywords: SDP3x, SDP31, SDP32, SDP800 Series, SDP810, SDP810
 
 The SDP3x Differential Pressure sensor allows you to use your SDP3x
 (`datasheet <https://www.sensirion.com/fileadmin/user_upload/customers/sensirion/Dokumente/8_Differential_Pressure/Datasheets/Sensirion_Differential_Pressure_Datasheet_SDP3x_Digital.pdf>`__,
-`sparkfun <https://www.sparkfun.com/products/17874>`__)
+`sparkfun <https://www.sparkfun.com/products/17874>`__) or SDP800 Series (`datasheet <https://www.sensirion.com/fileadmin/user_upload/customers/sensirion/Dokumente/8_Differential_Pressure/Datasheets/Sensirion_Differential_Pressure_Datasheet_SDP8xx_Digital.pdf>`__)
 sensors with ESPHome.
 
 .. figure:: images/sdp31.jpg
@@ -35,6 +35,7 @@ Configuration variables:
 - **name** (**Required**, string): The name for this sensor.
 - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for lambdas/multiple sensors.
 - **address** (*Optional*, int): The I²C address of the sensor. Defaults to ``0x21``.
+- **measurement_mode** (*Optional*): The measurement mode of the sensor. Valid options are ``differential_pressure`` and ``mass_flow``. Defaults to ``differential_pressure``.
 - **update_interval** (*Optional*, :ref:`config-time`): The interval to check the sensor. Defaults to ``60s``.
 - All other options from :ref:`Sensor <config-sensor>`.
 

--- a/index.rst
+++ b/index.rst
@@ -283,7 +283,7 @@ Environmental
     RuuviTag, components/sensor/ruuvitag, ruuvitag.jpg, Temperature & Humidity & Accelerometer
     SCD30, components/sensor/scd30, scd30.jpg, CO2 & Temperature & Humidity
     SCD4X, components/sensor/scd4x, scd4x.jpg, CO2 & Temperature & Humidity
-    SDP3x, components/sensor/sdp3x, sdp31.jpg, Pressure
+    SDP3x / SDP800 Series, components/sensor/sdp3x, sdp31.jpg, Pressure
     SHT3X-D, components/sensor/sht3xd, sht3xd.jpg, Temperature & Humidity
     SHT4X, components/sensor/sht4x, sht4x.jpg, Temperature & Humidity
     SHTCx, components/sensor/shtcx, shtc3.jpg, Temperature & Humidity


### PR DESCRIPTION
## Description:
add sdp800 series documentation to sdp3x component

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#2779

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
