### PR TITLE
Added note for “SetOption78 1” in Tasmota

### DIFF
--- a/guides/migrate_sonoff_tasmota.rst
+++ b/guides/migrate_sonoff_tasmota.rst
@@ -8,6 +8,10 @@ Migrating from Sonoff Tasmota
 Migrating from previous Sonoff Tasmota setups is very easy. You just need to have
 ESPHome create a binary for you and then upload that in the Tasmota web interface.
 
+.. note::
+
+    If you are using Tasmota 7.2+ it is necessary to run the command “SetOption78 1” in the Tasmota console and restart your device to be able to upgrade to esphome.
+
 Getting the Binary
 ------------------
 

--- a/guides/migrate_sonoff_tasmota.rst
+++ b/guides/migrate_sonoff_tasmota.rst
@@ -8,7 +8,6 @@ Migrating from Sonoff Tasmota
 Migrating from previous Sonoff Tasmota setups is very easy. You just need to have
 ESPHome create a binary for you and then upload that in the Tasmota web interface.
 
-
 Getting the Binary
 ------------------
 

--- a/guides/migrate_sonoff_tasmota.rst
+++ b/guides/migrate_sonoff_tasmota.rst
@@ -8,9 +8,6 @@ Migrating from Sonoff Tasmota
 Migrating from previous Sonoff Tasmota setups is very easy. You just need to have
 ESPHome create a binary for you and then upload that in the Tasmota web interface.
 
-.. note::
-
-    If you are using Tasmota 7.2+ it is necessary to run the command “SetOption78 1” in the Tasmota console and restart your device to be able to upgrade to esphome.
 
 Getting the Binary
 ------------------
@@ -62,7 +59,7 @@ Happy Hacking!
 
 .. note::
 
-    If you are using Tasmota 8+ on ESP8266 and get an error after uploading the firmware, first upload ``tasmota-minimal.bin.gz`` from Tasmota repository, next upload firmware generated from ESPHome. Another way to try is to simply ``gzip`` the ESPHome binary and upload the ``.gz`` file instead.
+    If you are using Tasmota 8+ on ESP8266 and get an error after uploading the firmware, first upload ``tasmota-minimal.bin.gz`` from Tasmota repository, next upload firmware generated from ESPHome. Another way to try is to simply ``gzip`` the ESPHome binary and upload the ``.gz`` file instead. If you are using Tasmota 7.2+ it is necessary to run the command “SetOption78 1” in the Tasmota console and restart your device to be able to upgrade to esphome.
 
 See Also
 --------


### PR DESCRIPTION
## Description:

If you are using Tasmota 7.2+ it is necessary to run the command “SetOption78 1” in the Tasmota console and restart your device to be able to upgrade to esphome.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
