### PR TITLE
addded: BME680 IAQ Class

### DIFF
--- a/components/sensor/bme680_bsec.rst
+++ b/components/sensor/bme680_bsec.rst
@@ -62,7 +62,7 @@ The :ref:`I²C <i2c>` is required to be set up in your configuration for this se
           name: "BME680 IAQ Accuracy"
  
       - platform: template
-        name: "BME680 IAQ Class"
+        name: "BME680 IAQ Classification"
         icon: "mdi:checkbox-marked-circle-outline"
         lambda: |-
           if ( int(id(iaq).state) <= 50) {
@@ -310,6 +310,7 @@ See Also
 - :ref:`sensor-filters`
 - :doc:`bme680`
 - :apiref:`bme680_bsec/bme680_bsec.h`
+- `BME680 VOC classification <https://community.bosch-sensortec.com/t5/MEMS-sensors-forum/BME680-VOC-classification/td-p/26154>`__
 - `BSEC Arduino Library <https://github.com/BoschSensortec/BSEC-Arduino-library>`__ by `Bosch Sensortec <https://www.bosch-sensortec.com/>`__
 - `Bosch Sensortec Community <https://community.bosch-sensortec.com/>`__
 - :ghedit:`Edit`

--- a/components/sensor/bme680_bsec.rst
+++ b/components/sensor/bme680_bsec.rst
@@ -50,6 +50,7 @@ The :ref:`I²C <i2c>` is required to be set up in your configuration for this se
           name: "BME680 Humidity"
         iaq:
           name: "BME680 IAQ"
+          id: iaq
         co2_equivalent:
           name: "BME680 CO2 Equivalent"
         breath_voc_equivalent:
@@ -59,6 +60,35 @@ The :ref:`I²C <i2c>` is required to be set up in your configuration for this se
       - platform: bme680_bsec
         iaq_accuracy:
           name: "BME680 IAQ Accuracy"
+ 
+     - platform: template
+        name: "BME680 IAQ Class"
+        icon: "mdi:checkbox-marked-circle-outline"
+        lambda: |-
+          if ( int(id(iaq).state) <= 50) {
+            return {"Excellent"};
+          }
+          else if (int(id(iaq).state) >=51 && int(id(iaq).state) < 100) {
+            return {"Good"};
+          }
+          else if (int(id(iaq).state) >=101 && int(id(iaq).state) < 150) {
+            return {"Lightly polluted"};
+          }
+          else if (int(id(iaq).state) >=151 && int(id(iaq).state) < 200) {
+            return {"Moderately pulluted"};
+          }
+          else if (int(id(iaq).state) >=201 && int(id(iaq).state) < 250) {
+            return {"Heavily Pulluted"};
+          }
+          else if (int(id(iaq).state) >=251 && int(id(iaq).state) < 350) {
+            return {"Severely pulluted"};
+          }
+          else if (int(id(iaq).state) > 351) {
+            return {"Extremely pulluted"};
+          }
+          else {
+            return {"error"};
+          }
 
 Configuration variables:
 

--- a/components/sensor/bme680_bsec.rst
+++ b/components/sensor/bme680_bsec.rst
@@ -68,22 +68,22 @@ The :ref:`I²C <i2c>` is required to be set up in your configuration for this se
           if ( int(id(iaq).state) <= 50) {
             return {"Excellent"};
           }
-          else if (int(id(iaq).state) >=51 && int(id(iaq).state) < 100) {
+          else if (int(id(iaq).state) >= 51 && int(id(iaq).state) <= 100) {
             return {"Good"};
           }
-          else if (int(id(iaq).state) >=101 && int(id(iaq).state) < 150) {
+          else if (int(id(iaq).state) >= 101 && int(id(iaq).state) <= 150) {
             return {"Lightly polluted"};
           }
-          else if (int(id(iaq).state) >=151 && int(id(iaq).state) < 200) {
+          else if (int(id(iaq).state) >= 151 && int(id(iaq).state) <= 200) {
             return {"Moderately pulluted"};
           }
-          else if (int(id(iaq).state) >=201 && int(id(iaq).state) < 250) {
+          else if (int(id(iaq).state) >= 201 && int(id(iaq).state) <= 250) {
             return {"Heavily Pulluted"};
           }
-          else if (int(id(iaq).state) >=251 && int(id(iaq).state) < 350) {
+          else if (int(id(iaq).state) >= 251 && int(id(iaq).state) <= 350) {
             return {"Severely pulluted"};
           }
-          else if (int(id(iaq).state) > 351) {
+          else if (int(id(iaq).state) >= 351) {
             return {"Extremely pulluted"};
           }
           else {

--- a/components/sensor/bme680_bsec.rst
+++ b/components/sensor/bme680_bsec.rst
@@ -61,7 +61,7 @@ The :ref:`I²C <i2c>` is required to be set up in your configuration for this se
         iaq_accuracy:
           name: "BME680 IAQ Accuracy"
  
-     - platform: template
+      - platform: template
         name: "BME680 IAQ Class"
         icon: "mdi:checkbox-marked-circle-outline"
         lambda: |-

--- a/components/sensor/bme680_bsec.rst
+++ b/components/sensor/bme680_bsec.rst
@@ -75,16 +75,16 @@ The :ref:`I²C <i2c>` is required to be set up in your configuration for this se
             return {"Lightly polluted"};
           }
           else if (int(id(iaq).state) >= 151 && int(id(iaq).state) <= 200) {
-            return {"Moderately pulluted"};
+            return {"Moderately polluted"};
           }
           else if (int(id(iaq).state) >= 201 && int(id(iaq).state) <= 250) {
-            return {"Heavily Pulluted"};
+            return {"Heavily polluted"};
           }
           else if (int(id(iaq).state) >= 251 && int(id(iaq).state) <= 350) {
-            return {"Severely pulluted"};
+            return {"Severely polluted"};
           }
           else if (int(id(iaq).state) >= 351) {
-            return {"Extremely pulluted"};
+            return {"Extremely polluted"};
           }
           else {
             return {"error"};


### PR DESCRIPTION
## Description:
I added a `text_sensor` example for the IAQ Classification. Based on the the table [provided by Bosch](https://community.bosch-sensortec.com/t5/MEMS-sensors-forum/BME680-VOC-classification/td-p/26154).

**Related issue (if applicable):** None

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** None

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
