### PR TITLE
Add newer HomeAssistant actions to list of all actions

### DIFF
--- a/guides/automations.rst
+++ b/guides/automations.rst
@@ -350,8 +350,8 @@ All Actions
 - :ref:`script.execute <script-execute_action>` / :ref:`script.stop <script-stop_action>` / :ref:`script.wait <script-wait_action>`
 - :ref:`logger.log <logger-log_action>`
 - :ref:`homeassistant.service <api-homeassistant_service_action>`
-- :ref:`homeassistant.event <homeassistant_event_action>`
-- :ref:`homeassistant.tag_scanned <homeassistant_tag_scanned_action>`
+- :ref:`homeassistant.event <api-homeassistant_event_action>`
+- :ref:`homeassistant.tag_scanned <api-homeassistant_tag_scanned_action>`
 - :ref:`mqtt.publish <mqtt-publish_action>` / :ref:`mqtt.publish_json <mqtt-publish_json_action>`
 - :ref:`switch.toggle <switch-toggle_action>` / :ref:`switch.turn_off <switch-turn_off_action>` / :ref:`switch.turn_on <switch-turn_on_action>`
 - :ref:`light.toggle <light-toggle_action>` / :ref:`light.turn_off <light-turn_off_action>` / :ref:`light.turn_on <light-turn_on_action>`

--- a/guides/automations.rst
+++ b/guides/automations.rst
@@ -350,8 +350,8 @@ All Actions
 - :ref:`script.execute <script-execute_action>` / :ref:`script.stop <script-stop_action>` / :ref:`script.wait <script-wait_action>`
 - :ref:`logger.log <logger-log_action>`
 - :ref:`homeassistant.service <api-homeassistant_service_action>`
-- :ref:`homeassistant.event <homeassistant-event-action>`
-- :ref:`homeassistant.tag_scanned <homeassistant-tag-scanned-action>`
+- :ref:`homeassistant.event <homeassistant_event_action>`
+- :ref:`homeassistant.tag_scanned <homeassistant_tag_scanned_action>`
 - :ref:`mqtt.publish <mqtt-publish_action>` / :ref:`mqtt.publish_json <mqtt-publish_json_action>`
 - :ref:`switch.toggle <switch-toggle_action>` / :ref:`switch.turn_off <switch-turn_off_action>` / :ref:`switch.turn_on <switch-turn_on_action>`
 - :ref:`light.toggle <light-toggle_action>` / :ref:`light.turn_off <light-turn_off_action>` / :ref:`light.turn_on <light-turn_on_action>`

--- a/guides/automations.rst
+++ b/guides/automations.rst
@@ -350,6 +350,8 @@ All Actions
 - :ref:`script.execute <script-execute_action>` / :ref:`script.stop <script-stop_action>` / :ref:`script.wait <script-wait_action>`
 - :ref:`logger.log <logger-log_action>`
 - :ref:`homeassistant.service <api-homeassistant_service_action>`
+- :ref:`homeassistant.event <homeassistant-event-action>`
+- :ref:`homeassistant.tag_scanned <homeassistant-tag-scanned-action>`
 - :ref:`mqtt.publish <mqtt-publish_action>` / :ref:`mqtt.publish_json <mqtt-publish_json_action>`
 - :ref:`switch.toggle <switch-toggle_action>` / :ref:`switch.turn_off <switch-turn_off_action>` / :ref:`switch.turn_on <switch-turn_on_action>`
 - :ref:`light.toggle <light-toggle_action>` / :ref:`light.turn_off <light-turn_off_action>` / :ref:`light.turn_on <light-turn_on_action>`


### PR DESCRIPTION
## Description:
The `homeassistant.event` and `homeassistant.tag_scanned` actions are missing from this list of all actions that are available. See https://esphome.io/components/api.html for more info about these actions.

## Checklist:

  - [X] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [X] Link added in `/index.rst` when creating new documents for new components or cookbook.
