### PR TITLE
Updating the ST7789 docs page to show limitation

### DIFF
--- a/components/display/st7789v.rst
+++ b/components/display/st7789v.rst
@@ -16,9 +16,8 @@ ST7789V (`datasheet <https://github.com/Xinyuan-LilyGO/TTGO-T-Display>`__,
 displays with ESPHome. Note that this component utilizes the 4-Wire :ref:`SPI bus <spi>`; the physical
 connection is already in place on the TTGO T-Display module as shown below.
 
-  | :exclamation:  Currently this only supports 135x240 pixel displays.
-  Other displays will not format and display correctly (e.g. 240x320, 240x240, etc.).
-  
+.. note::
+    Currently this only supports 135x240 pixel ST7789V displays. Other sizes (e.g. 240x320, 240x240) are not supported.
 
 .. figure:: images/st7789v-full.jpg
     :align: center

--- a/components/display/st7789v.rst
+++ b/components/display/st7789v.rst
@@ -16,6 +16,10 @@ ST7789V (`datasheet <https://github.com/Xinyuan-LilyGO/TTGO-T-Display>`__,
 displays with ESPHome. Note that this component utilizes the 4-Wire :ref:`SPI bus <spi>`; the physical
 connection is already in place on the TTGO T-Display module as shown below.
 
+  | :exclamation:  Currently this only supports 135x240 pixel displays.
+  Other displays will not format and display correctly (e.g. 240x320, 240x240, etc.).
+
+
 .. figure:: images/st7789v-full.jpg
     :align: center
     :width: 75.0%

--- a/components/display/st7789v.rst
+++ b/components/display/st7789v.rst
@@ -17,6 +17,7 @@ displays with ESPHome. Note that this component utilizes the 4-Wire :ref:`SPI bu
 connection is already in place on the TTGO T-Display module as shown below.
 
 .. note::
+
     Currently this only supports 135x240 pixel ST7789V displays. Other sizes (e.g. 240x320, 240x240) are not supported.
 
 .. figure:: images/st7789v-full.jpg

--- a/components/display/st7789v.rst
+++ b/components/display/st7789v.rst
@@ -18,6 +18,7 @@ connection is already in place on the TTGO T-Display module as shown below.
 
   | :exclamation:  Currently this only supports 135x240 pixel displays.
   Other displays will not format and display correctly (e.g. 240x320, 240x240, etc.).
+  
 
 .. figure:: images/st7789v-full.jpg
     :align: center

--- a/components/display/st7789v.rst
+++ b/components/display/st7789v.rst
@@ -19,7 +19,6 @@ connection is already in place on the TTGO T-Display module as shown below.
   | :exclamation:  Currently this only supports 135x240 pixel displays.
   Other displays will not format and display correctly (e.g. 240x320, 240x240, etc.).
 
-
 .. figure:: images/st7789v-full.jpg
     :align: center
     :width: 75.0%


### PR DESCRIPTION
## Description:

Added text to let users know that this platform only supports 135x240 pixel displays correctly. It does not work for other dimension displays because it is hardcoded. A pull exists to fix this, but has not yet been included. https://github.com/fraxinas/esphome/tree/fix_st7789v

Looking to prevent other users from assuming and purchasing modules that will not work correctly with ESPHome.

**More info here:** [st7789v Display Resolution Hardcoded To 135x240](https://github.com/esphome/issues/issues/1335)

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
