### PR TITLE
Add the ability to manually set unique_object_id for unique_id generation, instead of using name

### DIFF
--- a/components/binary_sensor/index.rst
+++ b/components/binary_sensor/index.rst
@@ -66,6 +66,9 @@ Advanced options:
   See https://developers.home-assistant.io/docs/core/entity/#generic-properties
   for a list of available options. Requires Home Assistant 2021.11 or newer.
   Set to ``""`` to remove the default entity category.
+- **unique_object_id** (*Optional*, string): Used instead of ``name`` for internal ``unique_id`` and ``object_id`` generation.
+  If ``name`` has changed and ``unique_object_id`` has not, a new Entity will not be created.
+  If ``name`` is localized and consists of non ASCII symbols, set ``unique_object_id`` as transliterated ``name``.
 - If MQTT enabled, all other options from :ref:`MQTT Component <config-mqtt-component>`.
 
 .. _binary_sensor-filters:

--- a/components/button/index.rst
+++ b/components/button/index.rst
@@ -53,6 +53,9 @@ Configuration variables:
 - **device_class** (*Optional*, string): The device class for the button.
   See https://developers.home-assistant.io/docs/core/entity/button/#available-device-classes
   for a list of available options.
+- **unique_object_id** (*Optional*, string): Used instead of ``name`` for internal ``unique_id`` and ``object_id`` generation.
+  If ``name`` has changed and ``unique_object_id`` has not, a new Entity will not be created.
+  If ``name`` is localized and consists of non ASCII symbols, set ``unique_object_id`` as transliterated ``name``.
 
 Automations:
 

--- a/components/climate/index.rst
+++ b/components/climate/index.rst
@@ -60,6 +60,9 @@ Advanced options:
   See https://developers.home-assistant.io/docs/core/entity/#generic-properties
   for a list of available options. Requires Home Assistant 2021.11 or newer.
   Set to ``""`` to remove the default entity category.
+- **unique_object_id** (*Optional*, string): Used instead of ``name`` for internal ``unique_id`` and ``object_id`` generation.
+  If ``name`` has changed and ``unique_object_id`` has not, a new Entity will not be created.
+  If ``name`` is localized and consists of non ASCII symbols, set ``unique_object_id`` as transliterated ``name``.
 
 MQTT options:
 

--- a/components/cover/index.rst
+++ b/components/cover/index.rst
@@ -44,6 +44,9 @@ Advanced options:
   See https://developers.home-assistant.io/docs/core/entity/#generic-properties
   for a list of available options. Requires Home Assistant 2021.11 or newer.
   Set to ``""`` to remove the default entity category.
+- **unique_object_id** (*Optional*, string): Used instead of ``name`` for internal ``unique_id`` and ``object_id`` generation.
+  If ``name`` has changed and ``unique_object_id`` has not, a new Entity will not be created.
+  If ``name`` is localized and consists of non ASCII symbols, set ``unique_object_id`` as transliterated ``name``.
 
 MQTT options:
 

--- a/components/esp32_camera.rst
+++ b/components/esp32_camera.rst
@@ -42,6 +42,9 @@ Configuration variables:
   See https://developers.home-assistant.io/docs/core/entity/#generic-properties
   for a list of available options. Requires Home Assistant 2021.11 or newer.
   Set to ``""`` to remove the default entity category.
+- **unique_object_id** (*Optional*, string): Used instead of ``name`` for internal ``unique_id`` and ``object_id`` generation.
+  If ``name`` has changed and ``unique_object_id`` has not, a new Entity will not be created.
+  If ``name`` is localized and consists of non ASCII symbols, set ``unique_object_id`` as transliterated ``name``.
 
 Connection Options:
 

--- a/components/fan/index.rst
+++ b/components/fan/index.rst
@@ -48,6 +48,9 @@ Configuration variables:
   See https://developers.home-assistant.io/docs/core/entity/#generic-properties
   for a list of available options. Requires Home Assistant 2021.11 or newer.
   Set to ``""`` to remove the default entity category.
+- **unique_object_id** (*Optional*, string): Used instead of ``name`` for internal ``unique_id`` and ``object_id`` generation.
+  If ``name`` has changed and ``unique_object_id`` has not, a new Entity will not be created.
+  If ``name`` is localized and consists of non ASCII symbols, set ``unique_object_id`` as transliterated ``name``.
 
 MQTT options:
 

--- a/components/light/index.rst
+++ b/components/light/index.rst
@@ -75,6 +75,9 @@ Advanced options:
   See https://developers.home-assistant.io/docs/core/entity/#generic-properties
   for a list of available options. Requires Home Assistant 2021.11 or newer.
   Set to ``""`` to remove the default entity category.
+- **unique_object_id** (*Optional*, string): Used instead of ``name`` for internal ``unique_id`` and ``object_id`` generation.
+  If ``name`` has changed and ``unique_object_id`` has not, a new Entity will not be created.
+  If ``name`` is localized and consists of non ASCII symbols, set ``unique_object_id`` as transliterated ``name``.
 - If MQTT enabled, all other options from :ref:`MQTT Component <config-mqtt-component>`.
 
 .. _light-toggle_action:

--- a/components/lock/index.rst
+++ b/components/lock/index.rst
@@ -41,6 +41,9 @@ Configuration variables:
 - **entity_category** (*Optional*, string): The category of the entity.
   See https://developers.home-assistant.io/docs/core/entity/#generic-properties
   for a list of available options. Set to ``""`` to remove the default entity category.
+- **unique_object_id** (*Optional*, string): Used instead of ``name`` for internal ``unique_id`` and ``object_id`` generation.
+  If ``name`` has changed and ``unique_object_id`` has not, a new Entity will not be created.
+  If ``name`` is localized and consists of non ASCII symbols, set ``unique_object_id`` as transliterated ``name``.
 - If MQTT enabled, All other options from :ref:`MQTT Component <config-mqtt-component>`.
 
 .. _lock-lock_action:

--- a/components/media_player/index.rst
+++ b/components/media_player/index.rst
@@ -37,6 +37,9 @@ Configuration variables:
 - **entity_category** (*Optional*, string): The category of the entity.
   See https://developers.home-assistant.io/docs/core/entity/#generic-properties
   for a list of available options. Set to ``""`` to remove the default entity category.
+- **unique_object_id** (*Optional*, string): Used instead of ``name`` for internal ``unique_id`` and ``object_id`` generation.
+  If ``name`` has changed and ``unique_object_id`` has not, a new Entity will not be created.
+  If ``name`` is localized and consists of non ASCII symbols, set ``unique_object_id`` as transliterated ``name``.
 
 Media Player Actions
 --------------------

--- a/components/number/index.rst
+++ b/components/number/index.rst
@@ -51,6 +51,9 @@ Configuration variables:
 - **device_class** (*Optional*, string): The device class for the number.
   See https://developers.home-assistant.io/docs/core/entity/number/#available-device-classes
   for a list of available options.
+- **unique_object_id** (*Optional*, string): Used instead of ``name`` for internal ``unique_id`` and ``object_id`` generation.
+  If ``name`` has changed and ``unique_object_id`` has not, a new Entity will not be created.
+  If ``name`` is localized and consists of non ASCII symbols, set ``unique_object_id`` as transliterated ``name``.
 
 Automations:
 

--- a/components/select/index.rst
+++ b/components/select/index.rst
@@ -42,6 +42,9 @@ Configuration variables:
   See https://developers.home-assistant.io/docs/core/entity/#generic-properties
   for a list of available options. Requires Home Assistant 2021.11 or newer.
   Set to ``""`` to remove the default entity category.
+- **unique_object_id** (*Optional*, string): Used instead of ``name`` for internal ``unique_id`` and ``object_id`` generation.
+  If ``name`` has changed and ``unique_object_id`` has not, a new Entity will not be created.
+  If ``name`` is localized and consists of non ASCII symbols, set ``unique_object_id`` as transliterated ``name``.
 
 Automations:
 

--- a/components/sensor/index.rst
+++ b/components/sensor/index.rst
@@ -67,6 +67,9 @@ Configuration variables:
   See https://developers.home-assistant.io/docs/core/entity/#generic-properties
   for a list of available options. Requires Home Assistant 2021.11 or newer.
   Set to ``""`` to remove the default entity category.
+- **unique_object_id** (*Optional*, string): Used instead of ``name`` for internal ``unique_id`` and ``object_id`` generation.
+  If ``name`` has changed and ``unique_object_id`` has not, a new Entity will not be created.
+  If ``name`` is localized and consists of non ASCII symbols, set ``unique_object_id`` as transliterated ``name``.
 
 Automations:
 

--- a/components/switch/index.rst
+++ b/components/switch/index.rst
@@ -61,6 +61,9 @@ Configuration variables:
 - **device_class** (*Optional*, string): The device class for the switch.
   See https://developers.home-assistant.io/docs/core/entity/switch/#available-device-classes
   for a list of available options. Requires Home Assistant 2022.3 or newer.
+- **unique_object_id** (*Optional*, string): Used instead of ``name`` for internal ``unique_id`` and ``object_id`` generation.
+  If ``name`` has changed and ``unique_object_id`` has not, a new Entity will not be created.
+  If ``name`` is localized and consists of non ASCII symbols, set ``unique_object_id`` as transliterated ``name``.
 - If MQTT enabled, All other options from :ref:`MQTT Component <config-mqtt-component>`.
 
 .. _switch-toggle_action:

--- a/components/text_sensor/index.rst
+++ b/components/text_sensor/index.rst
@@ -36,6 +36,9 @@ Configuration variables:
   See https://developers.home-assistant.io/docs/core/entity/#generic-properties
   for a list of available options. Requires Home Assistant 2021.11 or newer.
   Set to ``""`` to remove the default entity category.
+- **unique_object_id** (*Optional*, string): Used instead of ``name`` for internal ``unique_id`` and ``object_id`` generation.
+  If ``name`` has changed and ``unique_object_id`` has not, a new Entity will not be created.
+  If ``name`` is localized and consists of non ASCII symbols, set ``unique_object_id`` as transliterated ``name``.
 - If MQTT enabled, All other options from :ref:`MQTT Component <config-mqtt-component>`.
 
 Automations:


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes https://github.com/esphome/feature-requests/issues/1741

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** https://github.com/esphome/esphome/pull/4508

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
