### PR TITLE
Make Table of Contents scrollable

### DIFF
--- a/_static/custom.css
+++ b/_static/custom.css
@@ -13,6 +13,11 @@ div.body {
   min-width: initial;
 }
 
+div.sphinxsidebar {
+    max-height: 100%;
+    overflow-y: auto;
+}
+
 img.component-image {
   border: none;
   vertical-align: middle;


### PR DESCRIPTION
## Description:

Inspired by https://stackoverflow.com/a/57040610/1283519, this change makes the Table of Contents scrollable (the menu as seen on on the left side in a non-mobile browser).

Verified working on my Macbook Pro 13" in Firefox 94 by applying the CSS in the developer tools.

**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/2088

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
