### PR TITLE
Small spelling fix

### DIFF
--- a/components/sensor/max6675.rst
+++ b/components/sensor/max6675.rst
@@ -16,7 +16,7 @@ temperature sensor (`datasheet <https://datasheets.maximintegrated.com/en/ds/MAX
 
 .. _SainSmart: https://www.sainsmart.com/products/max6675-module-k-type-thermocouple-thermocouple-sensor-temperature-0-1024-for-arduino
 
-As the communication with the MAX66775 is done using SPI, you need
+As the communication with the MAX6675 is done using SPI, you need
 to have an :ref:`SPI bus <spi>` in your configuration with the **miso_pin** set (MOSI is not required).
 
 Connect ``GND`` to ``GND``, ``VCC`` to ``3.3V`` and the other three ``MISO`` (or ``SO`` for short),


### PR DESCRIPTION
## Description:
Small spelling fix, an extra `7` removed.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
