### PR TITLE
Revert "Process files with netlify (#1841)"

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,18 +3,6 @@
   command = "make netlify"
   environment = { BASE_URL = "https://esphome.io" }
 
-[build.processing]
-  # only size-minimize everything in production
-  skip_processing = true
-[build.processing.css]
-  bundle = true
-  minify = true
-[build.processing.js]
-  bundle = true
-  minify = true
-[build.processing.images]
-  compress = true
-
 [context.beta]
   environment = { BASE_URL = "https://beta.esphome.io" }
 
@@ -23,8 +11,6 @@
 
 [context.production]
   environment = { BASE_URL = "https://esphome.io", PRODUCTION = "YES" }
-[context.production.processing]
-  skip_processing = false
 
 # A basic redirect rule
 [[redirects]]


### PR DESCRIPTION
This reverts commit 3d78aecc4732a0c031be2d2d8ceec3d192e3f119.

Turns out that there's a time limit on builds, and sphinx output has a
whole lot of JS that gets bundled and minified.

We end up running up against the time limit and the whole build fails.
Therefore, revert it.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
