### PR TITLE
Removed copy/paste error from ina260 doc

### DIFF
--- a/components/sensor/ina260.rst
+++ b/components/sensor/ina260.rst
@@ -38,7 +38,6 @@ Configuration variables:
 ------------------------
 
 - **address** (*Optional*, int): Manually specify the I²C address of the sensor. Defaults to ``0x40``.
-  Defaults to ``0.002ohm``.
 - **current** (*Optional*): Use the current value of the sensor in amperes. All options from
   :ref:`Sensor <config-sensor>`.
 - **power** (*Optional*): Use the power value of the sensor in watts. All options from


### PR DESCRIPTION
## Description:

Fix doc issue as noted by randybb on Discord.
There was a clear copy/paste error in the ina260 documentation, naming 0.002ohm as the default for an I2C address.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
