### PR TITLE
Add border-radius to images + dropshadow to tables

### DIFF
--- a/_static/custom.css
+++ b/_static/custom.css
@@ -20,17 +20,17 @@ div.sphinxsidebar {
 
 img.component-image {
   border: none;
-  vertical-align: middle;
   display: block;
   margin-left: auto;
   margin-right: auto;
-  width: 100%;
   height: 85px;
   object-fit: contain;
+  border-radius: 10px;
 }
 
 table.docutils {
   width: 100%;
+  box-shadow: 4px 4px 8px -4px #00000075;
 }
 
 .blink-tag {


### PR DESCRIPTION
## Description:

The tables always feel "hacky" too me and I realized big portion of that is the harsh inlayed pictures of boards, sensors, ...

I think we can somewhat mitigate that with rounded borders plus giving the table a more visible dropshadow (in fact I copied the one over that is used on the guide cards on the initial page).

![image](https://user-images.githubusercontent.com/114137/160891905-6ecf769a-1c22-4f89-9fec-b7abc16de216.png)

Giving the tables itself also slightly rounded corners might help even further, but I did not want to change too much in one PR.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [X] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
