### PR TITLE
Update esp32.rst

### DIFF
--- a/devices/esp32.rst
+++ b/devices/esp32.rst
@@ -52,6 +52,17 @@ Some notes about the pins on the ESP32:
       - platform: gpio
         name: "Pin GPIO23"
         pin: GPIO23
+        
+** Note **
+
+Espp32 devices can sometime come without any flash layout. Just use esphome-flasher 117 to flash you bin for the first time via serial - it takes care of partitioning the esp32s.
+If you get the following in the logs repeatedly try using esphome-flasher (This does involved over ridding chrome safe browsing to download it)
+
+```
+rst:0x10 (RTCWDT_RTC_RESET),boot:0x13 (SPI_FAST_FLASH_BOOT)
+flash read err, 1000
+ets_main.c 371
+```
 
 See Also
 --------


### PR DESCRIPTION
Add note about using esphome-flasher to flash device first time or why not build this into the new web flasher as an option if it fails to boot with rst:0x10 (RTCWDT_RTC_RESET),boot:0x13 (SPI_FAST_FLASH_BOOT) error

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
