### PR TITLE
Update link to PlatformIO boards list

### DIFF
--- a/devices/esp32.rst
+++ b/devices/esp32.rst
@@ -8,7 +8,7 @@ Generic ESP32
 
 All devices based on the original ESP32 are supported by ESPHome. Simply select ``ESP32`` when
 the ESPHome wizard asks you for your platform and choose a board type
-from `this link <https://platformio.org/boards?count=1000&filter%5Bplatform%5D=espressif32>`__ when the wizard
+from `this link <https://registry.platformio.org/platforms/platformio/espressif32/boards>`__ when the wizard
 asks you for the board type.
 
 .. code-block:: yaml


### PR DESCRIPTION
## Description:

It looks like the PlatformIO website has changed a bit, breaking this link. I think this new link suits.

**Related issue (if applicable):** None.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** N/A

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [n/a] Link added in `/index.rst` when creating new documents for new components or cookbook.
