### PR TITLE
Fix esp32-arduino_framework ref

### DIFF
--- a/components/esp32.rst
+++ b/components/esp32.rst
@@ -31,8 +31,6 @@ Configuration variables:
 
     Support for the ESP32-S2 and ESP32-C3 is still in development and there could be issues.
 
-.. _esp32-arduino_framework:
-
 GPIO Pin Numbering
 ------------------
 
@@ -58,6 +56,8 @@ Some notes about the pins on the ESP32:
       - platform: gpio
         name: "Pin GPIO23"
         pin: GPIO23
+
+.. _esp32-arduino_framework:
 
 Arduino framework
 -----------------


### PR DESCRIPTION
## Description:

What should have been a link to "ESP32 Arduino Framework" was actually "GPIO Pin Numbering" which was a bit confusing, moved ref to fix.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** N/A

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
