### PR TITLE
Fix MAX31856 image

### DIFF
--- a/components/sensor/max31856.rst
+++ b/components/sensor/max31856.rst
@@ -3,12 +3,12 @@ MAX31856 Thermocouple Temperature Sensor
 
 .. seo::
     :description: Instructions for setting up MAX31856 Thermocouple temperature sensors.
-    :image: max31865.jpg
+    :image: max31856.jpg
 
 The ``MAX31856`` temperature sensor allows you to use your MAX31856 Thermocouple
 temperature sensor (`datasheet <https://datasheets.maximintegrated.com/en/ds/MAX31856.pdf>`__) with ESPHome
 
-.. figure:: images/max31865-full.jpg
+.. figure:: images/max31856-full.jpg
     :align: center
     :width: 50.0%
 


### PR DESCRIPTION
## Description:

The wrong image was selected for the MAX31856 (it was using the MAX31865 image), likely due to a simple typo. This switches to the correct image.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** N/A

## Checklist:

  - [X] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [X] Link added in `/index.rst` when creating new documents for new components or cookbook.
