### PR TITLE
expand substitution

### DIFF
--- a/guides/configuration-types.rst
+++ b/guides/configuration-types.rst
@@ -179,7 +179,7 @@ by their value. The syntax for a substitution is based on bash and is case-sensi
 Two substitution passes are performed allowing compound replacements.
 
 .. code-block:: yaml
-    
+
     substitutions:
       foo: yellow
       bar_yellow_value: !secret yellow_secret
@@ -235,7 +235,7 @@ Substitute !include variables
 ESPHome's ``!include`` accepts a list of variables that can be substituted within the included file.
 
 .. code-block:: yaml
-       
+
        binary_sensor:
          - platform: gpio
            id: button1
@@ -254,16 +254,16 @@ ESPHome's ``!include`` accepts a list of variables that can be substituted withi
 
 .. code-block:: yaml
 
-       - timing: !include click-single.yaml 
-         then:
-           - mqtt.publish:
-               topic: ${device_name}/button${id}/status
-               payload: single
-       - timing: !include click-double.yaml
-         then:
-           - mqtt.publish:
-               topic: ${device_name}/button${id}/status
-               payload: double
+    - timing: !include click-single.yaml 
+      then:
+        - mqtt.publish:
+            topic: ${device_name}/button${id}/status
+            payload: single
+    - timing: !include click-double.yaml
+      then:
+        - mqtt.publish:
+            topic: ${device_name}/button${id}/status
+            payload: double
 
 .. _command-line-substitutions:
 

--- a/guides/configuration-types.rst
+++ b/guides/configuration-types.rst
@@ -176,7 +176,24 @@ validating your configuration, ESPHome will automatically replace all occurrence
 by their value. The syntax for a substitution is based on bash and is case-sensitive: ``$substitution_key`` or
 ``${substitution_key}`` (same).
 
-Additionally, you can use the YAML ``<<`` syntax to create a single YAML file from which a number
+Two substitution passes are performed allowing compound replacements.
+
+.. code-block:: yaml
+    
+    substitutions:
+      foo: yellow
+      bar_yellow_value: !secret yellow_secret
+      bar_green_value: !secret green_secret
+    
+    something:
+      test: ${bar_${foo}_value}
+
+.. _YAML-insertion-operator:
+
+YAML insertion operator
+***********************
+
+Additionally, you can use the YAML insertion operator ``<<`` syntax to create a single YAML file from which a number
 of nodes inherit:
 
 .. code-block:: yaml
@@ -209,6 +226,44 @@ of nodes inherit:
 
     - Place them in a subdirectory (dashboard only shows files in top-level directory)
     - Prepend a dot to the filename, like ``.base.yaml``
+
+.. _substitute-include-variables:
+
+Substitute !include variables
+*****************************
+
+ESPHome's ``!include`` accepts a list of variables that can be substituted within the included file.
+
+.. code-block:: yaml
+       
+       binary_sensor:
+         - platform: gpio
+           id: button1
+           pin: GPIO16
+           on_multi_click: !include { file: on-multi-click.yaml, vars: { id: 1 } } # inline syntax
+         - platform: gpio
+           id: button2
+           pin: GPIO4
+           on_multi_click: !include
+             # multi-line syntax
+             file: on-multi-click.yaml
+             vars:
+               id: 2
+   
+``on-multi-click.yaml``:
+
+.. code-block:: yaml
+
+       - timing: !include click-single.yaml 
+         then:
+           - mqtt.publish:
+               topic: ${device_name}/button${id}/status
+               payload: single
+       - timing: !include click-double.yaml
+         then:
+           - mqtt.publish:
+               topic: ${device_name}/button${id}/status
+               payload: double
 
 .. _command-line-substitutions:
 

--- a/guides/configuration-types.rst
+++ b/guides/configuration-types.rst
@@ -236,20 +236,20 @@ ESPHome's ``!include`` accepts a list of variables that can be substituted withi
 
 .. code-block:: yaml
 
-       binary_sensor:
-         - platform: gpio
-           id: button1
-           pin: GPIO16
-           on_multi_click: !include { file: on-multi-click.yaml, vars: { id: 1 } } # inline syntax
-         - platform: gpio
-           id: button2
-           pin: GPIO4
-           on_multi_click: !include
-             # multi-line syntax
-             file: on-multi-click.yaml
-             vars:
-               id: 2
-   
+    binary_sensor:
+      - platform: gpio
+        id: button1
+        pin: GPIO16
+        on_multi_click: !include { file: on-multi-click.yaml, vars: { id: 1 } } # inline syntax
+      - platform: gpio
+        id: button2
+        pin: GPIO4
+        on_multi_click: !include
+          # multi-line syntax
+          file: on-multi-click.yaml
+          vars:
+            id: 2
+            
 ``on-multi-click.yaml``:
 
 .. code-block:: yaml


### PR DESCRIPTION
## Description:
Update Substitution section on the Configuration Types page to:
* Highlight 2 passes are performed esphome PR 3585 (https://github.com/esphome/esphome/pull/3583)

* Highlight variables can be substituted when including files esphome PR 3510 (https://github.com/esphome/esphome/pull/3510).  This is in the FAQ currently but should be highlighted in the substitution section as well.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [X] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
