### PR TITLE
Adding baseline application note

### DIFF
--- a/components/sensor/ccs811.rst
+++ b/components/sensor/ccs811.rst
@@ -113,5 +113,6 @@ See Also
 
 - :ref:`sensor-filters`
 - `CCS811 Application Note <https://cdn.sparkfun.com/datasheets/BreakoutBoards/CCS811_Programming_Guide.pdf>`__
+- `Baseline Save and Restore on CCS811 <https://www.sciosense.com/wp-content/uploads/documents/Application-Note-Baseline-Save-and-Restore-on-CCS811.pdf>`
 - :apiref:`ccs811/ccs811.h`
 - :ghedit:`Edit`


### PR DESCRIPTION
Added application note on conditioning period and baseline reading/writing


## Checklist:

  - [ x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ x] Link added in `/index.rst` when creating new documents for new components or cookbook.
