### PR TITLE
Remove misleading specification in example yaml

### DIFF
--- a/components/sensor/tcs34725.rst
+++ b/components/sensor/tcs34725.rst
@@ -46,8 +46,6 @@ as the color temperature in kelvin will show `0`.
           name: "TCS34725 Illuminance"
         color_temperature:
           name: "TCS34725 Color Temperature"
-        gain: 1x
-        integration_time: 2.4ms
         glass_attenuation_factor: 1.0
         address: 0x29
         update_interval: 60s


### PR DESCRIPTION

## Description:
Integration time of 2.4ms gives most inaccurate results. Auto integration time does a good job and is default. Reference yaml which most users copy should reflect this.


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
