### PR TITLE
feedback cover: fix typo

### DIFF
--- a/components/cover/feedback.rst
+++ b/components/cover/feedback.rst
@@ -68,7 +68,7 @@ Movement Sensors
 
 If movement feedback is available, the cover no longer operates in *optimistic mode* (assuming that movement starts
 as soon as an action is triggered) and can also react to commands issued to cover from an external control and still
-keep states in sync (useful for "smartization" of and existing cover).
+keep states in sync (useful for "smartization" of an existing cover).
 
 When there are no specific endstop sensors, and if the cover has builtin endstops and no external control logic,
 these movement sensors can optionally be use to infer the endstop state. 


### PR DESCRIPTION
## Description:

I found a typo in the documentation for the new feedback cover component introduced by @ianchi in https://github.com/esphome/esphome-docs/pull/1942

**Related issue (if applicable):**

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

## Checklist:

  - [X] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
