### PR TITLE
fix mistake in example for .active_index()

### DIFF
--- a/components/select/index.rst
+++ b/components/select/index.rst
@@ -299,7 +299,7 @@ advanced stuff (see the full API Reference for more info).
 
       auto index = id(my_select).active_index();
       if (index.has_value()) {
-        ESP_LOGI("main", "Option at index %d is active", index);
+        ESP_LOGI("main", "Option at index %d is active", index.value());
       } else {
         ESP_LOGI("main", "No option is active");
       }


### PR DESCRIPTION
Description:
This PR fixes a mistake in the example for .active_index() see: https://discord.com/channels/429907082951524364/429907082955718657/1047946066538008596

Pull request in esphome with YAML changes (if applicable): ./.

Checklist:
 I am merging into next because this is new documentation that has a matching pull-request in esphome as linked above.
or
X I am merging into current because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
