### PR TITLE
Clarify `accuracy_decimals` in sensor config

### DIFF
--- a/components/sensor/index.rst
+++ b/components/sensor/index.rst
@@ -50,7 +50,7 @@ Configuration variables:
   sensor. See https://developers.home-assistant.io/docs/core/entity/sensor/#available-state-classes
   for a list of available options. Set to ``""`` to remove the default state class of a sensor.
 - **icon** (*Optional*, icon): Manually set the icon to use for the sensor in the frontend.
-- **accuracy_decimals** (*Optional*, int): Manually set the accuracy of decimals to use when reporting values.
+- **accuracy_decimals** (*Optional*, int): Manually set the number of decimals to use when reporting values. This does not impact the actual value reported to Home Assistant, it just sets the number of decimals to use when displaying it.
 - **filters** (*Optional*): Specify filters to use for some basic
   transforming of values. See :ref:`Sensor Filters <sensor-filters>` for more information.
 - **internal** (*Optional*, boolean): Mark this component as internal. Internal components will


### PR DESCRIPTION
The documentation for `accuracy_decimals` was a bit vague and inaccurate (oh the irony). I think this is better.

As discussed in the Discord channel with @ssieb.

## Description:

In the current text "the accuracy of decimals" is used, which is a concept that doesn't quite exist. Decimals are not more or less accurate -- you just use more or less of them to represent a number at a certain accuracy. I've reworded that sentence, and added a bit more explanation of what the setting actually does.

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
