### PR TITLE
Fix typos on Geiger counter page

### DIFF
--- a/cookbook/geiger-counter.rst
+++ b/cookbook/geiger-counter.rst
@@ -10,7 +10,7 @@ With the help of :doc:`/components/sensor/pulse_counter` and the RadiationD v1.1
 a more or less precise messurement of the current radation level. But it should be good enough to warn you about critical events.  
 
 
-Assambly:
+Assembly:
 ---------
 
 .. figure:: images/radiationD-v1-1-cajoe_small.jpg
@@ -30,7 +30,7 @@ I just 3D printed an small housing the avoid touching the high voltage Geiger Mu
 (The tube should not be in direct sunlight. So maybe you will need another case.)
 
 
-Configuartion:
+Configuration:
 ---------------
 
 The block :doc:`/components/sensor/pulse_counter` will count the radation events per minute. 


### PR DESCRIPTION
## Description: 
Fixes the typos for "assembly" and "configuration"


**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
