### PR TITLE
Add id and teleinfo_id to teleinfo configuration variables

### DIFF
--- a/components/sensor/teleinfo.rst
+++ b/components/sensor/teleinfo.rst
@@ -107,10 +107,13 @@ In teleinfo platform:
 - **uart_id** (*Optional*, :ref:`config-id`): Manually specify the ID of the :ref:`UART Component <uart>` if you want
   to use multiple UART buses.
 
+- **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation or multiple hubs.
+
 Sensor
 ******
 
 - **tag_name** (**Required**, string): Specify the tag you want to retrieve from the Teleinformation.
+- **teleinfo_id** (*Optional*, :ref:`config-id`): Specify the ID of used hub.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
 - All other options from :ref:`Sensor <config-sensor>`.
 
@@ -118,6 +121,7 @@ Text Sensor
 ***********
 
 - **tag_name** (**Required**, string): Specify the tag you want to retrieve from the Teleinformation.
+- **teleinfo_id** (*Optional*, :ref:`config-id`): Specify the ID of used hub.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
 - All other options from :ref:`Text Sensor <config-text_sensor>`.
 


### PR DESCRIPTION
## Description:
Add id to teleinfo configuration variables and teleinfo_id to sensor and text_sensor in teleinfo.
They are in examples but not listed which can cause some confusion.

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
