### PR TITLE
Update ethernet.rst

### DIFF
--- a/components/ethernet.rst
+++ b/components/ethernet.rst
@@ -74,6 +74,8 @@ Configuration variables:
 Configuration for wESP32 board
 ------------------------------
 
+**Release 7 and upwards of the wESP32 board does not have a LAN8720 chip. Until support for the replacement RTL8201 is included in esphome, the wESP board will not work with the below configuration.**
+
 .. code-block:: yaml
 
     ethernet:


### PR DESCRIPTION
wESP32 have apparently changed their chipset. See https://community.home-assistant.io/t/silicognition-wesp32-ethernet-support-crosslink-from-hardware/424775?u=nickrout

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
