### PR TITLE
fixed example lambda key

### DIFF
--- a/components/output/modbus_controller.rst
+++ b/components/output/modbus_controller.rst
@@ -67,7 +67,7 @@ Possible return values for the lambda:
         - platform: modbus_controller
             modbus_controller_id: epever
             id: battery_capacity_output
-            lambda: |-
+            write_lambda: |-
               ESP_LOGD("main","Modbus Output incoming value = %f",x);
               uint16_t b_capacity = x ;
               payload.push_back(b_capacity);


### PR DESCRIPTION

## Description:

The example uses the `lambda` key for the lambda which is not supported in the output component. This key is changed to `write_lambda`. The example itself should be checked it it still makes sense.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
