### PR TITLE
Pulse counter total restore

### DIFF
--- a/components/sensor/pulse_counter.rst
+++ b/components/sensor/pulse_counter.rst
@@ -49,6 +49,7 @@ Configuration variables:
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
 
 - **total** (*Optional*): Report the total number of pulses.
+
   - **restore_value** (*Optional*, boolean): default *false*. Saves and loads the total number of pulses to RTC/Flash.
   - **min_save_interval** (*Optional*, :ref:`config-time`): The minimum time span between saving updated values to storage. This is to keep wearout of memory low. Defaults to ``0s``.
 

--- a/components/sensor/pulse_counter.rst
+++ b/components/sensor/pulse_counter.rst
@@ -49,6 +49,8 @@ Configuration variables:
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
 
 - **total** (*Optional*): Report the total number of pulses.
+  - **restore_value** (*Optional*, boolean): default *false*. Saves and loads the total number of pulses to RTC/Flash.
+  - **min_save_interval** (*Optional*, :ref:`config-time`): The minimum time span between saving updated values to storage. This is to keep wearout of memory low. Defaults to ``0s``.
 
 - All other options from :ref:`Sensor <config-sensor>`.
 
@@ -98,6 +100,8 @@ measure the total consumed energy in kWh.
         total:
           unit_of_measurement: 'kWh'
           name: 'Energy Meter House'
+          restore_value: True
+          min_save_interval: 5min
           filters:
             - multiply: 0.001  # (1/1000 pulses per kWh)
 

--- a/components/sensor/pulse_meter.rst
+++ b/components/sensor/pulse_meter.rst
@@ -31,6 +31,8 @@ Configuration variables:
 
 - **timeout** (*Optional*, :ref:`config-time`): If we don't see a pulse for this length of time, we assume 0 pulses/sec. Defaults to ``5 min``.
 - **total** (*Optional*, :ref:`config-id`): An additional sensor that outputs the total number of pulses counted.
+  - **restore_value** (*Optional*, boolean): default *false*. Saves and loads the total number of pulses to RTC/Flash.
+  - **min_save_interval** (*Optional*, :ref:`config-time`): The minimum time span between saving updated values to storage. This is to keep wearout of memory low. Defaults to ``0s``.
 - All other options from :ref:`Sensor <config-sensor>`.
 
 Converting units
@@ -75,6 +77,8 @@ measure the total consumed energy in kWh.
           name: "Electricity Total"
           unit_of_measurement: "kWh"
           accuracy_decimals: 3
+          restore_value: True
+          min_save_interval: 5min
           filters:
             - multiply: 0.001
 

--- a/components/sensor/pulse_meter.rst
+++ b/components/sensor/pulse_meter.rst
@@ -31,6 +31,7 @@ Configuration variables:
 
 - **timeout** (*Optional*, :ref:`config-time`): If we don't see a pulse for this length of time, we assume 0 pulses/sec. Defaults to ``5 min``.
 - **total** (*Optional*, :ref:`config-id`): An additional sensor that outputs the total number of pulses counted.
+
   - **restore_value** (*Optional*, boolean): default *false*. Saves and loads the total number of pulses to RTC/Flash.
   - **min_save_interval** (*Optional*, :ref:`config-time`): The minimum time span between saving updated values to storage. This is to keep wearout of memory low. Defaults to ``0s``.
 - All other options from :ref:`Sensor <config-sensor>`.


### PR DESCRIPTION
## Description:

Update documentation to reflect added feature to store / restore total pulse count from flash for `pulse_counter` & `pulse_meter` components.

**Related issue (if applicable):** N/a

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#3633

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
