### PR TITLE
Fix Typo in Code Example

### DIFF
--- a/components/cover/feedback.rst
+++ b/components/cover/feedback.rst
@@ -198,7 +198,7 @@ Most options can be left untouched, but some modifications are needed:
           id: open_binary_sensor
           sensor_id: open_current_sensor
           threshold: 0.5
-          filter:
+          filters:
             - delayed_off: 0.8s
         - platform: analog_threshold
           id: open_obstacle_binary_sensor


### PR DESCRIPTION
Changed filter to filters in the binary_sensor, so the Example would work if copied.

## Description:

According to the [binary_sensor](https://esphome.io/components/binary_sensor/index.html#config-binary-sensor) page the option should be called filters and not filter.
Fixing this allows copying and pasting the examples without errors.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
