### PR TITLE
Add MCP3208 to MCP3204 integration

### DIFF
--- a/components/sensor/mcp3204.rst
+++ b/components/sensor/mcp3204.rst
@@ -1,14 +1,15 @@
-MCP3204 4-Channel 12-Bit A/D Converter
-======================================
+MCP3204 & MCP3208 12-Bit A/D Converters
+=======================================
 
 .. seo::
-    :description: Instructions for setting up MCP3204 12-Bit Analog to Digital Converter in ESPHome.
-    :keywords: MCP3204
+    :description: Instructions for setting up MCP3204 & MCP3208 12-Bit Analog to Digital Converter in ESPHome.
+    :keywords: MCP3204 MCP3208
     :image: mcp3204.jpg
 
-The Microchip Technology Inc. MCP3204
+The Microchip Technology Inc. MCP3204 & MCP3208
 devices are successive approximation 12-bit Analog-to-Digital (A/D) converters with on-board sample and
-hold circuitry.
+hold circuitry. This integration is common for both device types.
+configure both devices as MCP3204 and observe the maximum number of channels as per variant used.
 
 .. figure:: images/mcp3204.jpg
     :align: center
@@ -19,17 +20,18 @@ hold circuitry.
 Component/Hub
 -------------
 
-The MCP3204 component allows you to use MCP3204 4-Channel 12-Bit A/D Converter
+The MCP3204 component allows you to use MCP3204 or MCP3208 12-Bit A/D Converter
 (`datasheet <https://ww1.microchip.com/downloads/en/DeviceDoc/21298e.pdf>`__) in ESPHome.
+The MCP3204 is a 4-channel and MCP3208 is an 8-channel device.
 It uses the :ref:`SPI Bus <spi>` for communication.
 
-Once configured, you can use any of the 4 pins as
+Once configured, you can use any of the 4 or 8 pins (depending on device variant) as
 sensors for your projects.
 
 Each pin will respond with a voltage calculated off of the ``reference_voltage`` (default is 3.3V).
 It calculates the voltage by multiplying the ``reference_voltage * value`` on the pin (basically the percentage of VREF)
 
-Most configurations will set the ``reference_voltage`` = VREF (pin 13 on the chip)
+Most configurations will set the ``reference_voltage`` = VREF pin
 
 .. code-block:: yaml
 
@@ -47,6 +49,12 @@ Most configurations will set the ``reference_voltage`` = VREF (pin 13 on the chi
         id: solar_voltage
         number: 0                     # MCP3204 pin number
 
+    # In case MCP3208 is used. you can specify pin number > 4
+      - platform: mcp3204             # Attached to pin 7 of the MCP3208.
+        update_interval: 1s
+        id: supply_voltage
+        number: 7                     # MCP3208 pin number
+
 
 Configuration variables:
 ************************
@@ -59,8 +67,8 @@ Configuration variables:
 Sensor
 ------
 
-The ``mcp3204`` sensor allows you to use your MCP3204 12-Bit A/D Converter sensors with ESPHome.
-First, setup a :ref:`MCP3204 Hub <mcp3204-component>` for your MCP3204 sensor and then use this
+The ``mcp3204`` sensor allows you to use your MCP3204 or MCP3208 12-Bit A/D Converter sensors with ESPHome.
+First, setup a :ref:`MCP3204 Hub <mcp3204-component>` for your MCP3204/8 sensor and then use this
 sensor platform to create individual sensors that will report the voltage to Home Assistant.
 
 Configuration variables:


### PR DESCRIPTION
## Description:

Both devices are a variant covered in a common datasheet. The only difference is the number of channels. This change attempts to update the documentation to explain this.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#3332

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
