### PR TITLE
Fix link to mqtt base component config

### DIFF
--- a/components/mqtt.rst
+++ b/components/mqtt.rst
@@ -275,8 +275,6 @@ then run the ``mqtt-fingerprint`` script of ESPHome to get the certificate:
       ssl_fingerprints:
         - a502ff13999f8b398ef1834f1123650b3236fc07
 
-.. _config-mqtt-component:
-
 
 .. _mqtt-tls-idf:
 
@@ -300,7 +298,7 @@ Also make sure to change the ``port`` of the mqtt broker. Most brokers use port 
     - mqtt.example.com -> Success
 
     If a secure connection is necessary for your device, you really want to set:
-    
+
     .. code-block:: yaml
 
         skip_cert_cn_check: false
@@ -342,6 +340,7 @@ Also make sure to change the ``port`` of the mqtt broker. Most brokers use port 
         m/XriWr/Cq4h/JfB7NTsezVslgkBaoU=
         -----END CERTIFICATE-----
 
+.. _config-mqtt-component:
 
 MQTT Component Base Configuration
 ---------------------------------


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
