### PR TITLE
Add priority to on_shutdown trigger.

### DIFF
--- a/components/esphome.rst
+++ b/components/esphome.rst
@@ -126,11 +126,15 @@ too many WiFi/MQTT connection attempts, Over-The-Air updates being applied or th
         then:
           - switch.turn_off: switch_1
 
-Configuration variables: See :ref:`Automation <automation>`.
+Configuration variables:
 
-- **priority** (*Optional*, float): The priority to execute your custom initialization code. A higher value
-  means a high priority and in case of shutdown triggers that the code is executed **later**. Priority is used primarily for the initialization order of components. Shutdowns for these components are handled in *reverse* order, such that e.g. sensors (600) are shutdown before the hardware components (800) they depend on.
-  Please note this is an ESPHome-internal value and any change will not be marked as a breaking change. Defaults to ``600``. For priority values refer to the list in the :ref:`esphome-on_boot` section.
+- **priority** (*Optional*, float): The priority to execute your custom shutdown code. A higher value
+  means a high priority and in case of shutdown triggers that the code is executed **later**. 
+  Priority is used primarily for the initialization order of components. Shutdowns for these components are handled in *reverse* order, such that e.g. sensors (600) are shutdown before the hardware components (800) they depend on.
+  Please note this is an ESPHome-internal value and any change will not be marked as a breaking change. 
+  Defaults to ``600``. For priority values refer to the list in the :ref:`esphome-on_boot` section.
+  
+- See :ref:`Automation <automation>`.
 
 .. _esphome-on_loop:
 

--- a/components/esphome.rst
+++ b/components/esphome.rst
@@ -115,17 +115,22 @@ too many WiFi/MQTT connection attempts, Over-The-Air updates being applied or th
 .. note::
 
     It's not guaranteed that all components are in a connected state when this automation is triggered. For
-    example, the MQTT client may have already disconnected.
+    example, the MQTT client may have already disconnected. For use-cases that require specific shutdown ordering, look at the ``priority`` parameter.
 
 .. code-block:: yaml
 
     esphome:
       # ...
       on_shutdown:
+        priority: 700
         then:
           - switch.turn_off: switch_1
 
 Configuration variables: See :ref:`Automation <automation>`.
+
+- **priority** (*Optional*, float): The priority to execute your custom initialization code. A higher value
+  means a high priority and in case of shutdown triggers that the code is executed **later**. Priority is used primarily for the initialization order of components. Shutdowns for these components are handled in *reverse* order, such that e.g. sensors (600) are shutdown before the hardware components (800) they depend on.
+  Please note this is an ESPHome-internal value and any change will not be marked as a breaking change. Defaults to ``600``. For priority values refer to the list in the :ref:`esphome-on_boot` section.
 
 .. _esphome-on_loop:
 


### PR DESCRIPTION
## Description:

Documentation update for priorities added to the `on_shutdown` trigger.
(For shutdown actions that depend on components that would otherwise be shutdown before this trigger would be handled)

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#3644

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
