### PR TITLE
Added example with the expanded form for file

### DIFF
--- a/components/display/index.rst
+++ b/components/display/index.rst
@@ -170,6 +170,13 @@ Next, create a ``font:`` section in your configuration:
         id: roboto
         size: 20
 
+      - file:
+          type: gfonts
+          family: Roboto
+          weight: 900
+        id: font2
+        size: 16
+
       - file: "fonts/tom-thumb.bdf"
         id: tomthumb
 


### PR DESCRIPTION
Added one example where file does not use the short form, but the YAML expanded one described below the examples.

## Description:


**Related issue (if applicable):** Per discussion on Discord https://discord.com/channels/429907082951524364/1069891727818768424/1069913652905377904

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** N/A

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
