### PR TITLE
fix typo in it.invert_on_off()

### DIFF
--- a/components/display/max7219digit.rst
+++ b/components/display/max7219digit.rst
@@ -150,7 +150,7 @@ Screen inversion
           it.print(0,0, id(digit_font), "Hello!");
 
 The function ``it.invert_on_off(true);`` will invert the display. So background pixels are on and texts pixels are
-off. ``it.invert_on_off(false);`` sets the display back to normal. In case no argument is used: ``it.inverst_on_off();``
+off. ``it.invert_on_off(false);`` sets the display back to normal. In case no argument is used: ``it.invert_on_off();``
 the inversion will toggle from on to off or visa versa. This will happen every time the display is updated.
 So a blinking effect is created. The background pixels are only set at the next update, the pixels drawn in
 the various function like print, line, etc. are directly influenced by the invert command.


### PR DESCRIPTION
## Description:
Typo. 

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
