### PR TITLE
Modbus document modbus binary output

### DIFF
--- a/components/output/modbus_controller.rst
+++ b/components/output/modbus_controller.rst
@@ -42,9 +42,10 @@ All other options from :ref:`Output <config-output>`.
 **Parameters passed into the lambda**
 
 - **x** (float): The float value to be sent to the modbus device for ``register_type: holding``
-- **x** (bool): The float value to be sent to the modbus device for ``register_type: coil``
+- **x** (bool): The boolean value to be sent to the modbus device for ``register_type: coil``
 
 - **payload** (`std::vector<uint16_t>&payload`): 
+
   - for ``register_type: holding``: empty vector for the payload. The lamdba can add 16 bit raw modbus register words.
   - for ``register_type: coil``: empty vector for the payload. If payload is set in the lambda it is sent as a custom command and must include all required bytes for a modbus request
     note: because the response contains data for all registers in the same range you have to use ``data[item->offset]`` to get the first response byte for your sensor.

--- a/components/output/modbus_controller.rst
+++ b/components/output/modbus_controller.rst
@@ -28,9 +28,10 @@ Configuration variables:
 - **register_count**: (*Optional*): only required for uncommon response encodings
   The number of registers this data point spans. Default is 1
 - **write_lambda** (*Optional*, :ref:`lambda <config-lambda>`):
-  Lambda is evaluated before the modbus write command is created. The value is passed in as ``float x`` and an empty vector is passed in as ``std::vector<uint16_t>&payload``
+  Lambda is evaluated before the modbus write command is created. The value is passed in as ``float x`` and an empty vector is passed in as ``std::vector<uint16_t>&payload``.
   You can directly define the payload by adding data to payload then the return value is ignored and the content of payload is used.
-- **multiply** (*Optional*, float): multiply the new value with this factor before sending the requests. Ignored if lambda is defined.
+- **register_type** (*Optional*): ``coil`` to create a binary outout or ``holding`` to create a float output.
+- **multiply** (*Optional*, float): multiply the new value with this factor before sending the requests. Ignored if lambda is defined. Only valid for ``register_type: holding``.
 - **offset**: (*Optional*, int): only required for uncommon response encodings
     offset from start address in bytes. If more than one register is read a modbus read registers command this value is used to find the start of this datapoint relative to start address. The component calculates the size of the range based on offset and size of the value type
 - **use_write_multiple**: (*Optional*, boolean): By default the modbus command ``Preset Single Registers`` (function code 6) is used for setting the holding register if only 1 register is set. If your device only supports ``Preset Multiple Registers`` (function code 16) set this option to true.
@@ -40,15 +41,19 @@ All other options from :ref:`Output <config-output>`.
 
 **Parameters passed into the lambda**
 
-- **x** (float): The float value to be sent to the modbus device
+- **x** (float): The float value to be sent to the modbus device for ``register_type: holding``
+- **x** (bool): The float value to be sent to the modbus device for ``register_type: coil``
 
-- **payload** (`std::vector<uint16_t>&payload`): empty vector for the payload. The lamdba can add 16 bit raw modbus register words.
-      note: because the response contains data for all registers in the same range you have to use ``data[item->offset]`` to get the first response byte for your sensor.
+- **payload** (`std::vector<uint16_t>&payload`): 
+  - for ``register_type: holding``: empty vector for the payload. The lamdba can add 16 bit raw modbus register words.
+  - for ``register_type: coil``: empty vector for the payload. If payload is set in the lambda it is sent as a custom command and must include all required bytes for a modbus request
+    note: because the response contains data for all registers in the same range you have to use ``data[item->offset]`` to get the first response byte for your sensor.
+
 - **item** (const pointer to a SensorItem derived object):  The sensor object itself.
 
 Possible return values for the lambda:
 
- - ``return <FLOATING_POINT_NUMBER>;`` the new value for the sensor.
+ - ``return <FLOATING_POINT_NUMBER / BOOL>;`` the new value for the sensor.
  - ``return <anything>; and fill payload with data`` if the payload is added from the lambda then these 16 bit words will be sent
  - ``return {};`` if you don't want write the command to the device (or do it from the lambda).
 


### PR DESCRIPTION
## Description:

document modbus binary_output option 

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#2931

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.

replaces https://github.com/esphome/esphome-docs/pull/1741 - didn't create a branch for it