### PR TITLE
Update xiaomi_ble.rst

### DIFF
--- a/components/sensor/xiaomi_ble.rst
+++ b/components/sensor/xiaomi_ble.rst
@@ -547,8 +547,8 @@ Optional with **name**, **id** (:ref:`config-id`) and all other options from :re
 
 .. _obtaining_the_mac_address:
 
-Obtaining The MAC Address
----------------------
+Obtaining the MAC address
+-------------------------
 To find the MAC Address so that ESPHome can identify the device, you can create a simple configuration without any sensor entries:
 
 .. code-block:: yaml
@@ -569,7 +569,7 @@ It can sometimes take some time for the first BLE broadcast to be received. Once
 
 .. _obtaining_the_bindkey:
 
-Obtaining The Bindkey
+Obtaining the Bindkey
 ---------------------
 
 To set up an encrypted device such as the LYWSD03MMC (with Xiaomi stock firmware) and CGD1, you first need to obtain the bind key. The ``xiaomi_ble`` sensor component is not able to automatically generate a bindkey so other workarounds are necessary.

--- a/components/sensor/xiaomi_ble.rst
+++ b/components/sensor/xiaomi_ble.rst
@@ -544,6 +544,11 @@ Optional with **name**, **id** (:ref:`config-id`) and all other options from :re
 - **formaldehyde**
 - **battery_level**
 
+
+.. _obtaining_the_mac_address:
+
+Obtaining The MAC Address
+---------------------
 To find the MAC Address so that ESPHome can identify the device, you can create a simple configuration without any sensor entries:
 
 .. code-block:: yaml


### PR DESCRIPTION
I spent a while trying to figure out how to find the Mac address for some miflora sensors. Somehow I missed it. I figured since MAC address and Bind Key are both "things you need" they should equal headings in the documentation.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
