### PR TITLE
Update ref to esp8266 restore_from_flash

### DIFF
--- a/components/switch/gpio.rst
+++ b/components/switch/gpio.rst
@@ -29,8 +29,8 @@ Configuration variables:
 - **name** (**Required**, string): The name for the switch.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
 - **restore_mode** (*Optional*): Control how the GPIO Switch attempts to restore state on bootup.
-  For restoring on ESP8266s, also see ``esp8266_restore_from_flash`` in the
-  :doc:`esphome section </components/esphome>`.
+  For restoring on ESP8266s, also see ``restore_from_flash`` in the
+  :doc:`esphome section </components/esp8266>`.
 
     - ``RESTORE_DEFAULT_OFF`` (Default) - Attempt to restore state and default to OFF if not possible to restore.
     - ``RESTORE_DEFAULT_ON`` - Attempt to restore state and default to ON.

--- a/components/switch/gpio.rst
+++ b/components/switch/gpio.rst
@@ -30,7 +30,7 @@ Configuration variables:
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
 - **restore_mode** (*Optional*): Control how the GPIO Switch attempts to restore state on bootup.
   For restoring on ESP8266s, also see ``restore_from_flash`` in the
-  :doc:`esphome section </components/esp8266>`.
+  :doc:`esp8266 section </components/esp8266>`.
 
     - ``RESTORE_DEFAULT_OFF`` (Default) - Attempt to restore state and default to OFF if not possible to restore.
     - ``RESTORE_DEFAULT_ON`` - Attempt to restore state and default to ON.


### PR DESCRIPTION
## Description:

It looks like esp8266_restore_from_flash is a deprecated config entry, and the proper way to specify this going forward is in the specific esp8266 platform heading. I've updated the docs to point you straight there.

**Related issue (if applicable):** None

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** N/A

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
