### PR TITLE
Update air_gradient_diy_air_quality_sensor.rst

### DIFF
--- a/cookbook/air_gradient_diy_air_quality_sensor.rst
+++ b/cookbook/air_gradient_diy_air_quality_sensor.rst
@@ -37,7 +37,7 @@ Documentation:
 - `AirGradient Shop for the PCB or PCB plus components <https://www.airgradient.com/diyshop/>`__
 - `AirGradient Setup Guide (3D printeable case, setup guide, etc.) <https://www.airgradient.com/diy/>`__
 
-`YAML configuration <https://github.com/ajfriesen/ESPHome-AirGradient/blob/main/air-gradient.yaml>`__
+`YAML configuration <https://github.com/ajfriesen/ESPHome-AirGradient/blob/main/air-gradient-diy.yaml>`__
 
 Soldering and setup video:
 


### PR DESCRIPTION
Corrected the link to YAML configuration on GitHub.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
