### PR TITLE
Added documentation on selecting a specific frame in an animated gif

### DIFF
--- a/components/display/index.rst
+++ b/components/display/index.rst
@@ -625,7 +625,7 @@ Animation
 *********
 
 Allows to use animated images on displays. Animation inherits all options from the image component.
-It adds additional lambda methods: ``next_frame()`` and ``prev_frame()`` to change the shown picture of a gif.
+It adds additional lambda methods: ``next_frame()``, ``prev_frame()`` and ``set_frame() to change the shown picture of a gif.
 
 .. code-block:: yaml
 
@@ -636,7 +636,7 @@ It adds additional lambda methods: ``next_frame()`` and ``prev_frame()`` to chan
 
 The animation can be rendered just like the image component with the ``image()`` function of the display component.
 
-To show the next frame of the animation call ``id(my_animation).next_frame()``, to show the previous picture use ``id(my_animation).prev_frame()``.
+To show the next frame of the animation call ``id(my_animation).next_frame()``, to show the previous picture use ``id(my_animation).prev_frame()``. To show a specific picture use ``id(my_animation).set_frame()``.
 This can be combined with all Lambdas:
 
 .. code-block:: yaml

--- a/components/display/index.rst
+++ b/components/display/index.rst
@@ -636,7 +636,7 @@ It adds additional lambda methods: ``next_frame()``, ``prev_frame()`` and ``set_
 
 The animation can be rendered just like the image component with the ``image()`` function of the display component.
 
-To show the next frame of the animation call ``id(my_animation).next_frame()``, to show the previous picture use ``id(my_animation).prev_frame()``. To show a specific picture use ``id(my_animation).set_frame()``.
+To show the next frame of the animation call ``id(my_animation).next_frame()``, to show the previous picture use ``id(my_animation).prev_frame()``. To show a specific picture use ``id(my_animation).set_frame(int frame)``.
 This can be combined with all Lambdas:
 
 .. code-block:: yaml

--- a/components/display/index.rst
+++ b/components/display/index.rst
@@ -625,7 +625,7 @@ Animation
 *********
 
 Allows to use animated images on displays. Animation inherits all options from the image component.
-It adds additional lambda methods: ``next_frame()``, ``prev_frame()`` and ``set_frame() to change the shown picture of a gif.
+It adds additional lambda methods: ``next_frame()``, ``prev_frame()`` and ``set_frame()`` to change the shown picture of a gif.
 
 .. code-block:: yaml
 


### PR DESCRIPTION
Updated `animation` documentation to include details on how to select a specific frame. Depends on esphome/esphome#3681.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#3681

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
