### PR TITLE
Document steps for adding a password to OTA

### DIFF
--- a/components/ota.rst
+++ b/components/ota.rst
@@ -197,8 +197,8 @@ through an ``on_boot`` trigger:
 Adding a password:
 ******************
 
-If OTA is already enabled without a password, simply add a `password:` line to the existing
-`ota:` config block.
+If OTA is already enabled without a password, simply add a ``password:`` line to the existing
+``ota:`` config block.
 
 See Also
 --------

--- a/components/ota.rst
+++ b/components/ota.rst
@@ -177,6 +177,9 @@ enum. These values are:
 Updating the password:
 ----------------------
 
+Changing an existing password:
+******************************
+
 Since the password is used both for compiling and uploading the regular ``esphome <file> run``
 won't work of course. This issue can be worked around by executing the operations separately
 through an ``on_boot`` trigger:
@@ -190,6 +193,12 @@ through an ``on_boot`` trigger:
     ota:
       password: "Old password"
       id: my_ota
+
+Adding a password:
+******************
+
+If OTA is already enabled without a password, simply add a `password:` line to the existing
+`ota:` config block.
 
 See Also
 --------


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** none

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** none

## Checklist:

  - [X] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [X] Link added in `/index.rst` when creating new documents for new components or cookbook.
