### PR TITLE
Update power_supply.rst

### DIFF
--- a/components/power_supply.rst
+++ b/components/power_supply.rst
@@ -30,7 +30,7 @@ Configuration variables:
   power supply so that it can be used by the outputs.
 - **pin** (**Required**, :ref:`Pin Schema <config-pin_schema>`): The
   GPIO pin to control the power supply on.
-- **enable_time** (*Optional*, :ref:`config-time`): The time to
+- **enable_time** (*Optional*, :ref:`config-time`): The time
   that the power supply needs for startup. The output component will
   wait for this period of time after turning on the PSU and before
   switching the output on. Defaults to ``20ms``.


### PR DESCRIPTION
removed superfluous 'to'

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
