### PR TITLE
Improve switch:restore_mode docs

### DIFF
--- a/components/switch/index.rst
+++ b/components/switch/index.rst
@@ -34,6 +34,7 @@ Configuration variables:
 - **restore_mode** (*Optional*): Control how the switch attempts to restore state on bootup.
   **NOTE** : Not all components consider **restore_mode**. Check the documentation of the specific component to understand how
   this feature works for a particular component or device.
+  **NOTE** : In order for this feature to work, the ``preferences`` component must be enabled, see :ref:`preferences-flash_write_interval` (TL;DR: Add "``preferences:``" to your config root).
   For restoring on ESP8266s, also see ``restore_from_flash`` in the
   :doc:`esp8266 section </components/esp8266>`.
 


### PR DESCRIPTION
## Description:

This PR adds a brief but necessary clarification to how `restore_mode` works, namely it won't do anything if `preferences` is not enabled.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 
https://github.com/esphome/esphome/pull/4122

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
