### PR TITLE
Update ethernet.rst

### DIFF
--- a/components/ethernet.rst
+++ b/components/ethernet.rst
@@ -108,7 +108,7 @@ Configuration for Olimex ESP32-EVB
       clk_mode: GPIO0_IN
       phy_addr: 0
 
-Configuration for LILYGO TTGO T-Internet-POE ESP32-WROOM LAN8270A Chip
+Configuration for LILYGO TTGO T-Internet-POE ESP32-WROOM LAN8720A Chip
 ----------------------------------------------------------------------
 
 .. code-block:: yaml


### PR DESCRIPTION
LILYGO TTGO LAN8270A-card does not exist, number must be misplaced since everything else is 8720A.

## Description:
Numbers misplaced in the headline of the LILYGO TTGO T-Internet-POE ESP32-WROOM LAN8720A. 

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
