### PR TITLE
Update index.rst

### DIFF
--- a/components/output/index.rst
+++ b/components/output/index.rst
@@ -43,7 +43,7 @@ Configuration variables:
 Float outputs only:
 
 - **min_power** (*Optional*, float): Sets the minimum output value of this output platform.
-  Must be in range from 0 to max_power. Defaults to ``0``.
+  Must be in range from 0 to max_power. Defaults to ``0``.  If zero_means_zero is ``false`` this will be output value when the entity is turned off.
 - **max_power** (*Optional*, float): Sets the maximum output value of this output platform.
   Must be in range from min_power to 1. Defaults to ``1``.
 - **zero_means_zero** (*Optional*, boolean): Sets the output to use actual 0 instead of ``min_power``.


### PR DESCRIPTION
## Description:
I was using the min_power variable in the output, but it wasn't obvious what zero_means_zero did.  Even with a few explanations I still didn't understand. I thought this small addition to the description of min_power variable would make it easier to understand.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
