### PR TITLE
Add support for V2 of the waveshare 5.83in e-paper display.

### DIFF
--- a/components/display/waveshare_epaper.rst
+++ b/components/display/waveshare_epaper.rst
@@ -91,6 +91,7 @@ Configuration variables:
   - ``4.20in``
   - ``4.20in-bV2`` - B/W rendering only
   - ``5.83in``
+  - ``5.83inv2``
   - ``7.50in``
   - ``7.50in-bV2`` - also supports v3, B/W rendering only
   - ``7.50in-bc`` - display with version sticker '(C)' on the back, B/W rendering only


### PR DESCRIPTION
Update the docs and add new model 5.83inv2 for the waveshare 5.83in V2.

## Description:


**Related issue (if applicable):** fixes [esphome/issues#2121](https://github.com/esphome/issues/issues/2121)

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#3660 

## Checklist:

  - [X] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
