### PR TITLE
Fix GitPod bootstrapping

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -4,4 +4,4 @@ ports:
 
 tasks:
 - before: pip3 install -r requirements.txt
-  command: make webserver
+  command: make live-html


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** None

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**  None

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.

Fixes GitPod bootstrapping.

By checking on the git history, #1786 switched from `webserver` into `live-html` but the GitPod file wasn't updated at that time.