### PR TITLE
Mark "variant" as required for `neopixelbus`

### DIFF
--- a/components/light/neopixelbus.rst
+++ b/components/light/neopixelbus.rst
@@ -38,7 +38,7 @@ Configuration variables:
 - **type** (*Optional*, string): The type of light. This is used to specify
   if it is an RGBW or RGB light and in which order the colors are. Defaults to
   ``GRB``. Change this if you have lights with white value and/or the colors are in the wrong order.
-- **variant** (*Required*, string): The chipset variant. You can read more about these
+- **variant** (**Required**, string): The chipset variant. You can read more about these
   `here <https://github.com/Makuna/NeoPixelBus/wiki/NeoPixelBus-object#neopixel-led-model-specific-methods>`__
   (some of the info on that page is not entirely correct).
   One of these values:

--- a/components/light/neopixelbus.rst
+++ b/components/light/neopixelbus.rst
@@ -38,12 +38,12 @@ Configuration variables:
 - **type** (*Optional*, string): The type of light. This is used to specify
   if it is an RGBW or RGB light and in which order the colors are. Defaults to
   ``GRB``. Change this if you have lights with white value and/or the colors are in the wrong order.
-- **variant** (*Optional*, string): The chipset variant. You can read more about these
+- **variant** (*Required*, string): The chipset variant. You can read more about these
   `here <https://github.com/Makuna/NeoPixelBus/wiki/NeoPixelBus-object#neopixel-led-model-specific-methods>`__
   (some of the info on that page is not entirely correct).
   One of these values:
 
-  - ``800KBPS`` (default)
+  - ``800KBPS``
   - ``400KBPS``
   - ``WS2812X``
   - ``SK6812``


### PR DESCRIPTION
## Description:

In October the "variant" field became mandatory, but the docs did not reflect that yet.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** https://github.com/esphome/esphome/pull/2616

## Checklist:

  - [X] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
