### PR TITLE
typo fix (double the) Update prometheus.rst

### DIFF
--- a/components/prometheus.rst
+++ b/components/prometheus.rst
@@ -56,7 +56,7 @@ and then adding a block with ``id`` and/or ``name`` fields for each sensor whose
 ``relabel``
 ***********
 
-Set the the ``id`` and ``name`` label values of the Prometheus metric for the sensor with the specified ID.
+Set the ``id`` and ``name`` label values of the Prometheus metric for the sensor with the specified ID.
 
 .. code-block:: yaml
 


### PR DESCRIPTION
fix typo (double the)

## Description:

a little one i stumbled across
**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
