### PR TITLE
lambda example in the script section

### DIFF
--- a/guides/automations.rst
+++ b/guides/automations.rst
@@ -723,6 +723,12 @@ script was already running.
       then:
         - script.execute: my_script
 
+or as lambda
+
+.. code-block:: yaml
+
+    lambda: 'id(my_script).execute();
+
 .. _script-stop_action:
 
 ``script.stop`` Action
@@ -750,6 +756,13 @@ will not be executed.
       then:
         - script.stop: my_script
 
+or as lambda
+
+.. code-block:: yaml
+    
+    lambda: 'id(my_script).stop();'
+
+
 .. _script-wait_action:
 
 ``script.wait`` Action
@@ -776,6 +789,14 @@ of the script are running in parallel, this will block until all of them have te
         - script.execute: my_script
         - script.wait: my_script
 
+or as lambda
+
+.. code-block:: yaml
+    
+    lambda: |-
+        id(my_script).execute();
+        id(my_script).wait();
+
 .. _script-is_running_condition:
 
 ``script.is_running`` Condition
@@ -793,6 +814,15 @@ of the given id is running, not how many.
           - script.is_running: my_script
         then:
           - logger.log: Script is running!
+
+or as lambda
+
+.. code-block:: yaml
+
+    lambda: -|
+        if(id(my_script).is_running() {
+            ESP_LOGI("main", "Script is running!");
+        }
 
 .. _for_condition:
 

--- a/guides/automations.rst
+++ b/guides/automations.rst
@@ -760,6 +760,7 @@ or as lambda
 
 .. code-block:: yaml
     
+    
     lambda: 'id(my_script).stop();'
 
 
@@ -790,6 +791,7 @@ of the script are running in parallel, this will block until all of them have te
         - script.wait: my_script
 
 or as lambda
+
 
 .. code-block:: yaml
     

--- a/guides/automations.rst
+++ b/guides/automations.rst
@@ -727,7 +727,7 @@ or as lambda
 
 .. code-block:: yaml
 
-    lambda: 'id(my_script).execute();
+        lambda: 'id(my_script).execute();
 
 .. _script-stop_action:
 
@@ -758,11 +758,9 @@ will not be executed.
 
 or as lambda
 
-.. code-block:: yaml
-    
-    
-    lambda: 'id(my_script).stop();'
+.. code-block:: yaml   
 
+    lambda: 'id(my_script).stop();'
 
 .. _script-wait_action:
 
@@ -792,9 +790,8 @@ of the script are running in parallel, this will block until all of them have te
 
 or as lambda
 
-
 .. code-block:: yaml
-    
+
     lambda: |-
         id(my_script).execute();
         id(my_script).wait();

--- a/guides/automations.rst
+++ b/guides/automations.rst
@@ -727,7 +727,7 @@ or as lambda
 
 .. code-block:: yaml
 
-        lambda: 'id(my_script).execute();
+    lambda: 'id(my_script).execute();
 
 .. _script-stop_action:
 


### PR DESCRIPTION
## Description:
I have included examples of 'lambda' in the "script" section. I played around for ages until I noticed that the round clamps at the end were missing. In the forum also searched someone who did not get an answer to his question. It will help others.

**Related issue (if applicable):** fixes none

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
