### PR TITLE
Add magnetometer calibration reference

### DIFF
--- a/components/sensor/qmc5883l.rst
+++ b/components/sensor/qmc5883l.rst
@@ -80,4 +80,5 @@ See Also
 - :ref:`sensor-filters`
 - :doc:`template`
 - :apiref:`qmc5883l/qmc5883l.h`
+- `Magnetometer calibration with esphome code <https://github.com/nliaudat/magnetometer_calibration>`__
 - :ghedit:`Edit`


### PR DESCRIPTION
Description:

Add magnetometer calibration reference with esphome code

**Related issue (if applicable): nothing

Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable): esphome/esphome#
Checklist:

    [ X] Branch: next is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against current.
    [X ] Link added in /index.rst when creating new documents for new components or cookbook. - Not applicable