### PR TITLE
Document that node name can be max 31 characters

### DIFF
--- a/components/esphome.rst
+++ b/components/esphome.rst
@@ -26,7 +26,8 @@ Configuration variables:
 
 - **name** (**Required**, string): This is the name of the node. It
   should always be unique in your ESPHome network. May only contain lowercase
-  characters, digits and hyphens. See :ref:`esphome-changing_node_name`.
+  characters, digits and hyphens, and can be at most 31 characters long.
+  See :ref:`esphome-changing_node_name`.
 
 Advanced options:
 


### PR DESCRIPTION
## Description:

Document that node name can be max 31 characters

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
