### PR TITLE
Add min/max_interval and measured_power to esp32_ble_beacon

### DIFF
--- a/components/esp32_ble_beacon.rst
+++ b/components/esp32_ble_beacon.rst
@@ -34,16 +34,16 @@ Advanced options:
   identify beacons within an iBeacon group. Defaults to ``61958``.
 - **min_interval** (*Optional*, int): The iBeacon minimum transmit interval in milliseconds from 20 to 10240.
   Setting this less than ``max_interval`` gives the BLE hardware a better chance to avoid
-  collisions with other BLE transmissions. Defaults to the iBeacon specification's defined interval: ``100``.
+  collisions with other BLE transmissions. Defaults to the iBeacon specification's defined interval: ``100ms``.
 - **max_interval** (*Optional*, int): The iBeacon maximum transmit interval in milliseconds from 20 to 10240.
   Setting this greater than ``min_interval`` gives the BLE hardware a better chance to avoid
-  collisions with other BLE transmissions. Defaults to the iBeacon specification's defined interval: ``100``.
-- **measured_power** (*Optional*, int): The power of the iBeacon as measured 1 meter from the device.
+  collisions with other BLE transmissions. Defaults to the iBeacon specification's defined interval: ``100ms``.
+- **measured_power** (*Optional*, int): The RSSI of the iBeacon as measured 1 meter from the device.
   This is used to calibrate the ranging calculations in iOS. The procedure for setting this value can
   be found in Apple's `Getting Started with iBeacon PDF <https://developer.apple.com/ibeacon/Getting-Started-with-iBeacon.pdf>`__
   under the heading *Calibrating iBeacon*. Between -128 to 0. Defaults to ``-59``.
-- **tx_power** (*Optional*, int): The transmission power of the iBeacon in dBm.
-  One of -12, -9, -6, -3, 0, 3, 6, 9. Defaults to ``3``.
+- **tx_power** (*Optional*, int): The transmit power of the iBeacon in dBm.
+  One of -12, -9, -6, -3, 0, 3, 6, 9. Defaults to ``3dBm``.
 
 Setting Up
 ----------

--- a/components/esp32_ble_beacon.rst
+++ b/components/esp32_ble_beacon.rst
@@ -32,6 +32,18 @@ Advanced options:
   the BLE receiver doesn't use it. Defaults to ``10167``.
 - **minor** (*Optional*, int): The iBeacon minor identifier of this beacon. Usually used to
   identify beacons within an iBeacon group. Defaults to ``61958``.
+- **min_interval** (*Optional*, int): The iBeacon minimum transmit interval in milliseconds from 20 to 10240.
+  Setting this less than ``max_interval`` gives the BLE hardware a better chance to avoid
+  collisions with other BLE transmissions. Defaults to the iBeacon specification's defined interval: ``100``.
+- **max_interval** (*Optional*, int): The iBeacon maximum transmit interval in milliseconds from 20 to 10240.
+  Setting this greater than ``min_interval`` gives the BLE hardware a better chance to avoid
+  collisions with other BLE transmissions. Defaults to the iBeacon specification's defined interval: ``100``.
+- **measured_power** (*Optional*, int): The power of the iBeacon as measured 1 meter from the device.
+  This is used to calibrate the ranging calculations in iOS. The procedure for setting this value can
+  be found in Apple's `Getting Started with iBeacon PDF <https://developer.apple.com/ibeacon/Getting-Started-with-iBeacon.pdf>`__
+  under the heading *Calibrating iBeacon*. Between -128 to 0. Defaults to ``-59``.
+- **tx_power** (*Optional*, int): The transmission power of the iBeacon in dBm.
+  One of -12, -9, -6, -3, 0, 3, 6, 9. Defaults to ``3``.
 
 Setting Up
 ----------

--- a/components/esp32_ble_beacon.rst
+++ b/components/esp32_ble_beacon.rst
@@ -32,10 +32,10 @@ Advanced options:
   the BLE receiver doesn't use it. Defaults to ``10167``.
 - **minor** (*Optional*, int): The iBeacon minor identifier of this beacon. Usually used to
   identify beacons within an iBeacon group. Defaults to ``61958``.
-- **min_interval** (*Optional*, int): The iBeacon minimum transmit interval in milliseconds from 20 to 10240.
+- **min_interval** (*Optional*, :ref:`config-time`): The iBeacon minimum transmit interval in milliseconds from 20 to 10240.
   Setting this less than ``max_interval`` gives the BLE hardware a better chance to avoid
   collisions with other BLE transmissions. Defaults to the iBeacon specification's defined interval: ``100ms``.
-- **max_interval** (*Optional*, int): The iBeacon maximum transmit interval in milliseconds from 20 to 10240.
+- **max_interval** (*Optional*, :ref:`config-time`): The iBeacon maximum transmit interval in milliseconds from 20 to 10240.
   Setting this greater than ``min_interval`` gives the BLE hardware a better chance to avoid
   collisions with other BLE transmissions. Defaults to the iBeacon specification's defined interval: ``100ms``.
 - **measured_power** (*Optional*, int): The RSSI of the iBeacon as measured 1 meter from the device.


### PR DESCRIPTION
## Description:

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#3859

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
