### PR TITLE
fix naming of configuration variable

### DIFF
--- a/components/sensor/mcp3008.rst
+++ b/components/sensor/mcp3008.rst
@@ -40,6 +40,7 @@ If you want just the scaled value you can use the read_data function
     # Example configuration entry
     mcp3008:
       cs_pin: D8
+      id: my_mcp
 
     # Example config of sensors.
     # This is a NTCB3950 10K thermocoupler attached to pin 0
@@ -49,6 +50,7 @@ If you want just the scaled value you can use the read_data function
       - platform: mcp3008             # Attached to pin 0 of the MCP3008.
         reference_voltage: 3.19
         update_interval: 1s
+        mcp3008_id: my_mcp
         id: freezer_temp_source
         number: 0                     # MCP3008 pin number
       - platform: resistance
@@ -79,7 +81,7 @@ sensor platform to create individual sensors that will report the voltage to Hom
 
 Configuration variables:
 
-- **id** (**Required**, :ref:`config-id`): The id of the parent MCP3008 component.
+- **mcp3008_id** (**Required**, :ref:`config-id`): The id of the parent MCP3008 component.
 - **number** (**Required**, int): The pin number of the MCP3008
 - **reference_voltage** (*Optional*, float): The reference voltage. Defaults to ``3.3V``.
 - **update_interval** (*Optional*, :ref:`config-time`): The interval to check the sensor. Defaults to ``1s``.


### PR DESCRIPTION
## Description:
This fixes an inconsistency in the documentation. As documented for [MCP3204](https://esphome.io/components/sensor/mcp3204.html), the `id`-variable should be called `mcp3008_id`. The corresponding component already accepts this variable, so no code change is needed. Additionally the example has been extended to clarify the usage of the configuration variable.

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
