### PR TITLE
Removing default setting

### DIFF
--- a/components/mqtt.rst
+++ b/components/mqtt.rst
@@ -149,7 +149,6 @@ discovery in your Home Assistant configuration with the following:
     # Example Home Assistant configuration.yaml entry
     mqtt:
       broker: ...
-      discovery: true
 
 And that should already be it 🎉 All devices defined through ESPHome should show up automatically
 in the entities section of Home Assistant.
@@ -308,7 +307,6 @@ Also make sure to change the ``port`` of the mqtt broker. Most brokers use port 
     mqtt:
       broker: test.mymqtt.local
       port: 8883
-      discovery: true
       discovery_prefix: ${mqtt_prefix}/homeassistant
       log_topic: ${mqtt_prefix}/logs
       # Evaluate carefully skip_cert_cn_check
@@ -353,7 +351,6 @@ MQTT can have some overrides for specific options.
     name: "Component Name"
     # Optional variables:
     retain: true
-    discovery: true
     availability:
       topic: livingroom/status
       payload_available: online


### PR DESCRIPTION
`discovery: true` is on by default and therefore not required here.  You only need this to set `discovery: false`

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
