### PR TITLE
replace deprecated hexencode usage

### DIFF
--- a/components/exposure_notifications.rst
+++ b/components/exposure_notifications.rst
@@ -19,7 +19,7 @@ nearby COVID-19 exposure notification bluetooth messages sent by phones running 
         then:
           - lambda: |
               ESP_LOGD("main", "Got notification:");
-              ESP_LOGD("main", "  RPI: %s", hexencode(x.rolling_proximity_identifier).c_str());
+              ESP_LOGD("main", "  RPI: %s", format_hex_pretty(x.rolling_proximity_identifier).c_str());
               ESP_LOGD("main", "  RSSI: %d", x.rssi);
 
 Configuration variables:
@@ -67,7 +67,7 @@ minute, the indicator will be on.
         then:
           - lambda: |
               ESP_LOGD("main", "Got notification:");
-              ESP_LOGD("main", "  RPI: %s", hexencode(x.rolling_proximity_identifier).c_str());
+              ESP_LOGD("main", "  RPI: %s", format_hex_pretty(x.rolling_proximity_identifier).c_str());
               ESP_LOGD("main", "  RSSI: %d", x.rssi);
 
           # Stop existing timer so that turn_off doesn't get called

--- a/components/tuya.rst
+++ b/components/tuya.rst
@@ -107,7 +107,7 @@ The type of ``x`` variable is depending on ``datapoint_type`` configuration vari
           datapoint_type: raw
           then:
             - lambda: |-
-                ESP_LOGD("main", "on_datapoint_update %s", hexencode(x).c_str());
+                ESP_LOGD("main", "on_datapoint_update %s", format_hex_pretty(x).c_str());
                 id(voltage).publish_state((x[0] << 8 | x[1]) * 0.1);
                 id(current).publish_state((x[3] << 8 | x[4]) * 0.001);
                 id(power).publish_state((x[6] << 8 | x[7]) * 0.1);
@@ -126,7 +126,7 @@ The type of ``x`` variable is depending on ``datapoint_type`` configuration vari
           then:
             - lambda: |-
                 if (x.type == tuya::TuyaDatapointType::RAW) {
-                  ESP_LOGD("main", "on_datapoint_update %s", hexencode(x.value_raw).c_str());
+                  ESP_LOGD("main", "on_datapoint_update %s", format_hex_pretty(x.value_raw).c_str());
                 } else {
                   ESP_LOGD("main", "on_datapoint_update %hhu", x.type);
                 }


### PR DESCRIPTION
## Description:

hexencode is deprecated.  Replace uses in the docs.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
