### PR TITLE
Add docs for select has_option(...) and has_index(...)

### DIFF
--- a/components/select/index.rst
+++ b/components/select/index.rst
@@ -282,7 +282,7 @@ advanced stuff (see the full API Reference for more info).
       auto size = id(my_select).size();
       ESP_LOGI("main", "Select has %d options", size);
 
-- ``.index_of(<option name>)``: Retrieve the index offset for an option value.
+- ``.index_of(<option value>)``: Retrieve the index offset for an option value.
 
   .. code-block:: cpp
 
@@ -315,6 +315,24 @@ advanced stuff (see the full API Reference for more info).
         ESP_LOGI("main", "Option at %d is: %s", index, value);
       } else {
         ESP_LOGE("main", "Index %d does not exist", index);
+      }
+
+- ``.has_option(<option value>)``: Check if the select contains the given option value.
+
+  .. code-block:: cpp
+
+      auto option = "Happy";
+      if (id(my_select).has_option(option)) {
+        ESP_LOGI("main", "Select has option '%s'", option);
+      }
+
+- ``.has_index(<index offset>)``: Check if the select contains an option value for the given index offset.
+
+  .. code-block:: cpp
+
+      auto index = 3;
+      if (id(my_select).has_index(index)) {
+        ESP_LOGI("main", "Select has index offset %d", index);
       }
 
 See Also


### PR DESCRIPTION
## Description:

Documentation of new methods `Select::has_option(...)` and `Select::has_index(...)`.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#3457

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
