### PR TITLE
remove keep_user_credentials

### DIFF
--- a/guides/creators.rst
+++ b/guides/creators.rst
@@ -50,9 +50,6 @@ Example configuration
     # In combination with the `ap` this allows the user
     # to provision wifi credentials to the device.
     captive_portal:
-      # Optionally, preserve provisioned credentials
-      # over subsequent OTA updates.
-      keep_user_credentials: true
 
     # Sets up Bluetooth LE (Only on ESP32) to allow the user
     # to provision wifi credentials to the device.


### PR DESCRIPTION
`keep_user_credentials` is no longer a valid option, and causes the build to fail.

See https://esphome.io/components/wifi.html?highlight=wifi#user-entered-credentials

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
