### PR TITLE
update numbercall function names

### DIFF
--- a/components/number/index.rst
+++ b/components/number/index.rst
@@ -309,8 +309,8 @@ advanced stuff (see the full API Reference for more info).
       call.perform();
 
   Check the API reference for information on the methods that are available for
-  the ``NumberCall`` object. You can for example also use ``call.to_min()``
-  to set the number to its minimum value or ``call.increment(true)`` to increment
+  the ``NumberCall`` object. You can for example also use ``call.number_to_min()``
+  to set the number to its minimum value or ``call.number_increment(true)`` to increment
   the number by its step size with the cycle feature enabled.
 
 - ``.state``: Retrieve the current value of the number. Is ``NAN`` if no value has been read or set.


### PR DESCRIPTION
I think its number_to_min and number_increment according to https://esphome.io/api/classesphome_1_1number_1_1_number_call.html for the lambda example

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
