### PR TITLE
Sensor for ltr390 is uv, not uvi

### DIFF
--- a/components/sensor/ltr390.rst
+++ b/components/sensor/ltr390.rst
@@ -21,7 +21,7 @@ The :ref:`I²C Bus <i2c>` is required to be set up in your configuration for thi
 
     sensor:
       - platform: ltr390
-        uvi:
+        uv:
           name: "UV Index"
         light:
           name: "Light"


### PR DESCRIPTION
## Description:

The `uvi` sensor in the example is invalid, the correct key is `uv`.

[Definition](https://github.com/esphome/esphome/blob/b20760c93c3f8874e0d73d515e0e88d04a7c87aa/esphome/components/ltr390/sensor.py#L25)
[Passing test](https://github.com/esphome/esphome/blob/dev/tests/test2.yaml#L258-L260)

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
