### PR TITLE
Update resistance.rst

### DIFF
--- a/components/sensor/resistance.rst
+++ b/components/sensor/resistance.rst
@@ -44,6 +44,19 @@ is close to GND (DOWNSTREAM) or it is closer to VCC (UPSTREAM).
         id: source_sensor
         pin: A0
 
+Note:
+------------------------
+Some boards like NodeMCUv2 needs to multiply adc reading by 3.3 to provide accurate result because they have built-in voltage divider on ADC pin (https://arduino.stackexchange.com/a/71952)
+
+.. code-block:: yaml
+
+    # Example source sensor:
+      - platform: adc
+        id: source_sensor
+        pin: A0
+        filters:
+          - multiply: 3.3
+
 Configuration variables:
 ------------------------
 

--- a/components/sensor/resistance.rst
+++ b/components/sensor/resistance.rst
@@ -46,7 +46,7 @@ is close to GND (DOWNSTREAM) or it is closer to VCC (UPSTREAM).
 
 Note:
 ------------------------
-Some boards like NodeMCUv2 needs to multiply adc reading by 3.3 to provide accurate result because they have built-in voltage divider on ADC pin (https://arduino.stackexchange.com/a/71952)
+Some boards like NodeMCUv2 needs to multiply ADC reading by 3.3 to provide accurate result because they have built-in voltage divider on ADC pin (https://arduino.stackexchange.com/a/71952)
 
 .. code-block:: yaml
 


### PR DESCRIPTION
Spent many hours to figure it out why my NTC reading are incorrect. Found out that ADC readings must be multiplied by 3.3 because built-in voltage divider on ADC pin on some boards.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
