### PR TITLE
Add framework workaround to the config example

### DIFF
--- a/components/rp2040.rst
+++ b/components/rp2040.rst
@@ -18,6 +18,19 @@ This component contains platform-specific options for the RP2040 platform.
     rp2040:
       board: rpipicow
 
+.. note::
+
+    For now, you need the following added to the config or you will get compile errors and board not found:
+
+    # Example configuration entry
+    rp2040:
+      board: rpipicow
+      framework:
+        platform_version: https://github.com/maxgerhardt/platform-raspberrypi.git
+
+.. code-block:: yaml
+
+
 Configuration variables:
 ------------------------
 

--- a/components/rp2040.rst
+++ b/components/rp2040.rst
@@ -22,13 +22,13 @@ This component contains platform-specific options for the RP2040 platform.
 
     For now, you need the following added to the config or you will get compile errors and board not found:
 
+.. code-block:: yaml
+
     # Example configuration entry
     rp2040:
       board: rpipicow
       framework:
         platform_version: https://github.com/maxgerhardt/platform-raspberrypi.git
-
-.. code-block:: yaml
 
 
 Configuration variables:


### PR DESCRIPTION
## Description:

Without the framework override, you will get various compile errors and missing board definitions.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
