### PR TITLE
Document slow_pwm triggers

### DIFF
--- a/components/output/slow_pwm.rst
+++ b/components/output/slow_pwm.rst
@@ -50,47 +50,19 @@ Configuration variables:
 Example:
 --------
 
-
-
 .. code-block:: yaml
 
-    esphome:
-      name: testing
-      on_boot:
-        priority: -100
-        then:
-          output.set_level:
-            id: my_slow_pwm
-            level: 25%
-              
-    output:
-      - platform: template
-        id: output1
-        type: binary
-        write_action:
-          - then:
-              - lambda: ESP_LOGD("Template Output","set state to %d",state);
 
+    output:
       - platform: slow_pwm
         id: my_slow_pwm
         period: 15s
-        # pin: 5
-        # state_change_action:
-        #  - lambda: |-
-        #      ESP_LOGD("SLOW PWM","toggle to state %d",state);
-        #      auto *out1 = id(output1);
-        #      if (state)
-        #        out1->turn_on();
-        #      else
-        #        out1->turn_off();
-
         turn_on_action:
           - lambda: |-
               auto *out1 = id(output1);
               out1->turn_on();
         turn_off_action:
           - output.turn_off: output1
-
 
 
 See Also

--- a/components/output/slow_pwm.rst
+++ b/components/output/slow_pwm.rst
@@ -30,11 +30,68 @@ heating element through a relay where a fast PWM update cycle would not be appro
 Configuration variables:
 ------------------------
 
-- **pin** (**Required**, :ref:`Pin Schema <config-pin_schema>`): The pin to pulse.
 - **id** (**Required**, :ref:`config-id`): The id to use for this output component.
 - **period** (**Required**, :ref:`config-time`): The duration of each cycle. (i.e. a 10s
   period at 50% duty would result in the pin being turned on for 5s, then off for 5s)
+- **pin** (*Optional*, :ref:`Pin Schema <config-pin_schema>`): The pin to pulse.
+- **toggle_action**  (*Optional*, :ref:`Automation <automation>`): An automation to perform when the load is toggled. If a `lambda` is used the ``bool state`` parameter holds the new status.
+- **turn_on_action**  (*Optional*, :ref:`Automation <automation>`): An automation to perform when the load is turned_on. Can be used to controll for example a switch or output component.
+- **turn_off_action** (*Optional*, :ref:`Automation <automation>`): An automation to perform when the load is turned_off. ``turn_on_action`` and ``turn_off_action`` must be configured together
+
 - All other options from :ref:`Output <config-output>`.
+
+
+.. note::
+
+    - If ``pin`` is defined the gpio pin state is writen before any action is executed.
+    - ``toggle_action`` and ``turn_on/off_action`` can be used togther. ``toggle_action`` is called before ``turn_on/off_action``. It's recommended to use either ``toggle_action`` or ``turn_on/off_action`` to change the state of an output. Using both automations together is only recommended for montitoring
+
+
+Example:
+--------
+
+
+
+.. code-block:: yaml
+
+    esphome:
+      name: testing
+      on_boot:
+        priority: -100
+        then:
+          output.set_level:
+            id: my_slow_pwm
+            level: 25%
+              
+    output:
+      - platform: template
+        id: output1
+        type: binary
+        write_action:
+          - then:
+              - lambda: ESP_LOGD("Template Output","set state to %d",state);
+
+      - platform: slow_pwm
+        id: my_slow_pwm
+        period: 15s
+        # pin: 5
+        # toggle_action:
+        #  - lambda: |-
+        #      ESP_LOGD("SLOW PWM","toggle to state %d",state);
+        #      auto *out1 = id(output1);
+        #      if (state)
+        #        out1->turn_on();
+        #      else
+        #        out1->turn_off();
+
+        turn_on_action:
+          - lambda: |-
+              auto *out1 = id(output1);
+              out1->turn_on();
+        turn_off_action:
+          - output.turn_off: output1
+
+
 
 See Also
 --------

--- a/components/output/slow_pwm.rst
+++ b/components/output/slow_pwm.rst
@@ -34,7 +34,7 @@ Configuration variables:
 - **period** (**Required**, :ref:`config-time`): The duration of each cycle. (i.e. a 10s
   period at 50% duty would result in the pin being turned on for 5s, then off for 5s)
 - **pin** (*Optional*, :ref:`Pin Schema <config-pin_schema>`): The pin to pulse.
-- **toggle_action**  (*Optional*, :ref:`Automation <automation>`): An automation to perform when the load is toggled. If a `lambda` is used the ``bool state`` parameter holds the new status.
+- **state_change_action**  (*Optional*, :ref:`Automation <automation>`): An automation to perform when the load is switched. If a `lambda` is used the ``bool state`` parameter holds the new status.
 - **turn_on_action**  (*Optional*, :ref:`Automation <automation>`): An automation to perform when the load is turned_on. Can be used to controll for example a switch or output component.
 - **turn_off_action** (*Optional*, :ref:`Automation <automation>`): An automation to perform when the load is turned_off. ``turn_on_action`` and ``turn_off_action`` must be configured together
 
@@ -44,7 +44,7 @@ Configuration variables:
 .. note::
 
     - If ``pin`` is defined the gpio pin state is writen before any action is executed.
-    - ``toggle_action`` and ``turn_on/off_action`` can be used togther. ``toggle_action`` is called before ``turn_on/off_action``. It's recommended to use either ``toggle_action`` or ``turn_on/off_action`` to change the state of an output. Using both automations together is only recommended for montitoring
+    - ``state_change_action`` and ``turn_on/off_action`` can be used togther. ``state_change_action`` is called before ``turn_on/off_action``. It's recommended to use either ``state_change_action`` or ``turn_on/off_action`` to change the state of an output. Using both automations together is only recommended for montitoring
 
 
 Example:
@@ -75,7 +75,7 @@ Example:
         id: my_slow_pwm
         period: 15s
         # pin: 5
-        # toggle_action:
+        # state_change_action:
         #  - lambda: |-
         #      ESP_LOGD("SLOW PWM","toggle to state %d",state);
         #      auto *out1 = id(output1);

--- a/components/output/slow_pwm.rst
+++ b/components/output/slow_pwm.rst
@@ -34,17 +34,17 @@ Configuration variables:
 - **period** (**Required**, :ref:`config-time`): The duration of each cycle. (i.e. a 10s
   period at 50% duty would result in the pin being turned on for 5s, then off for 5s)
 - **pin** (*Optional*, :ref:`Pin Schema <config-pin_schema>`): The pin to pulse.
-- **state_change_action**  (*Optional*, :ref:`Automation <automation>`): An automation to perform when the load is switched. If a `lambda` is used the ``bool state`` parameter holds the new status.
-- **turn_on_action**  (*Optional*, :ref:`Automation <automation>`): An automation to perform when the load is turned_on. Can be used to controll for example a switch or output component.
-- **turn_off_action** (*Optional*, :ref:`Automation <automation>`): An automation to perform when the load is turned_off. ``turn_on_action`` and ``turn_off_action`` must be configured together
+- **state_change_action**  (*Optional*, :ref:`Automation <automation>`): An automation to perform when the load is switched. If a lambda is used the boolean ``state`` parameter holds the new status.
+- **turn_on_action**  (*Optional*, :ref:`Automation <automation>`): An automation to perform when the load is turned on. Can be used to control for example a switch or output component.
+- **turn_off_action** (*Optional*, :ref:`Automation <automation>`): An automation to perform when the load is turned off. ``turn_on_action`` and ``turn_off_action`` must be configured together.
 
 - All other options from :ref:`Output <config-output>`.
 
 
 .. note::
 
-    - If ``pin`` is defined the gpio pin state is writen before any action is executed.
-    - ``state_change_action`` and ``turn_on/off_action`` can be used togther. ``state_change_action`` is called before ``turn_on/off_action``. It's recommended to use either ``state_change_action`` or ``turn_on/off_action`` to change the state of an output. Using both automations together is only recommended for montitoring
+    - If ``pin`` is defined the GPIO pin state is writen before any action is executed.
+    - ``state_change_action`` and ``turn_on_action``/``turn_off_action`` can be used togther. ``state_change_action`` is called before ``turn_on_action``/``turn_off_action``. It's recommended to use either ``state_change_action`` or ``turn_on_action``/``turn_off_action`` to change the state of an output. Using both automations together is only recommended for monitoring.
 
 
 Example:


### PR DESCRIPTION
## Description:

Document triggers added in PR#2921

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#2921

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
