### PR TITLE
id cannot be the same as the component name

### DIFF
--- a/components/touchscreen/xpt2046.rst
+++ b/components/touchscreen/xpt2046.rst
@@ -27,7 +27,7 @@ The :ref:`SPI <spi>` is required to be set up in your configuration for this sen
     # Example configuration entry
     touchscreen:
       platform: xpt2046
-      id: touchscreen
+      id: my_touchscreen
       cs_pin: 17
       interrupt_pin: 16
       update_interval: 50ms
@@ -103,15 +103,15 @@ values nor ``swap_x_y``.
     # Touchscreen
     touchscreen:
       platform: xpt2046
-      id: touchscreen
+      id: my_touchscreen
       cs_pin: 17
       on_touch:
         - lambda: |-
               ESP_LOGI("cal", "x=%d, y=%d, x_raw=%d, y_raw=%0d",
-                  id(touchscreen).x,
-                  id(touchscreen).y,
-                  id(touchscreen).x_raw,
-                  id(touchscreen).y_raw
+                  id(my_touchscreen).x,
+                  id(my_touchscreen).y,
+                  id(my_touchscreen).x_raw,
+                  id(my_touchscreen).y_raw
                   );
 
 Get a stylus or a similar object, run the project and touch the corners of the screen at
@@ -176,8 +176,8 @@ using a display lambda similar to the following.
       - platform: ili9341
         lambda: |-
           it.fill(BLACK);
-          if (id(touchscreen).touched)
-            it.filled_circle(id(touchscreen).x, id(touchscreen).y, 10, RED);
+          if (id(my_touchscreen).touched)
+            it.filled_circle(id(my_touchscreen).x, id(my_touchscreen).y, 10, RED);
 
 To be exact, the component does the following
 


### PR DESCRIPTION
The id cannot be the same as the component name, the example will not compile.

## Description:
Config example will not compile if `id` has the same name as a component.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
