### PR TITLE
Enable NeoPixel support for ESP32-S3

### DIFF
--- a/components/light/neopixelbus.rst
+++ b/components/light/neopixelbus.rst
@@ -135,7 +135,7 @@ settings vary by method:
 - **esp32_rmt**: An alternative method for ESP32 that uses the RMT peripheral to send data.
   Available on all output pins. Additional options:
 
-  - **channel** (*Optional*): The RMT channel to use. The ESP32 has channels 0-7, ESP32-S2 0-3 and ESP32-C3 0-1.
+  - **channel** (*Optional*): The RMT channel to use. The ESP32 has channels 0-7, ESP32-S2 0-3, ESP32-S3 0-3, and ESP32-C3 0-1.
     Defaults to 6 on ESP32, and 1 on other ESP32 variants.
 
 The following method is available only for two-wire chips (specify ``data_pin`` and ``clock_pin``):


### PR DESCRIPTION
## Description:
ESP32-S3 devices now can use NeoPixel. This change updates the documentation

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#4435

## Checklist:

  - [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
