### PR TITLE
docs: update the quantile link

### DIFF
--- a/components/sensor/index.rst
+++ b/components/sensor/index.rst
@@ -392,7 +392,7 @@ Configuration variables:
 ******************************
 
 A simple `exponential moving average
-<https://en.wikipedia.org/wiki/Moving_average#Exponential_moving_average>`__ over the last few
+<https://www.itl.nist.gov/div898/software/dataplot/refman2/auxillar/quantile.htm>`__ over the last few
 values. It can be used to have a short update interval on the sensor but only push
 out an average on a specific interval (thus increasing resolution).
 


### PR DESCRIPTION


## Description:

The quantile link has been updated to a more descriptive one, which gives a better idea of the quantile function.

**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/3622

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** None

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
