### PR TITLE
Added alternative pin labeling for 74HC595

### DIFF
--- a/components/sn74hc595.rst
+++ b/components/sn74hc595.rst
@@ -46,9 +46,9 @@ Configuration variables:
 ************************
 
 - **id** (**Required**, :ref:`config-id`): The id to use for this SN74HC595 component.
-- **data_pin** (**Required**, :ref:`Pin Schema <config-pin_schema>`): Pin connected to SN74HC595 SER input.
-- **clock_pin** (**Required**, :ref:`Pin Schema <config-pin_schema>`): Pin connected to SN74HC595 SRCLK pin
-- **latch_pin** (**Required**, :ref:`Pin Schema <config-pin_schema>`): Pin connected to SN74HC595 RCLK pin
+- **data_pin** (**Required**, :ref:`Pin Schema <config-pin_schema>`): Pin connected to SN74HC595 SER (SD) input.
+- **clock_pin** (**Required**, :ref:`Pin Schema <config-pin_schema>`): Pin connected to SN74HC595 SRCLK (SH_CP) pin
+- **latch_pin** (**Required**, :ref:`Pin Schema <config-pin_schema>`): Pin connected to SN74HC595 RCLK (ST_CP) pin
 - **oe_pin** (*Optional*, :ref:`Pin Schema <config-pin_schema>`): Pin connected to SN74HC595 OE pin
 - **sr_count** (*Optional*, int): Number of daisy-chained shift registers, up-to 4. Defaults to ``1``.
 


### PR DESCRIPTION


## Description:
Some datasheets talk about the `SD`, `SH_CP` and `ST_CP` pins, I though to add the alternative label names in the documentation.

**Related issue (if applicable):** -
**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** - 

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
