### PR TITLE
Add Git credential config docs

### DIFF
--- a/components/external_components.rst
+++ b/components/external_components.rst
@@ -42,6 +42,8 @@ Configuration variables:
 
   - **url** (**Required**, url): HTTP git repository url. See :ref:`external-components_git`.
   - **ref** (*Optional*, string): Git ref (branch or tag). If not specified the default branch is used.
+  - **username** (*Optional*, string): Username for the Git server, if one is required
+  - **password** (*Optional*, string): Password for the Git server, if one is required
 
   local options:
 

--- a/components/external_components.rst
+++ b/components/external_components.rst
@@ -184,6 +184,12 @@ folder and components will then be loaded from this local copy. The local path o
 varies per repository name and ref name, so repositories with different refs are considered different
 repositories and updated independently.
 
+If required, you can supply a username and password to use when authenticating with the remote git
+server using the ``username`` and ``password`` fields. This is most useful when combined with the
+``!secret``  feature, to load the values in from a ``secrets.yaml`` file. This is not a comprehensive
+security measure; your username and password will necessarily be stored in clear text within the
+``.esphome`` directory.
+
 .. _external-components_refresh:
 
 Refresh


### PR DESCRIPTION
## Description:

Add docs for the proposed new Git credential config fields, and explanatory text about some of the risks associated with how the credentials are stored.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#2825

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - ~Link added in `/index.rst` when creating new documents for new components or cookbook.~
