### PR TITLE
add link to Total Daily Energy Sensor

### DIFF
--- a/components/sensor/cse7766.rst
+++ b/components/sensor/cse7766.rst
@@ -9,7 +9,7 @@ CSE7766 Power Sensor
 The ``cse7766`` sensor platform allows you to use your CSE7766 voltage/current and power sensors
 (`datasheet <http://dl.itead.cc/S31/CSE7766.pdf>`__) sensors with
 ESPHome. This sensor is commonly found in Sonoff POW R2. CSE7759B is similar to CSE7766
-and works with this integration.
+and works with this integration. Optionally :doc:`Total Daily Energy Sensor <total_daily_energy>` can be used to convert power ``W`` into ``kWh``, for example to add to the Home Assistant Energy Dashboard.
 
 .. note::
 


### PR DESCRIPTION
adding these sensors to the HA Energy dashboard will be a common use and a link to the Total Daily Energy Sensor  must therefore be made to achieve that. Hopefully making it easier to find your way as DIY explorer in ESPHome.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
