### PR TITLE
Update diy.rst

### DIFF
--- a/guides/diy.rst
+++ b/guides/diy.rst
@@ -87,6 +87,7 @@ Custom Components & Code
 - `ADEMCO/VISTA/Honeywell alarm system custom component <https://github.com/Dilbert66/esphome-vistaECP>`__ by :ghuser:`Dilbert66`
 - `Winsen ZE08-CH2O (Formaldehyde sensor) custom component <https://gist.github.com/cretep/f96606dc6a4eae0d85993d6085959220>`__ by :ghuser:`cretep`
 - `ZclMqttBridge custom component <https://github.com/HyperReap/zcl_mqtt_bridge>`__ by :ghuser:`HyperReap`
+- `Custom ESPHome for using XTronical's DAC WAV player <https://github.com/jn3va/ESPHomeXTronicalWAVPlayer>`__ by :ghuser:`jn3va`
 
 Sample Configurations
 ---------------------


### PR DESCRIPTION
Addition of example of custom component and code for using XTronical's WAV player XT_DAC_Audio from ESPHome.

## Description:
Added link

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
