### PR TITLE
New Coolix protocol. New midea_ir climate component.

### DIFF
--- a/components/climate/ir_climate.rst
+++ b/components/climate/ir_climate.rst
@@ -163,7 +163,7 @@ Additional configuration is available for this platform
 
 Configuration variables:
 
-- **use_fahrenheit** (*Optional*, boolean): Allows you to transfer the temperature to the air conditioner in degrees Fahrenheit. The air conditioner display also shows the temperature in Fahrenheit. Defaults to ``False``.
+- **use_fahrenheit** (*Optional*, boolean): Allows you to transfer the temperature to the air conditioner in degrees Fahrenheit. The air conditioner display also shows the temperature in Fahrenheit. Defaults to ``false``.
 
 .. code-block:: yaml
 

--- a/components/climate/ir_climate.rst
+++ b/components/climate/ir_climate.rst
@@ -163,7 +163,7 @@ Additional configuration is available for this platform
 
 Configuration variables:
 
-- **use_fahrenheits** (*Optional*, boolean): Allows you to transfer the temperature to the air conditioner in degrees Fahrenheit. The air conditioner display also shows the temperature in Fahrenheit. Defaults to ``False``.
+- **use_fahrenheit** (*Optional*, boolean): Allows you to transfer the temperature to the air conditioner in degrees Fahrenheit. The air conditioner display also shows the temperature in Fahrenheit. Defaults to ``False``.
 
 .. code-block:: yaml
 
@@ -172,7 +172,7 @@ Configuration variables:
       - platform: midea_ir
         name: "AC"
         sensor: room_temperature
-        use_fahrenheits: true
+        use_fahrenheit: true
 
 
 .. _climate_ir_lg:

--- a/components/climate/ir_climate.rst
+++ b/components/climate/ir_climate.rst
@@ -34,6 +34,8 @@ submit a feature request (see FAQ).
 +---------------------------------------+---------------------+----------------------+
 | :ref:`LG<climate_ir_lg>`              | ``climate_ir_lg``   | yes                  |
 +---------------------------------------+---------------------+----------------------+
+| Midea                                 | ``midea_ir``        | yes                  |
++---------------------------------------+---------------------+----------------------+
 | Mitsubishi                            | ``mitsubishi``      |                      |
 +---------------------------------------+---------------------+----------------------+
 | TCL112, Fuego                         | ``tcl112``          | yes                  |
@@ -149,6 +151,30 @@ IR receiver.
         name: "Living Room AC"
         receiver_id: rcvr
 
+.. _midea_ir:
+
+``midea_ir`` Climate
+-------------------------
+
+These air conditioners support two protocols: Midea and Coolix. Therefore, when using an IR receiver, it considers both protocols and publishes the received states.
+
+Additional configuration is available for this platform
+
+
+Configuration variables:
+
+- **use_fahrenheits** (*Optional*, boolean): Allows you to transfer the temperature to the air conditioner in degrees Fahrenheit. The air conditioner display also shows the temperature in Fahrenheit. Defaults to ``False``.
+
+.. code-block:: yaml
+
+    # Example configuration entry
+    climate:
+      - platform: midea_ir
+        name: "AC"
+        sensor: room_temperature
+        use_fahrenheits: true
+
+
 .. _climate_ir_lg:
 
 ``climate_ir_lg`` Climate
@@ -237,6 +263,7 @@ See Also
   :apiref:`daikin.h <daikin/daikin.h>`
   :apiref:`fujitsu_general.h <fujitsu_general/fujitsu_general.h>`,
   :apiref:`hitachi_ac344.h <hitachi_ac344/hitachi_ac344.h>`,
+  :apiref:`midea_ir.h <midea_ir/midea_ir.h>`,
   :apiref:`mitsubishi.h <mitsubishi/mitsubishi.h>`,
   :apiref:`tcl112.h <tcl112/tcl112.h>`,
   :apiref:`yashima.h <yashima/yashima.h>`

--- a/components/remote_receiver.rst
+++ b/components/remote_receiver.rst
@@ -30,19 +30,21 @@ Configuration variables:
 - **dump** (*Optional*, list): Decode and dump these remote codes in the logs (at log.level=DEBUG).
   Set to ``all`` to dump all available codecs:
 
+  - **coolix**: Decode and dump Coolix infrared codes.
+  - **dish**: Decode and dump Dish infrared codes.
+  - **jvc**: Decode and dump JVC infrared codes.
   - **lg**: Decode and dump LG infrared codes.
   - **midea**: Decode and dump Midea infrared codes.
   - **nec**: Decode and dump NEC infrared codes.
   - **panasonic**: Decode and dump Panasonic infrared codes.
   - **pioneer**: Decode and dump Pioneer infrared codes.
-  - **jvc**: Decode and dump JVC infrared codes.
+  - **raw**: Print all remote codes in their raw form. Useful for using arbitrary protocols.
+  - **rc5**: Decode and dump RC5 IR codes.
+  - **rc_switch**: Decode and dump RCSwitch RF codes.
   - **samsung**: Decode and dump Samsung infrared codes.
   - **samsung36**: Decode and dump Samsung36 infrared codes.
   - **sony**: Decode and dump Sony infrared codes.
   - **toshiba_ac**: Decode and dump Toshiba AC infrared codes.
-  - **rc_switch**: Decode and dump RCSwitch RF codes.
-  - **rc5**: Decode and dump RC5 IR codes.
-  - **raw**: Print all remote codes in their raw form. Useful for using arbitrary protocols.
 
 - **tolerance** (*Optional*, int): The percentage that the remote signal lengths can deviate in the
   decoding process. Defaults to ``25%``.
@@ -59,6 +61,13 @@ Configuration variables:
 
 Automations:
 
+- **on_coolix** (*Optional*, :ref:`Automation <automation>`): An automation to perform when a
+  Coolix remote code has been decoded. A variable ``x`` of type :apiclass:`remote_base::CoolixData`
+  is passed to the automation for use in lambdas.
+- **on_dish** (*Optional*, :ref:`Automation <automation>`): An automation to perform when a
+  dish network remote code has been decoded. A variable ``x`` of type :apistruct:`remote_base::DishData`
+  is passed to the automation for use in lambdas.
+  Beware that Dish remotes use a different carrier frequency (57.6kHz) that many receiver hardware don't decode.
 - **on_jvc** (*Optional*, :ref:`Automation <automation>`): An automation to perform when a
   JVC remote code has been decoded. A variable ``x`` of type :apistruct:`remote_base::JVCData`
   is passed to the automation for use in lambdas.
@@ -78,11 +87,11 @@ Automations:
       Therefore, if the the configuration file has come from an earlier version of ESPhome, it is necessary to reverse the order of the address and command bits when moving to 2021.12 or above.
       For example, address: 0x84ED, command: 0x13EC becomes 0xB721 and 0x37C8 respectively.
 
-- **on_sony** (*Optional*, :ref:`Automation <automation>`): An automation to perform when a
-  Sony remote code has been decoded. A variable ``x`` of type :apistruct:`remote_base::SonyData`
+- **on_panasonic** (*Optional*, :ref:`Automation <automation>`): An automation to perform when a
+  Panasonic remote code has been decoded. A variable ``x`` of type :apistruct:`remote_base::PanasonicData`
   is passed to the automation for use in lambdas.
-- **on_toshiba_ac** (*Optional*, :ref:`Automation <automation>`): An automation to perform when a
-  Toshiba AC remote code has been decoded. A variable ``x`` of type :apistruct:`remote_base::ToshibaAcData`
+- **on_pioneer** (*Optional*, :ref:`Automation <automation>`): An automation to perform when a
+  pioneer remote code has been decoded. A variable ``x`` of type :apistruct:`remote_base::PioneerData`
   is passed to the automation for use in lambdas.
 - **on_raw** (*Optional*, :ref:`Automation <automation>`): An automation to perform when a
   raw remote code has been decoded. A variable ``x`` of type ``std::vector<int>``
@@ -99,16 +108,12 @@ Automations:
 - **on_samsung36** (*Optional*, :ref:`Automation <automation>`): An automation to perform when a
   Samsung36 remote code has been decoded. A variable ``x`` of type :apistruct:`remote_base::Samsung36Data`
   is passed to the automation for use in lambdas.
-- **on_panasonic** (*Optional*, :ref:`Automation <automation>`): An automation to perform when a
-  Panasonic remote code has been decoded. A variable ``x`` of type :apistruct:`remote_base::PanasonicData`
+- **on_sony** (*Optional*, :ref:`Automation <automation>`): An automation to perform when a
+  Sony remote code has been decoded. A variable ``x`` of type :apistruct:`remote_base::SonyData`
   is passed to the automation for use in lambdas.
-- **on_pioneer** (*Optional*, :ref:`Automation <automation>`): An automation to perform when a
-  pioneer remote code has been decoded. A variable ``x`` of type :apistruct:`remote_base::PioneerData`
+- **on_toshiba_ac** (*Optional*, :ref:`Automation <automation>`): An automation to perform when a
+  Toshiba AC remote code has been decoded. A variable ``x`` of type :apistruct:`remote_base::ToshibaAcData`
   is passed to the automation for use in lambdas.
-  - **on_dish** (*Optional*, :ref:`Automation <automation>`): An automation to perform when a
-  dish network remote code has been decoded. A variable ``x`` of type :apistruct:`remote_base::DishData`
-  is passed to the automation for use in lambdas.
-  Beware that Dish remotes use a different carrier frequency (57.6kHz) that many receiver hardware don't decode.
 
 .. _remote-receiver-binary-sensor:
 
@@ -143,6 +148,16 @@ Configuration variables:
 
 Remote code selection (exactly one of these has to be included):
 
+- **coolix**: Trigger on a decoded Coolix remote code with the given data.
+
+  - **data** (**Required**, int): The 24-bit Coolix code to trigger on, see dumper output for more info.
+
+- **dish**: Trigger on a decoded Dish Network remote code with the given data.
+  Beware that Dish remotes use a different carrier frequency (57.6kHz) that many receiver hardware don't decode.
+
+  - **address** (*Optional*, int): The number of the receiver to target, between 1 and 16 inclusive. Defaults to ``1``.
+  - **command** (**Required**, int): The Dish command to listen for, between 0 and 63 inclusive.
+
 - **jvc**: Trigger on a decoded JVC remote code with the given data.
 
   - **data** (**Required**, int): The JVC code to trigger on, see dumper output for more info.
@@ -168,15 +183,14 @@ Remote code selection (exactly one of these has to be included):
   - **address** (**Required**, int): The address to trigger on, see dumper output for more info.
   - **command** (**Required**, int): The NEC command to listen for.
 
-- **sony**: Trigger on a decoded Sony remote code with the given data.
+- **panasonic**: Trigger on a decoded Panasonic remote code with the given data.
 
-  - **data** (**Required**, int): The Sony code to trigger on, see dumper output for more info.
-  - **nbits** (*Optional*, int): The number of bits of the remote code. Defaults to ``12``.
+  - **address** (**Required**, int): The address to trigger on, see dumper output for more info.
+  - **command** (**Required**, int): The command.
 
-- **toshiba_ac**: Trigger on a decoded Toshiba AC remote code with the given data.
+- **pioneer**: Trigger on a decoded Pioneer remote code with the given data.
 
   - **rc_code_1** (**Required**, int): The remote control code to trigger on, see dumper output for more details.
-  - **rc_code_2** (*Optional*, int): The second part of the remote control code to trigger on, see dumper output for more details.
 
 - **raw**: Trigger on a raw remote code with the given code.
 
@@ -187,31 +201,6 @@ Remote code selection (exactly one of these has to be included):
 
   - **address** (**Required**, int): The address to trigger on, see dumper output for more info.
   - **command** (**Required**, int): The RC5 command to listen for.
-
-- **samsung**: Trigger on a decoded Samsung remote code with the given data.
-
-  - **data** (**Required**, int): The data to trigger on, see dumper output for more info.
-  - **nbits** (*Optional*, int): The number of bits of the remote code. Defaults to ``32``.
-
-- **samsung36**: Trigger on a decoded Samsung36 remote code with the given data.
-
-  - **address** (**Required**, int): The address to trigger on, see dumper output for more info.
-  - **command** (**Required**, int): The command.
-
-- **panasonic**: Trigger on a decoded Panasonic remote code with the given data.
-
-  - **address** (**Required**, int): The address to trigger on, see dumper output for more info.
-  - **command** (**Required**, int): The command.
-
-- **pioneer**: Trigger on a decoded Pioneer remote code with the given data.
-
-  - **rc_code_1** (**Required**, int): The remote control code to trigger on, see dumper output for more details.
-
-- **dish**: Trigger on a decoded Dish Network remote code with the given data.
-  Beware that Dish remotes use a different carrier frequency (57.6kHz) that many receiver hardware don't decode.
-
-  - **address** (*Optional*, int): The number of the receiver to target, between 1 and 16 inclusive. Defaults to ``1``.
-  - **command** (**Required**, int): The Dish command to listen for, between 0 and 63 inclusive.
 
 - **rc_switch_raw**: Trigger on a decoded RC Switch raw remote code with the given data.
 
@@ -247,6 +236,26 @@ Remote code selection (exactly one of these has to be included):
   - **device** (**Required**, int): The device. Range is 1 to 3.
   - **state** (**Required**, boolean): The on/off state to trigger on.
   - **protocol** (*Optional*): The RC Switch protocol to use, see :ref:`remote_transmitter-rc_switch-protocol` for more info.
+
+- **samsung**: Trigger on a decoded Samsung remote code with the given data.
+
+  - **data** (**Required**, int): The data to trigger on, see dumper output for more info.
+  - **nbits** (*Optional*, int): The number of bits of the remote code. Defaults to ``32``.
+
+- **samsung36**: Trigger on a decoded Samsung36 remote code with the given data.
+
+  - **address** (**Required**, int): The address to trigger on, see dumper output for more info.
+  - **command** (**Required**, int): The command.
+
+- **sony**: Trigger on a decoded Sony remote code with the given data.
+
+  - **data** (**Required**, int): The Sony code to trigger on, see dumper output for more info.
+  - **nbits** (*Optional*, int): The number of bits of the remote code. Defaults to ``12``.
+
+- **toshiba_ac**: Trigger on a decoded Toshiba AC remote code with the given data.
+
+  - **rc_code_1** (**Required**, int): The remote control code to trigger on, see dumper output for more details.
+  - **rc_code_2** (*Optional*, int): The second part of the remote control code to trigger on, see dumper output for more details.
 
 .. note::
 

--- a/components/remote_transmitter.rst
+++ b/components/remote_transmitter.rst
@@ -78,54 +78,46 @@ Configuration variables:
 If you're looking for the same functionality as is default in the ``rpi_rf`` integration in
 Home Assistant, you'll want to set the **times** to 10 and the **wait_time** to 0s.
 
-.. _remote_transmitter-transmit_raw:
+.. _remote_transmitter-transmit_coolix:
 
-``remote_transmitter.transmit_raw`` Action
+``remote_transmitter.transmit_coolix`` Action
 ******************************************
 
-This :ref:`action <config-action>` sends a raw code to a remote transmitter.
+This :ref:`action <config-action>` sends a 24-bit Coolix infrared remote code to a remote transmitter.
 
 .. code-block:: yaml
 
     on_...:
-      - remote_transmitter.transmit_raw:
-          code: [4088, -1542, 1019, -510, 513, -1019, 510, -509, 511, -510, 1020,
-                 -1020, 1022, -1019, 510, -509, 511, -510, 511, -509, 511, -510,
-                 1020, -1019, 510, -511, 1020, -510, 512, -508, 510, -1020, 1022,
-                 -1021, 1019, -1019, 511, -510, 510, -510, 1022, -1020, 1019,
-                 -1020, 511, -511, 1018, -1022, 1020, -1019, 1021, -1019, 1020,
-                 -511, 510, -1019, 1023, -1019, 1019, -510, 512, -508, 510, -511,
-                 512, -1019, 510, -509]
+      - remote_transmitter.transmit_coolix:
+          data: 0xB23FE4
 
 Configuration variables:
 
-- **code** (**Required**, list): The raw code to send as a list of integers.
-  Positive numbers represent a digital high signal and negative numbers a digital low signal.
-  The number itself encodes how long the signal should last (in microseconds).
-- **carrier_frequency** (*Optional*, float): Optionally set a frequency to send the signal
-  with for infrared signals. Defaults to ``0Hz``.
-- All other options from :ref:`remote_transmitter-transmit_action`.
+- **data** (**Required**, int): The Coolix code to send, see dumper output for more info.
 
-.. _remote_transmitter-transmit_pronto:
+.. _remote_transmitter-transmit_dish:
 
-``remote_transmitter.transmit_pronto`` Action
-*********************************************
+``remote_transmitter.transmit_dish`` Action
+************************************************
 
-This :ref:`action <config-action>` sends a raw code to a remote transmitter specified in Pronto format.
+This :ref:`action <config-action>` sends a Dish Network infrared remote code to a remote transmitter.
 
 .. code-block:: yaml
 
     on_...:
-      - remote_transmitter.transmit_pronto:
-          data: "0000 006D 0010 0000 0008 0020 0008 0046 000A 0020 0008 0020 0008 001E 000A 001E 000A 0046 000A 001E 0008 0020 0008 0020 0008 0046 000A 0046 000A 0046 000A 001E 000A 001E 0008 06C3"
+      - remote_transmitter.transmit_dish:
+          address: 1
+          command: 16
 
 Configuration variables:
 
-- **data** (**Required**, string): The raw code to send specified as a string.
-  A lot of remote control Pronto codes can be found on http://remotecentral.com
+- **address** (*Optional*, int): The number of the receiver to target, between 1 and 16 inclusive. Defaults to ``1``.
+- **command** (**Required**, int): The command to send, between 0 and 63 inclusive.
 - All other options from :ref:`remote_transmitter-transmit_action`.
 
+You can find a list of commands in the `LIRC project <https://sourceforge.net/p/lirc-remotes/code/ci/master/tree/remotes/dishnet/Dish_Network.lircd.conf>`__.
 
+.. _remote_transmitter-transmit_jvc:
 
 ``remote_transmitter.transmit_jvc`` Action
 ******************************************
@@ -141,6 +133,8 @@ This :ref:`action <config-action>` sends a JVC infrared remote code to a remote 
 Configuration variables:
 
 - **data** (**Required**, int): The JVC code to send, see dumper output for more info.
+
+.. _remote_transmitter-transmit_lg:
 
 ``remote_transmitter.transmit_lg`` Action
 *****************************************
@@ -202,82 +196,7 @@ Configuration variables:
 - **command** (**Required**, int): The NEC command to send.
 - All other options from :ref:`remote_transmitter-transmit_action`.
 
-``remote_transmitter.transmit_sony`` Action
-*******************************************
-
-This :ref:`action <config-action>` a Sony infrared remote code to a remote transmitter.
-
-.. code-block:: yaml
-
-    on_...:
-      - remote_transmitter.transmit_sony:
-          data: 0x123
-          nbits: 12
-
-Configuration variables:
-
-- **data** (**Required**, int): The Sony code to send, see dumper output for more info.
-- **nbits** (*Optional*, int): The number of bits to send. Defaults to ``12``.
-- All other options from :ref:`remote_transmitter-transmit_action`.
-
-``remote_transmitter.transmit_rc5`` Action
-******************************************
-
-This :ref:`action <config-action>` sends an RC5 infrared remote code to a remote transmitter.
-
-.. code-block:: yaml
-
-    on_...:
-      - remote_transmitter.transmit_rc5:
-          address: 0x1F
-          command: 0x3F
-
-Configuration variables:
-
-- **address** (**Required**, int): The address to send, see dumper output for more details.
-- **command** (**Required**, int): The RC5 command to send.
-- All other options from :ref:`remote_transmitter-transmit_action`.
-
-``remote_transmitter.transmit_samsung`` Action
-**********************************************
-
-This :ref:`action <config-action>` sends a Samsung infrared remote code to a remote transmitter.
-It transmits codes up to 64 bits in length in a single packet.
-
-.. code-block:: yaml
-
-    on_...:
-      - remote_transmitter.transmit_samsung:
-          data: 0x1FEF05E4
-      # additional example for 48-bit codes:
-      - remote_transmitter.transmit_samsung:
-          data: 0xB946F50A09F6
-          nbits: 48
-
-Configuration variables:
-
-- **data** (**Required**, int): The data to send, see dumper output for more details.
-- **nbits** (*Optional*, int): The number of bits to send. Defaults to ``32``.
-- All other options from :ref:`remote_transmitter-transmit_action`.
-
-``remote_transmitter.transmit_samsung36`` Action
-************************************************
-
-This :ref:`action <config-action>` sends a Samsung36 infrared remote code to a remote transmitter.
-It transmits the ``address`` and ``command`` in two packets separated by a "space".
-
-.. code-block:: yaml
-
-    on_...:
-      - remote_transmitter.transmit_samsung36:
-          address: 0x0400
-          command: 0x000E00FF      
-
-Configuration variables:
-
-- **address** (**Required**, int): The address to send, see dumper output for more details.
-- **command** (**Required**, int): The Samsung36 command to send, see dumper output for more details.
-- All other options from :ref:`remote_transmitter-transmit_action`.
+.. _remote_transmitter-transmit_panasonic:
 
 ``remote_transmitter.transmit_panasonic`` Action
 ************************************************
@@ -297,26 +216,7 @@ Configuration variables:
 - **command** (**Required**, int): The command to send.
 - All other options from :ref:`remote_transmitter-transmit_action`.
 
-``remote_transmitter.transmit_dish`` Action
-************************************************
-
-This :ref:`action <config-action>` sends a Dish Network infrared remote code to a remote transmitter.
-
-.. code-block:: yaml
-
-    on_...:
-      - remote_transmitter.transmit_dish:
-          address: 1
-          command: 16
-
-Configuration variables:
-
-- **address** (*Optional*, int): The number of the receiver to target, between 1 and 16 inclusive. Defaults to ``1``.
-- **command** (**Required**, int): The command to send, between 0 and 63 inclusive.
-- All other options from :ref:`remote_transmitter-transmit_action`.
-
-You can find a list of commands in the `LIRC project <https://sourceforge.net/p/lirc-remotes/code/ci/master/tree/remotes/dishnet/Dish_Network.lircd.conf>`__.
-
+.. _remote_transmitter-transmit_pioneer:
 
 ``remote_transmitter.transmit_pioneer`` Action
 **********************************************
@@ -347,25 +247,74 @@ At the time this action was created, Pioneer maintained listings of IR codes use
 If unable to find your specific device in the documentation, find a device in the same class; the codes
 are largely shared among devices within a given class.
 
-``remote_transmitter.transmit_toshiba_ac`` Action
-*************************************************
+.. _remote_transmitter-transmit_pronto:
 
-This :ref:`action <config-action>` sends a Toshiba AC infrared remote code to a remote transmitter.
+``remote_transmitter.transmit_pronto`` Action
+*********************************************
+
+This :ref:`action <config-action>` sends a raw code to a remote transmitter specified in Pronto format.
 
 .. code-block:: yaml
 
     on_...:
-      - remote_transmitter.transmit_toshiba_ac:
-          rc_code_1: 0xB24DBF4040BF
-          rc_code_2: 0xD5660001003C
+      - remote_transmitter.transmit_pronto:
+          data: "0000 006D 0010 0000 0008 0020 0008 0046 000A 0020 0008 0020 0008 001E 000A 001E 000A 0046 000A 001E 0008 0020 0008 0020 0008 0046 000A 0046 000A 0046 000A 001E 000A 001E 0008 06C3"
 
 Configuration variables:
 
-- **rc_code_1** (**Required**, int): The remote control code to send, see dumper output for more details.
-- **rc_code_2** (*Optional*, int): The secondary remote control code to send; some codes are sent in
-  two parts.
-- **Note:** this action transmits codes using the new(er) Toshiba AC protocol and likely will not work with older units.
+- **data** (**Required**, string): The raw code to send specified as a string.
+  A lot of remote control Pronto codes can be found on http://remotecentral.com
 - All other options from :ref:`remote_transmitter-transmit_action`.
+
+.. _remote_transmitter-transmit_raw:
+
+``remote_transmitter.transmit_raw`` Action
+******************************************
+
+This :ref:`action <config-action>` sends a raw code to a remote transmitter.
+
+.. code-block:: yaml
+
+    on_...:
+      - remote_transmitter.transmit_raw:
+          code: [4088, -1542, 1019, -510, 513, -1019, 510, -509, 511, -510, 1020,
+                 -1020, 1022, -1019, 510, -509, 511, -510, 511, -509, 511, -510,
+                 1020, -1019, 510, -511, 1020, -510, 512, -508, 510, -1020, 1022,
+                 -1021, 1019, -1019, 511, -510, 510, -510, 1022, -1020, 1019,
+                 -1020, 511, -511, 1018, -1022, 1020, -1019, 1021, -1019, 1020,
+                 -511, 510, -1019, 1023, -1019, 1019, -510, 512, -508, 510, -511,
+                 512, -1019, 510, -509]
+
+Configuration variables:
+
+- **code** (**Required**, list): The raw code to send as a list of integers.
+  Positive numbers represent a digital high signal and negative numbers a digital low signal.
+  The number itself encodes how long the signal should last (in microseconds).
+- **carrier_frequency** (*Optional*, float): Optionally set a frequency to send the signal
+  with for infrared signals. Defaults to ``0Hz``.
+- All other options from :ref:`remote_transmitter-transmit_action`.
+
+.. _remote_transmitter-transmit_rc5:
+
+``remote_transmitter.transmit_rc5`` Action
+******************************************
+
+This :ref:`action <config-action>` sends an RC5 infrared remote code to a remote transmitter.
+
+.. code-block:: yaml
+
+    on_...:
+      - remote_transmitter.transmit_rc5:
+          address: 0x1F
+          command: 0x3F
+
+Configuration variables:
+
+- **address** (**Required**, int): The address to send, see dumper output for more details.
+- **command** (**Required**, int): The RC5 command to send.
+- All other options from :ref:`remote_transmitter-transmit_action`.
+
+.. _remote_transmitter-transmit_rc_switch_raw:
 
 ``remote_transmitter.transmit_rc_switch_raw`` Action
 ****************************************************
@@ -405,6 +354,8 @@ All RC Switch ``protocol`` settings have these settings:
   - **one** (*Optional*): The number of high/low pulses for a one bit, defaults to ``[3, 1]``
   - **inverted** (*Optional*, boolean): If this protocol is inverted. Defaults to ``false``.
 
+.. _remote_transmitter-transmit_rc_switch_type_a:
+
 ``remote_transmitter.transmit_rc_switch_type_a`` Action
 *******************************************************
 
@@ -429,6 +380,8 @@ Configuration variables:
   for more information.
 - All other options from :ref:`remote_transmitter-transmit_action`.
 
+.. _remote_transmitter-transmit_rc_switch_type_b:
+
 ``remote_transmitter.transmit_rc_switch_type_b`` Action
 *******************************************************
 
@@ -452,6 +405,8 @@ Configuration variables:
 - **protocol** (*Optional*): The RC Switch protocol to use, see :ref:`remote_transmitter-rc_switch-protocol`
   for more information.
 - All other options from :ref:`remote_transmitter-transmit_action`.
+
+.. _remote_transmitter-transmit_rc_switch_type_c:
 
 ``remote_transmitter.transmit_rc_switch_type_c`` Action
 *******************************************************
@@ -479,6 +434,8 @@ Configuration variables:
   for more information.
 - All other options from :ref:`remote_transmitter-transmit_action`.
 
+.. _remote_transmitter-transmit_rc_switch_type_d:
+
 ``remote_transmitter.transmit_rc_switch_type_d`` Action
 *******************************************************
 
@@ -501,6 +458,93 @@ Configuration variables:
 - **state** (**Required**, boolean): The on/off state to send.
 - **protocol** (*Optional*): The RC Switch protocol to use, see :ref:`remote_transmitter-rc_switch-protocol`
   for more information.
+- All other options from :ref:`remote_transmitter-transmit_action`.
+
+.. _remote_transmitter-transmit_samsung:
+
+``remote_transmitter.transmit_samsung`` Action
+**********************************************
+
+This :ref:`action <config-action>` sends a Samsung infrared remote code to a remote transmitter.
+It transmits codes up to 64 bits in length in a single packet.
+
+.. code-block:: yaml
+
+    on_...:
+      - remote_transmitter.transmit_samsung:
+          data: 0x1FEF05E4
+      # additional example for 48-bit codes:
+      - remote_transmitter.transmit_samsung:
+          data: 0xB946F50A09F6
+          nbits: 48
+
+Configuration variables:
+
+- **data** (**Required**, int): The data to send, see dumper output for more details.
+- **nbits** (*Optional*, int): The number of bits to send. Defaults to ``32``.
+- All other options from :ref:`remote_transmitter-transmit_action`.
+
+.. _remote_transmitter-transmit_samsung36:
+
+``remote_transmitter.transmit_samsung36`` Action
+************************************************
+
+This :ref:`action <config-action>` sends a Samsung36 infrared remote code to a remote transmitter.
+It transmits the ``address`` and ``command`` in two packets separated by a "space".
+
+.. code-block:: yaml
+
+    on_...:
+      - remote_transmitter.transmit_samsung36:
+          address: 0x0400
+          command: 0x000E00FF      
+
+Configuration variables:
+
+- **address** (**Required**, int): The address to send, see dumper output for more details.
+- **command** (**Required**, int): The Samsung36 command to send, see dumper output for more details.
+- All other options from :ref:`remote_transmitter-transmit_action`.
+
+.. _remote_transmitter-transmit_sony:
+
+``remote_transmitter.transmit_sony`` Action
+*******************************************
+
+This :ref:`action <config-action>` a Sony infrared remote code to a remote transmitter.
+
+.. code-block:: yaml
+
+    on_...:
+      - remote_transmitter.transmit_sony:
+          data: 0x123
+          nbits: 12
+
+Configuration variables:
+
+- **data** (**Required**, int): The Sony code to send, see dumper output for more info.
+- **nbits** (*Optional*, int): The number of bits to send. Defaults to ``12``.
+- All other options from :ref:`remote_transmitter-transmit_action`.
+
+.. _remote_transmitter-transmit_toshiba_ac:
+
+``remote_transmitter.transmit_toshiba_ac`` Action
+*************************************************
+
+This :ref:`action <config-action>` sends a Toshiba AC infrared remote code to a remote transmitter.
+
+.. code-block:: yaml
+
+    on_...:
+      - remote_transmitter.transmit_toshiba_ac:
+          rc_code_1: 0xB24DBF4040BF
+          rc_code_2: 0xD5660001003C
+
+Configuration variables:
+
+- **rc_code_1** (**Required**, int): The remote control code to send, see dumper output for more details.
+- **rc_code_2** (*Optional*, int): The secondary remote control code to send; some codes are sent in
+  two parts.
+- **Note:** this action transmits codes using the new(er) Toshiba AC protocol and likely will not work with older units.
 - All other options from :ref:`remote_transmitter-transmit_action`.
 
 .. _remote-setting-up-infrared:

--- a/components/remote_transmitter.rst
+++ b/components/remote_transmitter.rst
@@ -81,7 +81,7 @@ Home Assistant, you'll want to set the **times** to 10 and the **wait_time** to 
 .. _remote_transmitter-transmit_coolix:
 
 ``remote_transmitter.transmit_coolix`` Action
-******************************************
+*********************************************
 
 This :ref:`action <config-action>` sends a 24-bit Coolix infrared remote code to a remote transmitter.
 
@@ -98,7 +98,7 @@ Configuration variables:
 .. _remote_transmitter-transmit_dish:
 
 ``remote_transmitter.transmit_dish`` Action
-************************************************
+*******************************************
 
 This :ref:`action <config-action>` sends a Dish Network infrared remote code to a remote transmitter.
 


### PR DESCRIPTION
## Description:

New Coolix protocol. New midea_ir climate component.
Additionally, I sorted the IR protocols alphabetically.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#2847

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
