### PR TITLE
Update mcp3008 to fix wrong component description

### DIFF
--- a/components/sensor/mcp3008.rst
+++ b/components/sensor/mcp3008.rst
@@ -1,5 +1,5 @@
 MCP3008 8-Channel 10-Bit A/D Converter
-====================
+======================================
 
 .. seo::
     :description: Instructions for setting up MCP3008 10 Bit Analog to Digital Converter in ESPHome.

--- a/components/sensor/mcp3008.rst
+++ b/components/sensor/mcp3008.rst
@@ -1,4 +1,4 @@
-MCP3008 I/O Expander
+MCP3008 8-Channel 10-Bit A/D Converter
 ====================
 
 .. seo::


### PR DESCRIPTION
This chip is an AD converter, not an I/O Expander

## Description:

This is a small PR to fix wrong component description.

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
