### PR TITLE
feat: Doc to support templatable code for Midea IR

### DIFF
--- a/components/climate/climate_ir.rst
+++ b/components/climate/climate_ir.rst
@@ -183,6 +183,7 @@ Configuration variables:
         use_fahrenheit: true
 
 .. note::
+
     - See :ref:`Transmit Midea<remote_transmitter-transmit_midea>` to send custom commands, including Follow Me mode.
     - See :ref:`Toshiba<toshiba>` below if you are looking for compatibility with Midea model MAP14HS1TBL or similar.
 

--- a/components/climate/climate_ir.rst
+++ b/components/climate/climate_ir.rst
@@ -183,7 +183,7 @@ Configuration variables:
         use_fahrenheit: true
 
 .. note::
-
+    - See :ref:`Transmit Midea<remote_transmitter-transmit_midea>` to send custom commands, including Follow Me mode.
     - See :ref:`Toshiba<toshiba>` below if you are looking for compatibility with Midea model MAP14HS1TBL or similar.
 
 

--- a/components/remote_transmitter.rst
+++ b/components/remote_transmitter.rst
@@ -207,10 +207,16 @@ This :ref:`action <config-action>` sends a 40-bit Midea code to a remote transmi
     on_...:
       - remote_transmitter.transmit_midea:
           code: [0xA2, 0x08, 0xFF, 0xFF, 0xFF]
+    
+    on_...:
+      - remote_transmitter.transmit_midea:
+          code: !lambda |-
+            // Send a FollowMe code with the current temperature.
+            return {0xA4, 0x82, 0x48, 0x7F, (uint8_t)(id(temp_sensor).state + 1)};
 
 Configuration variables:
 
-- **code** (**Required**, list): The 40-bit Midea code to send as a list of hex or integers.
+- **code** (**Required**, list, :ref:`templatable <config-templatable>`): The 40-bit Midea code to send as a list of hex or integers.
 - All other options from :ref:`remote_transmitter-transmit_action`.
 
 ``remote_transmitter.transmit_nec`` Action


### PR DESCRIPTION
## Description:
This change on the Midea IR component makes the _code_ property templatable which, by example, allows to send follow me commands without having to connect the ESPHome device to the Midea AC.

**Related issue (if applicable):** fixes <[Add midea_ir.follow_me action #1627](https://github.com/esphome/feature-requests/issues/1627)>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#4053

## Checklist:

  - [X] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
