### PR TITLE
Use generic GPIO pins in MHZ19 example

### DIFF
--- a/components/sensor/mhz19.rst
+++ b/components/sensor/mhz19.rst
@@ -27,8 +27,8 @@ TX/RX labels are from the perspective of the MH-Z19). Additionally, you need to 
 
     # Example configuration entry
     uart:
-      rx_pin: D0
-      tx_pin: D1
+      rx_pin: GPIO3
+      tx_pin: GPIO1
       baud_rate: 9600
 
     sensor:


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
