### PR TITLE
Add reset_reason text sensor to debug component

### DIFF
--- a/components/debug.rst
+++ b/components/debug.rst
@@ -25,6 +25,8 @@ ESP heap memory (free space, maximum free block size and fragmentation level) an
       - platform: debug
         device:
           name: "Device Info"
+        reset_reason:
+          name: "Reset Reason"
 
     sensor:
       - platform: debug
@@ -64,6 +66,13 @@ Configuration variables:
     - Flash id
     - SDK, Core & Boot versions
     - Reset reason & information
+
+  Accepts these options:
+
+  - **name** (**Required**, string): The name of the sensor.
+  - All other options from :ref:`Text Sensor <config-text_sensor>`.
+
+- **reset_reason** (*Optional*): Reports the last reboot reason in a human-readable form.
 
   Accepts these options:
 


### PR DESCRIPTION
## Description:

Add a dedicated text_sensor to `debug` component for showing last reboot reason.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#3814

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
