### PR TITLE
Document new Bedjet `heat_mode` config

### DIFF
--- a/components/climate/bedjet.rst
+++ b/components/climate/bedjet.rst
@@ -41,6 +41,10 @@ Configuration variables:
 - **ble_client_id** (**Required**, :ref:`config-id`): The ID of the BLE Client.
 - **time_id** (*Optional*, :ref:`config-id`): The ID of a :ref:`Time Component <time>` which
   can be used to set the time on the BedJet device.
+- **heat_mode** (*Optional*, string): The primary heating mode to use for `HVACMode.HEAT`:
+  - ``"heat"`` (Default) - Setting ``hvac_mode=heat`` uses the BedJet "HEAT" mode.
+  - ``"extended"`` - Setting ``hvac_mode=heat`` uses BedJet "EXT HEAT" mode.
+  - Whichever is not selected will be made available as a custom preset.
 - All other options from :ref:`Climate <config-climate>`.
 
 lambda calls


### PR DESCRIPTION
## Description:

Add new `heat_mode` config documentation.

**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/3314

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** https://github.com/esphome/esphome/pull/3519

## Checklist:

  - [X] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
