### PR TITLE
Spelling mistake public/publish

### DIFF
--- a/components/switch/template.rst
+++ b/components/switch/template.rst
@@ -89,7 +89,7 @@ Configuration options:
 
 .. note::
 
-    This action can also be written in lambdas, the parameter of the `public_state` method denotes if
+    This action can also be written in lambdas, the parameter of the `publish_state` method denotes if
     the switch is currently on or off:
 
     .. code-block:: cpp


### PR DESCRIPTION
## Description:
Extremely minor spelling fix for documentation

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
