### PR TITLE
Add note about remote package secrets (and fix lint.py)

### DIFF
--- a/guides/configuration-types.rst
+++ b/guides/configuration-types.rst
@@ -363,8 +363,8 @@ them locally with their own subsitution value.
 
 .. note::
 
-  Remote packages cannot have ``secret`` lookups in them. They should instead make use of substitutions with an
-  optional default in the packaged YAML, which the local device YAML can set using values from the local secrets.
+    Remote packages cannot have ``secret`` lookups in them. They should instead make use of substitutions with an
+    optional default in the packaged YAML, which the local device YAML can set using values from the local secrets.
 
 .. code-block:: yaml
 

--- a/guides/configuration-types.rst
+++ b/guides/configuration-types.rst
@@ -361,6 +361,11 @@ Packages can also be loaded from a git repository by utilizing the correct confi
 :ref:`config-substitutions` can be used inside the remote packages which allows users to override
 them locally with their own subsitution value.
 
+.. note::
+
+  Remote packages cannot have ``secret`` lookups in them. They should instead make use of substitutions with an
+  optional default in the packaged YAML, which the local device YAML can set using values from the local secrets.
+
 .. code-block:: yaml
 
     packages:

--- a/lint.py
+++ b/lint.py
@@ -375,7 +375,7 @@ def lint_directive_formatting(fname, content):
             if j == k and num_indent != 4:
                 errors.append(
                     "Directive '{}' must be indented with 4 spaces, not {}. See "
-                    "{}:{}".format(directive_name, num_indent, f, j + 1)
+                    "{}:{}".format(directive_name, num_indent, fname, j + 1)
                 )
                 break
 

--- a/lint.py
+++ b/lint.py
@@ -379,6 +379,8 @@ def lint_directive_formatting(fname, content):
                 )
                 break
 
+    return errors
+
 
 @lint_re_check(
     r"https://esphome.io/",

--- a/lint.py
+++ b/lint.py
@@ -357,7 +357,7 @@ def lint_directive_formatting(fname, content):
         if lines[j]:
             errors.append(
                 "Directive '{}' is not followed by an empty line. Please insert an "
-                "empty line after {}:{}".format(directive_name, f, j)
+                "empty line after {}:{}".format(directive_name, fname, j)
             )
             continue
 

--- a/lint.py
+++ b/lint.py
@@ -356,8 +356,12 @@ def lint_directive_formatting(fname, content):
         # Empty line must follow
         if lines[j]:
             errors.append(
-                "Directive '{}' is not followed by an empty line. Please insert an "
-                "empty line after {}:{}".format(directive_name, fname, j)
+                (
+                    j,
+                    1,
+                    "Directive '{}' is not followed by an empty line. Please insert an "
+                    "empty line after {}:{}".format(directive_name, fname, j),
+                )
             )
             continue
 
@@ -374,8 +378,12 @@ def lint_directive_formatting(fname, content):
             num_indent = num_spaces - base_indentation
             if j == k and num_indent != 4:
                 errors.append(
-                    "Directive '{}' must be indented with 4 spaces, not {}. See "
-                    "{}:{}".format(directive_name, num_indent, fname, j + 1)
+                    (
+                        j + 1,
+                        num_indent,
+                        "Directive '{}' must be indented with 4 spaces, not {}. See "
+                        "{}:{}".format(directive_name, num_indent, fname, j + 1),
+                    )
                 )
                 break
 


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/2654

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
