### PR TITLE
Document BedJet clock methods

### DIFF
--- a/components/climate/bedjet.rst
+++ b/components/climate/bedjet.rst
@@ -59,6 +59,28 @@ From :ref:`lambdas <config-lambda>`, you can call methods to do some advanced st
             then:
             - lambda: |-
                 id(my_bedjet_fan).upgrade_firmware();
+- ``.send_local_time``: If `time_id` is set, attempt to sync the clock now.
+
+  .. code-block:: yaml
+
+      button:
+        - platform: template
+          name: "Sync Clock"
+          on_press:
+            then:
+            - lambda: |-
+                id(my_bedjet_fan).send_local_time();
+- ``.set_clock``: Set the BedJet clock to a specified time; works with or without a `time_id`.
+
+  .. code-block:: yaml
+
+      button:
+        - platform: template
+          name: "Set Clock to 10:10pm"
+          on_press:
+            then:
+            - lambda: |-
+                id(my_bedjet_fan).set_clock(22, 10);
 
 Known issues:
 -------------

--- a/components/climate/bedjet.rst
+++ b/components/climate/bedjet.rst
@@ -59,6 +59,7 @@ From :ref:`lambdas <config-lambda>`, you can call methods to do some advanced st
             then:
             - lambda: |-
                 id(my_bedjet_fan).upgrade_firmware();
+
 - ``.send_local_time``: If `time_id` is set, attempt to sync the clock now.
 
   .. code-block:: yaml

--- a/components/climate/bedjet.rst
+++ b/components/climate/bedjet.rst
@@ -70,6 +70,7 @@ From :ref:`lambdas <config-lambda>`, you can call methods to do some advanced st
             then:
             - lambda: |-
                 id(my_bedjet_fan).send_local_time();
+
 - ``.set_clock``: Set the BedJet clock to a specified time; works with or without a `time_id`.
 
   .. code-block:: yaml


### PR DESCRIPTION
## Description:

New public methods added in BedJet component, enabling use from lambdas.

**Related issue (if applicable):** Adds functionality called out in https://github.com/esphome/issues/issues/3307

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** https://github.com/esphome/esphome/pull/3503

## Checklist:

  - [X] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
