### PR TITLE
Add notes about Midea MAP14HS1TBL

### DIFF
--- a/components/climate/climate_ir.rst
+++ b/components/climate/climate_ir.rst
@@ -174,6 +174,10 @@ Configuration variables:
         sensor: room_temperature
         use_fahrenheit: true
 
+.. note::
+
+    - See :ref:`Toshiba<toshiba>` below if you are looking for compatibility with Midea model MAP14HS1TBL or similar.
+
 
 .. _climate_ir_lg:
 
@@ -232,6 +236,9 @@ Configuration variables:
       ``update_interval`` must be less than seven minutes or the ``RAC-PT1411HWRU`` will revert to using its own
       internal temperature sensor; a value of 30 seconds seems to work well. See :doc:`/components/sensor/index`
       for more information.
+    
+    - This climate IR component is also known to work with Midea model MAP14HS1TBL and may work with other similar
+      models, as well. (Midea acquired Toshiba's product line and re-branded it.)
 
 
 .. _whirlpool:


### PR DESCRIPTION
## Description:

Adds a note in Climate IR about compatibility with Midea MAP14HS1TBL.

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
