### PR TITLE
Docs for Insignia AC component

### DIFF
--- a/components/climate/climate_ir.rst
+++ b/components/climate/climate_ir.rst
@@ -34,6 +34,8 @@ submit a feature request (see FAQ).
 | Hitachi                               | ``hitachi_ac344``   | yes                  |
 |                                       | ``hitachi_ac424``   |                      |
 +---------------------------------------+---------------------+----------------------+
+| :ref:`Insignia<insignia>`             | ``insignia``        | no                   |
++---------------------------------------+---------------------+----------------------+
 | :ref:`LG<climate_ir_lg>`              | ``climate_ir_lg``   | yes                  |
 +---------------------------------------+---------------------+----------------------+
 | Midea                                 | ``midea_ir``        | yes                  |
@@ -152,6 +154,72 @@ IR receiver.
       - platform: coolix
         name: "Living Room AC"
         receiver_id: rcvr
+
+.. _insignia:
+
+Insignia Portable AC
+------------------
+
+The ``insignia`` platform supports the Insignia NS-AC08PWH1 portable air conditioner. It's possible other makes and models uses these codes, but haven't been tested.
+
+Refer to https://github.com/andrewmv/ac-control-stuff#device-insignia-ns-ac08pwh1 for more information about the device and the IR codes it uses.
+
+This AC unit supports a "Follow Me" feature, in which the factory remote control regularly samples the air temperature, and transmits this to the air conditioner. The AC unit then uses this transmitted value as the room temperature, and ignores its own sensor.
+
+By specifying a ``sensor`` and a ``follow_me`` switch in your configuration, this platform can emulate the Follow Me feature of the remote, and regularly send the sensor information to the air conditioner. Specify ``update_interval`` to control how frequently this happens. The default is every 1 minute, and should be adequate for most situations. Must be a value less than 7 minutes, otherwise the AC will conclude the remote control is out of range, disable Follow Me, and ignore subsequent temperature updates.
+
+This AC unit supports an LED toggle feature, where all the LEDs on the unit are disabled. You can access this feature by specifying an ``led_switch``.
+
+.. note::
+
+    - The IR timing for this platform is very precise, and using an ESP8266 as the target platform doesn't work reliably. An ESP32 is recommended.
+
+Additional configuration may be specified for this platform:
+
+- **update_interval** (*Optional*, :ref:`config-time`): The interval with which to transmit the value of the sensor when Follow Me is enabled.
+- **follow_me_switch** (*Optional*, :ref:`config-id`): The ID of a switch component (for example, a template switch) which will be used to enable / disable the Follow Me feature. If not provided, Follow Me will be disabled. If provided, sensor must also be provided.
+- **led_switch** (*Optional*, :ref:`config-id`): The ID of a switch component (for example, a template switch) which will be used to enable / disable the LEDs on the AC unit. If not provided, there will be no way to control this feature without using the factory remote. Using ``assumed_state: true`` is advised, since the command sent by this switch is not idempotent.
+
+.. code-block:: yaml
+
+    # Example configuration entry
+    climate:
+      - platform: insignia
+        name: Insignia AC
+        update_interval: 60s
+        sensor: temperature_sensor
+        follow_me_switch: insignia_follow_me_switch
+        led_switch: insignia_led_switch
+        supports_heat: false
+
+    remote_transmitter:
+      pin: 
+        number: GPIO23
+        inverted: false
+      carrier_duty_percent: 50%
+
+    sensor:
+      platform: dht 
+      model: DHT22
+      pin: GPIO22
+      temperature:
+        name: Temperature Sensor
+        id: temperature_sensor
+      humidity:
+        name: Humidity Sensor
+        id: humidity_sensor
+
+    switch:
+      - platform: template
+        name: Follow Me Switch
+        id: insignia_follow_me_switch
+        optimistic: true
+      - platform: template
+        name: Insignia LED Switch
+        id: insignia_led_switch
+        optimistic: true
+        assumed_state: true
+
 
 .. _midea_ir:
 

--- a/components/climate/climate_ir.rst
+++ b/components/climate/climate_ir.rst
@@ -158,7 +158,7 @@ IR receiver.
 .. _insignia:
 
 Insignia Portable AC
-------------------
+--------------------
 
 The ``insignia`` platform supports the Insignia NS-AC08PWH1 portable air conditioner. It's possible other makes and models uses these codes, but haven't been tested.
 


### PR DESCRIPTION
## Description:

Docs for proposed Insignia AC component. 

Replaces PR#2063, which was based on the wrong branch.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#3456

## Checklist:

  - [ X ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
