### PR TITLE
Implements documentation for esphome pull request #3352

### DIFF
--- a/components/number/index.rst
+++ b/components/number/index.rst
@@ -164,6 +164,41 @@ Configuration variables:
 - **value** (**Required**, float, :ref:`templatable <config-templatable>`):
   The value to set the number to.
 
+.. _number-increment_action:
+
+``number.increment`` Action
+***************************
+
+This is an :ref:`Action <config-action>` for incrementing a number state.
+
+.. code-block:: yaml
+
+    - number.increment:
+        id: my_number
+        value: -10
+
+Configuration variables:
+
+- **id** (**Required**, :ref:`config-id`): The ID of the number to set.
+- **value** (**Required**, float, :ref:`templatable <config-templatable>`):
+  The value to add to the number.
+
+.. _number-toggle_action:
+
+``number.toggle`` Action
+************************
+
+This is an :ref:`Action <config-action>` for toggling a number state. It requires that both min_value and max_value of the number are defined. If the current value is closer to min_value, the number will be set to max_value. If the current value is closer to max_value, the number will be set to min_valie.
+
+.. code-block:: yaml
+
+    - number.toggle:
+        id: my_number
+
+Configuration variables:
+
+- **id** (**Required**, :ref:`config-id`): The ID of the number to set.
+
 .. _number-lambda_calls:
 
 lambda calls
@@ -179,6 +214,8 @@ advanced stuff (see the full API Reference for more info).
       // Within lambda, push a value of 42
       auto call = id(my_number).make_call();
       call.set_value(42);
+      // call.set_increment(-10); // would decrement by 10
+      // call.set_toggle(true); // would toggle the number between min and max value
       call.perform();
 
 - ``.state``: Retrieve the current value of the number. Is ``NAN`` if no value has been read or set.

--- a/web-api/index.rst
+++ b/web-api/index.rst
@@ -291,9 +291,19 @@ a GET request to ``/number/desired_delay`` could yield this payload:
     }
 
 POST requests on the other hand allow setting the number, the available
-method is ``set``. The following parameter can be used:
+methods are ``set``, ``increment`` and ``toggle``. The following parameter can be used with ``set``:
 
 -  **value**: The value you want to set the number to. The value must be within the
    minimum and maximum range of the number otherwise it will be ignored.
 
 For example POST ``/number/desired_delay/set?value=24`` will set the number to 24.
+
+The following parameters can be used with ``increment``:
+
+-  **value**: The value you want to add to the number, can be negative. If the addition results in a value outside of the range of the number, it will be clamped to the minimum or maximum value of the range.
+
+For example POST ``/number/desired_delay/increment?value=-10`` will decrement the number by 10.
+
+The method ``toggle`` does not have any parameters. If the current value of number is closer to the minimum of the range, then the number will be set to the maximum value of the range. If the current value of number is closer to the maximum of the range, then the number will be set to the minimum of the range. Note, that if minimum and maximum of the range are not defined, then the method ``toggle`` will have no effect.
+
+For example POST ``/number/desired_delay/toggle`` would set the number to either min_value or max_value (if both are defined).


### PR DESCRIPTION
Replaces pull request #1997 which was referenced to `current` instead of `next`

## Description:

Implements documentation for esphome pull request #3352.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#3352

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
