### PR TITLE
Feature/rtsp server

### DIFF
--- a/components/rtsp_server.rst
+++ b/components/rtsp_server.rst
@@ -5,7 +5,7 @@ RTSP Server Component
     :description: Instructions for setting up an RTSP Server with the ESP32 Camera in ESPHome
     :image: camera.png
 
-The ``rtsp_server`` component allows you to stream vide from ESP32-based camera boards in ESPHome to
+The ``rtsp_server`` component allows you to stream video from ESP32-based camera boards in ESPHome to
 any RTSP-compatible application (VLC Media Player; GStreamer; etc).
 
 An ``esp32_camera`` configuration item is required to use this component.
@@ -20,4 +20,3 @@ Configuration variables:
 
 - **port** (**Required**, number): The port number on which to listen
 - **camera** (**Required**, :ref:`config-id`) The camera from which to stream video
-

--- a/components/rtsp_server.rst
+++ b/components/rtsp_server.rst
@@ -8,6 +8,13 @@ RTSP Server Component
 The ``rtsp_server`` component allows you to stream video from ESP32-based camera boards in ESPHome to
 any RTSP-compatible application (VLC Media Player; GStreamer; etc).
 
+Currently, only UDP transport is supported; therefore, ensure that you have the appropriate firewall / routing 
+configurations to support UDP transport.  Many application permit explicit definition of the UDP port ranges
+to use.
+
+Sample FFMPEG RTSP capture, using a defined UDP port range:
+`ffmpeg -loglevel debug -rtsp_transport udp -min_port 12160 -max_port 12165 -i rtsp://camera.local:8675 -vcodec copy out.mkv`
+
 An :ref:`esp32_camera <esp32_camera>` configuration item is required to use this component.
 
 .. code-block:: yaml

--- a/components/rtsp_server.rst
+++ b/components/rtsp_server.rst
@@ -1,0 +1,23 @@
+RTSP Server Component
+======================
+
+.. seo::
+    :description: Instructions for setting up an RTSP Server with the ESP32 Camera in ESPHome
+    :image: camera.png
+
+The ``rtsp_server`` component allows you to stream vide from ESP32-based camera boards in ESPHome to
+any RTSP-compatible application (VLC Media Player; GStreamer; etc).
+
+An ``esp32_camera`` configuration item is required to use this component.
+
+.. code-block:: yaml
+    rtsp_server:
+      port: 8675
+      camera: cam1
+
+Configuration variables:
+------------------------
+
+- **port** (**Required**, number): The port number on which to listen
+- **camera** (**Required**, :ref:`config-id`) The camera from which to stream video
+

--- a/components/rtsp_server.rst
+++ b/components/rtsp_server.rst
@@ -8,7 +8,7 @@ RTSP Server Component
 The ``rtsp_server`` component allows you to stream video from ESP32-based camera boards in ESPHome to
 any RTSP-compatible application (VLC Media Player; GStreamer; etc).
 
-An ``esp32_camera`` configuration item is required to use this component.
+An :ref:`esp32_camera <esp32_camera>` configuration item is required to use this component.
 
 .. code-block:: yaml
     rtsp_server:

--- a/index.rst
+++ b/index.rst
@@ -594,6 +594,7 @@ Misc Components
 
     ESP32 Camera, components/esp32_camera, camera.svg
     ESP32 Camera Web Server, components/esp32_camera_web_server, camera.svg
+    RTSP Server, components/rtsp_server.rst, camera.svg
     Stepper, components/stepper/index, stepper.svg
     Servo, components/servo, servo.svg
 


### PR DESCRIPTION
## Description:
Add Documentation for the RTSP server component

Supersedes: https://github.com/esphome/esphome-docs/pull/1240

**Related issue (if applicable):** fixes [esphome/feature-requests#960](https://github.com/esphome/feature-requests/issues/960)

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#1905

## Checklist:

  - [x ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ x] Link added in `/index.rst` when creating new documents for new components or cookbook.
