### PR TITLE
correct details in SEN5x documentation

### DIFF
--- a/components/sensor/sen5x.rst
+++ b/components/sensor/sen5x.rst
@@ -114,7 +114,7 @@ Configuration variables:
 
   - All other options from :ref:`Sensor <config-sensor>`.
 
-- **nox** (*Optional*): NOx Index. Note: Only available with Sen54 or Sen55. The sensor will be ignored on unsupported models.
+- **nox** (*Optional*): NOx Index. Note: Only available with Sen55. The sensor will be ignored on unsupported models.
 
   - **name** (**Required**, string): The name of the sensor.
   - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.

--- a/components/sensor/sen5x.rst
+++ b/components/sensor/sen5x.rst
@@ -162,7 +162,7 @@ Configuration variables:
 Wiring:
 -------
 
-The sensor has a JST GHR-06V-S 6 pin type connector, with a 1.5mm pitch. The cable needs this connector:
+The sensor has a JST GHR-06V-S 6 pin type connector, with a 1.25mm pitch. The cable needs this connector:
 
 .. figure:: images/jst6pin.png
     :align: center


### PR DESCRIPTION
## Description:

Correcting the pitch details of the JST GH connector.  Source: https://www.jst.com/products/crimp-style-connectors-wire-to-board-type/gh-connector/

Also removing references to SEN54 in NOx, as this is only available on SEN55

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** N/A

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
