### PR TITLE
`homeassistant` text sensor remove obsolete old version specification

### DIFF
--- a/components/text_sensor/homeassistant.rst
+++ b/components/text_sensor/homeassistant.rst
@@ -16,7 +16,7 @@ states from your Home Assistant instance using the :doc:`native API </components
         name: "Weather Forecast From Home Assistant"
         entity_id: sensor.weather_forecast
 
-With Home Assistant 2021.6 or newer, entity state attributes can also be imported.
+Entity state attributes can also be imported:
 
 .. code-block:: yaml
 
@@ -34,7 +34,6 @@ Configuration variables:
 - **entity_id** (**Required**, string): The entity ID to import from Home Assistant.
 - **attribute** (*Optional*, string): The name of the state attribute to import from the
   specified entity. The entity state is used when this option is omitted.
-  Requires Home Assistant 2021.6 or newer.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
 - All other options from :ref:`Text Sensor <config-text_sensor>`.
 


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
