### PR TITLE
format clean up 2022-05

### DIFF
--- a/components/number/index.rst
+++ b/components/number/index.rst
@@ -184,10 +184,10 @@ step size (default: 1).
 Configuration variables:
 
 - **id** (**Required**, :ref:`config-id`): The ID of the number component to update.
-- **cycle** (**Optional**, boolean): Whether or not to set the number to its minimum
+- **cycle** (*Optional*, boolean): Whether or not to set the number to its minimum
   value when the increment pushes the value beyond its maximum value. This will only
   work when the number component uses a minimum and maximum value.
-  Defaults to ``true``. 
+  Defaults to ``true``.
 
 .. _number-decrement_action:
 
@@ -209,10 +209,10 @@ step size (default: 1).
 Configuration variables:
 
 - **id** (**Required**, :ref:`config-id`): The ID of the number component to update.
-- **cycle** (**Optional**, boolean): Whether or not to set the number to its maximum
+- **cycle** (*Optional*, boolean): Whether or not to set the number to its maximum
   value when the decrement pushes the value below its minimum value. This will only
   work when the number component uses a minimum and maximum value.
-  Defaults to ``true``. 
+  Defaults to ``true``.
 
 .. _number-to-min_action:
 
@@ -286,7 +286,7 @@ Configuration variables:
   lambda for this field, then return one of the following enum values:
   ``NUMBER_OP_TO_MIN``, ``NUMBER_OP_TO_MAX``, ``NUMBER_OP_DECREMENT`` or
   ``NUMBER_OP_INCREMENT``.
-- **cycle** (**Optional**, bool, :ref:`templatable <config-templatable>`):
+- **cycle** (*Optional*, bool, :ref:`templatable <config-templatable>`):
   Can be used with ``DECREMENT`` or ``INCREMENT`` to specify whether or not to
   wrap around the value when respectively the minimum or maximum value of the
   number is exceeded.

--- a/components/select/index.rst
+++ b/components/select/index.rst
@@ -143,8 +143,8 @@ This is an :ref:`Action <config-action>` for selecting the next option in a sele
 Configuration variables:
 
 - **id** (**Required**, :ref:`config-id`): The ID of the select to set.
-- **cycle** (**Optional**, boolean): Whether or not to jump back to the first option
-  of the select when the last option is currently selected. Defaults to ``true``. 
+- **cycle** (*Optional*, boolean): Whether or not to jump back to the first option
+  of the select when the last option is currently selected. Defaults to ``true``.
 
 .. _select-previous_action:
 
@@ -166,8 +166,8 @@ a select component.
 Configuration variables:
 
 - **id** (**Required**, :ref:`config-id`): The ID of the select to set.
-- **cycle** (**Optional**, boolean): Whether or not to jump to the last option
-  of the select when the first option is currently selected. Defaults to ``true``. 
+- **cycle** (*Optional*, boolean): Whether or not to jump to the last option
+  of the select when the first option is currently selected. Defaults to ``true``.
 
 .. _select-first_action:
 
@@ -240,7 +240,7 @@ Configuration variables:
   ``NEXT`` (case insensitive). When writing a lambda for this field, then return
   one of the following enum values: ``SELECT_OP_FIRST``, ``SELECT_OP_LAST``,
   ``SELECT_OP_PREVIOUS`` or ``SELECT_OP_NEXT``.
-- **cycle** (**Optional**, bool, :ref:`templatable <config-templatable>`):
+- **cycle** (*Optional*, bool, :ref:`templatable <config-templatable>`):
   Can be used for options ``NEXT`` and ``PREVIOUS`` to specify whether or not to
   wrap around the options list when respectively the last or first option in
   the select is currently active.

--- a/components/sensor/scd4x.rst
+++ b/components/sensor/scd4x.rst
@@ -66,14 +66,14 @@ Configuration variables:
   is set.
 
 
-- **measurement_mode** (*Optional*): Set measurement mode for scd4x. 
+- **measurement_mode** (*Optional*): Set measurement mode for scd4x.
 
-  - **periodic** : The sensor takes a new measurement every 5 seconds. This is the default mode.
-  - **low_power_periodic**: The sensor takes a new measurement every 30 seconds. Make sure ``update_interval`` is at least 30 seconds.
-  - **single_shot**: A measurement is started in every update interval. A measurement takes 5 seconds. This mode is only available on scd41 and useful if low power consumption is required. 
+  - ``periodic``: The sensor takes a new measurement every 5 seconds. This is the default mode.
+  - ``low_power_periodic``: The sensor takes a new measurement every 30 seconds. Make sure ``update_interval`` is at least 30 seconds.
+  - ``single_shot``: A measurement is started in every update interval. A measurement takes 5 seconds. This mode is only available on scd41 and useful if low power consumption is required.
     The automatic self-calibration is optimized for single shot measurements performed every 5 minutes.
     To reduce noise levels, you can can perform several single shot measurements in a row and average the output values using a :ref:`sensor-filters`.
-  - **single_shot_rht_only**: A measurement is started in every update interval. A measurement takes 50 ms. Only humidity and temperature is measured. CO2 is reported as 0 ppm. This mode is only available on scd41 and useful if low power consumption is required. 
+  - ``single_shot_rht_only``: A measurement is started in every update interval. A measurement takes 50 ms. Only humidity and temperature is measured. CO2 is reported as 0 ppm. This mode is only available on scd41 and useful if low power consumption is required.
 
 
 - **ambient_pressure_compensation_source** (*Optional*, :ref:`config-id`): Set an external pressure sensor ID used for ambient pressure compensation.

--- a/components/sensor/sen5x.rst
+++ b/components/sensor/sen5x.rst
@@ -88,7 +88,7 @@ Configuration variables:
   - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in automation and lambdas.
   - All other options from :ref:`Sensor <config-sensor>`.
 
-- **auto_cleaning_interval** (Optional): Reads/Writes the interval in seconds of the periodic fan-cleaning.
+- **auto_cleaning_interval** (*Optional*): Reads/Writes the interval in seconds of the periodic fan-cleaning.
 
 - **temperature** (*Optional*): Temperature.Note only available with Sen54 or Sen55. The sensor will be ignored on unsupported models.
 
@@ -102,16 +102,16 @@ Configuration variables:
 
   - **name** (**Required**, string): The name of the sensor.
   - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
-  
+
   - **algorithm_tuning** (*Optional*): The VOC algorithm can be customized by tuning 6 different parameters. For more details see `Engineering Guidelines for SEN5x <https://sensirion.com/media/documents/25AB572C/61E961EA/Sensirion_Engineering_Guidelines_SEN5x.pdf>`__
 
-    - **index_offset** (*Optional*): VOC index representing typical (average) conditions. Allowed values are in range 1..250. The default value is 100. 
+    - **index_offset** (*Optional*): VOC index representing typical (average) conditions. Allowed values are in range 1..250. The default value is 100.
     - **learning_time_offset_hours** (*Optional*): Time constant to estimate the VOC algorithm offset from the history in hours. Past events will be forgotten after about twice the  learning time. Allowed values are in range 1..1000. The default value is 12 hour
-    - **learning_time_gain_hours** (*Optional*): Time constant to estimate the VOC algorithm gain from the history in hours. Past events will be forgotten after about twice the learning time. Allowed values are in range 1..1000. The default value is 12 hours. 
+    - **learning_time_gain_hours** (*Optional*): Time constant to estimate the VOC algorithm gain from the history in hours. Past events will be forgotten after about twice the learning time. Allowed values are in range 1..1000. The default value is 12 hours.
     - **gating_max_duration_minutes** (*Optional*): Maximum duration of gating in minutes (freeze of estimator during high VOC index signal). Zero disables the gating. Allowed values are in range 0..3000. The default value is 180 minutes
     - **std_initial** (*Optional*): Initial estimate for standard deviation. Lower value boosts events during initial learning period, but may result in larger device-todevice variations. Allowed values are in range 10..5000. The default value is 50.
-    - **gain_factor:** (*Optional*): Gain factor to amplify or to attenuate the VOC index output. Allowed values are in range 1..1000. The default value is 230.
-  
+    - **gain_factor** (*Optional*): Gain factor to amplify or to attenuate the VOC index output. Allowed values are in range 1..1000. The default value is 230.
+
   - All other options from :ref:`Sensor <config-sensor>`.
 
 - **nox** (*Optional*): NOx Index. Note: Only available with Sen54 or Sen55. The sensor will be ignored on unsupported models.
@@ -120,24 +120,24 @@ Configuration variables:
   - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
 
   - **algorithm_tuning** (*Optional*): The NOx algorithm can be customized by tuning 5 different parameters.For more details see `Engineering Guidelines for SEN5x <https://sensirion.com/media/documents/25AB572C/61E961EA/Sensirion_Engineering_Guidelines_SEN5x.pdf>`__
-  
-    - **index_offset** (*Optional*): NOx index representing typical (average) conditions. Allowed values are in range 1..250. The default value is 100. 
+
+    - **index_offset** (*Optional*): NOx index representing typical (average) conditions. Allowed values are in range 1..250. The default value is 100.
     - **learning_time_offset_hours** (*Optional*): Time constant to estimate the NOx algorithm offset from the history in hours. Past events will be forgotten after about twice the  learning time. Allowed values are in range 1..1000. The default value is 12 hour
-    - **learning_time_gain_hours** (*Optional*): Time constant to estimate the NOx algorithm gain from the history in hours. Past events will be forgotten after about twice the learning time. Allowed values are in range 1..1000. The default value is 12 hours. 
+    - **learning_time_gain_hours** (*Optional*): Time constant to estimate the NOx algorithm gain from the history in hours. Past events will be forgotten after about twice the learning time. Allowed values are in range 1..1000. The default value is 12 hours.
     - **gating_max_duration_minutes** (*Optional*): Maximum duration of gating in minutes (freeze of estimator during high NOx index signal). Zero disables the gating. Allowed values are in range 0..3000. The default value is 180 minutes
     - **std_initial** (*Optional*): The initial estimate for standard deviation parameter has no impact for NOx. This parameter is still in place for consistency reasons with the VOC tuning parameters command. This parameter must always be set to 50.
-    - **gain_factor:** (*Optional*)
+    - **gain_factor** (*Optional*): Gain factor to amplify or to attenuate the VOC index output. Allowed values are in range 1..1000. The default value is 230.
 
   - All other options from :ref:`Sensor <config-sensor>`.
 
 - **store_baseline** (*Optional*, boolean): Stores and retrieves the baseline VOC and NOx information for quicker startups. Defaults to ``true``
-- **temperature_compensation** (*Optional*): These parameters allow to compensate temperature effects of the design-in at customer side by applying a custom temperature offset to the ambient temperature. 
+- **temperature_compensation** (*Optional*): These parameters allow to compensate temperature effects of the design-in at customer side by applying a custom temperature offset to the ambient temperature.
 
-  The compensated ambient temperature is calculated as follows: 
+  The compensated ambient temperature is calculated as follows:
 
-      T_Ambient_Compensated = T_Ambient + (slope*T_Ambient) + offset 
+      T_Ambient_Compensated = T_Ambient + (slope*T_Ambient) + offset
 
-  Where slope and offset are the values set with this command, smoothed with the specified time constant. The time constant is how fast the slope and offset are applied. After the specified value in seconds, 63% of the new slope and offset are applied. 
+  Where slope and offset are the values set with this command, smoothed with the specified time constant. The time constant is how fast the slope and offset are applied. After the specified value in seconds, 63% of the new slope and offset are applied.
   More details about the tuning of these parameters are included in the application note `Temperature Acceleration and Compensation Instructions for SEN5x. <https://sensirion.com/media/documents/9B9DE2A7/61E957EB/Sensirion_Temperature_Acceleration_and_Compensation_Instructions_SEN.pdf>`__
 
 
@@ -146,9 +146,9 @@ Configuration variables:
   - **time_constant** (*Optional*): Time constant in seconds. Defaults to ``0``
 
 - **acceleration_mode** (*Optional*): Allowed value are ``low``, ``medium`` and ``high``. (default is ``low``)
-  
-  By default, the RH/T acceleration algorithm is optimized for a sensor which is positioned in free air. If the sensor is integrated into another device, the ambient RH/T output values might not be optimal due to different thermal behavior. 
-  This parameter can be used to adapt the RH/T acceleration behavior for the actual use-case, leading in an improvement of the ambient RH/T output accuracy. There is a limited set of different modes available. 
+
+  By default, the RH/T acceleration algorithm is optimized for a sensor which is positioned in free air. If the sensor is integrated into another device, the ambient RH/T output values might not be optimal due to different thermal behavior.
+  This parameter can be used to adapt the RH/T acceleration behavior for the actual use-case, leading in an improvement of the ambient RH/T output accuracy. There is a limited set of different modes available.
   Medium and high accelerations are particularly indicated for air quality monitors which are subjected to large temperature changes. Low acceleration is advised for stationary devices not subject to large variations in temperature
 
 - **address** (*Optional*, int): Manually specify the I²C address of the sensor.
@@ -177,12 +177,12 @@ Automatic Cleaning:
 
 When the module is in Measurement-Mode an automatic fan-cleaning procedure will be triggered periodically following a defined cleaning interval. This will accelerate the fan to maximum speed for 10 seconds to blow out the accumulated dust inside the fan.
 
-- Measurement values are not updated while the fan-cleaning is running. 
+- Measurement values are not updated while the fan-cleaning is running.
 - The cleaning interval is set to 604’800 seconds (i.e., 168 hours or 1 week).
-- The interval can be configured using the Set Automatic Cleaning Interval command. 
-- Set the interval to 0 to disable the automatic cleaning. 
-- A sensor reset, resets the cleaning interval to its default value 
-- If the sensor is switched off, the time counter is reset to 0. Make sure to trigger a cleaning cycle at least every week if the sensor is switched off and on periodically (e.g., once per day). 
+- The interval can be configured using the Set Automatic Cleaning Interval command.
+- Set the interval to 0 to disable the automatic cleaning.
+- A sensor reset, resets the cleaning interval to its default value
+- If the sensor is switched off, the time counter is reset to 0. Make sure to trigger a cleaning cycle at least every week if the sensor is switched off and on periodically (e.g., once per day).
 - The cleaning procedure can also be started manually with the ``start_autoclean_fan`` Action
 
 The Sen5x sensor has an automatic fan-cleaning which will accelerate the built-in fan to maximum speed for 10 seconds in order to blow out the dust accumulated inside the fan.

--- a/components/sensor/sps30.rst
+++ b/components/sensor/sps30.rst
@@ -111,13 +111,13 @@ Configuration variables:
   - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in automation and lambdas.
   - All other options from :ref:`Sensor <config-sensor>`.
 
-- **pm_size** (*Optional*): Typical particle size in μm. 
+- **pm_size** (*Optional*): Typical particle size in μm.
 
   - **name** (**Required**, string): The name for this sensor.
   - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in automation and lambdas.
   - All other options from :ref:`Sensor <config-sensor>`.
 
-- **auto_cleaning_interval** (Optional): The interval in seconds of the periodic fan-cleaning.
+- **auto_cleaning_interval** (*Optional*): The interval in seconds of the periodic fan-cleaning.
 
 - **address** (*Optional*, int): Manually specify the I²C address of the sensor.
   Defaults to ``0x69``.


### PR DESCRIPTION
## Description:

Just clean up of formatting, mostly wrong back ticks, indentation, etc.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
