### PR TITLE
Fix typo in text-sensor documentation

### DIFF
--- a/components/text_sensor/version.rst
+++ b/components/text_sensor/version.rst
@@ -38,7 +38,7 @@ Disabling the compilation timestamp:
         name: "ESPHome Version"
         hide_timestamp: true
 
-This will, for example, change the output of the senser from:
+This will, for example, change the output of the sensor from:
 
 ``1.15.0-dev (Jun 8 2020, 18:53:16)`` to ``1.15.0-dev``
 


### PR DESCRIPTION
## Description:

This is a simple pull request to fix a typo in the documentation of text-sensor.

## Checklist:

  - [x ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.
