### PR TITLE
Update mirabella-genio-bulb.rst

### DIFF
--- a/cookbook/mirabella-genio-bulb.rst
+++ b/cookbook/mirabella-genio-bulb.rst
@@ -248,10 +248,6 @@ variable ``output_component1``.
 3.4 CWWW Mirabella Genio Downlights
 ***********************************
 
-Kmart also sell a `downlight option <https://www.kmart.com.au/product/mirabella-genio-wi-fi-dimmable-9w-led-downlight/2754331>`__, which works quite well however the PWM method that is used is different to the way the CWWW lights in ESPHome works.
-
-A `project by ssieb <https://github.com/ssieb/custom_components/tree/master/cwww2>`__ resolves this using a custom component.
-
 .. code-block:: yaml
 
     esphome:


### PR DESCRIPTION
No need for external component warning, it's built-in. Fix for https://github.com/esphome/esphome-docs/pull/2306

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
