### PR TITLE
Added Precise Elevation Calculation

### DIFF
--- a/components/sun.rst
+++ b/components/sun.rst
@@ -50,12 +50,12 @@ Automation:
 - **on_sunrise** (*Optional*, :ref:`Automation <automation>`): An automation to perform at sunrise
   when the sun crosses a specified angle.
 
-  - **elevation** (*Optional*, float): The elevation to cross. Defaults to 0° (horizon) (more precisely -0.833° due to atmospheric refraction).
+  - **elevation** (*Optional*, float): The elevation to cross. Defaults to -0.833° (the horizon, slightly less than 0° to compensate for atmospheric refraction).
 
 - **on_sunset** (*Optional*, :ref:`Automation <automation>`): An automation to perform at sunset
   when the sun crosses a specified angle.
 
-  - **elevation** (*Optional*, float): The elevation to cross. Defaults to 0° (horizon) (more precisely -0.833° due to atmospheric refraction).
+  - **elevation** (*Optional*, float): The elevation to cross. Defaults to -0.833° (the horizon, slightly less than 0° to compensate for atmospheric refraction).```
 
 ``sun`` Sensor
 --------------
@@ -111,7 +111,7 @@ Configuration variables:
   ``sunset``.
 - **name** (**Required**, string): The name of the text sensor.
 - **elevation** (*Optional*, float): The elevation to calculate the next sunrise/sunset event
-  for. Defaults to ``0°`` (more precisely ``-0.833°`` due to atmospheric refraction).
+  for. Defaults to -0.833° (the horizon, slightly less than 0° to compensate for atmospheric refraction).
 - **format** (*Optional*, string): The format to format the time value with, see :ref:`display-strftime`
   for more information. Defaults to ``%X``.
 

--- a/components/sun.rst
+++ b/components/sun.rst
@@ -50,12 +50,12 @@ Automation:
 - **on_sunrise** (*Optional*, :ref:`Automation <automation>`): An automation to perform at sunrise
   when the sun crosses a specified angle.
 
-  - **elevation** (*Optional*, float): The elevation to cross. Defaults to 0° (horizon).
+  - **elevation** (*Optional*, float): The elevation to cross. Defaults to 0° (horizon) (more precisely -0.833° due to atmospheric refraction).
 
 - **on_sunset** (*Optional*, :ref:`Automation <automation>`): An automation to perform at sunset
   when the sun crosses a specified angle.
 
-  - **elevation** (*Optional*, float): The elevation to cross. Defaults to 0° (horizon).
+  - **elevation** (*Optional*, float): The elevation to cross. Defaults to 0° (horizon) (more precisely -0.833° due to atmospheric refraction).
 
 ``sun`` Sensor
 --------------
@@ -111,7 +111,7 @@ Configuration variables:
   ``sunset``.
 - **name** (**Required**, string): The name of the text sensor.
 - **elevation** (*Optional*, float): The elevation to calculate the next sunrise/sunset event
-  for. Defaults to ``0°``.
+  for. Defaults to ``0°`` (more precisely ``-0.833°`` due to atmospheric refraction).
 - **format** (*Optional*, string): The format to format the time value with, see :ref:`display-strftime`
   for more information. Defaults to ``%X``.
 


### PR DESCRIPTION
Added the precise calculation for sunrise and sunset elevation, it caused me confusion when trying to do some math with sunrise and sunset.

More info
https://en.wikipedia.org/wiki/Sunrise_equation#Generalized_equation
https://gml.noaa.gov/grad/solcalc/calcdetails.html

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
