### PR TITLE
Add doc for number mode

### DIFF
--- a/components/number/index.rst
+++ b/components/number/index.rst
@@ -43,7 +43,11 @@ Configuration variables:
   for a list of available options. Requires Home Assistant 2021.11 or newer.
   Set to ``""`` to remove the default entity category.
 - **unit_of_measurement** (*Optional*, string): Manually set the unit
-  of measurement for the number.
+  of measurement for the number. Requires Home Assistant Core 2021.12 or newer.
+- **mode** (*Optional*, string): Defines how the number should be displayed in the frontend.
+  See https://developers.home-assistant.io/docs/core/entity/number/#properties
+  for a list of available options. Requires Home Assistant Core 2021.12 or newer.
+  Defaults to ``"auto"``.
 
 Automations:
 


### PR DESCRIPTION
## Description:

Related:
- https://github.com/esphome/esphome/pull/2838
- https://github.com/esphome/aioesphomeapi/pull/148
- https://github.com/home-assistant/core/pull/60653

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#2838

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
