### PR TITLE
Document cache_services option for bluetooth proxies

### DIFF
--- a/components/bluetooth_proxy.rst
+++ b/components/bluetooth_proxy.rst
@@ -33,6 +33,7 @@ Configuration:
     bluetooth_proxy:
 
 - **active** (*Optional*, boolean): Enables proxying active connections. Defaults to ``false``. Requires Home Assistant 2022.10 or later.
+- **cache_services** (*Optional*, boolean): Enables caching services in NVS flash storage which significantly speeds up active connections. Defaults to ``true`` when using the ESP-IDF framework.
 
 The Bluetooth proxy depends on :doc:`esp32_ble_tracker` so make sure to add that to your configuration.
 


### PR DESCRIPTION
https://github.com/esphome/esphome-docs/pull/2520

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
