### PR TITLE
Clarify bang bang sensor needs °C

### DIFF
--- a/components/climate/bang_bang.rst
+++ b/components/climate/bang_bang.rst
@@ -69,7 +69,7 @@ Do note that the actions are only called when the current temperature leaves the
 Configuration variables:
 ------------------------
 
-- **sensor** (**Required**, :ref:`config-id`): The sensor that is used to measure the current temperature.
+- **sensor** (**Required**, :ref:`config-id`): The sensor that is used to measure the current temperature (must be in `°C`).
 - **default_target_temperature_low** (**Required**, float): The default low target temperature for
   the control algorithm. This can be dynamically set in the frontend later.
 - **default_target_temperature_high** (**Required**, float): The default high target temperature for


### PR DESCRIPTION
This isn't stated elsewhere in the docs and I spent a while figuring out why it wasn't working when everything else was set to `°F`

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
