### PR TITLE
Ethernet wESP32 rev 7, AiThinker, SLZB-06 and appearance

### DIFF
--- a/components/ethernet.rst
+++ b/components/ethernet.rst
@@ -73,8 +73,10 @@ Configuration variables:
     clock signal that will not travel reliably over these types of connections. For more
     information and wiring details refer to the link in the *See also* section.
 
-Configuration for Olimex ESP32-POE
-----------------------------------
+Configurations
+--------------
+
+**Olimex ESP32-POE**
 
 .. code-block:: yaml
 
@@ -86,8 +88,8 @@ Configuration for Olimex ESP32-POE
       phy_addr: 0
       power_pin: GPIO12
 
-Configuration for Olimex ESP32-EVB
-----------------------------------
+
+**Olimex ESP32-EVB**
 
 .. code-block:: yaml
 
@@ -98,8 +100,7 @@ Configuration for Olimex ESP32-EVB
       clk_mode: GPIO0_IN
       phy_addr: 0
 
-Configuration for Olimex ESP32-GATEWAY
---------------------------------------
+**Olimex ESP32-GATEWAY**
 
 .. code-block:: yaml
 
@@ -110,8 +111,7 @@ Configuration for Olimex ESP32-GATEWAY
       clk_mode: GPIO17_OUT
       phy_addr: 0
 
-Configuration for LILYGO TTGO T-Internet-POE ESP32-WROOM LAN8270A Chip
-----------------------------------------------------------------------
+**LILYGO TTGO T-Internet-POE ESP32-WROOM LAN8270A**
 
 .. code-block:: yaml
 
@@ -122,8 +122,7 @@ Configuration for LILYGO TTGO T-Internet-POE ESP32-WROOM LAN8270A Chip
       clk_mode: GPIO17_OUT
       phy_addr: 0
 
-Configuration for Wireless Tag WT32-ETH01
------------------------------------------
+**Wireless Tag WT32-ETH01** and **SMLIGHT SLZB-06**
 
 .. code-block:: yaml
 
@@ -135,8 +134,7 @@ Configuration for Wireless Tag WT32-ETH01
       phy_addr: 1
       power_pin: GPIO16
 
-Configuration for OpenHacks LAN8720
------------------------------------
+**OpenHacks LAN8720**
 
 .. code-block:: yaml
 
@@ -152,8 +150,7 @@ Configuration for OpenHacks LAN8720
     you are monitoring the serial output and reboot the device several times to see if it boots into the 
     program properly.
 
-Configuration for wESP32 board (up to rev.6)
---------------------------------------------
+**wESP32 board (up to rev.5)**
 
 .. code-block:: yaml
 
@@ -166,11 +163,24 @@ Configuration for wESP32 board (up to rev.6)
 
 .. note::
 
-    Revision 7 and upwards of the wESP32 board does not have a LAN8720 chip. Until support for the 
-    replacement RTL8201 is included in ESPHome, the wESP board rev.7 will not work with the above configuration.
+    Revision 5 and below of the wESP32 board use the LAN8720 Ethernet PHY.
 
-Configuration for ESP32-Ethernet-Kit board
-------------------------------------------
+**wESP32 board (rev.7 and upwards)**
+
+.. code-block:: yaml
+    ethernet:
+      type: RTL8201
+      mdc_pin: GPIO16
+      mdio_pin: GPIO17
+      clk_mode: GPIO0_IN
+      phy_addr: 0
+
+.. note::
+
+    Revision 7 and newer of the wESP32 board use the RTL8201 Ethernet PHY. Support for the RTL8201 is available from ESPHome version 2022.12 upwards.
+
+
+**ESP32-Ethernet-Kit**
 
 .. code-block:: yaml
 
@@ -183,8 +193,7 @@ Configuration for ESP32-Ethernet-Kit board
       power_pin: GPIO5
       
 
-Configuration for M5Stack PoESP32 Unit
---------------------------------------
+**M5Stack PoESP32 Unit**
 
 .. code-block:: yaml
 
@@ -193,6 +202,19 @@ Configuration for M5Stack PoESP32 Unit
       mdc_pin: GPIO23
       mdio_pin: GPIO18
       clk_mode: GPIO0_IN
+      phy_addr: 1
+      power_pin: GPIO5
+
+
+**AIThinker ESP32-G Gateway Unit**
+
+.. code-block:: yaml
+
+    ethernet:
+      type: LAN8720
+      mdc_pin: GPIO23
+      mdio_pin: GPIO18
+      clk_mode: GPIO17_OUT
       phy_addr: 1
       power_pin: GPIO5
 

--- a/components/ethernet.rst
+++ b/components/ethernet.rst
@@ -224,6 +224,7 @@ See Also
 --------
 
 - :doc:`network`
+- :doc:`ethernet_info`
 - :apiref:`ethernet/ethernet_component.h`
 - `ESP32 Ethernet PHY connection info <https://pcbartists.com/design/embedded/esp32-ethernet-phy-schematic-design/>`__
 - :ghedit:`Edit`

--- a/components/ethernet.rst
+++ b/components/ethernet.rst
@@ -168,6 +168,7 @@ Configurations
 **wESP32 board (rev.7 and upwards)**
 
 .. code-block:: yaml
+
     ethernet:
       type: RTL8201
       mdc_pin: GPIO16

--- a/components/ethernet.rst
+++ b/components/ethernet.rst
@@ -32,7 +32,7 @@ Configuration variables:
 ------------------------
 
 - **type** (**Required**, string): The type of LAN chipset/phy. Must be one of
-  ``LAN8720``, ``TLK110`` or ``IP101`` (see datasheet for more details).
+  ``LAN8720``, ``RTL8201``, ``DP83848`` or ``IP101``.
 - **mdc_pin** (**Required**, :ref:`config-pin`): The MDC pin of the board.
   Usually this is ``GPIO23``.
 - **mdio_pin** (**Required**, :ref:`config-pin`): The MDIO pin of the board.
@@ -171,10 +171,11 @@ Configuration examples
       phy_addr: 1
       power_pin: GPIO5
 
-**wESP32 board (up to rev.5)**
+**wESP32 board**
 
 .. code-block:: yaml
 
+    # for board up to rev.5
     ethernet:
       type: LAN8720
       mdc_pin: GPIO16
@@ -182,14 +183,7 @@ Configuration examples
       clk_mode: GPIO0_IN
       phy_addr: 0
 
-.. note::
-
-    Revision 5 and below of the wESP32 board use the LAN8720 Ethernet PHY.
-
-**wESP32 board (rev.7 and upwards)**
-
-.. code-block:: yaml
-
+    # for board rev.7 and up
     ethernet:
       type: RTL8201
       mdc_pin: GPIO16
@@ -199,7 +193,7 @@ Configuration examples
 
 .. note::
 
-    Revision 7 and newer of the wESP32 board use the RTL8201 Ethernet PHY. Support for the RTL8201 is available from ESPHome version 2022.12 upwards.
+    Revision 5 and below of the wESP32 board use the LAN8720 Ethernet PHY. Revision 7 and newer of it use the RTL8201 Ethernet PHY. Support for RTL8201 is available from ESPHome version 2022.12 upwards.
 
 **OpenHacks LAN8720**
 
@@ -213,8 +207,8 @@ Configuration examples
 
 .. note::
 
-    This board has an issue that might cause the ESP32 to boot in program mode. When testing, make sure 
-    you are monitoring the serial output and reboot the device several times to see if it boots into the 
+    This board has an issue that might cause the ESP32 to boot in program mode. When testing, make sure
+    you are monitoring the serial output and reboot the device several times to see if it boots into the
     program properly.
 
 

--- a/components/ethernet.rst
+++ b/components/ethernet.rst
@@ -224,7 +224,7 @@ See Also
 --------
 
 - :doc:`network`
-- :doc:`ethernet_info`
+- :doc:`text_sensor/ethernet_info`
 - :apiref:`ethernet/ethernet_component.h`
 - `ESP32 Ethernet PHY connection info <https://pcbartists.com/design/embedded/esp32-ethernet-phy-schematic-design/>`__
 - :ghedit:`Edit`

--- a/components/ethernet.rst
+++ b/components/ethernet.rst
@@ -73,8 +73,8 @@ Configuration variables:
     clock signal that will not travel reliably over these types of connections. For more
     information and wiring details refer to the link in the *See also* section.
 
-Configurations
---------------
+Configuration examples
+----------------------
 
 **Olimex ESP32-POE**
 
@@ -134,7 +134,32 @@ Configurations
       phy_addr: 1
       power_pin: GPIO16
 
-**OpenHacks LAN8720**
+**ESP32-Ethernet-Kit**
+
+.. code-block:: yaml
+
+    ethernet:
+      type: IP101
+      mdc_pin: GPIO23
+      mdio_pin: GPIO18
+      clk_mode: GPIO0_IN
+      phy_addr: 1
+      power_pin: GPIO5
+      
+
+**M5Stack PoESP32 Unit**
+
+.. code-block:: yaml
+
+    ethernet:
+      type: IP101
+      mdc_pin: GPIO23
+      mdio_pin: GPIO18
+      clk_mode: GPIO0_IN
+      phy_addr: 1
+      power_pin: GPIO5
+
+**AIThinker ESP32-G Gateway Unit**
 
 .. code-block:: yaml
 
@@ -142,13 +167,9 @@ Configurations
       type: LAN8720
       mdc_pin: GPIO23
       mdio_pin: GPIO18
+      clk_mode: GPIO17_OUT
       phy_addr: 1
-
-.. note::
-
-    This board has an issue that might cause the ESP32 to boot in program mode. When testing, make sure 
-    you are monitoring the serial output and reboot the device several times to see if it boots into the 
-    program properly.
+      power_pin: GPIO5
 
 **wESP32 board (up to rev.5)**
 
@@ -180,34 +201,7 @@ Configurations
 
     Revision 7 and newer of the wESP32 board use the RTL8201 Ethernet PHY. Support for the RTL8201 is available from ESPHome version 2022.12 upwards.
 
-
-**ESP32-Ethernet-Kit**
-
-.. code-block:: yaml
-
-    ethernet:
-      type: IP101
-      mdc_pin: GPIO23
-      mdio_pin: GPIO18
-      clk_mode: GPIO0_IN
-      phy_addr: 1
-      power_pin: GPIO5
-      
-
-**M5Stack PoESP32 Unit**
-
-.. code-block:: yaml
-
-    ethernet:
-      type: IP101
-      mdc_pin: GPIO23
-      mdio_pin: GPIO18
-      clk_mode: GPIO0_IN
-      phy_addr: 1
-      power_pin: GPIO5
-
-
-**AIThinker ESP32-G Gateway Unit**
+**OpenHacks LAN8720**
 
 .. code-block:: yaml
 
@@ -215,9 +209,14 @@ Configurations
       type: LAN8720
       mdc_pin: GPIO23
       mdio_pin: GPIO18
-      clk_mode: GPIO17_OUT
       phy_addr: 1
-      power_pin: GPIO5
+
+.. note::
+
+    This board has an issue that might cause the ESP32 to boot in program mode. When testing, make sure 
+    you are monitoring the serial output and reboot the device several times to see if it boots into the 
+    program properly.
+
 
 
 See Also


### PR DESCRIPTION
## Description:

Since https://github.com/esphome/esphome-docs/pull/2512 was missed during release, making a new PR against current now, adding some more...

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
