### PR TITLE
light: add RESTORE_AND_OFF/RESTORE_AND_ON LightRestoreMode

### DIFF
--- a/components/light/index.rst
+++ b/components/light/index.rst
@@ -43,6 +43,8 @@ Configuration variables:
     - ``RESTORE_DEFAULT_ON`` - Attempt to restore state and default to ON.
     - ``RESTORE_INVERTED_DEFAULT_OFF`` - Attempt to restore state inverted from the previous state and default to OFF.
     - ``RESTORE_INVERTED_DEFAULT_ON`` - Attempt to restore state inverted from the previous state and default to ON.
+    - ``RESTORE_AND_OFF`` - Attempt to restore state but initialize the light as OFF.
+    - ``RESTORE_AND_ON`` - Attempt to restore state but initialize the light as ON.
     - ``ALWAYS_OFF`` - Always initialize the light as OFF on bootup.
     - ``ALWAYS_ON`` - Always initialize the light as ON on bootup.
 


### PR DESCRIPTION
## Description:
Add two new (RESTORE_AND_OFF and RESTORE_AND_ON) restore_mode to light component. It's simular that ALWAYS_OFF and ALWAYS_OFF, but save settings, such as brightness or color temperature, to rtc/flash

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** https://github.com/esphome/esphome/pull/3238

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
