### PR TITLE
Update modbus_controller.rst

### DIFF
--- a/components/select/modbus_controller.rst
+++ b/components/select/modbus_controller.rst
@@ -40,7 +40,7 @@ Configuration variables:
     - ``U_DWORD_R`` (unsigned 32 bit integer from 2 registers low word first)
     - ``S_DWORD_R`` (signed 32 bit integer from 2 registers low word first)
     - ``U_QWORD`` (unsigned 64 bit integer from 4 registers = 64bit)
-    - ``S_QWORD`` (unsigned 64 bit integer from 4 registers = 64bit)
+    - ``S_QWORD`` (signed 64 bit integer from 4 registers = 64bit)
     - ``U_QWORD_R`` (unsigned 64 bit integer from 4 registers low word first)
     - ``U_QWORD_R`` (signed 64 bit integer from 4 registers low word first)
 


### PR DESCRIPTION
S_QWORD is signed, not unsigned

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
