### PR TITLE
Document configuration for serving static files in web_server

### DIFF
--- a/components/web_server.rst
+++ b/components/web_server.rst
@@ -172,7 +172,7 @@ ESPHome will output the detected media type for a file when adding the file to f
 
 .. code-block::
 
-  INFO Adding web app file: www/index.html as app/index.html (size 2087, text/html, encoding none)
+    INFO Adding web app file: www/index.html as app/index.html (size 2087, text/html, encoding none)
 
 
 Compression
@@ -198,7 +198,7 @@ ESPHome will output the detected compression algorithm for a file when adding th
 
 .. code-block::
 
-  INFO Adding web app file: www/index.html.gz as app/index.html (size 1057, text/html, encoding gzip)
+    INFO Adding web app file: www/index.html.gz as app/index.html (size 1057, text/html, encoding gzip)
 
 Multiple compression algorithms are detected (gzip, compress, bzip2, xz, br) but it is recommended to use ``gzip``
 as it is currently the most widely supported one in web browsers.
@@ -223,40 +223,40 @@ A production build of an Angular application produces the following static files
 
 .. code-block::
 
-  index.html
-  main.14bf39656ae912e1.js
-  polyfills.5902314ff3f2eac9.js
-  runtime.f7d50caa802bfcbd.js
-  styles.42da88a97f9b7241.css
+    index.html
+    main.14bf39656ae912e1.js
+    polyfills.5902314ff3f2eac9.js
+    runtime.f7d50caa802bfcbd.js
+    styles.42da88a97f9b7241.css
 
 Files are compressed using ``gzip`` compression utility by running ``gzip *.html *.css *.js``, producing:
 
 .. code-block::
 
-  index.html.gz
-  main.14bf39656ae912e1.js.gz
-  polyfills.5902314ff3f2eac9.js.gz
-  runtime.f7d50caa802bfcbd.js.gz
-  styles.42da88a97f9b7241.css.gz
+    index.html.gz
+    main.14bf39656ae912e1.js.gz
+    polyfills.5902314ff3f2eac9.js.gz
+    runtime.f7d50caa802bfcbd.js.gz
+    styles.42da88a97f9b7241.css.gz
 
 ESPHome is configured with the following code block:
 
 .. code-block:: yaml
 
-  # Web app configuration
-  web_server:
-    app:
-      source: ../dist/my_app
+    # Web app configuration
+    web_server:
+      app:
+        source: ../dist/my_app
 
 ESPHome ``compile`` inlines (embeds) the files in firmware and makes them available under ``/app/`` URL prefix:
 
 .. code-block::
 
-  INFO Adding web app file: ../dist/my_app/index.html.gz as app/index.html (size 1057, text/html, encoding gzip)
-  INFO Adding web app file: ../dist/my_app/polyfills.5902314ff3f2eac9.js.gz as app/polyfills.5902314ff3f2eac9.js (size 12248, application/javascript, encoding gzip)
-  INFO Adding web app file: ../dist/my_app/main.14bf39656ae912e1.js.gz as app/main.14bf39656ae912e1.js (size 154552, application/javascript, encoding gzip)
-  INFO Adding web app file: ../dist/my_app/styles.42da88a97f9b7241.css.gz as app/styles.42da88a97f9b7241.css (size 23125, text/css, encoding gzip)
-  INFO Adding web app file: ../dist/my_app/runtime.f7d50caa802bfcbd.js.gz as app/runtime.f7d50caa802bfcbd.js (size 669, application/javascript, encoding gzip)
+    INFO Adding web app file: ../dist/my_app/index.html.gz as app/index.html (size 1057, text/html, encoding gzip)
+    INFO Adding web app file: ../dist/my_app/polyfills.5902314ff3f2eac9.js.gz as app/polyfills.5902314ff3f2eac9.js (size 12248, application/javascript, encoding gzip)
+    INFO Adding web app file: ../dist/my_app/main.14bf39656ae912e1.js.gz as app/main.14bf39656ae912e1.js (size 154552, application/javascript, encoding gzip)
+    INFO Adding web app file: ../dist/my_app/styles.42da88a97f9b7241.css.gz as app/styles.42da88a97f9b7241.css (size 23125, text/css, encoding gzip)
+    INFO Adding web app file: ../dist/my_app/runtime.f7d50caa802bfcbd.js.gz as app/runtime.f7d50caa802bfcbd.js (size 669, application/javascript, encoding gzip)
 
 Navigating browser to ``http://<node_name>.local/app/index.html`` or ``http://<node_name>.local/app/`` or ``http://<node_name>.local/app`` will
 open the application.

--- a/components/web_server.rst
+++ b/components/web_server.rst
@@ -60,6 +60,9 @@ Configuration variables:
 - **ota** (*Optional*, boolean): Turn on or off the OTA feature inside webserver. Strongly not suggested without enabled authentication settings. Default: `true`
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
 - **version** (*Optional*, string): 1 or 2. Version 1 displays as a table. Version 2 uses web components and has more functionality. Default: `2`
+- **app** (*Optional*): Enables inlining (embedding) and serving static files from flash.
+
+  - **source** (**Required**, local directory): Path to local directory containing static files to inline (embed) and serve under ``/app/`` URL prefix.
 
 .. note::
 
@@ -91,8 +94,6 @@ Configuration variables:
         web_server:
           local: true
           
-          
-
     All of the assets are inlined, compressed and served from flash
 
 Here be Dragons
@@ -130,6 +131,136 @@ V2 embeds the css within the js file so is not required, however you could inclu
 
 Copy https://oi.esphome.io/v2/www.js to a V2 folder in your yaml folder.
         
+
+Serving static files or web applications
+========================================
+
+:doc:`/web-api/index` provides a powerful REST and Event Source API that can be used for managing various aspects
+of an ESPHome device. The default web server interface provides a generic web page for interfacing with the device,
+but sometimes a more tailored made solution is needed (e.g. displaying real-time charts, exposing only a subset of
+switches, etc.).
+
+Web application configuration of ``web_server`` component allows for inlining (embedding) of web application
+files (HTML, Javascript, CSS) into flash storage of a device and serving them directly from the device under
+``/app/`` URL prefix.
+
+Example ``web_server`` configuration for embedding and serving static files from local ``www`` directory:
+
+.. code-block:: yaml
+
+    # Example configuration entry
+    web_server:
+      app:
+        source: www
+
+The above configuration block will inline (embed) all files from the local directory ``www`` and serve them under
+``/app/`` URL prefix - for example:
+
+- local file ``www/index.html`` will be accessible by visiting ``http://<node_name>.local/app/index.html``
+- local file ``www/app.js`` will be accessible by visiting ``http://<node_name>.local/app/app.js``
+
+
+Media (MIME) types
+------------------
+
+Web browsers expect web servers to serve static files with ``Content-Type`` header containing IANA Media Type
+(MIME type) for the particular file. ESPHome will try to auto-detect files' media types based on the list
+of known file extensions. The location of the list is dependent on the operating system: registry on Windows,
+``/etc/mime.types`` on Unix-like systems). See https://docs.python.org/3.8/library/mimetypes.html for details.
+
+ESPHome will output the detected media type for a file when adding the file to firmware:
+
+.. code-block::
+
+  INFO Adding web app file: www/index.html as app/index.html (size 2087, text/html, encoding none)
+
+
+Compression
+-----------
+
+It is recommended that static web application files (HTML, Javascript, CSS, ...) are compressed to better utilize
+the available flash space on a device. Determining which files to compress is beyond the scope of ESPHome as some
+files compress really well (text files) while others (images) don't.
+
+Web application inlining logic of ``web_server`` component expects the application files to be compressed by the
+provider of the files and that files are marked as compressed by having a correct file extension for the chosen
+compression algorithm (e.g. ``.gz`` for ``gzip`` compression). ESPHome will store compressed files in flash and
+serve them in a compressed form under the name of the original (non-compressed) file with the correct setting
+of HTTP ``Transfer-Encoding`` header. All modern web browsers are able to perform decompression on-the-fly and
+process the file in an uncompressed form.
+
+For example:
+
+- local file ``www/index.html.gz`` will be accessible as ``http://<node_name>.local/app/index.html`` and ESPHome
+  will set headers ``Content-Type: text/html`` and ``Transfer-Encoding: gzip`` when serving the file.
+
+ESPHome will output the detected compression algorithm for a file when adding the file to firmware:
+
+.. code-block::
+
+  INFO Adding web app file: www/index.html.gz as app/index.html (size 1057, text/html, encoding gzip)
+
+Multiple compression algorithms are detected (gzip, compress, bzip2, xz, br) but it is recommended to use ``gzip``
+as it is currently the most widely supported one in web browsers.
+
+
+Accessing the application (index.html)
+--------------------------------------
+
+All statically served files can be accessed directly by navigating to ``http://<node_name>.local/app/<file_name>``.
+
+A shortcut for accessing ``index.html`` is provided by either navigating to:
+
+- ``http://<node_name>.local/app/`` which serves ``index.html`` file if the file exists (eror 404 otherwise),
+- or ``http://<node_name>.local/app`` which redirects the browser to ``http://<node_name>.local/app/`` which,
+  in-turn, serves ``index.html`` file.
+
+
+Example
+-------
+
+A production build of an Angular application produces the following static files in ``../dist/my_app``:
+
+.. code-block::
+
+  index.html
+  main.14bf39656ae912e1.js
+  polyfills.5902314ff3f2eac9.js
+  runtime.f7d50caa802bfcbd.js
+  styles.42da88a97f9b7241.css
+
+Files are compressed using ``gzip`` compression utility by running ``gzip *.html *.css *.js``, producing:
+
+.. code-block::
+
+  index.html.gz
+  main.14bf39656ae912e1.js.gz
+  polyfills.5902314ff3f2eac9.js.gz
+  runtime.f7d50caa802bfcbd.js.gz
+  styles.42da88a97f9b7241.css.gz
+
+ESPHome is configured with the following code block:
+
+.. code-block:: yaml
+
+  # Web app configuration
+  web_server:
+    app:
+      source: ../dist/my_app
+
+ESPHome ``compile`` inlines (embeds) the files in firmware and makes them available under ``/app/`` URL prefix:
+
+.. code-block::
+
+  INFO Adding web app file: ../dist/my_app/index.html.gz as app/index.html (size 1057, text/html, encoding gzip)
+  INFO Adding web app file: ../dist/my_app/polyfills.5902314ff3f2eac9.js.gz as app/polyfills.5902314ff3f2eac9.js (size 12248, application/javascript, encoding gzip)
+  INFO Adding web app file: ../dist/my_app/main.14bf39656ae912e1.js.gz as app/main.14bf39656ae912e1.js (size 154552, application/javascript, encoding gzip)
+  INFO Adding web app file: ../dist/my_app/styles.42da88a97f9b7241.css.gz as app/styles.42da88a97f9b7241.css (size 23125, text/css, encoding gzip)
+  INFO Adding web app file: ../dist/my_app/runtime.f7d50caa802bfcbd.js.gz as app/runtime.f7d50caa802bfcbd.js (size 669, application/javascript, encoding gzip)
+
+Navigating browser to ``http://<node_name>.local/app/index.html`` or ``http://<node_name>.local/app/`` or ``http://<node_name>.local/app`` will
+open the application.
+
 
 See Also
 --------


### PR DESCRIPTION
## Description:

Document configuration for serving inlined (embedded) static files from flash in `web_server` component.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#3317

## Checklist:

  - [X] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook. - no link needed
