### PR TITLE
send_first_at for exponential_moving_average

### DIFF
--- a/components/sensor/index.rst
+++ b/components/sensor/index.rst
@@ -399,6 +399,9 @@ Configuration variables:
 
 - **alpha** (*Optional*, float): The forget factor/alpha value of the filter. Defaults to ``0.1``.
 - **send_every** (*Optional*, int): How often a sensor value should be pushed out. Defaults to ``15``.
+- **send_first_at** (*Optional*, int): By default, the very first raw value on boot is immediately
+  published. With this parameter you can specify when the very first value is to be sent.
+  Defaults to ``1``.
 
 ``throttle``
 ************


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#3240

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
