### PR TITLE
Fixed erroneous Nextion Sensor attributes

### DIFF
--- a/components/sensor/nextion.rst
+++ b/components/sensor/nextion.rst
@@ -31,12 +31,11 @@ See :doc:`/components/display/nextion` for setting up the display
         name: "Current Humidity"
         component_name: humidity # pageX.humidity for a global
         nextion_precision: 1
-        update_interval: 4s
+        interval: 4s
       - platform: nextion
         nextion_id: nextion1
         name: "Current Temperature"
         variable_name: temperature
-        hass_component_name: sensor.temperature
       - platform: nextion
         id: s01
         component_id: 2

--- a/components/sensor/nextion.rst
+++ b/components/sensor/nextion.rst
@@ -30,8 +30,8 @@ See :doc:`/components/display/nextion` for setting up the display
       - platform: nextion
         name: "Current Humidity"
         component_name: humidity # pageX.humidity for a global
-        nextion_precision: 1
-        interval: 4s
+        precision: 1
+        update_interval: 4s
       - platform: nextion
         nextion_id: nextion1
         name: "Current Temperature"


### PR DESCRIPTION
## Description:

Fixes the attributes in the Nextion Sensor example that ESPHome does not validate.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
