### PR TITLE
Removing information that after some testing isn't true

### DIFF
--- a/components/rp2040.rst
+++ b/components/rp2040.rst
@@ -21,7 +21,7 @@ This component contains platform-specific options for the RP2040 platform.
 Configuration variables:
 ------------------------
 
-- **board** (*Optional*, string): The board type. Valid options are ``rpipico`` and ``rpipicow``.
+- **board** (*Optional*, string): The board type. Valid option is ``rpipicow``.
 
 See Also
 --------


### PR DESCRIPTION
Raspberry pico W is supported, but the vanilla raspberry pico clearly is not. After trying "rpipico" as a board this error shows up "Error: Unknown board ID 'rpipico'". It is bit misleading, because from what I know about esphome you cannot just have a device that communicates through USB and doesn't connect to WiFi. 

I think it is important to understand that RP2040 isn't like ESP. Every RP2040 board doesn't support esphome, but basically any ESP device can support esphome.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
