### PR TITLE
Copy and paste error

### DIFF
--- a/components/text_sensor/mqtt_subscribe.rst
+++ b/components/text_sensor/mqtt_subscribe.rst
@@ -23,7 +23,7 @@ Configuration variables:
 ------------------------
 
 - **name** (**Required**, string): The name of the text sensor.
-- **topic** (**Required**, string): The MQTT topic to listen for numeric messages.
+- **topic** (**Required**, string): The MQTT topic to listen for string data.
 - **qos** (*Optional*, int): The MQTT QoS to subscribe with. Defaults to ``0``.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
 - All other options from :ref:`Text Sensor <config-text_sensor>`.


### PR DESCRIPTION
There was, what I believe to be a copy and paste error carried over from the mqtt sensor which only allows numeric data.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
