### PR TITLE
Support for MH-ET 2.13" black/white/red display (GDEY0213Z98)

### DIFF
--- a/components/display/waveshare_epaper.rst
+++ b/components/display/waveshare_epaper.rst
@@ -79,6 +79,7 @@ Configuration variables:
   - ``1.54in``
   - ``1.54inv2``
   - ``2.13in`` - not tested
+  - ``2.13in-mhet-tricolor`` - MH-ET Live 2.13 B/W/R and B/W/Y
   - ``2.13in-ttgo`` - T5_V2.3 tested. Also works for Wemos D1 Mini ePaper Shield 2.13 1.0.0 "LOLIN"
   - ``2.13in-ttgo-b73`` - T5_V2.3 with B73 display tested
   - ``2.13in-ttgo-b74`` - T5_V2.3.1 with B74 display tested


### PR DESCRIPTION
## Description:

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#4146

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
