### PR TITLE
Correct error in ST7789V TFT example

### DIFF
--- a/components/display/st7789v.rst
+++ b/components/display/st7789v.rst
@@ -96,7 +96,7 @@ To bring in color images:
       - file: "image.jpg"
         id: my_image
         resize: 200x200
-        type: RGB565
+        type: RGB24
 
     ...
 


### PR DESCRIPTION
Change reference to non existent `RGB565` type in `RGB24`

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
