### PR TITLE
Fix Gitpod launch command to use live-html target

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -4,4 +4,4 @@ ports:
 
 tasks:
 - before: pip3 install -r requirements.txt
-  command: make webserver
+  command: make live-html


### PR DESCRIPTION
## Description:

#1786 removed the `webserver` target with a much snazzier `live-html` one. However, the Gitpod workspace launch configuration references this older target and no longer works out of the box as intended.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** N/A

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
