### PR TITLE
Update example to use Color::BLACK not COLOR_BLACK

### DIFF
--- a/components/display/ili9341.rst
+++ b/components/display/ili9341.rst
@@ -35,7 +35,7 @@ beyond the typical SPI connections, it is better suited for use with the ESP32.
         reset_pin: 33
 
         lambda: |-
-          it.fill(COLOR_BLACK);
+          it.fill(Color::BLACK);
           it.print(0, 0, id(my_font), id(my_red), TextAlign::TOP_LEFT, "Hello World!");
 
 Configuration variables:


### PR DESCRIPTION
## Description:

COLOR_BLACK now generates a deprecation warning, update the example to use the recommended name.

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
