### PR TITLE
Added example for 16x32 display in addressable_light.rst

### DIFF
--- a/components/display/addressable_light.rst
+++ b/components/display/addressable_light.rst
@@ -140,10 +140,10 @@ It's possible to use two 8x32 LED matrices in a 16x32 configuration (one above t
 
     display:
       - platform: addressable_light
-        id: led_matrix_32x8_display
-        addressable_light_id: led_matrix_32x8
+        id: led_matrix_32x16_display
+        addressable_light_id: led_matrix_32x16
         width: 32
-        height: 8
+        height: 16
         pixel_mapper: |-
           int iMatrixOffset = y >= 8 ? 256 : 0;
           if (x % 2 == 0) {

--- a/components/display/addressable_light.rst
+++ b/components/display/addressable_light.rst
@@ -134,6 +134,24 @@ Below is a definition that includes a pixel_mapper suitable for these 8x32 matri
         rotation: 0°
         update_interval: 16ms
 
+It's possible to use two 8x32 LED matrices in a 16x32 configuration (one above the other) by using the following definition:
+
+.. code-block:: yaml
+
+    display:
+      - platform: addressable_light
+        id: led_matrix_32x8_display
+        addressable_light_id: led_matrix_32x8
+        width: 32
+        height: 8
+        pixel_mapper: |-
+          int iMatrixOffset = y >= 8 ? 256 : 0;
+          if (x % 2 == 0) {
+            return (x * 8) + (y % 8) + iMatrixOffset;
+          }
+          return (x * 8) + iMatrixOffset + (7 - (y % 8));
+        rotation: 0°
+        update_interval: 16ms
 
 See Also
 --------


### PR DESCRIPTION
Added example for 16x32 WS2812B matrix display

## Description:

I have added an example definition for using two 8x32 WS2812B LED matrices in a 16x32 configuration.

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
