### PR TITLE
Fix documentation for MQTT client's subscribe method.

### DIFF
--- a/components/mqtt.rst
+++ b/components/mqtt.rst
@@ -347,7 +347,7 @@ Configuration variables:
 
     .. code-block:: cpp
 
-        id(mqtt_client).subscribe("the/topic", [=](const std::string &payload) {
+        id(mqtt_client).subscribe("the/topic", [=](const std::string &topic, const std::string &payload) {
             // do something with payload
         });
 


### PR DESCRIPTION
## Description:

Fix documentation for MQTT client's subscribe method.

subscribe() takes a callback with two arguments, topic and payload.

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
