### PR TITLE
Add some sign that the link is to the API

### DIFF
--- a/components/text_sensor/custom.rst
+++ b/components/text_sensor/custom.rst
@@ -60,7 +60,7 @@ Configuration variables:
 
     - All options from :ref:`Text Sensor <config-text_sensor>`.
 
-See :apiclass:`TextSensor <text_sensor::TextSensor>`
+See from API :apiclass:`TextSensor <text_sensor::TextSensor>`
 
 See Also
 --------

--- a/components/text_sensor/custom.rst
+++ b/components/text_sensor/custom.rst
@@ -60,9 +60,8 @@ Configuration variables:
 
     - All options from :ref:`Text Sensor <config-text_sensor>`.
 
-See from API :apiclass:`TextSensor <text_sensor::TextSensor>`
-
 See Also
 --------
 
+- :apiclass:`TextSensor <text_sensor::TextSensor>`
 - :ghedit:`Edit`

--- a/components/text_sensor/custom.rst
+++ b/components/text_sensor/custom.rst
@@ -63,5 +63,5 @@ Configuration variables:
 See Also
 --------
 
-- :apiclass:`TextSensor <text_sensor::TextSensor>`
+- :apiclass:`API Reference <text_sensor::TextSensor>`
 - :ghedit:`Edit`


### PR DESCRIPTION
At first glance one would assume it should take you to the base text sensor esphome doc

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
