### PR TITLE
doc: Fix typos in modbus_controller.rst

### DIFF
--- a/components/sensor/modbus_controller.rst
+++ b/components/sensor/modbus_controller.rst
@@ -27,9 +27,9 @@ Configuration variables:
     - U_DWORD_R (unsigned 32 bit integer from 2 registers low word first)
     - S_DWORD_R (signed 32 bit integer from 2 registers low word first)
     - U_QWORD (unsigned 64 bit integer from 4 registers = 64bit)
-    - S_QWORD (unsigned 64 bit integer from 4 registers = 64bit)
+    - S_QWORD (signed 64 bit integer from 4 registers = 64bit)
     - U_QWORD_R (unsigned 64 bit integer from 4 registers low word first)
-    - U_QWORD_R signed 64 bit integer from 4 registers low word first)
+    - S_QWORD_R (signed 64 bit integer from 4 registers low word first)
     - FP32 (32 bit IEEE 754 floating point from 2 registers)
     - FP32_R (32 bit IEEE 754 floating point - same as FP32 but low word first)s
 


### PR DESCRIPTION
Fix typos regarding signed/unsigned.