### PR TITLE
Update custom.rst

### DIFF
--- a/components/switch/custom.rst
+++ b/components/switch/custom.rst
@@ -50,6 +50,7 @@ And in YAML:
 
       switches:
         name: "My Custom Switches"
+        id: my_custom_switch
 
 Configuration variables:
 


### PR DESCRIPTION
Adding ID reference cos I spent 3 hours trying to find why I got this error

Couldn't find ID 'my_custom_switch'. Please check you have defined an ID with that name in your configuration.

## Description:
This change makes the implementation clearer

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
