### PR TITLE
Update sen5x.rst

### DIFF
--- a/components/sensor/sen5x.rst
+++ b/components/sensor/sen5x.rst
@@ -114,7 +114,7 @@ Configuration variables:
   
   - All other options from :ref:`Sensor <config-sensor>`.
 
-- **nox** (*Optional*): NOx Index. Note: Only available with Sen54 or Sen55. The sensor will be ignored on unsupported models.
+- **nox** (*Optional*): NOx Index. Note: Only available with Sen55. The sensor will be ignored on unsupported models.
 
   - **name** (**Required**, string): The name of the sensor.
   - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.


### PR DESCRIPTION
corrected availability of NOx sensor: NOx is limited to SEN55!!! SEN54 does not give NOx Index!

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
