### PR TITLE
document that cron behaves like days_of_week, not like crontab

### DIFF
--- a/components/time.rst
+++ b/components/time.rst
@@ -106,7 +106,7 @@ Configuration variables:
   Defaults to ``*`` (all days). The names SUN to SAT are automatically substituted.
   Range is from 1 (Sunday) to 7 (Saturday).
 - **cron** (*Optional*, string): Alternatively, you can specify a whole cron expression like
-  ``* /5 * * * *``. Please note years and some special characters like ``L``, ``#`` are currently not supported. Please note the day of week field is interpreted like the **days_of_week** variable (range from 1 (Sunday) to 7 (Saturday)) and not like other cron implementations would do it (range from 0 (Sunday) to 7 (Sunday)).
+  ``* /5 * * * *``. Please note that years and some special characters like ``L``, ``#`` are currently not supported. Also, the day of week field is interpreted like the **days_of_week** variable (range from 1 (Sunday) to 7 (Saturday)) and not like other cron implementations would do it (range from 0 (Sunday) to 7 (Sunday)).
 
 - See :ref:`Automation <automation>`.
 

--- a/components/time.rst
+++ b/components/time.rst
@@ -106,7 +106,7 @@ Configuration variables:
   Defaults to ``*`` (all days). The names SUN to SAT are automatically substituted.
   Range is from 1 (Sunday) to 7 (Saturday).
 - **cron** (*Optional*, string): Alternatively, you can specify a whole cron expression like
-  ``* /5 * * * *``. Please note years and some special characters like ``L``, ``#`` are currently not supported.
+  ``* /5 * * * *``. Please note years and some special characters like ``L``, ``#`` are currently not supported. Please note the day of week field is interpreted like the **days_of_week** variable (range from 1 (Sunday) to 7 (Saturday)) and not like other cron implementations would do it (range from 0 (Sunday) to 7 (Sunday)).
 
 - See :ref:`Automation <automation>`.
 


### PR DESCRIPTION
## Description:

People used to [`crontab(5)`](https://manpages.debian.org/buster/cron/crontab.5.en.html) will just write 6-7 to mean Sat-Sun and that will mean Fri-Sat in reality.

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
