### PR TITLE
Add the possibility to transform strings for LCD displays

### DIFF
--- a/components/display/lcd_display.rst
+++ b/components/display/lcd_display.rst
@@ -243,15 +243,15 @@ defines a dot at the upper left and lower right of the character.
           it.print("Hello, world \x08 \x07!");
 
 
-Transform Lambda
-----------------
+Transformation Lambda
+---------------------
 
 The LCD displays are produced with several ROM variants defining different character sets.
 On the other hand the native character encoding of the yaml configuration and most of code
-editors is UTF-8. An `it.printf("Temp %4.1f °C", id(temp).state);` lambda cannot be used
+editors is UTF-8. An ``it.printf("Temp %4.1f °C", id(temp).state);`` lambda cannot be used
 as is.
 
-The `transform` lambda allows the user to define a transformation function run immediately
+The ``transform`` lambda allows the user to define a transformation function run immediately
 before the string is output to the LCD. The input string is supplied in the argument `x`
 and the lambda needs to return the result in the LDC's character set. The following snippet
 transforms the degree character to the `0xdf` byte needed for the LCD.
@@ -261,7 +261,7 @@ transforms the degree character to the `0xdf` byte needed for the LCD.
     display:
       - platform: lcd_pcf8574
         ...
-        translate: |-
+        transform: |-
           std::string str = x;
           static const std::string degree = "°";
           for (size_t index = str.find(degree, 0);

--- a/components/display/lcd_display.rst
+++ b/components/display/lcd_display.rst
@@ -242,6 +242,36 @@ defines a dot at the upper left and lower right of the character.
         lambda: |-
           it.print("Hello, world \x08 \x07!");
 
+
+Transform Lambda
+----------------
+
+The LCD displays are produced with several ROM variants defining different character sets.
+On the other hand the native character encoding of the yaml configuration and most of code
+editors is UTF-8. An `it.printf("Temp %4.1f °C", id(temp).state);` lambda cannot be used
+as is.
+
+The `transform` lambda allows the user to define a transformation function run immediately
+before the string is output to the LCD. The input string is supplied in the argument `x`
+and the lambda needs to return the result in the LDC's character set. The following snippet
+transforms the degree character to the `0xdf` byte needed for the LCD.
+
+.. code-block:: yaml
+
+    display:
+      - platform: lcd_pcf8574
+        ...
+        translate: |-
+          std::string str = x;
+          static const std::string degree = "°";
+          for (size_t index = str.find(degree, 0);
+              index != std::string::npos;
+              index = str.find(degree, index + 1) )
+            str.replace(index, degree.length(), "\xdf");
+          return str;
+        lambda: |-
+          it.printf("Temp %4.1f °C", id(temp).state);
+
 See Also
 --------
 

--- a/components/display/lcd_display.rst
+++ b/components/display/lcd_display.rst
@@ -53,6 +53,10 @@ Configuration variables:
   See :ref:`display-lcd_lambda` for more information.
 - **update_interval** (*Optional*, :ref:`config-time`): The interval to re-draw the screen. Defaults to ``1s``.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
+- **user_characters** (*Optional*, list): The list of user-defined characters. See :ref:`display-user_defined_characters`
+  for more information.
+- **transform** (*Optional*, :ref:`lambda <config-lambda>`): The lambda to transform the printed string before
+  sending to the LCD. See :ref:`display-transformation_lambda` for more information.
 
 .. _lcd-gpio:
 
@@ -104,6 +108,10 @@ Configuration variables:
   See :ref:`display-lcd_lambda` for more information.
 - **update_interval** (*Optional*, :ref:`config-time`): The interval to re-draw the screen. Defaults to ``1s``.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
+- **user_characters** (*Optional*, list): The list of user-defined characters. See :ref:`display-user_defined_characters`
+  for more information.
+- **transform** (*Optional*, :ref:`lambda <config-lambda>`): The lambda to transform the printed string before
+  sending to the LCD. See :ref:`display-transformation_lambda` for more information.
 
 .. _display-lcd_lambda:
 
@@ -203,6 +211,8 @@ turns off 90 seconds after the last activation of the sensor.
             - lambda: |-
                 id(mydisplay).no_backlight();
 
+.. _display-user_defined_characters:
+
 User Defined Characters
 -----------------------
 
@@ -242,6 +252,8 @@ defines a dot at the upper left and lower right of the character.
         lambda: |-
           it.print("Hello, world \x08 \x07!");
 
+
+.. _display-transformation_lambda:
 
 Transformation Lambda
 ---------------------

--- a/components/display/lcd_display.rst
+++ b/components/display/lcd_display.rst
@@ -264,9 +264,14 @@ editors is UTF-8. An ``it.printf("Temp %4.1f °C", id(temp).state);`` lambda can
 as is.
 
 The ``transform`` lambda allows the user to define a transformation function run immediately
-before the string is output to the LCD. The input string is supplied in the argument `x`
+before the string is output to the LCD. The input string is supplied in the argument ``x``
 and the lambda needs to return the result in the LDC's character set. The following snippet
-transforms the degree character to the `0xdf` byte needed for the LCD.
+transforms the degree character to the ``0xdf`` byte needed for the LCD.
+
+Note that such transformation will change the length of the string, making calculation
+of the precise column positions difficult. If you for example want to compute the
+starting position to righ-align a string on the LCD, you will most probably need
+to implement a rudimentary UTF-8 parser to calculate the correct length.
 
 .. code-block:: yaml
 


### PR DESCRIPTION
## Description:

The LCD displays are produced with several ROM variants defining different character sets. On the other hand the native character encoding of the yaml configuration and most of code editors is UTF-8. An `it.printf("Temp %4.1f °C", id(temp).state);` lambda cannot be used as is.

The `transform` lambda allows the user to define a transformation function run immediately before the string is output to the LCD.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#3563

## Checklist:

  - [X] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
