### PR TITLE
added reset energy action to pzemdc

### DIFF
--- a/components/sensor/pzemdc.rst
+++ b/components/sensor/pzemdc.rst
@@ -62,6 +62,20 @@ Configuration variables:
 - **address** (*Optional*, int): The address of the sensor if multiple sensors are attached to
   the same UART bus. You will need to set the address of each device manually. Defaults to ``1``.
 
+.. _pzemdc-reset_energy_action:
+
+``pzemdc.reset_energy`` Action
+******************************
+
+This action resets the total energy value of the pzemdc device with the given ID when executed.
+
+.. code-block:: yaml
+
+    on_...:
+      then:
+        - pzemdc.reset_energy: pzemdc_1
+
+
 See Also
 --------
 


### PR DESCRIPTION
## Description:
I've added a action to reset the energy on the pzemdc device.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#4481

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
