### PR TITLE
updates schema generator

### DIFF
--- a/markdown.py
+++ b/markdown.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # reStructuredText (RST) to GitHub-flavored Markdown converter
 
-import re
 import sys
 from docutils import core, nodes, writers
 from urllib import parse
@@ -32,8 +31,7 @@ class Translator(nodes.NodeVisitor):
         raise nodes.StopTraversal
 
     def visit_title(self, node):
-        self.version = re.match(r"(\d+\.\d+\.\d+).*", node.children[0]).group(1)
-        raise nodes.SkipChildren
+        pass
 
     def visit_title_reference(self, node):
         raise Exception(

--- a/schema_doc.py
+++ b/schema_doc.py
@@ -834,7 +834,14 @@ class SchemaGeneratorVisitor(nodes.NodeVisitor):
                 self.app.config.html_baseurl,
                 self.docname + ".html#" + title.parent["ids"][0],
             )
-            markdown += f"\n\n*See also: [{self.props_section_title}]({url})*"
+            if (
+                self.props_section_title is not None
+                and self.props_section_title.endswith(title.astext())
+            ):
+                markdown += f"\n\n*See also: [{self.props_section_title}]({url})*"
+            else:
+                markdown += f"\n\n*See also: [{self.getMarkdown(title)}]({url})*"
+
         return markdown
 
     def update_prop(self, node, props):


### PR DESCRIPTION
## Description:

This is a small fix for docs generator where the **See also** links points to a wrong content

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
