### PR TITLE
Allow to set user defined characters on LCD

### DIFF
--- a/components/display/lcd_display.rst
+++ b/components/display/lcd_display.rst
@@ -203,6 +203,29 @@ turns off 90 seconds after the last activation of the sensor.
             - lambda: |-
                 id(mydisplay).no_backlight();
 
+User Defined Characters
+-----------------------
+
+The LCD display has the possibility to define up to eight user defined characters occupying the characters
+``0`` to ``7`` and mirrored at ``8`` to ``15`` (i.e. ``\x08`` can be used instead of the ``\0`` that can
+be problematic in strings). Each character has eight lines of five bits, with the first line on the top
+and the most significant bit on the left, meaning that ``0x10`` followed by six zeros and a ``0x01`` defines
+a dot at the upper left and lower right of the character.
+
+.. code-block:: yaml
+
+    display:
+      - platform: lcd_pcf8574
+        id: mydisplay
+        # ...
+        user_characters:
+          - position: 0
+            data: [ 0x00, 0x0a, 0x00, 0x04, 0x04, 0x11, 0x0e, 0x00 ]
+          - position: 7
+            data: [ 0x00, 0x0a, 0x00, 0x04, 0x04, 0x00, 0x0e, 0x11 ]
+        lambda: |-
+          it.print("Hello, world \x08 \x07!");
+
 See Also
 --------
 

--- a/components/display/lcd_display.rst
+++ b/components/display/lcd_display.rst
@@ -209,8 +209,8 @@ User Defined Characters
 The LCD display has the possibility to define up to eight user defined characters occupying the characters
 ``0`` to ``7`` and mirrored at ``8`` to ``15`` (i.e. ``\x08`` can be used instead of the ``\0`` that can
 be problematic in strings). Each character has eight lines of five bits, with the first line on the top
-and the most significant bit on the left, meaning that ``0x10`` followed by six zeros and a ``0x01`` defines
-a dot at the upper left and lower right of the character.
+and the most significant bit on the left, meaning that ``0b10000`` followed by six zeros and a ``0b00001``
+defines a dot at the upper left and lower right of the character.
 
 .. code-block:: yaml
 
@@ -220,9 +220,25 @@ a dot at the upper left and lower right of the character.
         # ...
         user_characters:
           - position: 0
-            data: [ 0x00, 0x0a, 0x00, 0x04, 0x04, 0x11, 0x0e, 0x00 ]
+            data:
+              - 0b00000
+              - 0b01010
+              - 0b00000
+              - 0b00100
+              - 0b00100
+              - 0b10001
+              - 0b01110
+              - 0b00000
           - position: 7
-            data: [ 0x00, 0x0a, 0x00, 0x04, 0x04, 0x00, 0x0e, 0x11 ]
+            data:
+              - 0b00000
+              - 0b01010
+              - 0b00000
+              - 0b00100
+              - 0b00100
+              - 0b00000
+              - 0b01110
+              - 0b10001
         lambda: |-
           it.print("Hello, world \x08 \x07!");
 


### PR DESCRIPTION
## Description:

The LCD displays driven by lcd_base support the definition of user defined characters. This PR documents the code allowing the user to use this feature.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#3322

## Checklist:

  - [X] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
