### PR TITLE
Add default ota port for rp2040

### DIFF
--- a/components/ota.rst
+++ b/components/ota.rst
@@ -16,8 +16,8 @@ ESPHome also has an "OTA safe mode". If for some reason your
 node gets into a boot loop, ESPHome will automatically try to detect
 this and will go over into a safe mode after the configured unsuccessful boot
 attempts (Defaults to ``10``). In that mode, all components are disabled and only Serial
-Logging + Network(WiFi or Ethernet) + OTA are initialized, so that you can upload a new 
-binary. You can trigger entering safe mode by either configuring a dedicated button or 
+Logging + Network(WiFi or Ethernet) + OTA are initialized, so that you can upload a new
+binary. You can trigger entering safe mode by either configuring a dedicated button or
 switch to do that or by pressing the reset button on the board for ``num_attempts`` times.
 
 
@@ -34,8 +34,12 @@ Configuration variables:
 -  **safe_mode** (*Optional*, boolean): Whether to enable safe mode.
    Defaults to ``true``.
 -  **password** (*Optional*, string): The password to use for updates.
--  **port** (*Optional*, int): The port to use for OTA updates. Defaults
-   to ``3232`` for the ESP32 and ``8266`` for the ESP8266.
+-  **port** (*Optional*, int): The port to use for OTA updates.
+   Defaults:
+
+   - ``3232`` for the ESP32
+   - ``8266`` for the ESP8266
+   - ``2040`` for the RP2040
 -  **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
 -  **reboot_timeout** (*Optional*, :ref:`config-time`): The amount of time to wait before rebooting when in
    safe mode. Defaults to ``5min``.


### PR DESCRIPTION
## Description:
Adds the default port for OTA on rp2040

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
