### PR TITLE
Add live reloading

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,4 @@ RUN pip3 install --no-cache-dir --no-binary :all: -r requirements.txt
 EXPOSE 8000
 WORKDIR /data/esphomedocs
 
-CMD ["make", "webserver"]
+CMD ["make", "live-html"]

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,12 @@
 ESPHOME_PATH = ../esphome
 ESPHOME_REF = 2022.1.0
 
-.PHONY: html html-strict cleanhtml deploy help webserver Makefile netlify netlify-api api netlify-dependencies svg2png copy-svg2png minify
+.PHONY: html html-strict cleanhtml deploy help live-html Makefile netlify netlify-api api netlify-dependencies svg2png copy-svg2png minify
 
 html:
 	sphinx-build -M html . _build -j auto -n $(O)
+live-html:
+	sphinx-autobuild . _build -j auto -n $(O) --host 0.0.0.0
 
 html-strict:
 	sphinx-build -M html . _build -W -j auto -n $(O)
@@ -47,9 +49,6 @@ copy-svg2png:
 	cp svg2png/*.png _build/html/_images/
 
 netlify: netlify-dependencies netlify-api html copy-svg2png
-
-webserver: html
-	cd "_build/html" && python3 -m http.server
 
 lint: html-strict
 	python3 travis.py

--- a/guides/contributing.rst
+++ b/guides/contributing.rst
@@ -236,15 +236,12 @@ To check your documentation changes locally, you first need install Sphinx (with
     # in ESPHome-Docs repo:
     pip install -r requirements.txt
 
-Then, use the provided Makefile to build the changes and start a simple web server:
+Then, use the provided Makefile to build the changes and start a live-updating web server:
 
 .. code-block:: bash
 
     # Start web server on port 8000
-    make webserver
-
-    # Updates then happen via:
-    make html
+    make live-html
 
 Notes
 *****

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 sphinx==4.3.2
+sphinx-autobuild==2021.3.14


### PR DESCRIPTION
Replace the existing webserver target with a live-reloading target.

Adds a dependency on https://github.com/executablebooks/sphinx-autobuild

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
