### PR TITLE
Add support for timing budget with vl53l0x sensor.

### DIFF
--- a/components/sensor/vl53l0x.rst
+++ b/components/sensor/vl53l0x.rst
@@ -74,6 +74,9 @@ Configuration variables:
   have multiple VL53L0X on the same i2c bus. In this case you have to assign a different pin to each VL53L0X.
 - **timeout** (*Optional*, :ref:`config-time`): Sensor setup timeout. Default to ``10ms``.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
+- **timing_budget** (*Optional*, int): Set the timing budget the sensor will use for a single range measurement. 
+  Range is from 17000us - 4294967295us, inclusive. The timing budget allows the user to trade off speed for accuracy.
+  If not specified, the default timing budget is about 33000us.
 - All other options from :ref:`Sensor <config-sensor>`.
 
 


### PR DESCRIPTION
## Description:

Add support for timing budget with vl53l0x sensor.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#3732

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
