### PR TITLE
Update xiaomi_ble.rst

### DIFF
--- a/components/sensor/xiaomi_ble.rst
+++ b/components/sensor/xiaomi_ble.rst
@@ -181,8 +181,8 @@ Hygro thermometer, small square body, segment LCD, encrypted, broadcasts tempera
 There are the following possibilities to operate this sensor:
 
 1. Xiaomi stock firmware (requires a bindkey in order to decrypt the received data, see :ref:`obtaining_the_bindkey`)
-2. Device flashed with `ATC MiThermometer <https://github.com/atc1441/ATC_MiThermometer>`__ custom firmware
-3. Device flashed with `PVVX MiThermometer <https://github.com/pvvx/ATC_MiThermometer>`__ custom firmware
+2. Device flashed with `PVVX MiThermometer <https://github.com/pvvx/ATC_MiThermometer>`__ custom firmware
+3. Device flashed with `ATC MiThermometer <https://github.com/atc1441/ATC_MiThermometer>`__ custom firmware
 
    - "Mi Like" advertisement (dummy bindkey required)
    - "Custom" advertisement (no bindkey required)
@@ -203,6 +203,22 @@ Configuration example for Xiaomi stock firmware or ATC MiThermometer firmware se
         battery_level:
           name: "LYWSD03MMC Battery Level"
 
+Configuration example for PVVX MiThermometer firmware set to "Custom" advertisement:
+
+.. code-block:: yaml
+
+    sensor:
+      - platform: pvvx_mithermometer
+        mac_address: "A4:C1:38:B1:CD:7F"
+        temperature:
+          name: "PVVX Temperature"
+        humidity:
+          name: "PVVX Humidity"
+        battery_level:
+          name: "PVVX Battery-Level"
+        battery_voltage:
+          name: "PVVX Battery-Voltage"
+
 Configuration example for ATC MiThermometer firmware set to "Custom" advertisement:
 
 .. code-block:: yaml
@@ -221,21 +237,6 @@ Configuration example for ATC MiThermometer firmware set to "Custom" advertiseme
         signal_strength:
           name: "ATC Signal"
 
-Configuration example for PVVX MiThermometer firmware set to "Custom" advertisement:
-
-.. code-block:: yaml
-
-    sensor:
-      - platform: pvvx_mithermometer
-        mac_address: "A4:C1:38:B1:CD:7F"
-        temperature:
-          name: "PVVX Temperature"
-        humidity:
-          name: "PVVX Humidity"
-        battery_level:
-          name: "PVVX Battery-Level"
-        battery_voltage:
-          name: "PVVX Battery-Voltage"
 
 MHO-C303
 ********
@@ -591,8 +592,8 @@ For this, you load the `application <https://zaluthar.github.io/TelinkFlasher.ht
 Other encrypted devices
 ***********************
 1.
-The easiest method (confirmed to work for LYWSD03MMC) is to use the `Telink flasher method <https://github.com/atc1441/ATC_MiThermometer>`__. The accompanying `video
-<https://www.youtube.com/watch?v=NXKzFG61lNs>`_ shows how to wirelessly flash a LYWSD03MMC, or how to obtain the bind key of the stock firmware (watch till around 13:10). The custom firmware allows you to change several settings of the device, including the smiley and the advertising interval. Keep in mind that when flashing the custom firmware, you need to enable the 'Advertising Type' to be 'Mi Like' and to give ESPHome a dummy bind key, as it still expects one even though the custom firmware does not encrypt the data.
+The easiest method (confirmed to work for LYWSD03MMC) is to use the `Telink flasher method <https://github.com/pvvx/ATC_MiThermometer>`__. The accompanying `video
+<https://www.youtube.com/watch?v=NXKzFG61lNs>`_ shows how to wirelessly flash a LYWSD03MMC, or how to obtain the bind key of the stock firmware (watch till around 13:10). The custom firmware allows you to change several settings of the device, including the smiley and the advertising interval. Follow the instructions on the site using Telink Flasher - best results with a Bluetooth-enabled Android phone. Note that with ``pvvx`` default settings advertisment is set to ``Custom`` with no encryption. No need for ``bind_key`` in this case, you can just add the sensors to your ESPHome config as described above.
 
 2.
 The other option is to use the original Mi Home app to add the sensor once. While adding the device, a new key is generated and uploaded into the Xiaomi cloud and to the device itself. Currently a chinese server needs to be selected as the rest of the world doesn't support most of these devices yet. Once generated, the key will not change again until the device is removed and re-added in the Xiaomi app.
@@ -612,6 +613,29 @@ Another option is to use a SSL packet sniffer. It can be setup on either an Andr
 The ``bind_key`` is the 32 digits "value" item in the above output which needs to be inserted into the config file.
 
 
+Improving reception performance
+-------------------------------
+
+Use a board with Ethernet connection to the network, to offload ESP32's radio module from WiFi traffic, this gains performance on bluetooth side. 
+To maximize the chances of catching advertisments of the sensors, you can set ``interval`` equal to ``window`` in :doc:`/components/esp32_ble_tracker` scan parameter settings:
+
+.. code-block:: yaml
+
+    esp32_ble_tracker:
+      scan_parameters: 
+        interval: 5s # try with 300ms if you don't have LAN module
+        window: 5s # try with 300ms if you don't have LAN module
+        active: false
+
+Avoid placing the ESP node in racks, close to routers/switches or other network equipment as EMI interference will degrade bluetooth signal reception. For best results put as far away as possible, at least 3 meters distance from any other such equipment.
+
+
+Security considerations
+-----------------------
+
+You should at least protect your sensors with a custom pairing PIN code.
+
+
 See Also
 --------
 
@@ -620,10 +644,12 @@ See Also
 - :apiref:`xiaomi_lywsd03mmc/xiaomi_ble.h`
 - Passive BLE monitor integration for Home Assistant (ble_monitor custom component) `<https://github.com/custom-components/ble_monitor>`__
   by `@Magalex2x14 <https://github.com/Magalex2x14>`__ and `@Ernst79 <https://github.com/Ernst79>`__
-- Xiaomi LYWSD03MMC passive sensor readout `<https://github.com/ahpohl/xiaomi_lywsd03mmc>`__ by `@ahpohl <https://github.com/ahpohl>`__
-- Custom firmware for the Xiaomi Thermometer LYWSD03MMC `<https://github.com/atc1441/ATC_MiThermometer>`__
-- TeLink flasher application `<https://atc1441.github.io/TelinkFlasher.html>`__
+- Custom firmware (PVVX) for the Xiaomi Thermometer LYWSD03MMC `<https://github.com/pvvx/ATC_MiThermometer>`__
+- TeLink flasher application (PVVX) `<https://pvvx.github.io/ATC_MiThermometer/TelinkMiFlasher.html>`__
+- Custom firmware (ATC) for the Xiaomi Thermometer LYWSD03MMC `<https://github.com/atc1441/ATC_MiThermometer>`__
+- TeLink flasher application (ATC) `<https://atc1441.github.io/TelinkFlasher.html>`__
 - TeLink flasher application modified for CGDK2 `<https://zaluthar.github.io/TelinkFlasher.html>`__
+- Xiaomi LYWSD03MMC passive sensor readout `<https://github.com/ahpohl/xiaomi_lywsd03mmc>`__ by `@ahpohl <https://github.com/ahpohl>`__
 - Cloud Tokens Extractor: `<https://github.com/PiotrMachowski/Xiaomi-cloud-tokens-extractor>`__
 
 - :ghedit:`Edit`


### PR DESCRIPTION
- added tips for improving reception performance
- some clarifications about TeLink flasher
- moved PVVX above ATC as PVVX is maintained, ATC seems to be abandoned, as per the message of the author in the repo, redirecting users to PVVX.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
