### PR TITLE
Drop oscillation_output option from H-bridge fan

### DIFF
--- a/components/fan/hbridge.rst
+++ b/components/fan/hbridge.rst
@@ -51,12 +51,10 @@ Configuration variables:
   :ref:`float output <output>` connected to the Enable pin of the h-bridge (if h-bridge uses enable).
 - **decay_mode** (*Optional*, string): The decay mode you want to use with
   the h-bridge. Either ``slow`` (braking) or ``fast`` (coasting). Defaults to ``slow``.
-- **name** (**Required**, string): The name for this fan.
-- **oscillation_output** (*Optional*, :ref:`config-id`): The id of the
-  :ref:`output <output>` to use for the oscillation state of this fan. Default is empty.
 - **speed_count** (*Optional*, int): Set the number of supported discrete speed levels. The value is used
   to calculate the percentages for each speed. E.g. ``2`` means that you have 50% and 100% while ``100``
   will allow 1% increments in the output. Defaults to ``100``.
+- **name** (**Required**, string): The name for this fan.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
 - All other options from :ref:`Fan Component <config-fan>`.
 


### PR DESCRIPTION
## Description:

It doesn't and has never supported this option.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
