### PR TITLE
Add documentation describing new color pallet mode for ili9341 displays

### DIFF
--- a/components/display/ili9341.rst
+++ b/components/display/ili9341.rst
@@ -59,7 +59,11 @@ Configuration variables:
 - **auto_clear_enabled** (*Optional*, boolean): Whether to automatically clear the display in each loop (''true'', default),
   or to keep the existing display content (must overwrite explicitly, e.g., only on data change).
 - **pages** (*Optional*, list): Show pages instead of a single lambda. See :ref:`display-pages`.
-- **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
+- **id** (*Optional*, :ref:`confihttps://github.com/esphome/esphome.gitg-id`): Manually specify the ID used for code generation.
+- **color_palette** (*Optional*): The type of color pallet that will be used in the ESP's internal 8-bits-per pixel buffer.  This can be used to improve color depth quality of the image.  For example if you know that the display will only be showing grayscale images, the clarity of the display can be improved by targeting the available colors to monochrome only.  Options are:
+  
+  - ``NONE`` (default)
+  - ``GRAYSCALE``
 
 Configuration examples
 **********************

--- a/components/display/ili9341.rst
+++ b/components/display/ili9341.rst
@@ -59,7 +59,7 @@ Configuration variables:
 - **auto_clear_enabled** (*Optional*, boolean): Whether to automatically clear the display in each loop (''true'', default),
   or to keep the existing display content (must overwrite explicitly, e.g., only on data change).
 - **pages** (*Optional*, list): Show pages instead of a single lambda. See :ref:`display-pages`.
-- **id** (*Optional*, :ref:`confihttps://github.com/esphome/esphome.gitg-id`): Manually specify the ID used for code generation.
+- **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
 - **color_palette** (*Optional*): The type of color pallet that will be used in the ESP's internal 8-bits-per pixel buffer.  This can be used to improve color depth quality of the image.  For example if you know that the display will only be showing grayscale images, the clarity of the display can be improved by targeting the available colors to monochrome only.  Options are:
   
   - ``NONE`` (default)

--- a/components/display/ili9341.rst
+++ b/components/display/ili9341.rst
@@ -60,7 +60,7 @@ Configuration variables:
   or to keep the existing display content (must overwrite explicitly, e.g., only on data change).
 - **pages** (*Optional*, list): Show pages instead of a single lambda. See :ref:`display-pages`.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
-- **color_palette** (*Optional*): The type of color pallet that will be used in the ESP's internal 8-bits-per pixel buffer.  This can be used to improve color depth quality of the image.  For example if you know that the display will only be showing grayscale images, the clarity of the display can be improved by targeting the available colors to monochrome only.  Options are:
+- **color_palette** (*Optional*): The type of color pallet that will be used in the ESP's internal 8-bits-per-pixel buffer.  This can be used to improve color depth quality of the image.  For example if you know that the display will only be showing grayscale images, the clarity of the display can be improved by targeting the available colors to monochrome only.  Options are:
   
   - ``NONE`` (default)
   - ``GRAYSCALE``


### PR DESCRIPTION
## Description:
Add documentation describing new color pallet mode for ili9341 displays.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#2490

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
