### PR TITLE
add min_value and max_value filter sensors in docs

### DIFF
--- a/components/sensor/index.rst
+++ b/components/sensor/index.rst
@@ -121,6 +121,8 @@ Filters are processed in the order they are defined in your configuration.
     filters:
       - offset: 2.0
       - multiply: 1.2
+      - min_value: 0
+      - max_value: 50
       - calibrate_linear:
           - 0.0 -> 0.0
           - 40.0 -> 45.0
@@ -171,6 +173,29 @@ Adds a constant value to each sensor value.
 Multiplies each value by a constant value.
 
 .. _sensor-filter-calibrate_linear:
+
+``min_value``
+************
+
+Minimum value limit value for the ``min`` value. 
+
+.. code-block:: yaml
+
+    # Example filters:
+    filters:
+      - min_value: 0
+
+``max_value``
+************
+
+Maximum value limit value for the ``max`` value. 
+
+.. code-block:: yaml
+
+    # Example filters:
+    filters:
+      - max_value: 50
+
 
 ``calibrate_linear``
 ********************

--- a/components/sensor/index.rst
+++ b/components/sensor/index.rst
@@ -172,7 +172,6 @@ Adds a constant value to each sensor value.
 
 Multiplies each value by a constant value.
 
-
 ``min_value``
 ************
 

--- a/components/sensor/index.rst
+++ b/components/sensor/index.rst
@@ -172,7 +172,6 @@ Adds a constant value to each sensor value.
 
 Multiplies each value by a constant value.
 
-.. _sensor-filter-calibrate_linear:
 
 ``min_value``
 ************
@@ -196,6 +195,7 @@ Maximum value limit value for the ``max`` value.
     filters:
       - max_value: 50
 
+.. _sensor-filter-calibrate_linear:
 
 ``calibrate_linear``
 ********************

--- a/components/sensor/index.rst
+++ b/components/sensor/index.rst
@@ -173,7 +173,7 @@ Adds a constant value to each sensor value.
 Multiplies each value by a constant value.
 
 ``min_value``
-************
+*************
 
 Minimum value limit value for the ``min`` value. 
 
@@ -184,7 +184,7 @@ Minimum value limit value for the ``min`` value.
       - min_value: 0
 
 ``max_value``
-************
+*************
 
 Maximum value limit value for the ``max`` value. 
 


### PR DESCRIPTION
## Description:

Added in the documentation the new filters for threshold value sensors for maximum and minimum values.

**Related issue (if applicable):** fixes [#1581](https://github.com/esphome/feature-requests/issues/1581)

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#3605

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
