### PR TITLE
Clarify Wireless Install requirements

### DIFF
--- a/guides/getting_started_hassio.rst
+++ b/guides/getting_started_hassio.rst
@@ -68,7 +68,7 @@ tour of the ESPHome Dashboard interface.
 On the front page you will see all configurations for nodes you created. For each file,
 there are three basic actions you can perform:
 
-- **INSTALL**: This compiles the firmware for your node and installs it. Installation happens wirelessy if you have enabled the :doc:`/components/ota` in your configuration. Alternatively you can install it from your browser or via a device connected to the machine running the ESPHome Dashboard.
+- **INSTALL**: This compiles the firmware for your node and installs it. Installation happens wirelessly if the device is already running ESPHome firmware with :doc:`/components/ota` enabled in its configuration, and it is connected wirelessly to the same subnet that the Home Assistant/ESPHome computer is on. Alternatively you can install it from your browser or via a device connected to the machine running the ESPHome Dashboard.
 
 - **SHOW LOGS**: With this command you can view all the logs the node is outputting. If a USB device is
   connected, it will attempt to use the serial connection. Otherwise it will use the built-in OTA logs.


### PR DESCRIPTION
## Description:
Update to clarify that Wireless Install requires the Device to be on same subnet as the Home Assistant computer. (and device must already have ESPHome intsalled)

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [X] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [X] Link added in `/index.rst` when creating new documents for new components or cookbook.
