### PR TITLE
Add M5Stack PoESP32 Unit ethernet configuration

### DIFF
--- a/components/ethernet.rst
+++ b/components/ethernet.rst
@@ -181,6 +181,21 @@ Configuration for ESP32-Ethernet-Kit board
       clk_mode: GPIO0_IN
       phy_addr: 1
       power_pin: GPIO5
+      
+
+Configuration for M5Stack PoESP32 Unit
+--------------------------------------
+
+.. code-block:: yaml
+
+    ethernet:
+      type: IP101
+      mdc_pin: GPIO23
+      mdio_pin: GPIO18
+      clk_mode: GPIO0_IN
+      phy_addr: 1
+      power_pin: GPIO5
+
 
 See Also
 --------


### PR DESCRIPTION
## Description:

Add working ethernet configuration for M5Stack PoESP32 Unit

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
