### PR TITLE
Docs for templated ble_client.write_action

### DIFF
--- a/components/ble_client.rst
+++ b/components/ble_client.rst
@@ -118,6 +118,20 @@ Example usage:
               characteristic_uuid: 6490FAFE-0734-732C-8705-91B653A081FC
               # List of bytes to write.
               value: [0x01, 0xab, 0xff]
+          - ble_client.ble_write:
+              id: my_ble_client
+              service_uuid: F61E3BE9-2826-A81B-970A-4D4DECFABBAE
+              characteristic_uuid: 6490FAFE-0734-732C-8705-91B653A081FC
+              # A lambda returning an std::vector<uint8_t>.
+              value: !lambda |-
+                  return {0x13, 0x37};
+
+Configuration variables:
+
+- **id** (**Required**, :ref:`config-id`): ID of the associated BLE client.
+- **service_uuid** (**Required**, UUID): UUID of the service to write to.
+- **characteristic_uuid** (**Required**, UUID): UUID of the service's characteristic to write to.
+- **value** (**Required**, Array of bytes or :ref:`lambda <config-lambda>`): The value to be written.
 
 BLE Overview
 ------------


### PR DESCRIPTION
## Description:

This PR adds the ability to template values with the ble_client.write_action introduced in https://github.com/esphome/esphome/pull/3398. One of the use case is setting the position of SwitchBot covers. Other use cases are: dimming lights, controlling actuators over BLE.

Note that while the Switchbot example works, it will drain the battery of the SwitchBot. For a better experience, on-demand BLE connection is needed. This featured ("delayed BLE actions") is tracked in https://github.com/esphome/esphome/pull/3434.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#3715

## Checklist:

  - [XX] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
