### PR TITLE
Update ezo.rst

### DIFF
--- a/components/sensor/ezo.rst
+++ b/components/sensor/ezo.rst
@@ -152,7 +152,7 @@ From :ref:`lambdas <config-lambda>`, you can interact with the sensor in various
 
   .. code-block:: cpp
 
-      id(ph_ezo).set_calibration_point_low(10.00);
+      id(ph_ezo).set_calibration_point_high(10.00);
 
 
 - ``clear_calibration()``: Clears all calibration points.


### PR DESCRIPTION
Change for Set Calibration High FROM set_calibration_point_low TO set_calibration_point_high

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
