### PR TITLE
Add breadcrumbs to the top of pages

### DIFF
--- a/_static/custom.css
+++ b/_static/custom.css
@@ -186,3 +186,7 @@ div.index-shields {
     margin-left: 32px;
   }
 }
+
+.breadcrumbs li {
+  display: inline;
+}

--- a/_templates/layout.html
+++ b/_templates/layout.html
@@ -27,6 +27,17 @@
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 {% endblock %}
 
+{% block relbar_top %}
+  {% if parents|length > 0 %}
+  <ul class="breadcrumbs">
+    {%- for doc in parents %}
+      <li><a href="{{ doc.link|e }}">{{ doc.title }}</a> ➔</li>
+    {%- endfor %}
+      <li>{{title}}</li>
+  </ul>
+  {% endif %}
+{% endblock %}
+
 {% block footer %}
   <div id="upgrade-footer">
     A new version has been release since you last visited this page: {{ release }} 🎉

--- a/devices/index.rst
+++ b/devices/index.rst
@@ -1,4 +1,4 @@
-Cookbook
+Devices
 ========
 
 .. toctree::


### PR DESCRIPTION
## Description:
I've recently fallen in love with ESPHome after migrating my Tasmota devices and removing any need for MQTT. One little nitpick I've bumped into when reaching documentation as a beginner was simply orienting myself within the website, especially when coming to a page from a search engine. This PR adds breadcrumb links to the top of pages to provide some context:
![image](https://user-images.githubusercontent.com/7294642/196060124-2b3298c4-948a-41d5-b055-adf2c390ed15.png)

I take no offense if this is an undesired change - feel free to close the PR if so.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** N/A

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
