### PR TITLE
ac_dimmer: remove warning in header

### DIFF
--- a/components/output/ac_dimmer.rst
+++ b/components/output/ac_dimmer.rst
@@ -5,14 +5,6 @@ AC Dimmer Component
     :description: Instructions for setting up AC Dimmer integration in ESPHome.
     :image: ac_dimmer.svg
 
-.. warning::
-
-    This component has not been fully tested yet, if you are testing this component
-    please share your experience with the dimmer hardware and light model and
-    configuration here https://github.com/esphome/feature-requests/issues/278
-
-    Thanks!
-
 The ``ac_dimmer`` component allows you to connect a dimmable light or other load
 which supports phase control dimming to your ESPHome project.
 


### PR DESCRIPTION
Rationale: The thread linked is closed and locked + the linked PR is also closed and locked.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
