### PR TITLE
Add documentation for binary sensor map sum type

### DIFF
--- a/components/sensor/binary_sensor_map.rst
+++ b/components/sensor/binary_sensor_map.rst
@@ -13,7 +13,7 @@ This sensor is **mostly used for touch** devices but could be used for any ``bin
 Add your binary sensors as ``channels`` to the binary sensor map. The binary sensor map then publishes a value depending
 on the type of the binary sensor map and the values specified with each channel.
 
-This platform currently supports only one measurement type: ``GROUP``, but others might get added later.
+This platform currently supports two measurement types: ``GROUP`` and ``SUM``, but others might get added later.
 You need to specify which type of mapping you want with the ``type:`` configuration value:
 
 - ``GROUP`` Each channel has its own value. The sensor publishes the average value of all active
@@ -46,6 +46,45 @@ You need to specify which type of mapping you want with the ``type:`` configurat
       - platform: mpr121
         channel: 0
         id: touchkey0
+      # ...
+      
+- ``SUM`` Each channel has its own value. The sensor publishes the sum of all active
+  binary sensors values.
+
+.. code-block:: yaml
+
+    # Example configuration entry
+    sensor:
+  - platform: binary_sensor_map
+    id: group_0
+    name: 'Group Map 0'
+    type: sum
+    channels:
+      - binary_sensor: bit0
+        value: 1
+      - binary_sensor: bit1
+        value: 2
+      - binary_sensor: bit2
+        value: 4
+      - binary_sensor: bit3
+        value: 8
+
+binary_sensor:
+  - platform: gpio
+    pin: 4
+    id: bit0
+
+  - platform: gpio
+    pin: 5
+    id: bit1
+
+  - platform: gpio
+    pin: 6
+    id: bit2
+
+  - platform: gpio
+    pin: 7
+    id: bit3
       # ...
 
 Configuration variables:

--- a/components/sensor/binary_sensor_map.rst
+++ b/components/sensor/binary_sensor_map.rst
@@ -13,7 +13,7 @@ This sensor is **mostly used for touch** devices but could be used for any ``bin
 Add your binary sensors as ``channels`` to the binary sensor map. The binary sensor map then publishes a value depending
 on the type of the binary sensor map and the values specified with each channel.
 
-This platform currently supports two measurement types: ``GROUP`` and ``SUM``, but others might get added later.
+This platform currently supports two measurement types: ``GROUP`` and ``SUM``, and others might get added later.
 You need to specify which type of mapping you want with the ``type:`` configuration value:
 
 - ``GROUP`` Each channel has its own value. The sensor publishes the average value of all active

--- a/components/sensor/binary_sensor_map.rst
+++ b/components/sensor/binary_sensor_map.rst
@@ -55,36 +55,36 @@ You need to specify which type of mapping you want with the ``type:`` configurat
 
     # Example configuration entry
     sensor:
-  - platform: binary_sensor_map
-    id: group_0
-    name: 'Group Map 0'
-    type: sum
-    channels:
-      - binary_sensor: bit0
-        value: 1
-      - binary_sensor: bit1
-        value: 2
-      - binary_sensor: bit2
-        value: 4
-      - binary_sensor: bit3
-        value: 8
+      - platform: binary_sensor_map
+        id: group_0
+        name: 'Group Map 0'
+        type: sum
+        channels:
+          - binary_sensor: bit0
+            value: 1
+          - binary_sensor: bit1
+            value: 2
+          - binary_sensor: bit2
+            value: 4
+          - binary_sensor: bit3
+            value: 8
 
-binary_sensor:
-  - platform: gpio
-    pin: 4
-    id: bit0
+    binary_sensor:
+      - platform: gpio
+        pin: 4
+        id: bit0
 
-  - platform: gpio
-    pin: 5
-    id: bit1
+      - platform: gpio
+        pin: 5
+        id: bit1
 
-  - platform: gpio
-    pin: 6
-    id: bit2
+      - platform: gpio
+        pin: 6
+        id: bit2
 
-  - platform: gpio
-    pin: 7
-    id: bit3
+      - platform: gpio
+        pin: 7
+        id: bit3
       # ...
 
 Configuration variables:


### PR DESCRIPTION
## Description:

This adds documentation for binary_sensor_map sum type.


**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#3541

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
