### PR TITLE
Fix misleading status led note

### DIFF
--- a/components/light/status_led.rst
+++ b/components/light/status_led.rst
@@ -47,9 +47,9 @@ Configuration variables:
 
     .. code-block:: yaml
 
-      pin:
-        number: GPIO2
-        inverted: true
+        pin:
+          number: GPIO2
+          inverted: true
 
 
 

--- a/components/light/status_led.rst
+++ b/components/light/status_led.rst
@@ -47,10 +47,9 @@ Configuration variables:
 
     .. code-block:: yaml
 
-        status_led:
-          pin:
-            number: GPIO2
-            inverted: true
+      pin:
+        number: GPIO2
+        inverted: true
 
 
 


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
