### PR TITLE
Document sensor id and how it relates to the name

### DIFF
--- a/components/sensor/index.rst
+++ b/components/sensor/index.rst
@@ -38,7 +38,8 @@ override them if you want to.
 
 Configuration variables:
 
-- **name** (**Required**, string): The name for the sensor.
+- **id** (*Optional*, string): Manually specify the ID for code generation. At least one of **id** and **name** must be specified.
+- **name** (*Optional*, string): The name for the sensor. At least one of **id** and **name** must be specified.
 - **unit_of_measurement** (*Optional*, string): Manually set the unit
   of measurement the sensor should advertise its values with. This does
   not actually do any maths (conversion between units).


### PR DESCRIPTION
## Description:

Document the existance of `id` and that `name` is not required if `id` exists

**Related issue (if applicable):** None

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** None

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
