### PR TITLE
Describe MQTT discovery object_id generator

### DIFF
--- a/components/mqtt.rst
+++ b/components/mqtt.rst
@@ -47,6 +47,9 @@ Configuration variables:
   to use. Can be one of ``legacy`` or ``mac``. Defaults to ``legacy``, which
   generates unique_id in format ``ESP<component_type><default_object_id>``.
   ``mac`` generator uses format ``<mac_address>-<component_type>-<fnv1_hash(friendly_name)>``.
+- **discovery_object_id_generator** (*Optional*, string): The object_id generator
+  to use. Can be one of ``none`` or ``device_name``. Defaults to ``none`` which
+  does not generate unique_id. ``device_name`` generator uses format ``<device_name>_<friendly_name>``.
 - **use_abbreviations** (*Optional*, boolean): Whether to use
   `Abbreviations <https://www.home-assistant.io/docs/mqtt/discovery/>`__
   in discovery messages. Defaults to ``true``.
@@ -159,6 +162,17 @@ With Docker:
 This will remove all retained messages with the topic
 ``<DISCOVERY_PREFIX>/+/NODE_NAME/#``. If you want to purge on another
 topic, simply add ``--topic <your_topic>`` to the command.
+
+Home Assistant generates entity names for all discovered devices based on entity type and
+entity name (e.g. ``sensor.uptime``). Numeric suffixes are appended to entity names when
+multiple devices use the same name for a sensor, making it harder to distinguish between
+similar sensors on different devices. Home Assistant 2021.12 allows MQTT devices to change
+this behaviour by specifying ``object_id`` discovery attribute which replaces the sensor
+name part of the generated entity name. Setting ``discovery_object_id_generator: device_name``
+in ESPHome MQTT integration configuration will cause Home Assistant to include device name
+in the generated entity names (e.g. ``sensor.uptime`` becomes ``sensor.<device name>_uptime``),
+making it easier to distinguish the entities in various entity lists.
+
 
 .. _mqtt-defaults:
 

--- a/components/mqtt.rst
+++ b/components/mqtt.rst
@@ -49,7 +49,7 @@ Configuration variables:
   ``mac`` generator uses format ``<mac_address>-<component_type>-<fnv1_hash(friendly_name)>``.
 - **discovery_object_id_generator** (*Optional*, string): The object_id generator
   to use. Can be one of ``none`` or ``device_name``. Defaults to ``none`` which
-  does not generate unique_id. ``device_name`` generator uses format ``<device_name>_<friendly_name>``.
+  does not generate object_id. ``device_name`` generator uses format ``<device_name>_<friendly_name>``.
 - **use_abbreviations** (*Optional*, boolean): Whether to use
   `Abbreviations <https://www.home-assistant.io/docs/mqtt/discovery/>`__
   in discovery messages. Defaults to ``true``.


### PR DESCRIPTION
## Description:

This pull requests describes newly proposed MQTT discovery `object_id` generator for Home Assistant 2021.12+ allowing the discovered entity names to include the name of the device.

**Related issue (if applicable):** implelements esphome/feature-requests#1569

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#3114

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
