### PR TITLE
Add note about hlw8012 BL0937 SEL pin

### DIFF
--- a/components/sensor/hlw8012.rst
+++ b/components/sensor/hlw8012.rst
@@ -99,6 +99,31 @@ the initial measurement mode to match whichever mode the device uses, and disabl
         initial_mode: CURRENT
         change_mode_every: 4294967295
 
+SEL Pin Inversion
+-----------------
+
+If using model ``BL0937`` the function of the SEL pin is inverted compared to default. When SEL=0 current is measured,
+when SEL=1 voltage is measured. To accommodate this change use the following configuration:
+
+.. code-block:: yaml
+
+    # Example configuration entry for device BL0937 using inverted SEL pin functionality
+    sensor:
+      - platform: hlw8012
+        model: BL0937
+        sel_pin:  
+          number: 12
+          inverted: true
+        cf_pin: 4
+        cf1_pin: 5
+        current:
+          name: "BL0937 Current"
+        voltage:
+          name: "BL0937 Voltage"
+        power:
+          name: "BL0937 Power"
+        update_interval: 60s
+
 See Also
 --------
 


### PR DESCRIPTION
According to the datasheet of BL0937 (https://www.belling.com.cn/media/file_object/bel_product/BL0937/datasheet/BL0937_V1.02_en.pdf) if SEL=0 current is measured, otherwise voltage. This has to be accommodated by inverting the SEL pin function. Hint in documentation makes this clear.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
