### PR TITLE
remove invalid method from docs

### DIFF
--- a/guides/automations.rst
+++ b/guides/automations.rst
@@ -801,7 +801,6 @@ or as lambda
 
     lambda: |-
         id(my_script).execute();
-        id(my_script).wait();
 
 .. _script-is_running_condition:
 


### PR DESCRIPTION
## Description:
The `.wait()` method doesn't exist.

**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/3732

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
