### PR TITLE
Document cache_services option for bluetooth proxies

### DIFF
--- a/components/bluetooth_proxy.rst
+++ b/components/bluetooth_proxy.rst
@@ -34,6 +34,8 @@ Configuration:
 
 - **active** (*Optional*, boolean): Enables proxying active connections. Defaults to ``false``. Requires Home Assistant 2022.10 or later.
 
+- **cache_services** (*Optional*, boolean): Enables caching services in NVS flash storage which significantly speeds up active connections. Defaults to ``true`` when using the ESP-IDF framework.
+
 The Bluetooth proxy depends on :doc:`esp32_ble_tracker` so make sure to add that to your configuration.
 
 .. note::


### PR DESCRIPTION
## Description:

Document `cache_services` option for bluetooth proxies

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** https://github.com/esphome/esphome/pull/4171

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
