### PR TITLE
Revise SM300D2 documentation

### DIFF
--- a/components/sensor/sm300d2.rst
+++ b/components/sensor/sm300d2.rst
@@ -19,16 +19,24 @@ The ``sm300d2`` sensor platform allows you to use the SM300D2 7-in-1 Air Quality
     :width: 50.0%
 
 
-The SM300D2 sensor supports connections via UART or RS485. This platform only supports UART-connections.
+Although the SM300D2 sensor supports connections via UART or RS485, this platform only supports UART
+connections. The LCD module which is often sold with/for these sensor boards can work over either UART
+or RS485, so you can use the LCD over RS485 and an ESP over UART at the same time (see
+:ref:`note below <pins-note>` regarding powering everything).
+
 Make sure you have a :ref:`UART bus <uart>` in your configuration with the ``rx_pin`` connected to the
-TX pin of the sensor. The sensor does not support receiving data, so the ``tx_pin`` does not need to be
-connected. The sensor expects the baud rate to be set at 9600.
+sensor's TX pin. The sensor does not support receiving data, so the ``tx_pin`` does not need to be
+connected. The UART bus should be set to a baud rate of 9600 to match the sensor's output. Setting the
+``rx_pin``'s mode to ``INPUT_PULLDOWN`` may help improve reliability if you're regularly getting missed
+or bad/incomplete readings.
 
 .. code-block:: yaml
 
     # Example configuration entry
     uart:
-      rx_pin: D0
+      rx_pin:
+        number: D0
+        mode: INPUT_PULLDOWN
       tx_pin: D1
       baud_rate: 9600
 
@@ -54,43 +62,43 @@ Configuration variables:
 ------------------------
 
 
-- **co2** (**Required**): The CO₂ data from the sensor in parts per million (ppm).
+- **co2** (**Required**): The information for the CO₂ sensor. Readings in parts per million (ppm).
 
   - **name** (**Required**, string): The name of the CO₂ sensor.
   - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.
   - All other options from :ref:`Sensor <config-sensor>`.
 
-- **formaldehyde** (**Required**): The formaldehyde data of the sensor in micrograms per cubic meter air (µg/m³).
+- **formaldehyde** (**Required**): The information for the formaldehyde sensor. Readings in µg/m³.
 
   - **name** (**Required**, string): The name of the formaldehyde sensor.
   - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.
   - All other options from :ref:`Sensor <config-sensor>`.
 
-- **tvoc** (**Required**): The total volatile organic compounds (TVOC) data of the sensor in micrograms per cubic meter air (µg/m³).
+- **tvoc** (**Required**): The information for the total volatile organic compounds (TVOC) sensor. Readings in µg/m³.
 
   - **name** (**Required**, string): The name of the TVOC sensor.
   - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.
   - All other options from :ref:`Sensor <config-sensor>`.
 
-- **pm_2_5** (**Required**): The PM2.5 data of the sensor in micrograms per cubic meter air (µg/m³).
+- **pm_2_5** (**Required**): The information for the **Weight Concentration** sensor for fine particles up to 2.5μm. Readings in µg/m³.
 
   - **name** (**Required**, string): The name of the PM2.5 sensor.
   - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.
   - All other options from :ref:`Sensor <config-sensor>`.
 
-- **pm_10_0** (**Required**): The PM10 data of the sensor in micrograms per cubic meter air (µg/m³).
+- **pm_10_0** (**Required**): The information for the **Weight Concentration** sensor for coarse particles up to 10μm. Readings in µg/m³.
 
   - **name** (**Required**, string): The name of the PM10 sensor.
   - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.
   - All other options from :ref:`Sensor <config-sensor>`.
 
-- **temperature** (**Required**): The temperature data of the sensor in degrees celsius (°C).
+- **temperature** (**Required**): The information for the temperature sensor. Readings in degrees celsius (°C).
 
   - **name** (**Required**, string): The name of the temperature sensor.
   - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.
   - All other options from :ref:`Sensor <config-sensor>`.
 
-- **humidity** (**Required**): The humidity data of the sensor in percent relative humidity (%).
+- **humidity** (**Required**): The information for the relative humidity sensor. Readings in %.
 
   - **name** (**Required**, string): The name of the humidity sensor.
   - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.
@@ -110,10 +118,18 @@ Configuration variables:
 
     Pins on the SM300D2. UART RX is not in use.
 
+.. _pins-note:
+
 .. note::
 
-    ``5V`` should be connected to power supply (supported voltage is 4.8 V to 5.2 V), ``GD`` to ``GND`` pin
+    The board's ``GD`` pin must be connected to a ``GND`` pin on the ESP.
 
+    The sensor board requires between 4.8 and 5.2 volts via the ``5V`` pin in either the UART or RS485 socket, as they
+    are connected. If you're using a USB-powered ESP module with a 5V input pin (i.e. ``VIN``) exposed, you can choose
+    to connect the UART ``5V`` pin to the ESP's ``VIN`` and then power everything through either the LCD module or the
+    ESP module, with a single power cable. If you choose to power the ESP separately from the sensor board, leave the
+    UART ``5V`` pin unconnected.
+    
 
 See Also
 --------


### PR DESCRIPTION
## Description:
Adds information about the LCD modules which are often sold with/for these sensors, and using them in conjunction with an ESP.  Also notes that INPUT_PULLDOWN mode may help with reliability, and aligns some of the config descriptions with other air quality sensors.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
