### PR TITLE
Add magnetometer calibration reference

### DIFF
--- a/components/sensor/hmc5883l.rst
+++ b/components/sensor/hmc5883l.rst
@@ -95,4 +95,5 @@ See Also
 - :doc:`template`
 - :apiref:`hmc5883l/hmc5883l.h`
 - `HMC5883L Library <https://github.com/jarzebski/Arduino-HMC5883L>`__ by `Korneliusz Jarzębski <https://github.com/jarzebski>`__
+- `Magnetometer calibration with esphome code <https://github.com/nliaudat/magnetometer_calibration>`__
 - :ghedit:`Edit`


### PR DESCRIPTION

## Description:
Add magnetometer calibration reference with esphome code

**Related issue (if applicable): nothing

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ X] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [X ] Link added in `/index.rst` when creating new documents for new components or cookbook. - Not applicable
