### PR TITLE
Examples of Daly BMS control using uart.write

### DIFF
--- a/components/sensor/daly_bms.rst
+++ b/components/sensor/daly_bms.rst
@@ -237,7 +237,7 @@ First you need to setup binary sensors for charging and disharging MOS
   
 .. code-block:: yaml  
 
-  
+    
     binary_sensor:
       - platform: daly_bms
         charging_mos_enabled:
@@ -253,7 +253,7 @@ Then you can add switches
   
 .. code-block:: yaml  
 
-  
+    
     switch:
       - platform: template
         name: "Daly Charging MOS"
@@ -298,7 +298,7 @@ Also you can add select to change battery level
   
 .. code-block:: yaml  
 
-  
+    
     select:
       - platform: template
         name: "Daly Battery Level setup"

--- a/components/sensor/daly_bms.rst
+++ b/components/sensor/daly_bms.rst
@@ -228,6 +228,133 @@ Configuration variables:
   - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.
   - All other options from :ref:`Binary Sensor <config-binary_sensor>`.
 
+
+Control BMS
+-----------
+At this moment Daly sensor platform don't suppport controlling you BMS, but you can make some stuff using uart.write
+
+First you need to setup binary sensors for charging and disharging MOS  
+  
+.. code-block:: yaml
+  
+    binary_sensor:
+      - platform: daly_bms
+        charging_mos_enabled:
+          name: "Daly Charging MOS"
+          id: bin_daly_chg_mos # binary MOS sensor must have ID to use with switch
+          internal: True # but you can make it internal to avoid duplication
+        discharging_mos_enabled:
+          name: "Daly Discharging MOS"
+          id: bin_daly_dischg_mos # binary MOS sensor must have ID to use with switch
+          internal: True # but you can make it internal to avoid duplication
+
+Then you can add switches  
+  
+.. code-block:: yaml
+  
+    switch:
+      - platform: template
+        name: "Daly Charging MOS"
+        lambda: |-
+          if (id(bin_daly_chg_mos).state) {
+            return true;
+          } else {
+            return false;
+          }
+        turn_on_action:
+          - uart.write:
+              data: [0xA5, 0x40, 0xDA, 0x08, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xC8]
+          - logger.log: 
+              format: "Send cmd to Daly: Set charge MOS on"
+        turn_off_action:
+          - uart.write:
+              data: [0xA5, 0x40, 0xDA, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xC7]
+          - logger.log: 
+              format: "Send cmd to Daly: Set charge MOS off"
+
+      - platform: template
+        name: "Daly Discharging MOS"
+        lambda: |-
+          if (id(bin_daly_dischg_mos).state) {
+            return true;
+          } else {
+            return false;
+          }
+        turn_on_action:
+          - uart.write:
+              data: [0xA5, 0x40, 0xD9, 0x08, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xC7]
+          - logger.log: 
+              format: "Send cmd to Daly: Set discharge MOS on"
+        turn_off_action:
+          - uart.write:
+              data: [0xA5, 0x40, 0xD9, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xC6]
+          - logger.log: 
+              format: "Send cmd to Daly: Set discharge MOS off"
+
+
+Also you can add select to change battery level
+  
+.. code-block:: yaml  
+  
+    select:
+      - platform: template
+        name: "Daly Battery Level setup"
+        optimistic: True
+        options:
+          - 100%
+          - 75%
+          - 50%
+          - 25%
+          - 0%
+        initial_option: 100%
+        on_value:
+          then:
+            - if:
+                condition:
+                  lambda: 'return x == "100%";'
+                then:
+                  - uart.write:
+                      data: [0xA5, 0x40, 0x21, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0xE8, 0xF9]
+                  - logger.log: 
+                      format: "Send cmd to Daly: Set SOC to 100%"
+                else:
+                  - if:
+                      condition:
+                        lambda: 'return x == "75%";'
+                      then:
+                        - uart.write:
+                            data: [0xA5, 0x40, 0x21, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xEE, 0xFE]
+                        - logger.log: 
+                            format: "Send cmd to Daly: Set SOC to 75%"
+                      else:
+                        - if:
+                            condition:
+                              lambda: 'return x == "50%";'
+                            then:
+                              - uart.write:
+                                  data: [0xA5, 0x40, 0x21, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0xF4, 0x03]
+                              - logger.log: 
+                                  format: "Send cmd to Daly: Set SOC to 50%"
+                            else:
+                              - if:
+                                  condition:
+                                    lambda: 'return x == "25%";'
+                                  then:
+                                    - uart.write:
+                                        data: [0xA5, 0x40, 0x21, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xFA, 0x08]
+                                    - logger.log: 
+                                        format: "Send cmd to Daly: Set SOC to 25%"
+                                  else:
+                                    - if:
+                                        condition:
+                                          lambda: 'return x == "0%";'
+                                        then:
+                                          - uart.write:
+                                              data: [0xA5, 0x40, 0x21, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0E]
+                                          - logger.log: 
+                                              format: "Send cmd to Daly: Set SOC to 0%"
+                                              
+                                                
 UART Connection
 ---------------
 

--- a/components/sensor/daly_bms.rst
+++ b/components/sensor/daly_bms.rst
@@ -310,7 +310,7 @@ Also you can add select to change battery level
           - 25%
           - 0%
         initial_option: 100%
-        on_value:
+        set_action:
           then:
             - if:
                 condition:

--- a/components/sensor/daly_bms.rst
+++ b/components/sensor/daly_bms.rst
@@ -235,7 +235,8 @@ At this moment Daly sensor platform don't suppport controlling you BMS, but you 
 
 First you need to setup binary sensors for charging and disharging MOS  
   
-.. code-block:: yaml
+.. code-block:: yaml  
+
   
     binary_sensor:
       - platform: daly_bms
@@ -250,7 +251,8 @@ First you need to setup binary sensors for charging and disharging MOS
 
 Then you can add switches  
   
-.. code-block:: yaml
+.. code-block:: yaml  
+
   
     switch:
       - platform: template
@@ -295,6 +297,7 @@ Then you can add switches
 Also you can add select to change battery level
   
 .. code-block:: yaml  
+
   
     select:
       - platform: template


### PR DESCRIPTION
Add a couple of examples of Daly BMS control using uart.write

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
