### PR TITLE
Mention MH-Z14 as working with MH-Z19 library.

### DIFF
--- a/components/sensor/mhz19.rst
+++ b/components/sensor/mhz19.rst
@@ -8,7 +8,7 @@ MH-Z19 CO_2 and Temperature Sensor
 
 The ``mhz19`` sensor platform allows you to use MH-Z19 CO_2 and temperature sensors
 (`refspace`_) with ESPHome.
-The CO_2 measurement also works with the MH-Z16 sensor.
+The CO_2 measurement also works with the MH-Z16 and MH-Z14 sensors.
 
 .. figure:: images/mhz19-full.jpg
     :align: center


### PR DESCRIPTION
## Description:
I have verified that MH-Z19 library works just fine also with the MH-Z14 CO2 sensor from the same manufacturer.

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
