### PR TITLE
Also run CI on PR edited event

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,7 @@ on:
     branches: [current, next]
 
   pull_request:
+    types: [opened, edited, reopened, synchronize]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Description:

When the base branch of a PR is changed, GitHub raises a `pull_request.edited` event. However, by default the `pull_request` Actions trigger only runs for `opened`, `synchronize` and `reopened` events. Add the `edited` event so that CI is triggered when the base branch is changed.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
