### PR TITLE
Remove recommendation from calibrate_linear

### DIFF
--- a/components/sensor/index.rst
+++ b/components/sensor/index.rst
@@ -197,8 +197,7 @@ the value the sensor shows.
 The arguments are a list of data points, each in the form ``MEASURED -> TRUTH``. ESPHome will
 then fit a linear equation to the values (using least squares). So you need to supply at least
 two values. If more than two values are given a linear solution will be calculated and may not
-represent each value exactly. It is recommended to use the filter calibrate linear only if two data
-points are sufficient.
+represent each value exactly.
 
 .. _sensor-calibrate_polynomial:
 


### PR DESCRIPTION
Requested here: https://github.com/esphome/esphome-docs/pull/1701#discussion_r789486034

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
