### PR TITLE
hydreon: Document temperature, lens_bad and em_sat

### DIFF
--- a/components/binary_sensor/hydreon_rgxx.rst
+++ b/components/binary_sensor/hydreon_rgxx.rst
@@ -40,7 +40,23 @@ Configuration variables:
 
 - **too_cold** (*Optional*): ``true`` if the sensor reports being too cold. Hydreon only mentions this feature for the RG-9.
 
-  - **name** (**Required**, string): The name for the voltage sensor.
+  - **name** (**Required**, string): The name for the sensor.
+
+  - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.
+
+  - All other options from :ref:`Binary Sensor <config-binary_sensor>`.
+
+- **lens_bad** (*Optional*): ``true`` if the sensor reports the lens being bad.
+
+  - **name** (**Required**, string): The name for the sensor.
+
+  - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.
+
+  - All other options from :ref:`Binary Sensor <config-binary_sensor>`.
+
+- **em_sat** (*Optional*): ``true`` if the sensor reports the Emitter being saturated.
+
+  - **name** (**Required**, string): The name for the sensor.
 
   - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.
 

--- a/components/sensor/hydreon_rgxx.rst
+++ b/components/sensor/hydreon_rgxx.rst
@@ -103,7 +103,7 @@ Configuration variables:
   - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.
   - All other options from :ref:`Sensor <config-sensor>`.
 
-- **temperature** (*Optional*): Temperature +-5°C. Only on RG-15.
+- **temperature** (*Optional*): Temperature +-5°C. Only on RG-9 Version 1.100 or later.
 
   - **name** (**Required**, string): The name for the sensor.
   - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.

--- a/components/sensor/hydreon_rgxx.rst
+++ b/components/sensor/hydreon_rgxx.rst
@@ -38,6 +38,8 @@ required to be set up in your configuration for this sensor to work.
       - platform: hydreon_rgxx
         too_cold:
           name: "too cold"
+        lens_bad:
+          name: "lens bad"
 
 .. code-block:: yaml
 
@@ -60,6 +62,8 @@ required to be set up in your configuration for this sensor to work.
           name: "rain total"
         r_int:
           name: "rain intensity"
+        temperature:
+          name: "outside temperature"
 
 Configuration variables:
 ------------------------
@@ -94,6 +98,12 @@ Configuration variables:
   - All other options from :ref:`Sensor <config-sensor>`.
 
 - **r_int** (*Optional*): Current rain intensity in ``mm/h``. Only on RG-15.
+
+  - **name** (**Required**, string): The name for the sensor.
+  - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.
+  - All other options from :ref:`Sensor <config-sensor>`.
+
+- **temperature** (*Optional*): Temperature +-5°C. Only on RG-15.
 
   - **name** (**Required**, string): The name for the sensor.
   - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.

--- a/components/sensor/hydreon_rgxx.rst
+++ b/components/sensor/hydreon_rgxx.rst
@@ -62,8 +62,6 @@ required to be set up in your configuration for this sensor to work.
           name: "rain total"
         r_int:
           name: "rain intensity"
-        temperature:
-          name: "outside temperature"
 
 Configuration variables:
 ------------------------


### PR DESCRIPTION
## Description:

Document new sensors `temperature`, `lens_bad` and `em_sat`.

**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/3248

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#3642

## Checklist:

  - [X] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
