### PR TITLE
Document how packages are merged into a configuration

### DIFF
--- a/guides/configuration-types.rst
+++ b/guides/configuration-types.rst
@@ -272,6 +272,10 @@ config in the main yaml file. All definitions from packages will be merged with 
 config in non-destructive way so you could always override some bits and pieces of package
 configuration.
 
+Dictionaries are merged key-by-key. Lists of components are merged by component
+ID if specified. Other lists are merged by concatenation. All other config
+values are replaced with the later value.
+
 Local packages
 **************
 


### PR DESCRIPTION
## Description:

Document how package config merging works.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#3555

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
