### PR TITLE
web_server: Fix Example configuration entry V1

### DIFF
--- a/components/web_server.rst
+++ b/components/web_server.rst
@@ -110,8 +110,10 @@ Force to turn off OTA function because the missing authentication.
     # Example configuration entry V1
     web_server:
       port: 80
+      version: 1
       ota: false
       css_include: "../../../esphome-docs/_static/webserver-v1.min.css"
+      css_url: ""
       js_include: "../../../esphome-docs/_static/webserver-v1.min.js"
       js_url: ""
 


### PR DESCRIPTION
## Description:
Fix Example configuration entry V1

add `version: 1` since v2 is default now
add missing `css_url: ""` (otherwise would double-include the css file


## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
