### PR TITLE
fixed time reference link

### DIFF
--- a/components/sun.rst
+++ b/components/sun.rst
@@ -112,7 +112,7 @@ Configuration variables:
 - **name** (**Required**, string): The name of the text sensor.
 - **elevation** (*Optional*, float): The elevation to calculate the next sunrise/sunset event
   for. Defaults to -0.833° (the horizon, slightly less than 0° to compensate for atmospheric refraction).
-- **format** (*Optional*, string): The format to format the time value with, see :ref:`display-strftime`
+- **format** (*Optional*, string): The format to format the time value with, see :ref:`strftime`
   for more information. Defaults to ``%X``.
 
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.


### PR DESCRIPTION
Should link to here
https://esphome.io/components/time.html#strftime

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
