### PR TITLE
Document available docker tags

### DIFF
--- a/guides/getting_started_command_line.rst
+++ b/guides/getting_started_command_line.rst
@@ -40,6 +40,21 @@ If you want to use `docker-compose` instead, here's a sample file:
         privileged: true
         network_mode: host
 
+The project provides multiple docker tags; please pick the one that suits you
+better:
+
+- ``latest`` and ``stable`` point to the latest stable release available. It's
+  not recommended to automatically update the container based on those tags
+  because of the possible breaking changes between releases.
+- Release-tracking tag ``YEAR.MONTH`` (e.g. ``2022.8``) points to the latest
+  stable patch release available within the required version. There should
+  never be a breaking change when upgrading the containers based on tags like
+  that.
+- ``beta`` points to the latest released beta version, and to the latest stable
+  release when there is no fresh beta release.
+- ``dev`` is the bleeding edge release; built daily based on the latest changes
+  in the ``dev`` branch.
+
 
 Connecting the ESP Device
 -------------------------


### PR DESCRIPTION
## Description:

I am adding the documentation about the available docker tags (including the ones I'm adding in the linked esphome PR).

Here's how the change looks:

<img width="678" alt="image" src="https://user-images.githubusercontent.com/629281/188207008-44abbc95-fea0-42be-b02c-6b446aaf1264.png">

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#3752

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
