### PR TITLE
Add docs for IP101 support

### DIFF
--- a/components/ethernet.rst
+++ b/components/ethernet.rst
@@ -6,9 +6,11 @@ Ethernet Component
     :image: ethernet.svg
     :keywords: Ethernet, ESP32
 
-This core ESPHome component sets up ethernet connections for ESP32s.
+This ESPHome component enables *wired* Ethernet connections for ESP32s.
+
 Ethernet for ESP8266 is not supported.
-This component can't be used in same time than Wifi one, even if your ESP32 has both wired.
+
+This component and the Wi-Fi component may **not** be used simultaneously, even if both are physically available.
 
 .. code-block:: yaml
 
@@ -29,24 +31,23 @@ This component can't be used in same time than Wifi one, even if your ESP32 has
 Configuration variables:
 ------------------------
 
-- **type** (**Required**, string): The type of LAN chipset. Must be one of
-  ``LAN8720`` or ``TLK110`` (see datasheet for more details).
+- **type** (**Required**, string): The type of LAN chipset/phy. Must be one of
+  ``LAN8720``, ``TLK110`` or ``IP101`` (see datasheet for more details).
 - **mdc_pin** (**Required**, :ref:`config-pin`): The MDC pin of the board.
   Usually this is ``GPIO23``.
 - **mdio_pin** (**Required**, :ref:`config-pin`): The MDIO pin of the board.
   Usually this is ``GPIO18``.
-- **clk_mode** (*Optional*, string): The clock mode of the data lines, this must be one
-  of these values: (see datasheet of your board for more details)
+- **clk_mode** (*Optional*, string): The clock mode of the data lines. See your board's
+  datasheet for more details. Must be one of the following values:
 
   - ``GPIO0_IN`` (Default) - External clock
   - ``GPIO0_OUT`` - Internal clock
   - ``GPIO16_OUT`` - Internal clock
   - ``GPIO17_OUT`` - Internal clock
 
-- **phy_addr** (*Optional*, int): The PHY addr type of the ethernet controller. Defaults to 0.
-- **power_pin** (*Optional*, :ref:`Pin Schema <config-pin_schema>`): The pin with which
-  to control the power of the board. Leave unspecified for no power pin (default)
-
+- **phy_addr** (*Optional*, int): The PHY addr type of the Ethernet controller. Defaults to 0.
+- **power_pin** (*Optional*, :ref:`Pin Schema <config-pin_schema>`): The pin controlling the
+  power/reset status of the Ethernet controller. Leave unspecified for no power pin (default).
 - **manual_ip** (*Optional*): Manually configure the static IP of the node.
 
   - **static_ip** (**Required**, IPv4 address): The static IP of your node.
@@ -66,9 +67,10 @@ Configuration variables:
 
 .. note::
 
-    If your ethernet board is not designed with an ESP32 built in, chances are that you are going
-    to use flying leads, dupont wires, etc. to connect the ethernet to the ESP32. This is
-    probably to fail as the ethernet interface uses a high frequency clock signal. For more
+    If your Ethernet board is not designed with an ESP32 built in, it's common to attempt
+    to use flying leads, dupont wires, etc. to connect the Ethernet controller to the ESP32.
+    This approach is likely to fail, however, as the Ethernet interface uses a high frequency
+    clock signal that will not travel reliably over these types of connections. For more
     information and wiring details refer to the link in the *See also* section.
 
 Configuration for Olimex ESP32-POE
@@ -151,7 +153,7 @@ Configuration for OpenHacks LAN8720
     program properly.
 
 Configuration for wESP32 board (up to rev.6)
--------------------------------------------------
+--------------------------------------------
 
 .. code-block:: yaml
 
@@ -166,6 +168,19 @@ Configuration for wESP32 board (up to rev.6)
 
     Revision 7 and upwards of the wESP32 board does not have a LAN8720 chip. Until support for the 
     replacement RTL8201 is included in ESPHome, the wESP board rev.7 will not work with the above configuration.
+
+Configuration for ESP32-Ethernet-Kit board
+------------------------------------------
+
+.. code-block:: yaml
+
+    ethernet:
+      type: IP101
+      mdc_pin: GPIO23
+      mdio_pin: GPIO18
+      clk_mode: GPIO0_IN
+      phy_addr: 1
+      power_pin: GPIO5
 
 See Also
 --------


### PR DESCRIPTION
## Description:

I bought an [ESP32-Ethernet-Kit ](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/hw-reference/esp32/get-started-ethernet-kit.html) for some reason and realized we needed support added for its phy. This PR adds support for the IP101 phy to the Ethernet component.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#3751

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
