### PR TITLE
Fix syntax in the script.is_running lambda example

### DIFF
--- a/guides/automations.rst
+++ b/guides/automations.rst
@@ -861,7 +861,7 @@ or as lambda
 .. code-block:: yaml
 
     lambda: -|
-        if(id(my_script).is_running() {
+        if (id(my_script).is_running()) {
             ESP_LOGI("main", "Script is running!");
         }
 


### PR DESCRIPTION
## Description:

Fixed syntax error in the script.is_running lambda example.

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
