### PR TITLE
Update FAQ to document NVS write error

### DIFF
--- a/guides/faq.rst
+++ b/guides/faq.rst
@@ -281,6 +281,22 @@ Some steps that can help with the issue:
   although it may also increase power (and possibly battery) usage of other devices also using power
   save mode.
 
+Component states not restored after reboot
+------------------------------------------
+
+If you notice that some components, like ``climate`` or some switches are randomly not restoring their
+state after a reboot, or you get periodic ``ESP_ERR_NVS_NOT_ENOUGH_SPACE`` errors in your debug log,
+it could be that the NVS portion of the flash memory is full due to repeatedly testing multiple
+configurations (usually large) in the same ESP32 board. Try wiping NVS with the following commands:
+
+.. code-block:: bash
+
+    dd if=/dev/zero of=nvs_zero bs=1 count=20480
+    esptool.py --chip esp32 --port /dev/ttyUSB0 write_flash 0x009000 nvs_zero
+
+Change ``/dev/ttyUSB0`` above to your serial port. If you have changed the partition layout, please adjust the
+above offsets and sizes accordingly.
+
 Docker Reference
 ----------------
 


### PR DESCRIPTION
## Description:

Document what to do when NVS preferences are not saved, usually due to that portion of the flash memory being full of garbage old configs. [#3647](https://github.com/esphome/esphome/pull/3647) will then show a debug message pointing the user to this tip.

Credit goes to [sentinelt](https://github.com/sentinelt) for the solution.

**Related issue (if applicable):** fixes <link to issue>
[#3066](https://github.com/esphome/issues/issues/3066)
**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
