### PR TITLE
adding documentation of newly added web_api turn_on option for light: color_brightness, currently pending in pull request 3325 of esphome

### DIFF
--- a/web-api/index.rst
+++ b/web-api/index.rst
@@ -171,6 +171,7 @@ creating a POST request at ``/light/<id>/turn_on?brightness=128&transition=2`` w
 ``turn_on`` optional URL parameters:
 
 -  **brightness**: The brightness of the light, from 0 to 255.
+-  **color_brightness**: The brightness of the RGB channels, from 0 to 255. Does not affect the white channel.
 -  **r**: The red color channel of the light, from 0 to 255.
 -  **g**: The green color channel of the light, from 0 to 255.
 -  **b**: The blue color channel of the light, from 0 to 255.


### PR DESCRIPTION
## Description:
Adding documentation of newly added web_api turn_on option for light: color_brightness, currently pending in pull request 3325 of esphome

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#3325

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
