### PR TITLE
remove temperature unit from example

### DIFF
--- a/components/climate/index.rst
+++ b/components/climate/index.rst
@@ -27,9 +27,9 @@ All climate platforms in ESPHome inherit from the climate configuration schema.
     climate:
       - platform: ...
         visual:
-          min_temperature: 18 °C
-          max_temperature: 25 °C
-          temperature_step: 0.1 °C
+          min_temperature: 18
+          max_temperature: 25
+          temperature_step: 0.1
 
 Configuration variables:
 


### PR DESCRIPTION
remove temperature unit from example, as configuration will not work with units present

## Description:


**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/2884

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [] Link added in `/index.rst` when creating new documents for new components or cookbook.
