### PR TITLE
homeassistant notify correct data keys

### DIFF
--- a/components/api.rst
+++ b/components/api.rst
@@ -85,7 +85,7 @@ calls straight from ESPHome :ref:`Automations <automation>`.
       - homeassistant.service:
           service: notify.html5
           data:
-            title: Button was pressed
+            message: Button was pressed
       # With templates and variables
       - homeassistant.service:
           service: notify.html5
@@ -262,7 +262,7 @@ straight from ESPHome :ref:`Automations <automation>`.
       - homeassistant.event:
           event: esphome.button_pressed
           data:
-            title: Button was pressed
+            message: Button was pressed
 
 Configuration options:
 


### PR DESCRIPTION
`title` is not a required key, but `message` is.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
