### PR TITLE
Fix pca9685 example

### DIFF
--- a/components/output/pca9685.rst
+++ b/components/output/pca9685.rst
@@ -24,7 +24,8 @@ global ``pca9685`` hub and give it an id, and then define the
 
     # Example configuration entry
     pca9685:
-      frequency: 500
+      - id: pca9685_hub1
+        frequency: 500
 
     # Individual outputs
     output:


### PR DESCRIPTION
## Description:

Fix the incorrect example yaml.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
