### PR TITLE
Delayed Startup Code

### DIFF
--- a/components/sensor/am2320.rst
+++ b/components/sensor/am2320.rst
@@ -24,6 +24,13 @@ The ``am2320`` Temperature+Humidity sensor allows you to use your AM2320
     Logs might include some warnings about receiving a NACK from the sensor.
     This is due to a wake call to the sensor which the sensor never acknowledges by design.
 
+.. note::
+
+    If there seems to be an issue with the ESP setting up a connection, the
+    sensor might not be fully started up. This can occur on a cold start of
+    your node. Check if a delay helps you by adding ``setup_priority: -1000``
+    in your sensor description.
+
 .. code-block:: yaml
 
     # Example configuration entry


### PR DESCRIPTION
Adding Note regarding the need of a delayed startup of the communication
between ESP and AM2320 sensor due to the sensor being slow on a cold startup.

## Description:


**Related issue (if applicable):** this issue was supposed to be fixed with https://github.com/esphome/esphome/pull/554 but appeared at my setup and this workaround seems to fix it

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** not applicable

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
