### PR TITLE
Update shelly_dimmer.rst

### DIFF
--- a/components/light/shelly_dimmer.rst
+++ b/components/light/shelly_dimmer.rst
@@ -5,7 +5,7 @@ Shelly Dimmer
     :description: Instructions for setting up a Shelly Dimmer 2.
     :image: shellydimmer2.jpg
 
-The ``shelly_dimmer`` component adds support for the dimming and power-metering functionality that can be found the `Shelly Dimmer 2 <https://shelly.cloud/knowledge-base/devices/shelly-dimmer-2/>`_. The interaction with mains is done via an STM32 microcontroller that is flashed with an `open source firmware <https://github.com/jamesturton/shelly-dimmer-stm32>`_.
+The ``shelly_dimmer`` component adds support for the dimming and power-metering functionality that can be found the `Shelly Dimmer 2 <https://shelly.cloud/knowledge-base/devices/shelly-dimmer-2/>`_. The interaction with mains is done via an STM32 microcontroller that is automatically (when configured) flashed with an `open source firmware <https://github.com/jamesturton/shelly-dimmer-stm32>`_.
 A detailed analysis of the Shelly Dimmer 2 hardware is given `here <https://github.com/arendst/Tasmota/issues/6914>`_.
 
 Warning!!! At the time of writing there seems to be no way to revert back to the "stock firmware", because there seems to be no way to revert to firmware of the STM32 co-processor.
@@ -84,14 +84,15 @@ Configuration variables:
 
 .. note::
 
-    When flashing Shelly Dimmer with esphome for the first time, flashing the STM firmware is necessary too for the dimmer to work:
+    When flashing Shelly Dimmer with esphome for the first time, automatic flashing the STM firmware is necessary too for the dimmer to work and enabled by the following configuration.:
 
     .. code-block:: yaml
 
         firmware:
           version: "51.6" #<-- set version here
           update: true
-
+    
+    There is no action required by the user to flash the STM32. There is no way to revert to stock firmware on the STM32 at the time of writing.
 
 - All other options from :ref:`Light <config-light>`.
 


### PR DESCRIPTION
Add some clarity around how the STM32 is flashed during this process.

## Description:

Update the docs for Shelly Dimmers to disambiguate the flashing of the STM32 inside. 

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
