### PR TITLE
feat: set a wider range for jpeg quality

### DIFF
--- a/components/esp32_camera.rst
+++ b/components/esp32_camera.rst
@@ -92,7 +92,7 @@ Image Settings:
     - ``1600x1200`` (UXGA)
 
 - **jpeg_quality** (*Optional*, int): The JPEG quality that the camera should encode images with.
-  From 10 (best) to 63 (worst). Defaults to ``10``.
+  From 6 (best) to 63 (worst). Defaults to ``10``.
 - **vertical_flip** (*Optional*, boolean): Whether to flip the image vertically. Defaults to ``true``.
 - **horizontal_mirror** (*Optional*, boolean): Whether to mirror the image horizontally. Defaults to ``true``.
 - **contrast** (*Optional*, int): The contrast to apply to the picture, from -2 to 2. Defaults to ``0``.


### PR DESCRIPTION
## Description:

A wider range has been set considering that enough RAM space is expected for the processing.

**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/3570

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#3872

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
