### PR TITLE
Add documentation for esp-idf ignore_efuse_mac_crc option

### DIFF
--- a/components/esp32.rst
+++ b/components/esp32.rst
@@ -71,6 +71,9 @@ of the ESP32 like ESP32S2, ESP32S3, ESP32C3 and single-core ESP32 chips.
       # Custom sdkconfig options
       sdkconfig_options:
         CONFIG_COMPILER_OPTIMIZATION_SIZE: y
+      # Advanced tweaking options
+      advanced:
+        ignore_efuse_mac_crc: false
 
 - **version** (*Optional*, string): The base framework version number to use, from 
   `ESP32 ESP-IDF releases <https://github.com/espressif/esp-idf/releases>`__. Defaults to ``recommended``. Additional values are:
@@ -82,6 +85,10 @@ of the ESP32 like ESP32S2, ESP32S3, ESP32C3 and single-core ESP32 chips.
 - **source** (*Optional*, string): The PlatformIO package or repository to use for the framework. This can be used to use a custom or patched version of the framework.
 - **platform_version** (*Optional*, string): The version of the `platformio/espressif32 <https://github.com/platformio/platform-espressif32/releases/>`__ package to use.
 - **sdkconfig_options** (*Optional*, mapping): Custom sdkconfig options to set in the ESP-IDF project.
+- **advanced** (*Optional*, mapping): Advanced options for highly specific tweaks.
+
+  - **ignore_efuse_mac_crc** (*Optional*, boolean): Can be set to ``true`` for devices on which the burnt in MAC address does not
+    match the also burnt in CRC for that MAC address, resulting in an error like ``Base MAC address from BLK0 of EFUSE CRC error``.
 
 See Also
 --------


### PR DESCRIPTION
## Description:

At the time of [my PR for adding the ignore_efuse_mac_crc_option](https://github.com/esphome/esphome/pull/2399), there was not yet documentation available for the `esp32:` component. I promised to write that documentation once the `esp32:` component was documented. Today I fulfill that promise.

Made this PR against `current`, since the PR code has already been merged.

**Related issue (if applicable):** fixes [#2495](https://github.com/esphome/issues/issues/2495)

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
