### PR TITLE
Update uart.rst

### DIFF
--- a/components/uart.rst
+++ b/components/uart.rst
@@ -76,6 +76,8 @@ used for hardware sharing change accordingly.
 
 The ESP32 has three UARTs. Any pair of GPIO pins can be used, as long as they support the proper output/input modes.
 
+NOTE: Be careful with ESP32 variant chips (ESP32-S3,ESP32-C3,ESP32-S2, etc). Most of these chips only support two hardware UARTs and software UARTs are only supported on the ESP8266 chips.
+
 The ESP8266 has two UARTs; the second of which is TX-only. Only a limited set of pins can be used. ``UART0`` may
 use either ``tx_pin: GPIO1`` and ``rx_pin: GPIO3``, or ``tx_pin: GPIO15`` and ``rx_pin: GPIO13``. ``UART1`` must
 use ``tx_pin: GPIO2``. Any other combination of pins will result in use of a software UART.

--- a/components/uart.rst
+++ b/components/uart.rst
@@ -30,12 +30,12 @@ In some cases only **TX** or **RX** exists as the device at the other end only a
     On the ESP32, this component uses the hardware UART units and is thus very accurate. On the ESP8266 however,
     ESPHome has to use a software implementation as there are no other hardware UART units available other than the
     ones used for logging. Therefore the UART data on the ESP8266 can have occasional data glitches especially with
-    higher baud rates..
+    higher baud rates. 
 
 .. note::
 
     From ESPHome 2021.8 the ``ESP8266SoftwareSerial`` UART ``write_byte`` function had the parity bit fixed to be correct
-    for the data being sent. This could cause unexpected issues if you are using the Software Serial and have devices that
+    for the data being sent. This could cause unexpected issues if you are using the Software UART and have devices that
     explicity check the parity. Most likely you will need to flip the ``parity`` flag in YAML.
 
 
@@ -65,7 +65,7 @@ Configuration variables:
 Hardware UARTs
 --------------
 
-Whenever possible, ESPHome will use the hardware UART unit on the processor for fast and accurate communication.
+Whenever possible, ESPHome will use the hardware UART unit on the ESP8266 for fast and accurate communication.
 When the hardware UARTs are all occupied, ESPHome will fall back to a software implementation that may not
 be accurate at higher baud rates.
 
@@ -74,13 +74,15 @@ be accurate at higher baud rates.
 logger and leave others available. If you have configured the logger to use a different hardware UART, the pins
 used for hardware sharing change accordingly.
 
-The ESP32 has three UARTs. Any pair of GPIO pins can be used, as long as they support the proper output/input modes.
-
-NOTE: Be careful with ESP32 variant chips (ESP32-S3,ESP32-C3,ESP32-S2, etc). Most of these chips only support two hardware UARTs and software UARTs are only supported on the ESP8266 chips.
+The ESP32 has three UARTs. ESP32 lite variant chips (ESP32-S3, ESP32-C3, ESP32-S2, etc) may have fewer UARTs (usually two). Any pair of GPIO pins can be used, as long as they support the proper output/input modes. 
 
 The ESP8266 has two UARTs; the second of which is TX-only. Only a limited set of pins can be used. ``UART0`` may
 use either ``tx_pin: GPIO1`` and ``rx_pin: GPIO3``, or ``tx_pin: GPIO15`` and ``rx_pin: GPIO13``. ``UART1`` must
 use ``tx_pin: GPIO2``. Any other combination of pins will result in use of a software UART.
+
+.. note::
+
+    The the Software UART is only available on the ESP8266. It is not available on ESP32 and variants.
 
 .. _uart-write_action:
 


### PR DESCRIPTION
## Description:
Added note about esp32 variants only having 2 not 3 uarts. Kind of a big deal!

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
