### PR TITLE
Update hbridge.rst

### DIFF
--- a/components/fan/hbridge.rst
+++ b/components/fan/hbridge.rst
@@ -50,7 +50,7 @@ Configuration variables:
 - **enable_pin** (*Optional*, :ref:`config-id`): The id of the
   :ref:`float output <output>` connected to the Enable pin of the h-bridge (if h-bridge uses enable).
 - **decay_mode** (*Optional*, string): The decay mode you want to use with
-  the h-bridge. Either ``slow`` (braking) or ``fast`` (coasting). Defaults to ``slow``.
+  the h-bridge. Either ``slow`` (coasting) or ``fast`` (braking). Defaults to ``slow``.
 - **speed_count** (*Optional*, int): Set the number of supported discrete speed levels. The value is used
   to calculate the percentages for each speed. E.g. ``2`` means that you have 50% and 100% while ``100``
   will allow 1% increments in the output. Defaults to ``100``.


### PR DESCRIPTION
Decay mode : Fast decay is braking vs slow decay , coasting

## Description:

fix labeling of decay mode

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
