### PR TITLE
ens210 must be lowercase

### DIFF
--- a/components/sensor/ens210.rst
+++ b/components/sensor/ens210.rst
@@ -23,7 +23,7 @@ The ``ENS210`` Temperature+Humidity sensor allows you to use your ENS210
 
     # Example configuration entry
     sensor:
-      - platform: ENS210
+      - platform: ens210
         temperature:
           name: "Living Room Temperature"
         humidity:


### PR DESCRIPTION
In the example config, it says `platform: ENS210`. It should be `platform: ens210`.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
