### PR TITLE
Fix typo in honeywellabp.rst

### DIFF
--- a/components/sensor/honeywellabp.rst
+++ b/components/sensor/honeywellabp.rst
@@ -42,7 +42,7 @@ the measurement range and ``unit_of_measurement`` to the appropriate unit for yo
 - **pressure** (*Optional*): The information for the pressure sensor.
 
   - **name** (**Required**, string): The name for the pressure sensor.
-  - **min_pressure** (**Required**, int or float): Minumim pressure for the pressure sensor, default unit ``psi``.
+  - **min_pressure** (**Required**, int or float): Minimum pressure for the pressure sensor, default unit ``psi``.
   - **max_pressure** (**Required**, int or float): Maximum pressure for the pressure sensor, default unit ``psi``.
   - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.
   - All other options from :ref:`Sensor <config-sensor>`.


### PR DESCRIPTION
## Description:
1 word typo 

**Related issue (if applicable):** fixes #3329 

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
