### PR TITLE
include i2c requirement in docs

### DIFF
--- a/components/sensor/mics_4514.rst
+++ b/components/sensor/mics_4514.rst
@@ -8,10 +8,11 @@ MiCS 4514 Gas Sensor
 
 This component exposes the different gas concentration sensors from the `MiCS-4514 <https://www.dfrobot.com/product-2417.html>`__.
 
-.. note::
-
+.. note::   
     The sensor has a 3-minute warmup period where data is unreliable and ESPHome will only start publishing sensor values after this time.
     If the sensor was already powered only, such as if you restarted or updated your ESPHome device, then it will start publishing immediately.
+
+    The :ref:`I²C Bus <i2c>` is required to be set up in your configuration for this sensor to work.
 
 .. code-block:: yaml
 

--- a/components/sensor/mics_4514.rst
+++ b/components/sensor/mics_4514.rst
@@ -10,6 +10,7 @@ This component exposes the different gas concentration sensors from the `MiCS-45
 
 .. note::
 
+
     The sensor has a 3-minute warmup period where data is unreliable and ESPHome will only start publishing sensor values after this time.
     If the sensor was already powered only, such as if you restarted or updated your ESPHome device, then it will start publishing immediately.
 

--- a/components/sensor/mics_4514.rst
+++ b/components/sensor/mics_4514.rst
@@ -8,7 +8,8 @@ MiCS 4514 Gas Sensor
 
 This component exposes the different gas concentration sensors from the `MiCS-4514 <https://www.dfrobot.com/product-2417.html>`__.
 
-.. note::   
+.. note::
+
     The sensor has a 3-minute warmup period where data is unreliable and ESPHome will only start publishing sensor values after this time.
     If the sensor was already powered only, such as if you restarted or updated your ESPHome device, then it will start publishing immediately.
 


### PR DESCRIPTION
mention the requirement for i2c to be set up for this sensor to function

## Description:
add i2c to the notes

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
