### PR TITLE
Document HTTP redirections follow options

### DIFF
--- a/components/http_request.rst
+++ b/components/http_request.rst
@@ -23,7 +23,7 @@ Configuration variables:
 - **timeout** (*Optional*, :ref:`config-time`): Timeout for request. Defaults to ``5s``.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
 - **force_redirects** (*Optional*, boolean): Enable HTTP forced redirection. Defaults to ``true``.
-- **redirect_limit** (*Optional*, integer): Maximum amount of redirects to follow when enabled.
+- **redirect_limit** (*Optional*, integer): Maximum amount of redirects to follow when enabled. Defaults to ``3``.
 
 ESP8266 Options:
 

--- a/components/http_request.rst
+++ b/components/http_request.rst
@@ -22,7 +22,7 @@ Configuration variables:
 - **useragent** (*Optional*, string): User-Agent header for requests. Defaults to ``ESPHome``.
 - **timeout** (*Optional*, :ref:`config-time`): Timeout for request. Defaults to ``5s``.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
-- **force_redirects** (*Optional*, boolean): Enable HTTP forced redirection. Defaults to ``true``.
+- **follow_redirects** (*Optional*, boolean): Enable following HTTP redirects. Defaults to ``true``.
 - **redirect_limit** (*Optional*, integer): Maximum amount of redirects to follow when enabled. Defaults to ``3``.
 
 ESP8266 Options:

--- a/components/http_request.rst
+++ b/components/http_request.rst
@@ -22,6 +22,8 @@ Configuration variables:
 - **useragent** (*Optional*, string): User-Agent header for requests. Defaults to ``ESPHome``.
 - **timeout** (*Optional*, :ref:`config-time`): Timeout for request. Defaults to ``5s``.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
+- **force_redirects** (*Optional*, boolean): Enable HTTP forced redirection. Defaults to ``true``.
+- **redirect_limit** (*Optional*, integer): Maximum amount of redirects to follow when enabled.
 
 ESP8266 Options:
 


### PR DESCRIPTION
Update documentation according to PR https://github.com/esphome/esphome/pull/3100

## Description:
Add force_redirect and redirect_limit options

**Related issue (if applicable):**

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#3100

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
