### PR TITLE
align template sensor unit display

### DIFF
--- a/components/sensor/xiaomi_miscale.rst
+++ b/components/sensor/xiaomi_miscale.rst
@@ -91,7 +91,7 @@ You have to replace the numbers in the lambdas to determine your weight which is
       - platform: template
         name: Impedance Aurélien
         id: impedance_user1
-        unit_of_measurement: 'ohm'
+        unit_of_measurement: 'Ω'
         icon: mdi:omega
         accuracy_decimals: 0
       - platform: template
@@ -103,7 +103,7 @@ You have to replace the numbers in the lambdas to determine your weight which is
       - platform: template
         name: Impedance Siham
         id: impedance_user2
-        unit_of_measurement: 'ohm'
+        unit_of_measurement: 'Ω'
         icon: mdi:omega
         accuracy_decimals: 0
 


### PR DESCRIPTION
## Description:

Just cosmetics to align the template sensor unit display with the impedance sensor unit which is Ω

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [current] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
