### PR TITLE
Updating xiaomi_ble.rst to add signal_strength to pvvx_mithermometer

### DIFF
--- a/components/sensor/xiaomi_ble.rst
+++ b/components/sensor/xiaomi_ble.rst
@@ -236,6 +236,8 @@ Configuration example for PVVX MiThermometer firmware set to "Custom" advertisem
           name: "PVVX Battery-Level"
         battery_voltage:
           name: "PVVX Battery-Voltage"
+        signal_strength:
+          name: "PVVX Signal"
 
 MHO-C303
 ********


### PR DESCRIPTION
## Description:

Updates the documentation to match the new option added in esphome/esphome#3688

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#3688

## Checklist:

  - [X] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
