### PR TITLE
Mention that update_interval can be never

### DIFF
--- a/components/sensor/template.rst
+++ b/components/sensor/template.rst
@@ -37,7 +37,7 @@ Configuration variables:
   Lambda to be evaluated every update interval to get the new value of the sensor
 - **update_interval** (*Optional*, :ref:`config-time`): The interval to publish the value of the
   sensor, either the result of the lambda function or if no lambda function the last value
-  published using the publish action. Defaults to ``60s``.
+  published using the publish action. Set to ``never`` to disable updates. Defaults to ``60s``.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
 - All other options from :ref:`Sensor <config-sensor>`.
 


### PR DESCRIPTION
## Description:

I know this is also mentioned in the `config-time` page, but it took me longer to see it than I'd like to admit. Mentioning it here as well can't hurt.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
