### PR TITLE
Adds missing update_interval config variable

### DIFF
--- a/components/display/st7735.rst
+++ b/components/display/st7735.rst
@@ -63,6 +63,7 @@ Configuration variables:
 - **invert_colors** (*Optional*, boolean): Invert LCD colors. Default is false.
 - **eight_bit_color** (*Optional*, boolean): 8bit mode. Default is false. This saves 50% of the buffer required for the display.
 - **reset_pin** (*Optional*, :ref:`Pin Schema <config-pin_schema>`): The RESET pin.
+- **update_interval** (*Optional*, :ref:`config-time`): time between display updates.
 
 Memory notes:
 *************

--- a/components/display/st7735.rst
+++ b/components/display/st7735.rst
@@ -63,7 +63,7 @@ Configuration variables:
 - **invert_colors** (*Optional*, boolean): Invert LCD colors. Default is false.
 - **eight_bit_color** (*Optional*, boolean): 8bit mode. Default is false. This saves 50% of the buffer required for the display.
 - **reset_pin** (*Optional*, :ref:`Pin Schema <config-pin_schema>`): The RESET pin.
-- **update_interval** (*Optional*, :ref:`config-time`): time between display updates.
+- **update_interval** (*Optional*, :ref:`config-time`): time between display updates. Default is 1s.
 
 Memory notes:
 *************

--- a/components/display/st7735.rst
+++ b/components/display/st7735.rst
@@ -63,7 +63,7 @@ Configuration variables:
 - **invert_colors** (*Optional*, boolean): Invert LCD colors. Default is false.
 - **eight_bit_color** (*Optional*, boolean): 8bit mode. Default is false. This saves 50% of the buffer required for the display.
 - **reset_pin** (*Optional*, :ref:`Pin Schema <config-pin_schema>`): The RESET pin.
-- **update_interval** (*Optional*, :ref:`config-time`): time between display updates. Default is 1s.
+- **update_interval** (*Optional*, :ref:`config-time`): Time between display updates. Default is 1s.
 
 Memory notes:
 *************


### PR DESCRIPTION
## Description:
Adds missing update_interval config variable

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
