### PR TITLE
Typo

### DIFF
--- a/components/button/index.rst
+++ b/components/button/index.rst
@@ -7,7 +7,7 @@ Button Component
 
 .. note::
 
-    To attach a physical buttons to ESPHome, see
+    To attach a physical button to ESPHome, see
     :doc:`GPIO Binary Sensor </components/binary_sensor/gpio>`.
 
 ESPHome has support for components to create button entities in Home Assistant. A button entity is


### PR DESCRIPTION
In line 10: Either "a button" or just "buttons" - in this context I'd prefer the former

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
