### PR TITLE
fix error for cover doc

### DIFF
--- a/components/cover/index.rst
+++ b/components/cover/index.rst
@@ -200,7 +200,7 @@ Lambdas
 From :ref:`lambdas <config-lambda>`, you can access the current state of the cover (note that these
 fields are read-only, if you want to act on the cover, use the ``make_call()`` method as shown above).
 
-- ``position``: Retrieve the current position of the cover, as a value between ``0.0`` (open) and ``1.0`` (closed).
+- ``position``: Retrieve the current position of the cover, as a value between ``0.0`` (closed) and ``1.0`` (open).
 
     .. code-block:: cpp
 


### PR DESCRIPTION
## Description:

I think there is an error in the line I changed. I must be 0.0 = closed and 1.0 = open as said above. Right now this is inconsistent.

This is written above:
```
position (Optional, float): The cover position to set.

0.0 = 0% = CLOSED

1.0 = 100% = OPEN
```

**Related issue (if applicable):**
none

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 
none

## Checklist:

  - [X] Branch: current (`next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.)
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
