### PR TITLE
Update modbus_controller.rst

### DIFF
--- a/components/sensor/modbus_controller.rst
+++ b/components/sensor/modbus_controller.rst
@@ -134,7 +134,8 @@ This example logs the value as parsed and the raw modbus bytes received for this
             ESP_LOGI("","Sensor properties: adress = 0x%X, offset = 0x%X value type=%d",item->start_address,item->offset,item->sensor_value_type);
             int i=0 ;
             for (auto val : data) {
-              ESP_LOGI("","data[%d]=0x%02X (%d)",i++ ,data[i],data[i]);
+              ESP_LOGI("","data[%d]=0x%02X (%d)",i,data[i],data[i]);
+              i++;
             }
             return x ;
 


### PR DESCRIPTION
In the example `i` gets incremented before the loop is over, but it is referenced again.
This can cause unexpected resutls if just blindly copy this example. (ask me, how i know :)

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
