### PR TITLE
Modbus restore mode update PR #4122

### DIFF
--- a/components/switch/modbus_controller.rst
+++ b/components/switch/modbus_controller.rst
@@ -13,10 +13,9 @@ Configuration variables:
 
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
 - **name** (**Required**, string): The name of the sensor.
-- **restore_mode** (*Optional*): **UNIMPLEMENTED** for this component. See :ref:`Switch <config-switch>`, since this configuration variable is inherited.
-  Restore mode is unimplemented for this component. This means the switch frontend will show an undetermined state until the real state is retrieved from
-  the device on the next refresh. For backward compatibility, once this feature is implemented, the default value for Modbus Controller Switch's **restore_mode** will
-  be ``DISABLED`` (recommended), which leaves initial state up to the hardware: usually the state lives in the device and ESPHome does not need to remember it.
+- **restore_mode** (*Optional*): See :ref:`Switch <config-switch>`, since this configuration variable is inherited. The default value for this setting is ``DISABLED`` (recommended).
+  ``DISABLED`` leaves the initial state up to the hardware: usually the state lives in the device and ESPHome does not need to remember it. The switch frontend will show an undetermined 
+  state until the real state is retrieved from the device on the next refresh. Use any other setting if a reboot of your ESPHome device is tied to a reboot of the modbus device.
 - **register_type** (**Required**): type of the modbus register.
 - **address** (**Required**, int): start address of the first register in a range
 - **offset** (*Optional*, int): not required in most cases


### PR DESCRIPTION
## Description:

This PR modifies ModbusSwitch documentation to describe the behavior of `restore_mode` for this component as per the proposed changes in https://github.com/esphome/esphome/pull/4122


**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**  [#4122](https://github.com/esphome/esphome/pull/4122)
## Checklist:

  - [X] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
