### PR TITLE
Add MagiQuest wand remote protocol

### DIFF
--- a/components/remote_receiver.rst
+++ b/components/remote_receiver.rst
@@ -31,6 +31,7 @@ Configuration variables:
   Set to ``all`` to dump all available codecs:
 
   - **lg**: Decode and dump LG infrared codes.
+  - **magiquest**: Decode and dump MagiQuest wand infrared codes.
   - **midea**: Decode and dump Midea infrared codes.
   - **nec**: Decode and dump NEC infrared codes.
   - **panasonic**: Decode and dump Panasonic infrared codes.
@@ -64,6 +65,9 @@ Automations:
   is passed to the automation for use in lambdas.
 - **on_lg** (*Optional*, :ref:`Automation <automation>`): An automation to perform when a
   LG remote code has been decoded. A variable ``x`` of type :apistruct:`remote_base::LGData`
+  is passed to the automation for use in lambdas.
+- **on_magiquest** (*Optional*, :ref:`Automation <automation>`): An automation to perform when a
+  MagiQuest wand remote code has been decoded. A variable ``x`` of type :apiclass:`remote_base::MagiQuestData`
   is passed to the automation for use in lambdas.
 - **on_midea** (*Optional*, :ref:`Automation <automation>`): An automation to perform when a
   Midea remote code has been decoded. A variable ``x`` of type :apiclass:`remote_base::MideaData`
@@ -151,6 +155,11 @@ Remote code selection (exactly one of these has to be included):
 
   - **data** (**Required**, int): The LG code to trigger on, see dumper output for more info.
   - **nbits** (*Optional*, int): The number of bits of the remote code. Defaults to ``28``.
+
+- **magiquest**: Trigger on a decoded MagiQuest wand remote code with the given wand ID.
+
+  - **wand_id** (**Required**, int): The MagiQuest wand ID to trigger on, see dumper output for more info.
+  - **magnitude** (*Optional*, int): The magnitude of swishes and swirls of the wand.  If omitted, will match on any activation of the wand.
 
 - **midea**: Trigger on a Midea remote code with the given code.
 

--- a/components/remote_transmitter.rst
+++ b/components/remote_transmitter.rst
@@ -160,6 +160,26 @@ Configuration variables:
 - **nbits** (*Optional*, int): The number of bits to send. Defaults to ``28``.
 - All other options from :ref:`remote_transmitter-transmit_action`.
 
+.. _remote_transmitter-transmit_magiquest:
+
+``remote_transmitter.transmit_magiquest`` Action
+********************************************
+
+This :ref:`action <config-action>` sends a MagiQuest wand code to a remote transmitter. 
+
+.. code-block:: yaml
+
+    on_...:
+      - remote_transmitter.transmit_magiquest:
+          wand_id: 0x01234567
+          magnitude: 0x080C
+
+Configuration variables:
+
+- **wand_id** (**Required**, int): The wand ID to send, as a hex integer.  See the dumper output for your wand ID.
+- **magnitude** (**Optional**, int): The magnitude of swishes and swirls of the want to transmit.  See the dumper output for examples.  If omitted, sends 0xFFFF (which the real wand never uses).
+- All other options from :ref:`remote_transmitter-transmit_action`.
+
 .. _remote_transmitter-transmit_midea:
 
 ``remote_transmitter.transmit_midea`` Action


### PR DESCRIPTION
## Description: Add MagiQuest wand remote protocol


**Related issue (if applicable):** fixes [Add decoder/IR remote receiver support for the MagiQuest wand (Halloween yay!)](https://github.com/esphome/feature-requests/issues/1483)

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#2963

## Checklist:

  - [X] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
