### PR TITLE
add dallas address sensor

### DIFF
--- a/components/sensor/dallas.rst
+++ b/components/sensor/dallas.rst
@@ -122,6 +122,15 @@ You will find something like this:
 
 .. figure:: images/dallas-log.png
 
+You can also use text sensor to get addresses:
+
+.. code-block:: yaml
+
+    text_sensor:
+      - platform: dallas
+        address:
+          name: dallas address
+
 Now we can add the individual sensors to our configuration:
 
 .. code-block:: yaml


### PR DESCRIPTION
## Description:

It is difficult to find out address of 1-wiere sensors in log over web.
It adds new text sensor which display all address as text sensor

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>
https://github.com/esphome/esphome/pull/4460
## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
