### PR TITLE
Prometheus: include internals

### DIFF
--- a/components/prometheus.rst
+++ b/components/prometheus.rst
@@ -27,6 +27,8 @@ Configuration variables:
 ------------------------
 
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
+- **include_internal** (*Optional*, boolean): Whether ``internal`` entities should be displayed on the
+  web interface. Defaults to ``false``.
 
 .. note::
 


### PR DESCRIPTION
## Description:

This adds documentation of the configuration option to allow the Prometheus component to also export internal components (like the web server already has).

**Related issue (if applicable):** fixes [<link to issue>](https://github.com/esphome/feature-requests/issues/1746)

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
