### PR TITLE
Added note on WAK signal for CCS811

### DIFF
--- a/components/sensor/ccs811.rst
+++ b/components/sensor/ccs811.rst
@@ -8,6 +8,12 @@ CCS811 CO_2 and Volatile Organic Compound Sensor
 The ``ccs811`` sensor platform allows you to use CCS811 CO_2 and volatile organic compound sensors
 (`Adafruit`_) with ESPHome.
 
+.. note::
+
+    Most CCS811 modules require the WAK pin to be pulled low to wake up the sensor, as outlined in the data sheets.  
+    Outside low-power scenarios, connecting WAK to ground is the recommended configuration. For low power installations, 
+    pulling WAK low should happen in software prior to taking the measures.
+    
 .. figure:: images/ccs811-full.jpg
     :align: center
     :width: 50.0%


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes #2331 - update to CCS811 documentation to hint on the usual need to ground the WAK pin

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
