### PR TITLE
Add link to "Restart Button" doc

### DIFF
--- a/components/switch/restart.rst
+++ b/components/switch/restart.rst
@@ -29,6 +29,7 @@ Configuration variables:
 See Also
 --------
 
+- :doc:`/components/button/restart`
 - :doc:`shutdown`
 - :doc:`safe_mode`
 - :doc:`template`


### PR DESCRIPTION
"Restart Button" page has link to "Restart Switch" but not vice versa

## Description:

Documentation improvement

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
