### PR TITLE
Fix minor typo in feedback cover docs

### DIFF
--- a/components/cover/feedback.rst
+++ b/components/cover/feedback.rst
@@ -216,7 +216,7 @@ Most options can be left untouched, but some modifications are needed:
           open_obstacle_sensor: open_obstacle_binary_sensor
           #... rest of options
 
-3. Malfunction detection is not directly supported by Feedback Cover, as the malfunction was very narrowly defined to a specif use case 
+3. Malfunction detection is not directly supported by Feedback Cover, as the malfunction was very narrowly defined to a specific use case 
    (while in other hardware configurations, the same situation is perfectly valid). 
 
    The malfunction alerted specifically when there was current in the opposite direction of the requested operation (possibly due to a relay welded).


### PR DESCRIPTION
## Description:
Fixes a minor typo

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
