### PR TITLE
Waveshare full update every

### DIFF
--- a/components/display/waveshare_epaper.rst
+++ b/components/display/waveshare_epaper.rst
@@ -107,9 +107,8 @@ Configuration variables:
 - **full_update_every** (*Optional*, int): E-Paper displays have two modes of switching to the next image: A partial
   update that only changes the pixels that have changed and a full update mode that first clears the entire display
   and then re-draws the image. The former is much quicker and nicer, but every so often a full update needs to happen
-  because artifacts accumulate. On the ``1.54in``, ``1.54inv2``, ``2.13in``, ``2.90in`` and ``2.90inv2`` models you have the option to switch only
-  do a full-redraw every x-th time using this option. Defaults to ``30`` on the described models and a full update for
-  all other models.
+  because artifacts accumulate. On some models you have the option to only do a full-redraw every x-th time using this
+  option. Defaults to ``30`` on models that support it and a full update for all other models.
 - **reset_duration** (*Optional*, :ref:`config-time`): Duration for the display reset operation. Defaults to ``200ms``.
   Setting this value to ``2ms`` may resolve issues with newer e-Paper Driver modules (e.g. Rev 2.1).
 - **lambda** (*Optional*, :ref:`lambda <config-lambda>`): The lambda to use for rendering the content on the display.


### PR DESCRIPTION
## Description:
The waveshare documentation lists some models that support the full_update_every variable, but this list is not complete. This change does not list them explicitly anymore.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** https://github.com/esphome/esphome/pull/4066

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
