### PR TITLE
Update mqtt to reflect changes in 2022.1

### DIFF
--- a/components/mqtt.rst
+++ b/components/mqtt.rst
@@ -416,7 +416,7 @@ Configuration variables:
 
     .. code-block:: cpp
 
-        id(mqtt_client).subscribe_json("the/topic", [=](JsonObject root) {
+        id(mqtt_client).subscribe_json("the/topic", [=](const std::string &topic, JsonObject root) {
             // do something with JSON-decoded value root
         });
 

--- a/components/mqtt.rst
+++ b/components/mqtt.rst
@@ -416,7 +416,7 @@ Configuration variables:
 
     .. code-block:: cpp
 
-        id(mqtt_client).subscribe_json("the/topic", [=](JsonObject &root) {
+        id(mqtt_client).subscribe_json("the/topic", [=](JsonObject root) {
             // do something with JSON-decoded value root
         });
 
@@ -518,7 +518,7 @@ Configuration options:
 
     .. code-block:: cpp
 
-        id(mqtt_client).publish_json("the/topic", [=](JsonObject &root) {
+        id(mqtt_client).publish_json("the/topic", [=](JsonObject root) {
           root["something"] = id(my_sensor).state;
         });
 


### PR DESCRIPTION
`root` is no longer passed by reference; update the documentation to reflect this.

Related issue: https://github.com/esphome/issues/issues/2960