### PR TITLE
Fixing subnet mask

### DIFF
--- a/components/wifi.rst
+++ b/components/wifi.rst
@@ -24,7 +24,7 @@ dramatically improve connection times.
       manual_ip:
         static_ip: 10.0.0.42
         gateway: 10.0.0.1
-        subnet: 255.255.255.0
+        subnet: 255.0.0.0
 
 .. code-block:: yaml
 

--- a/components/wifi.rst
+++ b/components/wifi.rst
@@ -22,9 +22,9 @@ dramatically improve connection times.
 
       # Optional manual IP
       manual_ip:
-        static_ip: 10.0.0.42
-        gateway: 10.0.0.1
-        subnet: 255.0.0.0
+        static_ip: 192.168.0.123
+        gateway: 192.168.0.1
+        subnet: 255.255.255.0
 
 .. code-block:: yaml
 


### PR DESCRIPTION
The subnet mask provided in the example is not compatible with the IPs provided.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
