### PR TITLE
Fix yaml example remote_transmitter.transmit_nexa

### DIFF
--- a/components/remote_transmitter.rst
+++ b/components/remote_transmitter.rst
@@ -224,7 +224,7 @@ This :ref:`action <config-action>` a Nexa RF remote code to a remote transmitter
 .. code-block:: yaml
 
     on_...:
-      - remote_transmitter.nexa:
+      - remote_transmitter.transmit_nexa:
           device: 0x38DDB4A
           state: 1
           group: 0


### PR DESCRIPTION
Fix yaml example for the remote_transmitter.transmit_nexa action

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
