### PR TITLE
Deep Sleep: ESP32 per-reason run duration

### DIFF
--- a/components/deep_sleep.rst
+++ b/components/deep_sleep.rst
@@ -34,6 +34,13 @@ Configuration variables:
 ------------------------
 
 - **run_duration** (*Optional*, :ref:`config-time`): The time duration the node should be active, i.e. run code.
+
+  Only on ESP32, instead of time, it is possible to specify run duration according to the wakeup reason from deep-sleep:
+
+  - **default** (*Required*, :ref:`config-time`): default run duration for timer wakeup and any unspecified wakeup reason.
+  - **gpio_wakeup_reason** (*Optional*, :ref:`config-time`): run duration if woken up by GPIO.
+  - **touch_wakeup_reason** (*Optional*, :ref:`config-time`): run duration if woken up by touch.
+
 - **sleep_duration** (*Optional*, :ref:`config-time`): The time duration to stay in deep sleep mode.
 - **touch_wakeup** (*Optional*, boolean): Only on ESP32. Use a touch event to wakeup from deep sleep. To be able
   to wakeup from a touch event, :ref:`esp32-touch-binary-sensor` must be configured properly.

--- a/components/deep_sleep.rst
+++ b/components/deep_sleep.rst
@@ -37,7 +37,7 @@ Configuration variables:
 
   Only on ESP32, instead of time, it is possible to specify run duration according to the wakeup reason from deep-sleep:
 
-  - **default** (*Required*, :ref:`config-time`): default run duration for timer wakeup and any unspecified wakeup reason.
+  - **default** (**Required**, :ref:`config-time`): default run duration for timer wakeup and any unspecified wakeup reason.
   - **gpio_wakeup_reason** (*Optional*, :ref:`config-time`): run duration if woken up by GPIO.
   - **touch_wakeup_reason** (*Optional*, :ref:`config-time`): run duration if woken up by touch.
 


### PR DESCRIPTION
## Description:

https://github.com/esphome/esphome/pull/2861 added variable
run_duration according to the wakeup reason from deep-sleep.

Document the new configuration, emphasize it is available on ESP32
only.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#2861

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
