### PR TITLE
update_interval missing in docs

### DIFF
--- a/components/modbus_controller.rst
+++ b/components/modbus_controller.rst
@@ -56,6 +56,9 @@ Configuration variables:
 - **command_throttle** (*Optional*, int): minimum time in milliseconds between 2 requests to the device. Default is 0ms
   Because some modbus devices limit the rate of requests the interval between sending requests to the device can be modified.
 
+- **update_interval** (*Optional*, :ref:`config-time`): The interval that the sensors should be checked.
+  Defaults to 60 seconds.
+
 
 Example
 -------


### PR DESCRIPTION
In modbus update interval may and maybe should be configured. This was hidden in the example and should be in the config variables.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
