### PR TITLE
Tuya automation and text sensor support

### DIFF
--- a/components/text_sensor/tuya.rst
+++ b/components/text_sensor/tuya.rst
@@ -1,0 +1,35 @@
+Tuya Text Sensor
+================
+
+.. seo::
+    :description: Instructions for setting up a Tuya device sensor.
+    :image: tuya.png
+
+The ``tuya`` text sensor platform creates a sensor from a tuya component
+and requires :doc:`/components/tuya` to be configured.
+
+You can create the text sensor as follows:
+
+.. code-block:: yaml
+
+    # Create a sensor
+    text_sensor:
+      - platform: "tuya"
+        name: "MyTextSensor"
+        sensor_datapoint: 18
+
+Configuration variables:
+------------------------
+
+- **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
+- **name** (**Required**, string): The name of the sensor.
+- **sensor_datapoint** (**Required**, int): The datapoint id number of the sensor.
+- All other options from :ref:`Text Sensor <config-text_sensor>`.
+
+See Also
+--------
+
+- :doc:`/components/tuya`
+- :doc:`/components/text_sensor/index`
+- :apiref:`tuya/text_sensor/tuya_text_sensor.h`
+- :ghedit:`Edit`

--- a/index.rst
+++ b/index.rst
@@ -524,6 +524,7 @@ Text Sensor Components
     Template Text Sensor, components/text_sensor/template, description.svg
     Custom Text Sensor, components/text_sensor/custom, language-cpp.svg
     Nextion Text Sensor, components/text_sensor/nextion, nextion.jpg
+    Tuya Text Sensor, components/text_sensor/tuya, tuya.png
 
 Climate Components
 ------------------


### PR DESCRIPTION
## Description:

Documentation for Tuya automation for datapoints and Tuya Text Sensor component.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#1812

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
