### PR TITLE
Command retain option for MQTT component

### DIFF
--- a/components/mqtt.rst
+++ b/components/mqtt.rst
@@ -266,6 +266,7 @@ MQTT can have some overrides for specific options.
       payload_not_available: offline
     state_topic: livingroom/custom_state_topic
     command_topic: livingroom/custom_command_topic
+    command_retain: false
 
 Configuration variables:
 
@@ -284,6 +285,8 @@ Configuration variables:
 -  **command_topic** (*Optional*, string): The topic to subscribe to for
    commands from the remote. Defaults to
    ``<TOPIC_PREFIX>/<COMPONENT_TYPE>/<COMPONENT_NAME>/command``.
+-  **command_retain** (*Optional*, boolean): Whether MQTT command messages
+   sent to the device should be retained or not. Default to ``false``.
 
 .. warning::
 


### PR DESCRIPTION
## Description:
New MQTT base component option 'command_retain` added.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#3078

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
