### PR TITLE
Revert "Document how packages are merged into a configuration"

### DIFF
--- a/guides/configuration-types.rst
+++ b/guides/configuration-types.rst
@@ -327,10 +327,6 @@ config in the main yaml file. All definitions from packages will be merged with 
 config in non-destructive way so you could always override some bits and pieces of package
 configuration.
 
-Dictionaries are merged key-by-key. Lists of components are merged by component
-ID if specified. Other lists are merged by concatenation. All other config
-values are replaced with the later value.
-
 Local packages
 **************
 


### PR DESCRIPTION
Reverts esphome/esphome-docs#2126. See https://github.com/esphome/issues/issues/3932; this documentation change was landed prematurely, before esphome/esphome#3555, and claims lists of components can be merged in ways that they actually cannot.