### PR TITLE
tcs34725: Add overexposure quirk note

### DIFF
--- a/components/sensor/tcs34725.rst
+++ b/components/sensor/tcs34725.rst
@@ -13,7 +13,7 @@ required to be set up in your configuration for this sensor to work.
 
 Note: If the `integration_time` is set too long for the light conditions, the sensor will overexpose.
 In this case the sensor may not show 100% on its clear channel. With an `integration_time` of `614ms`
-and a `gain` of `1x` the sensor will max out at around 4100 lx. If this case the individual color
+and a `gain` of `1x` the sensor will max out at around 4100 lx. In this case the individual color
 channels will show `100%`, the clear channel `25%`. The illumination in lux is shown as `0` as well
 as the color temperature in kelvin will show `0`.
 

--- a/components/sensor/tcs34725.rst
+++ b/components/sensor/tcs34725.rst
@@ -11,6 +11,12 @@ The ``tcs34725`` sensor platform allows you to use your TCS34725 RGB color senso
 `Adafruit`_), color temperature and illuminance sensors with ESPHome. The :ref:`I²C <i2c>` is
 required to be set up in your configuration for this sensor to work.
 
+Note: If the `integration_time` is set too long for the light conditions, the sensor will overexpose.
+In this case the sensor may not show 100% on its clear channel. With an `integration_time` of `614ms`
+and a `gain` of `1x` the sensor will max out at around 4100 lx. If this case the individual color
+channels will show `100%`, the clear channel `25%`. The illumination in lux is shown as `0` as well
+as the color temperature in kelvin will show `0`.
+
 .. figure:: images/tcs34725-full.jpg
     :align: center
     :width: 50.0%


### PR DESCRIPTION


## Description:
The sensor will max out pretty early if the integration time is set too long.

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
