### PR TITLE
added warning to waveshare 2.90inv2 inch display

### DIFF
--- a/components/display/waveshare_epaper.rst
+++ b/components/display/waveshare_epaper.rst
@@ -86,7 +86,7 @@ Configuration variables:
   - ``2.13in-ttgo-dke`` - T5_V2.3 with DKE group display (DEPG0213BN) tested
   - ``2.70in`` - currently not working with the HAT Rev 2.1 version
   - ``2.90in``
-  - ``2.90inv2`` - currently only working with the board Rev 2.1 version using ``full_update_every: 1`` (no partial refresh)
+  - ``2.90inv2`` - board rev 2.1 version currently only working using ``full_update_every: 1`` (no partial refresh)
   - ``2.90in-b`` - B/W rendering only
   - ``4.20in``
   - ``4.20in-bV2`` - B/W rendering only

--- a/components/display/waveshare_epaper.rst
+++ b/components/display/waveshare_epaper.rst
@@ -86,7 +86,7 @@ Configuration variables:
   - ``2.13in-ttgo-dke`` - T5_V2.3 with DKE group display (DEPG0213BN) tested
   - ``2.70in`` - currently not working with the HAT Rev 2.1 version
   - ``2.90in``
-  - ``2.90inv2``
+  - ``2.90inv2`` - currently only working with the board Rev 2.1 version using ``full_update_every: 1`` (no partial refresh)
   - ``2.90in-b`` - B/W rendering only
   - ``4.20in``
   - ``4.20in-bV2`` - B/W rendering only


### PR DESCRIPTION
## Description:
Added a warning to the 2.9 inch display because the board rev 2.1 version seems not to work without adding ``full_update_every: 1`` currently (which also means that partial refresh is not supported). Someone opened an issue some time before which is still open.

**Related issue:** warns about esphome/issues#2334 / esphome/issues#2459

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes:** hopefully obsolete with eventual merging of esphome/esphome#2912

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
