### PR TITLE
Add virtualenvs to sphinx ignore

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -81,7 +81,7 @@ language = "en"
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This patterns also effect to html_static_path and html_extra_path
-exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", 'env', 'venv', 'ENV', '.venv', '.env']
 
 # The reST default role (used for this markup: `text`) to use for all documents.
 # default_role = 'cpp:any'


### PR DESCRIPTION
We don't want to try and include these directories in our output

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
