### PR TITLE
logger: add option to include relative timestamp

### DIFF
--- a/components/logger.rst
+++ b/components/logger.rst
@@ -27,6 +27,10 @@ Configuration variables:
    specific component or tag. See :ref:`Manual Log Levels for more
    information <logger-manual_tag_specific_levels>`.
 -  **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
+-  **include_timestamps** (*Optional*, boolean): Include a timestamp into every log message.
+   The timestamp is number of milliseconds since start of ESP execution, and overflows
+   approximately every 49 days and 17 hours. Useful when debugging performance issues,
+   or optimizing battery-powered setups utilizing deep sleep.
 
 Advanced settings:
 


### PR DESCRIPTION
## Description:

Add an option to logger component to include a timestamp into every log message.
The timestamp is number of milliseconds since start of ESP execution, and overflows approximately every 49 days and 17 hours. Useful when debugging performance issues, or optimizing battery-powered setups utilizing deep sleep.

Example in which I debug latencies in my battery powered ESP eInk display that received data over BLE (excerpt with parts omitted for brevity):
```
[22:19:36][T       870][I][app:029]: Running through setup()...
[22:19:36][T       871][D][main:010]: (T871) Woke up
[22:19:36][T      1513][D][esp32_ble_tracker:214]: Starting scan...
...
[22:19:37][T      1898][D][myhomeiot_ble_client:069]: [3C:61:05:10:D7:6E] Found device
...
[22:19:37][T      1942][I][myhomeiot_ble_client:032]: [3C:61:05:10:D7:6E] Connecting
...
[22:19:37][T      2067][I][myhomeiot_ble_client:087]: [3C:61:05:10:D7:6E] Connected successfully, app_id (1)
...
[22:19:38][T      3126][D][main:059]: Sensor data received, JSON parsing result: Ok
...
[22:19:38][T      3264][D][main:094]: Starting eInk update
...
[22:19:44][T      9387][D][main:096]: Screen update complete
...
[22:19:44][T      9399][I][deep_sleep:103]: Beginning Deep Sleep
```

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#3137

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
