### PR TITLE
Update SCD30 sensor documentation

### DIFF
--- a/components/sensor/scd30.rst
+++ b/components/sensor/scd30.rst
@@ -74,6 +74,36 @@ Configuration variables:
 - **update_interval** (*Optional*, :ref:`config-time`): The interval to check the
   sensor. Defaults to ``60s``.
 
+
+Manual calibration:
+------------------------
+
+.. code-block:: yaml
+
+    # Example on how to implement a UI section in HA for manual calibration.
+    # Note: Please enter first a CO2 value before pressing the button.
+    button:
+      - platform: template
+        name: "SCD30 Force manual calibration"
+        entity_category: "config"
+        on_press:
+          then:
+            - scd30.force_recalibration_with_reference:
+                value: !lambda 'return id(co2_cal).state;'
+    
+    number:
+      - platform: template
+        name: "CO2 calibration value"
+        optimistic: true
+        min_value: 350
+        max_value: 4500
+        step: 1
+        id: co2_cal
+        icon: "mdi:molecule-co2"
+        entity_category: "config"
+
+
+
 See Also
 --------
 


### PR DESCRIPTION
Added section for manual calibration

## Description:
Added section for manual calibration

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#4362

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
