### PR TITLE
Update esp32.rst

### DIFF
--- a/components/esp32.rst
+++ b/components/esp32.rst
@@ -18,7 +18,7 @@ Configuration variables:
 
 - **board** (**Required**, string): The PlatformIO board ID that should
   be used. Choose the appropriate board from
-  `this list <https://platformio.org/boards?count=1000&filter%5Bplatform%5D=espressif32>`__.
+  `this list <https://registry.platformio.org/packages/platforms/platformio/espressif32/boards>`__.
   *This only affects pin aliases, flash size and some internal settings*, if unsure choose a generic board.
 - **framework** (*Optional*): Options for the underlying framework used by ESPHome.
   See :ref:`esp32-arduino_framework` and :ref:`esp32-espidf_framework`.


### PR DESCRIPTION
old link for espressif32 boards doesn't work any more

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
