### PR TITLE
Correct modbus_controller "value_type" signed and unsigned data type descriptions

### DIFF
--- a/components/output/modbus_controller.rst
+++ b/components/output/modbus_controller.rst
@@ -12,7 +12,7 @@ Configuration variables:
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
 - **name** (**Required**, string): The name of the sensor.
 - **address** (**Required**, int): start address of the first register in a range
-- **value_type** (**Required**): datatype of the modbus register data. The default data type for modbus is a 16 bit integer in big endian format (MSB first)
+- **value_type** (**Required**): data type of the modbus register data. The default data type for modbus is a 16 bit integer in big endian format (MSB first)
 
     - ``U_WORD`` (unsigned 16 bit integer from 1 register = 16bit)
     - ``S_WORD`` (signed 16 bit integer from 1 register = 16bit)
@@ -21,9 +21,9 @@ Configuration variables:
     - ``U_DWORD_R`` (unsigned 32 bit integer from 2 registers low word first)
     - ``S_DWORD_R`` (signed 32 bit integer from 2 registers low word first)
     - ``U_QWORD`` (unsigned 64 bit integer from 4 registers = 64bit)
-    - ``S_QWORD`` (unsigned 64 bit integer from 4 registers = 64bit)
+    - ``S_QWORD`` (signed 64 bit integer from 4 registers = 64bit)
     - ``U_QWORD_R`` (unsigned 64 bit integer from 4 registers low word first)
-    - ``U_QWORD_R`` signed 64 bit integer from 4 registers low word first)
+    - ``S_QWORD_R`` signed 64 bit integer from 4 registers low word first)
     - ``FP32`` (32 bit IEEE 754 floating point from 2 registers)
     - ``FP32_R`` (32 bit IEEE 754 floating point - same as FP32 but low word first)
 


### PR DESCRIPTION
## Description:
Changed some minor mistakes in the modbus_controller configuration variables documentation.

- S_QWORD from unsigned to signed 64 bit
- U_QWORD_R twice

## Checklist:

  - [] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
