### PR TITLE
Fix API reference link for ESP32 Camera Web Server

### DIFF
--- a/components/esp32_camera_web_server.rst
+++ b/components/esp32_camera_web_server.rst
@@ -43,5 +43,5 @@ Integrating the mjpeg web service into an NVR:
 See Also
 --------
 
-- :apiref:`esp32_camera_web_server/esp32_camera_web_server.h`
+- :apiref:`esp32_camera_web_server/camera_web_server.h`
 - :ghedit:`Edit`


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes broken link

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** N/A

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
