### PR TITLE
use_write_multiple for modbus_controller number and output

### DIFF
--- a/components/number/modbus_controller.rst
+++ b/components/number/modbus_controller.rst
@@ -53,6 +53,7 @@ Configuration variables:
 - **write_lambda** (*Optional*, :ref:`lambda <config-lambda>`): Lambda called before send.
   Lambda is evaluated before the modbus write command is created.
 - **multiply** (*Optional*, float): multiply the new value with this factor before sending the requests. Ignored if lambda is defined.
+- **use_write_multiple**: (*Optional*, boolean): By default the modbus command ``Preset Single Registers`` (function code 6) is used for setting the holding register if only 1 register is set. If your device only supports ``Preset Multiple Registers`` (function code 16) set this option to true.
 
 
 All other options from :ref:`Number <config-number>`.

--- a/components/output/modbus_controller.rst
+++ b/components/output/modbus_controller.rst
@@ -33,6 +33,7 @@ Configuration variables:
 - **multiply** (*Optional*, float): multiply the new value with this factor before sending the requests. Ignored if lambda is defined.
 - **offset**: (*Optional*, int): only required for uncommon response encodings
     offset from start address in bytes. If more than one register is read a modbus read registers command this value is used to find the start of this datapoint relative to start address. The component calculates the size of the range based on offset and size of the value type
+- **use_write_multiple**: (*Optional*, boolean): By default the modbus command ``Preset Single Registers`` (function code 6) is used for setting the holding register if only 1 register is set. If your device only supports ``Preset Multiple Registers`` (function code 16) set this option to true.
 
 All other options from :ref:`Output <config-output>`.
 


### PR DESCRIPTION
## Description:

document `use_write_multiple` for modbus number

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#2896

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
