### PR TITLE
Media Player: on_state trigger

### DIFF
--- a/components/media_player/index.rst
+++ b/components/media_player/index.rst
@@ -118,6 +118,22 @@ Configuration variables:
 
 **volume** (**Required**, percentage): The volume to set the media player to.
 
+.. _media_player-on_state_trigger:
+
+``media_player.on_state`` Trigger
+******************************************************
+
+This trigger is activated each time the state of the media player is updated 
+(for example, if the player is stop playing audio or received some command).
+
+.. code-block:: yaml
+
+    media_player:
+      - platform: i2s_audio  # or any other platform
+        # ...
+        on_state:
+        - logger.log: "State updated!"
+
 See Also
 --------
 

--- a/components/media_player/index.rst
+++ b/components/media_player/index.rst
@@ -121,7 +121,7 @@ Configuration variables:
 .. _media_player-on_state_trigger:
 
 ``media_player.on_state`` Trigger
-******************************************************
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 This trigger is activated each time the state of the media player is updated 
 (for example, if the player is stop playing audio or received some command).
@@ -132,7 +132,7 @@ This trigger is activated each time the state of the media player is updated
       - platform: i2s_audio  # or any other platform
         # ...
         on_state:
-        - logger.log: "State updated!"
+          - logger.log: "State updated!"
 
 See Also
 --------

--- a/components/media_player/index.rst
+++ b/components/media_player/index.rst
@@ -134,6 +134,51 @@ This trigger is activated each time the state of the media player is updated
         on_state:
           - logger.log: "State updated!"
 
+.. _media_player-on_play_trigger:
+
+``media_player.on_play`` Trigger
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This trigger is activated each time then the media player is started playing.
+
+.. code-block:: yaml
+
+    media_player:
+      - platform: i2s_audio  # or any other platform
+        # ...
+        on_play:
+          - logger.log: "Playback started!"
+
+.. _media_player-on_pause_trigger:
+
+``media_player.on_pause`` Trigger
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This trigger is activated every time the media player pauses playback.
+
+.. code-block:: yaml
+
+    media_player:
+      - platform: i2s_audio  # or any other platform
+        # ...
+        on_pause:
+          - logger.log: "Playback paused!"
+
+.. _media_player-on_idle_trigger:
+
+``media_player.on_idle`` Trigger
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This trigger is activated every time the media player finishes playing.
+
+.. code-block:: yaml
+
+    media_player:
+      - platform: i2s_audio  # or any other platform
+        # ...
+        on_idle:
+          - logger.log: "Playback finished!"
+
 See Also
 --------
 


### PR DESCRIPTION
## Description:

`on_state` trigger

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#3576

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
