### PR TITLE
Clarification for MCP23017

### DIFF
--- a/components/mcp230xx.rst
+++ b/components/mcp230xx.rst
@@ -146,6 +146,9 @@ pins for your projects. Within ESPHome they emulate a real internal GPIO pin
 and can therefore be used with many of ESPHome's components such as the GPIO
 binary sensor or GPIO switch.
 
+GPIO pins in the datasheet are labelled A0 to A7 and B0 to B7, these are mapped
+consecutively in this component to numbers from 0 to 15.
+
 .. code-block:: yaml
 
     # Example configuration entry
@@ -156,10 +159,10 @@ binary sensor or GPIO switch.
     # Individual outputs
     switch:
       - platform: gpio
-        name: "MCP23017 Pin #0"
+        name: "MCP23017 Pin A0"
         pin:
           mcp23xxx: mcp23017_hub
-          # Use pin number 0
+          # Use pin A0
           number: 0
           mode:
             output: true
@@ -168,11 +171,11 @@ binary sensor or GPIO switch.
     # Individual inputs
     binary_sensor:
       - platform: gpio
-        name: "MCP23017 Pin #1"
+        name: "MCP23017 Pin B7"
         pin:
           mcp23xxx: mcp23017_hub
-          # Use pin number 1
-          number: 1
+          # Use pin B7
+          number: 15
           # One of INPUT or INPUT_PULLUP
           mode:
             input: true


### PR DESCRIPTION
Datasheet pin labeling vs component pin addressing clarification.

## Description:
Datasheet pin labeling vs component pin addressing clarification. Tested with real devices to confirm.

**Related issue (if applicable):** fixes N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome #N/A

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
