### PR TITLE
Include documentation on Pronto receive capability

### DIFF
--- a/components/remote_receiver.rst
+++ b/components/remote_receiver.rst
@@ -39,7 +39,8 @@ Configuration variables:
   - **nexa**: Decode and dump Nexa (RF) codes.
   - **panasonic**: Decode and dump Panasonic infrared codes.
   - **pioneer**: Decode and dump Pioneer infrared codes.
-  - **raw**: Print all remote codes in their raw form. Useful for using arbitrary protocols.
+  - **pronto**: Print remote code in Pronto form. Useful for using arbitrary protocols.
+  - **raw**: Print all remote codes in their raw form. Also useful for using arbitrary protocols.
   - **rc5**: Decode and dump RC5 IR codes.
   - **rc_switch**: Decode and dump RCSwitch RF codes.
   - **samsung**: Decode and dump Samsung infrared codes.
@@ -96,6 +97,9 @@ Automations:
   is passed to the automation for use in lambdas.
 - **on_pioneer** (*Optional*, :ref:`Automation <automation>`): An automation to perform when a
   pioneer remote code has been decoded. A variable ``x`` of type :apistruct:`remote_base::PioneerData`
+  is passed to the automation for use in lambdas.
+- **on_pronto** (*Optional*, :ref:`Automation <automation>`): An automation to perform when a
+  Pronto remote code has been decoded. A variable ``x`` of type ``std::string``
   is passed to the automation for use in lambdas.
 - **on_raw** (*Optional*, :ref:`Automation <automation>`): An automation to perform when a
   raw remote code has been decoded. A variable ``x`` of type ``std::vector<int>``
@@ -203,6 +207,11 @@ Remote code selection (exactly one of these has to be included):
 - **pioneer**: Trigger on a decoded Pioneer remote code with the given data.
 
   - **rc_code_1** (**Required**, int): The remote control code to trigger on, see dumper output for more details.
+
+- **pronto**: Trigger on a Pronto remote code with the given code.
+
+  - **data** (**Required**, string): The code to listen for, see :ref:`remote_transmitter-transmit_raw`
+    for more info. Usually you only need to copy this directly from the dumper output.
 
 - **raw**: Trigger on a raw remote code with the given code.
 


### PR DESCRIPTION
## Description:

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#2826

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
