### PR TITLE
Clarification of the behavior of calibraty_linear filter

### DIFF
--- a/components/sensor/index.rst
+++ b/components/sensor/index.rst
@@ -191,7 +191,10 @@ the value the sensor shows.
 
 The arguments are a list of data points, each in the form ``MEASURED -> TRUTH``. ESPHome will
 then fit a linear equation to the values (using least squares). So you need to supply at least
-two values.
+two values. If more than two points are specified, they may not lie on a straight line. In this 
+case, the calculated results often do not correspond to the specified values. Especially for 
+non-linear relationships, the result can deviate strongly from the expected value. It is 
+recommended to use the filter calibrate linear only if two given data points are sufficient.
 
 .. _sensor-calibrate_polynomial:
 

--- a/components/sensor/index.rst
+++ b/components/sensor/index.rst
@@ -191,10 +191,9 @@ the value the sensor shows.
 
 The arguments are a list of data points, each in the form ``MEASURED -> TRUTH``. ESPHome will
 then fit a linear equation to the values (using least squares). So you need to supply at least
-two values. If more than two points are specified, they may not lie on a straight line. In this 
-case, the calculated results often do not correspond to the specified values. Especially for 
-non-linear relationships, the result can deviate strongly from the expected value. It is 
-recommended to use the filter calibrate linear only if two given data points are sufficient.
+two values. If more than two values are given a linear solution will be calculated and may not
+represent each value exactly. It is recommended to use the filter calibrate linear only if two data
+points are sufficient.
 
 .. _sensor-calibrate_polynomial:
 


### PR DESCRIPTION
## Description:
I was misunderstood, how calibrate linear works. I found others having the same trouble. Here is my first contribution to the documentation. So, please be gentle. ;-)

**Related issue (if applicable):** fixes (https://github.com/esphome/issues/issues/2768)

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
