### PR TITLE
Fix color temp units for strobe effect

### DIFF
--- a/components/light/index.rst
+++ b/components/light/index.rst
@@ -551,7 +551,7 @@ Configuration variables:
   - **green** (*Optional*, percentage): The green channel of the light, if applicable. Defaults to ``100%``.
   - **blue** (*Optional*, percentage): The blue channel of the light, if applicable. Defaults to ``100%``.
   - **white** (*Optional*, percentage): The white channel of the light, if applicable. Defaults to ``100%``.
-  - **color_temperature** (*Optional*, percentage): The color temperature of the light, if applicable. Defaults to ``100%``.
+  - **color_temperature** (*Optional*, float): The color temperature of the light (in `mireds <https://en.wikipedia.org/wiki/Mired>`__ or Kelvin), if applicable.
   - **cold_white** (*Optional*, percentage): The cold white channel of the light, if applicable. Defaults to ``100%``.
   - **warm_white** (*Optional*, percentage): The warm white channel of the light, if applicable. Defaults to ``100%``.
   - **duration** (**Required**, :ref:`config-time`): The duration this color should be active.


### PR DESCRIPTION
Percentage is not acceptable per config validation (cv.color_temperature).  Must be mireds or Kelvin.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
