### PR TITLE
Change limit from 4 to 256 for sn74hc595

### DIFF
--- a/components/sn74hc595.rst
+++ b/components/sn74hc595.rst
@@ -8,7 +8,7 @@ The SN74HC595 component allows you to use SN74HC595 shift registers as I/O expan
 (`datasheet <http://www.ti.com/lit/ds/symlink/sn74hc595.pdf>`__,
 `SparkFun`_) in ESPHome. It uses 3 wires (optionally 4) for communication.
 
-Once configured, you can use any of the 8 pins for your projects. Up-to 4 shift registers can be daisy-chained
+Once configured, you can use any of the 8 pins for your projects. Up-to 256 shift registers can be daisy-chained
 to provide more pins, without using more GPIO pins on the controller.
 
 Use of the OE pin is optional. If used, the pin should be pulled up externally.
@@ -50,7 +50,7 @@ Configuration variables:
 - **clock_pin** (**Required**, :ref:`Pin Schema <config-pin_schema>`): Pin connected to SN74HC595 SRCLK (SH_CP) pin
 - **latch_pin** (**Required**, :ref:`Pin Schema <config-pin_schema>`): Pin connected to SN74HC595 RCLK (ST_CP) pin
 - **oe_pin** (*Optional*, :ref:`Pin Schema <config-pin_schema>`): Pin connected to SN74HC595 OE pin
-- **sr_count** (*Optional*, int): Number of daisy-chained shift registers, up-to 4. Defaults to ``1``.
+- **sr_count** (*Optional*, int): Number of daisy-chained shift registers, up-to 256. Defaults to ``1``.
 
 
 Pin configuration variables:


### PR DESCRIPTION
## Description:
Increases the documented limit for daisy chained chips

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#4108

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
