### PR TITLE
LED Drivers - Fix typo

### DIFF
--- a/components/output/bp1658cj.rst
+++ b/components/output/bp1658cj.rst
@@ -10,7 +10,7 @@ BP1658CJ LED driver
 Component/Hub
 -------------
 
-The BP1658CJ component represents a BP1658CJ LED diver chain in
+The BP1658CJ component represents a BP1658CJ LED driver chain in
 ESPHome. Communication is done with two GPIO pins (DATA and CLK).
 
 To use the channels of this components, you first need to setup the

--- a/components/output/bp5758d.rst
+++ b/components/output/bp5758d.rst
@@ -10,7 +10,7 @@ BP5758D LED driver
 Component/Hub
 -------------
 
-The BP5758D component represents a BP5758D LED diver chain in
+The BP5758D component represents a BP5758D LED driver chain in
 ESPHome. Communication is done with two GPIO pins (DATA and CLK).
 
 To use the channels of this components, you first need to setup the

--- a/components/output/my9231.rst
+++ b/components/output/my9231.rst
@@ -11,7 +11,7 @@ MY9231/MY9291 LED driver
 Component/Hub
 -------------
 
-The MY9231/MY9291 component represents a MY9231/MY9291 LED diver chain
+The MY9231/MY9291 component represents a MY9231/MY9291 LED driver chain
 (`MY9231 description <http://www.my-semi.com.tw/file/MY9231_BF_0.91.pdf>`__,
 `MY9291 description <http://www.my-semi.com.tw/file/MY9291_BF_0.91.pdf>`__) in
 ESPHome. Communication is done with two GPIO pins (DI and DCKI) and multiple

--- a/components/output/sm16716.rst
+++ b/components/output/sm16716.rst
@@ -11,7 +11,7 @@ SM16716 LED driver
 Component/Hub
 -------------
 
-The SM16716 component represents a SM16716 LED diver chain
+The SM16716 component represents a SM16716 LED driver chain
 (`SM16716 description <https://github.com/sowbug/sm16716/blob/master/SM16716%20Datasheet%20%5BChinese%5D.pdf>`__,
 `SM16716 description <https://github.com/sowbug/sm16716/blob/master/SM16716%20Datasheet%20%5BChinese%5D.pdf>`__) in
 ESPHome. Communication is done with two GPIO pins (MOSI and SCLK) and multiple

--- a/components/output/sm2135.rst
+++ b/components/output/sm2135.rst
@@ -10,7 +10,7 @@ SM2135 LED driver
 Component/Hub
 -------------
 
-The SM2135 component represents a SM2135 LED diver chain
+The SM2135 component represents a SM2135 LED driver chain
 (`SM2135 description <https://github.com/arendst/Sonoff-Tasmota/files/3656603/SM2135E_zh-CN_en-US_translated.pdf>`__,
 `SM2135 description <https://github.com/arendst/Sonoff-Tasmota/files/3656603/SM2135E_zh-CN_en-US_translated.pdf>`__) in
 ESPHome. Communication is done with two GPIO pins (MOSI and SCLK).

--- a/components/output/sm2235.rst
+++ b/components/output/sm2235.rst
@@ -10,7 +10,7 @@ SM2235 LED driver
 Component/Hub
 -------------
 
-The SM2235 component represents a SM2235 LED diver chain in
+The SM2235 component represents a SM2235 LED driver chain in
 ESPHome. Communication is done with two GPIO pins (DATA and CLK).
 
 To use the channels of this components, you first need to setup the

--- a/components/output/sm2335.rst
+++ b/components/output/sm2335.rst
@@ -10,7 +10,7 @@ SM2335 LED driver
 Component/Hub
 -------------
 
-The SM2335 component represents a SM2335 LED diver chain in
+The SM2335 component represents a SM2335 LED driver chain in
 ESPHome. Communication is done with two GPIO pins (DATA and CLK).
 It is used in some smart light bulbs:
 


### PR DESCRIPTION
## Description:
Minor typo fix in many LED drivers
Merging to next because some only exist there.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
