### PR TITLE
Adding Whynter AC support

### DIFF
--- a/components/climate/climate_ir.rst
+++ b/components/climate/climate_ir.rst
@@ -272,6 +272,8 @@ Configuration variables:
   - ``DG11J1-3A``: Temperature range is from 18 to 32 (default)
   - ``DG11J1-91``: Temperature range is from 16 to 30
 
+.. _whynter:
+
 ``whynter`` Climate
 -------------------------
 

--- a/components/climate/climate_ir.rst
+++ b/components/climate/climate_ir.rst
@@ -48,6 +48,8 @@ submit a feature request (see FAQ).
 +---------------------------------------+---------------------+----------------------+
 | Yashima                               | ``yashima``         |                      |
 +---------------------------------------+---------------------+----------------------+
+| :ref:`Whynter<whynter>`               | ``whynter``         | yes                  |
++---------------------------------------+---------------------+----------------------+
 
 This component requires that you have configured a :doc:`/components/remote_transmitter`.
 
@@ -269,6 +271,27 @@ Configuration variables:
 
   - ``DG11J1-3A``: Temperature range is from 18 to 32 (default)
   - ``DG11J1-91``: Temperature range is from 16 to 30
+
+``whynter`` Climate
+-------------------------
+
+Additional configuration is available for this platform
+
+
+Configuration variables:
+
+- **use_fahrenheit** (*Optional*, boolean): Allows you to transfer the temperature to the air conditioner in degrees Fahrenheit. The air conditioner display also shows the temperature in Fahrenheit. Defaults to ``false``.
+
+.. code-block:: yaml
+
+    # Example configuration entry
+    climate:
+      - platform: whynter
+        name: "AC"
+        sensor: room_temperature
+        use_fahrenheit: true
+        supports_heat: true
+
 
 
 See Also


### PR DESCRIPTION
Adding support for Whynter air conditioners

## Description:


**Related issue (if applicable):** fixes https://github.com/esphome/feature-requests/issues/1767

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#[3641](https://github.com/esphome/esphome/pull/3641)

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
