### PR TITLE
Remove duplicated option in hmc5883l.rst

### DIFF
--- a/components/sensor/hmc5883l.rst
+++ b/components/sensor/hmc5883l.rst
@@ -52,7 +52,6 @@ Configuration variables:
 - **heading** (*Optional*): The heading of the sensor in degrees. All options from
   :ref:`Sensor <config-sensor>`.
 - **oversampling** (*Optional*): The oversampling parameter for the sensor.
-- **range** (*Optional*): The range parameter for the sensor.
 - **update_interval** (*Optional*, :ref:`config-time`): The interval to check the sensor. Defaults to ``60s``.
 - **oversampling** (*Optional*): Number of readings to average over for each sample. One of ``1x``, ``2x``,
   ``4x``, ``8x``. Defaults to ``1x``.


### PR DESCRIPTION
The **range** option was listed twice.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
