### PR TITLE
Add note that buttons are unidirectional

### DIFF
--- a/components/button/index.rst
+++ b/components/button/index.rst
@@ -98,8 +98,8 @@ Configuration variables:
 
     Buttons are designed to trigger an action on a device from Home Assistant, and have an unidirectional flow from 
     Home Assistant to ESPHome. If you press a button using this action, no button press event will be triggered in Home 
-    Assistant. If you want to trigger an event that can be acted upon in Home Assistant, you can use the 
-    :ref:```homeassistant.event`` <api-homeassistant_event_action>` action.
+    Assistant. If you want to trigger an automation in Home Assistant, you should use a
+    :ref:`Home Assistant event <api-homeassistant_event_action>` instead.
 
 .. _button-lambda_calls:
 

--- a/components/button/index.rst
+++ b/components/button/index.rst
@@ -94,6 +94,13 @@ Configuration variables:
 
 - **id** (**Required**, :ref:`config-id`): The ID of the button to set.
 
+.. note::
+
+    Buttons are designed to trigger an action on a device from Home Assistant, and have an unidirectional flow from 
+    Home Assistant to ESPHome. If you press a button using this action, no button press event will be triggered in Home 
+    Assistant. If you want to trigger an event that can be acted upon in Home Assistant, you can use the 
+    :ref:```homeassistant.event`` <api-homeassistant_event_action>` action.
+
 .. _button-lambda_calls:
 
 lambda calls


### PR DESCRIPTION
## Description:

Clarify that buttons are unidirectional from Home Assistant to ESPHome, and don't trigger in the reverse direction. See e.g. esphome/esphome#3002 and https://community.home-assistant.io/t/button-entity-is-not-consistent-with-switch-entity-for-example/381326.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
