### PR TITLE
Add documentation for enable_ipv6 flag.

### DIFF
--- a/components/ethernet.rst
+++ b/components/ethernet.rst
@@ -150,6 +150,7 @@ Configuration for Wireless Tag WT32-ETH01
 See Also
 --------
 
+- :doc:`network`
 - :apiref:`ethernet/ethernet_component.h`
 - `ESP32 Ethernet PHY connection info <https://pcbartists.com/design/embedded/esp32-ethernet-phy-schematic-design/>`__
 - :ghedit:`Edit`

--- a/components/network.rst
+++ b/components/network.rst
@@ -18,5 +18,5 @@ networks (WiFi, Ethernet).
 Configuration variables:
 ------------------------
 
-- **enable_ipv6** (*Optional*, boolean): Enables IPv6 support. Defaults to ``false``. Only available on ESP32 with esp-idf platform.
+- **enable_ipv6** (*Optional*, boolean): Enables IPv6 support. Defaults to ``false``. Only available on ESP32 with ESP-IDF framework.
 

--- a/components/network.rst
+++ b/components/network.rst
@@ -18,5 +18,5 @@ networks (WiFi, Ethernet).
 Configuration variables:
 ------------------------
 
-- **enable_ipv6** (*Optional*, boolean): Enables IPv6 support. Defaults to ``false``.
+- **enable_ipv6** (*Optional*, boolean): Enables IPv6 support. Defaults to ``false``. Only available on ESP32 with esp-idf platform.
 

--- a/components/network.rst
+++ b/components/network.rst
@@ -1,0 +1,22 @@
+Network component
+=================
+
+.. seo::
+    :description:
+    :image: network-wifi.svg
+    :keywords: Network, WiFi, WLAN, Ethernet, ESP32
+
+The network component is a global configuration for all types of 
+networks (WiFi, Ethernet).
+
+.. code-block:: yaml
+
+    # Example configuration
+    network:
+        enable_ipv6: true
+        
+Configuration variables:
+------------------------
+
+- **enable_ipv6** (*Optional*, boolean): Enables IPv6 support. Defaults to ``false``.
+

--- a/components/wifi.rst
+++ b/components/wifi.rst
@@ -62,6 +62,7 @@ Configuration variables:
   - **ap_timeout** (*Optional*, :ref:`config-time`): The time after which to enable the
     configured fallback hotspot. Defaults to ``1min``.
 
+- **enable_ipv6** (*Optional*, boolean): Enables IPv6 support. Defaults to ``false``.
 - **domain** (*Optional*, string): Set the domain of the node hostname used for uploading.
   For example, if it's set to ``.local``, all uploads will be sent to ``<HOSTNAME>.local``.
   Defaults to ``.local``.

--- a/components/wifi.rst
+++ b/components/wifi.rst
@@ -62,7 +62,6 @@ Configuration variables:
   - **ap_timeout** (*Optional*, :ref:`config-time`): The time after which to enable the
     configured fallback hotspot. Defaults to ``1min``.
 
-- **enable_ipv6** (*Optional*, boolean): Enables IPv6 support. Defaults to ``false``.
 - **domain** (*Optional*, string): Set the domain of the node hostname used for uploading.
   For example, if it's set to ``.local``, all uploads will be sent to ``<HOSTNAME>.local``.
   Defaults to ``.local``.
@@ -270,5 +269,6 @@ See Also
 --------
 
 - :doc:`captive_portal`
+- :doc:`network`
 - :apiref:`wifi/wifi_component.h`
 - :ghedit:`Edit`

--- a/index.rst
+++ b/index.rst
@@ -142,6 +142,7 @@ Core Components
     Core, components/esphome, cloud-circle.svg
     WiFi, components/wifi, network-wifi.svg
     MQTT, components/mqtt, mqtt.png
+    Network, components/network, network-wifi.svg
 
     I²C Bus, components/i2c, i2c.svg
     SPI Bus, components/spi, spi.svg


### PR DESCRIPTION
## Description:


**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#2953

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
