### PR TITLE
Fix 'See also CustomAPIDevice.' link

### DIFF
--- a/custom/custom_component.rst
+++ b/custom/custom_component.rst
@@ -123,7 +123,7 @@ Home Assistant, as well as starting services in Home Assistant.
       }
     };
 
-See also :apiclass:`CustomAPIDevice`.
+See also :apiclass:`api::CustomAPIDevice`.
 
 MQTT Custom Component
 ---------------------


### PR DESCRIPTION
## Description:

The link is broken for 'CustomAPIDevice'.

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
