### PR TITLE
clarify non normal cron - 6 fields with seconds

### DIFF
--- a/components/time.rst
+++ b/components/time.rst
@@ -57,7 +57,9 @@ This powerful automation can be used to run automations at specific intervals at
 specific times of day. The syntax is a subset of the `crontab <https://crontab.guru/>`__ syntax.
 
 There are two ways to specify time intervals: Either with using the ``seconds:``, ``minutes:``, ...
-keys as seen below or using a cron expression like ``* /5 * * * *``.
+keys as seen below or using a cron alike expression like ``* /5 * * * *``. 
+
+Be aware normal cron implementations does not know about seconds like this esphome implementation, therefore you got 6 fields (seconds,minutes,hours,dayofmonth,month,dayofweek).
 
 Basically, the automation engine looks at your configured time schedule every second and
 evaluates if the automation should run.


### PR DESCRIPTION
normal cron does not know about seconds and has typicaly only 5 fields, this is seconds aware and has 6 fields. This may be confusing without further noticing it.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
