### PR TITLE
Update esp32_ble_tracker.rst

### DIFF
--- a/components/esp32_ble_tracker.rst
+++ b/components/esp32_ble_tracker.rst
@@ -67,7 +67,7 @@ Configuration variables:
     Defaults to ``320ms``.
   - **window** (*Optional*, :ref:`config-time`): The time the ESP is actively listening for packets
     on a channel during each scan interval. If this is close to the ``interval`` value, the ESP will
-    spend more time listening to packets (but also consume more power).
+    spend more time listening to packets (but also consume more power). Defaults to ``30ms``
   - **duration** (*Optional*, :ref:`config-time`): The duration of each complete scan. This has no real
     impact on the device but can be used to debug the BLE stack. Defaults to ``5min``.
   - **active** (*Optional*, boolean): Whether to actively send scan requests to request more data


### PR DESCRIPTION
Added ``Defaults to 30ms`` to ``window`` parameter.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
