### PR TITLE
Fix CT clamp API URL

### DIFF
--- a/components/sensor/ct_clamp.rst
+++ b/components/sensor/ct_clamp.rst
@@ -79,5 +79,5 @@ See Also
 - `CT Clamp Guide <https://learn.openenergymonitor.org/electricity-monitoring/ct-sensors/introduction>`__
 - :doc:`adc`
 - :doc:`ads1115`
-- :apiref:`sensor/ct_clamp.h`
+- :apiref:`sensor/ct_clamp_sensor.h`
 - :ghedit:`Edit`


### PR DESCRIPTION
## Description:
Fixes the CT clamp API URL

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
