### PR TITLE
Update rotary_encoder.rst

### DIFF
--- a/components/sensor/rotary_encoder.rst
+++ b/components/sensor/rotary_encoder.rst
@@ -112,7 +112,7 @@ to the newly set internal value.
           value: 10
 
       # Templated
-      - sensor.my_rotary_encoder.publish:
+      - sensor.rotary_encoder.set_value:
           id: my_rotary_encoder
           value: !lambda 'return -1;'
 


### PR DESCRIPTION
changed # Templated to match #in some trigger
 old yaml
  # Templated
  - sensor.my_rotary_encoder.publish: id: my_rotary_encoder value: !lambda 'return -1;'

correct yaml

      # Templated
      - sensor.rotary_encoder.set_value:
          id: my_rotary_encoder
          value: !lambda 'return -1;'

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
