### PR TITLE
Bump sphinx from 4.3.2 to 5.0.1

### DIFF
--- a/github.py
+++ b/github.py
@@ -137,15 +137,15 @@ class ImageTableDirective(Table):
                 }
             )
 
-        col_widths = self.get_column_widths(cols)
         title, messages = self.make_title()
         table = nodes.table()
         table["classes"].append("table-center")
+        table["classes"].append("colwidths-given")
 
         # Set up column specifications based on widths
         tgroup = nodes.tgroup(cols=cols)
         table += tgroup
-        tgroup.extend(nodes.colspec(colwidth=col_width) for col_width in col_widths)
+        tgroup.extend(nodes.colspec(colwidth=1) for _ in range(cols))
 
         tbody = nodes.tbody()
         tgroup += tbody

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-sphinx==4.3.2
+sphinx==5.0.1
 sphinx-autobuild==2021.3.14


### PR DESCRIPTION
## Description:

Bump sphinx to 5.0.1 - This is a major version bump, but none of the breaking changes should apply to our docs and compile output looks fine (including sphinx-autobuild)

https://www.sphinx-doc.org/en/master/changes.html#release-5-0-0-released-may-30-2022

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [N/A] Link added in `/index.rst` when creating new documents for new components or cookbook.
