### PR TITLE
Multiplexing annotation outdated,

### DIFF
--- a/components/i2c.rst
+++ b/components/i2c.rst
@@ -61,12 +61,7 @@ Configuration variables:
          address: 0x76
          # ...
 
-       # If a I²C multiplexer is used all I²C devices can be additionally configured like:
-       - platform: bmp280
-         multiplexer:
-           id: multiplex0
-           channel: 0
-         # ...
+For I2C multiplexing see :ref:`TCA9548A I²C multiplexer <tca9548a>`.
 
 See Also
 --------

--- a/components/i2c.rst
+++ b/components/i2c.rst
@@ -66,5 +66,6 @@ For I2C multiplexing see :ref:`TCA9548A I²C multiplexer <tca9548a>`.
 See Also
 --------
 
+- :ref:`tca9548a`
 - :apiref:`i2c/i2c.h`
 - :ghedit:`Edit`

--- a/components/i2c.rst
+++ b/components/i2c.rst
@@ -61,11 +61,11 @@ Configuration variables:
          address: 0x76
          # ...
 
-For I2C multiplexing see :ref:`TCA9548A I²C multiplexer <tca9548a>`.
+For I2C multiplexing see :doc:`/components/tca9548a`.
 
 See Also
 --------
 
-- :ref:`tca9548a`
+- :doc:`/components/tca9548a`
 - :apiref:`i2c/i2c.h`
 - :ghedit:`Edit`


### PR DESCRIPTION
Added link to I2C Multiplexer

## Description:
The syntax here is not according to actual implementation. remove misleading config example, add link to multiplexer


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
