### PR TITLE
Override functionality for platformio_options

### DIFF
--- a/components/esphome.rst
+++ b/components/esphome.rst
@@ -179,8 +179,8 @@ You can view a full list of PlatformIO options here: https://docs.platformio.org
           override: true
 
 .. note::
-    Forcefully overriding values in ``platformio_options`` is concidered an advanced feature and should generally not be used unless you know what you're doing.
 
+    Forcefully overriding values in ``platformio_options`` is concidered an advanced feature and should generally not be used unless you know what you're doing.
 
 .. _esphome-includes:
 

--- a/components/esphome.rst
+++ b/components/esphome.rst
@@ -174,6 +174,13 @@ You can view a full list of PlatformIO options here: https://docs.platformio.org
       platformio_options:
         upload_speed: 115200
         board_build.f_flash: 80000000L
+        platform_packages:
+          value: ""
+          override: true
+
+.. note::
+    Forcefully overriding values in ``platformio_options`` is concidered an advanced feature and should generally not be used unless you know what you're doing.
+
 
 .. _esphome-includes:
 


### PR DESCRIPTION
## Description:



**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#3765

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
