### PR TITLE
Add auto gain setting to tsl2591 docs

### DIFF
--- a/components/sensor/tsl2591.rst
+++ b/components/sensor/tsl2591.rst
@@ -30,10 +30,10 @@ The TSL2591 device is available on breakout boards from a few vendors
 
 The sensor claims a dynamic range of 600 million to 1 with an effective maximum of 88000 lux.
 It achieves that large range by having a configurable ``gain`` value.
-Use a higher gain value when measuring less intense light sources.
 For many applications, you can use AUTO gain to have the ESP select a suitable gain setting based on
 the previous measurement. If light levels change dramatically this may cause the next reading to saturate,
 after which the gain will adjust down and subsequent readings will be in range.
+Use a higher gain value when measuring less intense light sources.
 On the other hand, if you get ADC readings of 65,535 for either physical sensor,
 you may be saturating that sensor and need to reduce the gain.
 This Wikipedia `article <https://en.wikipedia.org/wiki/Lux>`__ has a table of some lux values for comparison.

--- a/components/sensor/tsl2591.rst
+++ b/components/sensor/tsl2591.rst
@@ -31,6 +31,9 @@ The TSL2591 device is available on breakout boards from a few vendors
 The sensor claims a dynamic range of 600 million to 1 with an effective maximum of 88000 lux.
 It achieves that large range by having a configurable ``gain`` value.
 Use a higher gain value when measuring less intense light sources.
+For many applications, you can use AUTO gain to have the ESP select a suitable gain setting based on
+the previous measurement. If light levels change dramatically this may cause the next reading to saturate,
+after which the gain will adjust down and subsequent readings will be in range.
 On the other hand, if you get ADC readings of 65,535 for either physical sensor,
 you may be saturating that sensor and need to reduce the gain.
 This Wikipedia `article <https://en.wikipedia.org/wiki/Lux>`__ has a table of some lux values for comparison.
@@ -121,9 +124,10 @@ For the TSL2591 device:
   You cannot specify an arbitrary gain multiplier. It must be one of:
 
   - ``low``, ``1x``
-  - ``medium``, ``med``, ``25x``   *(default)*
+  - ``medium``, ``med``, ``25x``
   - ``high``, ``400x``
   - ``maximum``, ``max``, ``9500x``
+  - ``auto`` *(default)*
 
 - **update_interval** (*Optional*, :ref:`config-time`): The interval for checking the sensors.
   Defaults to ``60s``.


### PR DESCRIPTION
## Description:
Add new automatic gain setting in tsl2591 documentation.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#3071

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
