### PR TITLE
Remove copy paste config var mistake on mics-4514

### DIFF
--- a/components/sensor/mics_4514.rst
+++ b/components/sensor/mics_4514.rst
@@ -35,7 +35,6 @@ This component exposes the different gas concentration sensors from the `MiCS-45
 Configuration variables:
 ------------------------
 
-- **pin** (**Required**, :ref:`config-pin`): The pin where the DHT bus is connected.
 - **nitrogen_dioxide** (*Optional*): All options from :ref:`Sensor <config-sensor>`
 - **carbon_monoxide** (*Optional*): All options from :ref:`Sensor <config-sensor>`
 - **hydrogen** (*Optional*): All options from :ref:`Sensor <config-sensor>`


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
