### PR TITLE
Prometheus: allow custom 'id' and 'name' labels for metrics

### DIFF
--- a/components/binary_sensor/index.rst
+++ b/components/binary_sensor/index.rst
@@ -31,6 +31,8 @@ Configuration variables:
   sensor. See https://developers.home-assistant.io/docs/core/entity/binary-sensor/#available-device-classes
   for a list of available options.
 - **icon** (*Optional*, icon): Manually set the icon to use for the binary sensor in the frontend.
+- **metric_id** (*Optional*, string): Manually set the value of the `id` label of the Prometheus metric.
+- **metric_name** (*Optional*, string): Manually set the value of the `name` label of the Prometheus metric.
 - **filters** (*Optional*, list): A list of filters to apply on the binary sensor values such as
   inverting signals. See :ref:`binary_sensor-filters`.
 

--- a/components/cover/index.rst
+++ b/components/cover/index.rst
@@ -31,6 +31,8 @@ Configuration variables:
 - **device_class** (*Optional*, string): The device class for the
   sensor. See https://www.home-assistant.io/components/cover/ for a list of available options.
 - **icon** (*Optional*, icon): Manually set the icon to use for the cover in the frontend.
+- **metric_id** (*Optional*, string): Manually set the value of the `id` label of the Prometheus metric.
+- **metric_name** (*Optional*, string): Manually set the value of the `name` label of the Prometheus metric.
 
 Advanced options:
 

--- a/components/fan/index.rst
+++ b/components/fan/index.rst
@@ -28,6 +28,8 @@ Configuration variables:
 
 - **name** (**Required**, string): The name of the fan.
 - **icon** (*Optional*, icon): Manually set the icon to use for the fan in the frontend.
+- **metric_id** (*Optional*, string): Manually set the value of the `id` label of the Prometheus metric.
+- **metric_name** (*Optional*, string): Manually set the value of the `name` label of the Prometheus metric.
 - **restore_mode** (*Optional*): Control how the fan attempts to restore state on boot.
 
     - ``NO_RESTORE`` - Don't restore any state.

--- a/components/light/index.rst
+++ b/components/light/index.rst
@@ -27,6 +27,8 @@ All light configuration schemas inherit these options.
 Configuration variables:
 
 - **icon** (*Optional*, icon): Manually set the icon to use for the light in the frontend.
+- **metric_id** (*Optional*, string): Manually set the value of the `id` label of the Prometheus metric.
+- **metric_name** (*Optional*, string): Manually set the value of the `name` label of the Prometheus metric.
 - **effects** (*Optional*, list): A list of :ref:`light effects <light-effects>` to use for this light.
 - **gamma_correct** (*Optional*, float): Apply a `gamma correction
   factor <https://en.wikipedia.org/wiki/Gamma_correction>`__ to the light channels.

--- a/components/lock/index.rst
+++ b/components/lock/index.rst
@@ -6,7 +6,7 @@ Lock Component
     :image: folder-open.svg
 
 The ``lock`` domain includes all platforms that should function like a lock
-with lock/unlock actions. 
+with lock/unlock actions.
 
 .. note::
 
@@ -28,6 +28,8 @@ Configuration variables:
 - **name** (**Required**, string): The name of the lock.
 - **icon** (*Optional*, icon): Manually set the icon to use for the
   lock in the frontend.
+- **metric_id** (*Optional*, string): Manually set the value of the `id` label of the Prometheus metric.
+- **metric_name** (*Optional*, string): Manually set the value of the `name` label of the Prometheus metric.
 - **internal** (*Optional*, boolean): Mark this component as internal. Internal components will
   not be exposed to the frontend (like Home Assistant). Only specifying an ``id`` without
   a ``name`` will implicitly set this to true.

--- a/components/sensor/index.rst
+++ b/components/sensor/index.rst
@@ -50,6 +50,8 @@ Configuration variables:
   sensor. See https://developers.home-assistant.io/docs/core/entity/sensor/#available-state-classes
   for a list of available options. Set to ``""`` to remove the default state class of a sensor.
 - **icon** (*Optional*, icon): Manually set the icon to use for the sensor in the frontend.
+- **metric_id** (*Optional*, string): Manually set the value of the `id` label of the Prometheus metric.
+- **metric_name** (*Optional*, string): Manually set the value of the `name` label of the Prometheus metric.
 - **accuracy_decimals** (*Optional*, int): Manually set the accuracy of decimals to use when reporting values.
 - **filters** (*Optional*): Specify filters to use for some basic
   transforming of values. See :ref:`Sensor Filters <sensor-filters>` for more information.

--- a/components/switch/index.rst
+++ b/components/switch/index.rst
@@ -25,6 +25,8 @@ Configuration variables:
 - **name** (**Required**, string): The name of the switch.
 - **icon** (*Optional*, icon): Manually set the icon to use for the
   sensor in the frontend.
+- **metric_id** (*Optional*, string): Manually set the value of the `id` label of the Prometheus metric.
+- **metric_name** (*Optional*, string): Manually set the value of the `name` label of the Prometheus metric.
 - **inverted** (*Optional*, boolean): Whether to invert the binary
   state, i.e. report ON states as OFF and vice versa. Defaults
   to ``false``.


### PR DESCRIPTION
## Description:

Added the config fields `metric_id` and `metric_name` to all entities exported as Prometheus metrics.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#3529

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
