### PR TITLE
Add output pin definition to hbridge fan example configuration

### DIFF
--- a/components/fan/hbridge.rst
+++ b/components/fan/hbridge.rst
@@ -23,6 +23,14 @@ The `'hbridge`' fan platform allows you to use a compatible `h-bridge` (L298N, D
 .. code-block:: yaml
 
     # Example configuration entry
+    output:
+      - platform: esp8266_pwm
+        id: motor_forward_pin
+        pin: D1
+      - platform: esp8266_pwm
+        id: motor_reverse_pin
+        pin: D2
+    
     fan:
       - platform: hbridge
         id: my_fan

--- a/components/fan/hbridge.rst
+++ b/components/fan/hbridge.rst
@@ -24,12 +24,12 @@ The `'hbridge`' fan platform allows you to use a compatible `h-bridge` (L298N, D
 
     # Example configuration entry
     output:
-      - platform: esp8266_pwm
+      - platform: ...
         id: motor_forward_pin
-        pin: D1
-      - platform: esp8266_pwm
+        pin: GPIO5
+      - platform: ...
         id: motor_reverse_pin
-        pin: D2
+        pin: GPIO4
     
     fan:
       - platform: hbridge


### PR DESCRIPTION
To better understand how to use the hbridge fan component, the output pin definitions should be added to the example configuration to make it complete. Otherwise if the user just copy and pasted the example and fills in the pins directly (D1, D2, etc.), he will get an error and not directly notice what he is missing.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ X] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
