### PR TITLE
on_state gets only called on state change

### DIFF
--- a/components/binary_sensor/index.rst
+++ b/components/binary_sensor/index.rst
@@ -41,7 +41,7 @@ Automations:
 - **on_release** (*Optional*, :ref:`Automation <automation>`): An automation to perform
   when the button is released. See :ref:`binary_sensor-on_release`.
 - **on_state** (*Optional*, :ref:`Automation <automation>`): An automation to perform
-  when a state is published. See :ref:`binary_sensor-on_state`.
+  when a state change is published. See :ref:`binary_sensor-on_state`.
 - **on_click** (*Optional*, :ref:`Automation <automation>`): An automation to perform
   when the button is held down for a specified period of time.
   See :ref:`binary_sensor-on_click`.


### PR DESCRIPTION
## Description:

``on_state`` gets only called on state change, not every time a value gets published.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
