### PR TITLE
Rework reference to MQTT as its not really the point

### DIFF
--- a/components/sensor/index.rst
+++ b/components/sensor/index.rst
@@ -633,7 +633,7 @@ From :ref:`lambdas <config-lambda>`, you can call several methods on all sensors
 advanced stuff (see the full API Reference for more info).
 
 - ``publish_state()``: Manually cause the sensor to push out a value. It will then
-  be processed by the sensor filters, and once done be published to MQTT.
+  be processed by the sensor filters, and once filtered will propagate though ESPHome and though the API to Home Assistant or out via MQTT if configured. 
 
   .. code-block:: cpp
 


### PR DESCRIPTION
The text implies the published state will be pushed out via MQTT but that is only relevant and correct if MQTT is configured. I believe it's more correct to say the change will surface in ESPHome and the API before mentioning MQTT. The reference to MQTT could be deleted completely, and that may be clearer.

Operation clarified via issue 3940 https://github.com/esphome/issues/issues/3940

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
