### PR TITLE
Update Inkbird TH1 docs to show support for TH2 sensors

### DIFF
--- a/components/sensor/inkbird_ibsth1_mini.rst
+++ b/components/sensor/inkbird_ibsth1_mini.rst
@@ -1,21 +1,25 @@
-Inkbird IBS-TH1 and IBS-TH1 Mini BLE Sensor
-===========================================
+Inkbird IBS-TH1, IBS-TH1 Mini, and IBS-TH2 BLE Sensor
+=====================================================
 
 .. seo::
-    :description: Instructions for setting up Inkbird IBS-TH1 Bluetooth-based temperature and humidity sensors in ESPHome.
+    :description: Instructions for setting up Inkbird IBS-TH1/TH2 Bluetooth-based temperature and humidity sensors in ESPHome.
     :image: inkbird_isbth1_mini.jpg
-    :keywords: Inkbird, BLE, Bluetooth, IBS-TH1
+    :keywords: Inkbird, BLE, Bluetooth, IBS-TH1, IBS-TH2
 
-The ``inkbird_ibsth1_mini`` sensor platform lets you track the output of Inkbird IBS-TH1 and IBS-TH1 Mini Bluetooth
+The ``inkbird_ibsth1_mini`` sensor platform lets you track the output of Inkbird IBS-TH1, IBS-TH1 Mini, and IBS-TH2 Bluetooth
 Low Energy devices using the :doc:`/components/esp32_ble_tracker`. This component will track the
 temperature, external temperature (non mini only), humidity and the battery level of the IBS-TH1 device every time the
 sensor sends out a BLE broadcast. Note that contrary to other implementations, ESPHome can track as
-many IBS-TH1 devices at once as you want.
+many IBS-TH1/TH2 devices at once as you want.
 
 .. note::
 
     If an external temperature sensor is connected to the IBS-TH1, measurement from the internal sensor is not sent.
     Only one sensor will work at a time.
+
+.. note::
+
+    The external temperature sensor is not supported on the IBS-TH1 Mini or IBS-TH2
 
 .. figure:: images/inkbird_isbth1_mini-full.jpg
     :align: center
@@ -76,7 +80,7 @@ Configuration variables:
 Setting Up Devices
 ------------------
 
-To set up Inkbird IBS-TH1 devices you first need to find their MAC Address so that ESPHome can
+To set up Inkbird IBS-TH1/TH2 devices you first need to find their MAC Address so that ESPHome can
 identify them. So first, create a simple configuration without any ``inkbird_ibsth1_mini`` entries
 like so:
 
@@ -84,7 +88,7 @@ like so:
 
     esp32_ble_tracker:
 
-After uploading the ESP32 will immediately try to scan for BLE devices such as the Inkbird IBS-TH1. 
+After uploading the ESP32 will immediately try to scan for BLE devices such as the Inkbird IBS-TH1/TH2. 
 When it detects these sensors, it will automatically parse the BLE message print a
 message like this one:
 
@@ -95,7 +99,7 @@ message like this one:
     [13:36:43][D][esp32_ble_tracker:567]:   Name: 'sps'
 
 Note that it can sometimes take some time for the first BLE broadcast to be received. Please note that address type
-should say 'PUBLIC' and the device name should be 'sps', this is how you find the Inkbird IBS-TH1 among all the 
+should say 'PUBLIC' and the device name should be 'sps', this is how you find the Inkbird IBS-TH1/TH2 among all the 
 other devices.
 
 Then just copy the address (``38:81:D7:0A:9C:11``) into a new ``sensor.inkbird_ibsth1_mini`` platform
@@ -103,7 +107,7 @@ entry like in the configuration example at the top.
 
 .. note::
 
-    The ESPHome Inkbird IBS-TH1 integration listens passively to packets the device sends by itself.
+    The ESPHome Inkbird IBS-TH1/TH2 integration listens passively to packets the device sends by itself.
     ESPHome therefore has no impact on the battery life of the device.
 
 See Also


### PR DESCRIPTION
## Description:
The current Inkbird TH1 component appears to support TH2 sensors as well.  This should be reflected in the documentation.  I am running this on my own setup with success.


## Checklist:

  - [X] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [X] Link added in `/index.rst` when creating new documents for new components or cookbook.
