### PR TITLE
Add docker commandline for Windows

### DIFF
--- a/guides/contributing.rst
+++ b/guides/contributing.rst
@@ -614,10 +614,10 @@ Standard for the esphome-core codebase:
     
     .. code-block:: bash
 
-            # convert the volume format
-            $current_dir=(Get-Location).Path.ToLower().Replace(':','').Replace('\','/')
-            # Run lint only over changed files from powershell
-            docker run --rm -v "$($current_dir):/esphome" -it esphome/esphome-lint:dev script/quicklint
+        # convert the volume format
+        $current_dir=(Get-Location).Path.ToLower().Replace(':','').Replace('\','/')
+        # Run lint only over changed files from powershell
+        docker run --rm -v "$($current_dir):/esphome" -it esphome/esphome-lint:dev script/quicklint
     
     
          

--- a/guides/contributing.rst
+++ b/guides/contributing.rst
@@ -607,6 +607,20 @@ Standard for the esphome-core codebase:
 
         # Run lint only over changed files
         docker run --rm -v "${PWD}/":/esphome -it esphome/esphome-lint script/quicklint
+    
+    
+    If you are using Windows and have docker installed the syntax is slightly different.
+    If you have cloned esphome to ``c:\edev\esphome`` the volume format is ``c/edev/esphome``
+    
+    .. code-block:: bash
+
+            # convert the volume format
+            $current_dir=(Get-Location).Path.ToLower().Replace(':','').Replace('\','/')
+            # Run lint only over changed files from powershell
+            docker run --rm -v "$($current_dir):/esphome" -it esphome/esphome-lint:dev script/quicklint
+    
+    
+         
 
 ESPHome via Gitpod
 ******************

--- a/guides/contributing.rst
+++ b/guides/contributing.rst
@@ -617,7 +617,7 @@ Standard for the esphome-core codebase:
         # convert the volume format
         $current_dir=(Get-Location).Path.ToLower().Replace(':','').Replace('\','/')
         # Run lint only over changed files from powershell
-        docker run --rm -v "$($current_dir):/esphome" -it esphome/esphome-lint:dev script/quicklint
+        docker run --rm -v "$($current_dir):/esphome" -it esphome/esphome-lint script/quicklint
     
     
          


### PR DESCRIPTION
## Description:

Add example how to to use lint with Windows

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
