### PR TITLE
Add supported touch pins for esp32-s2/s3 - take 2

### DIFF
--- a/components/binary_sensor/esp32_touch.rst
+++ b/components/binary_sensor/esp32_touch.rst
@@ -104,7 +104,10 @@ Configuration variables:
 Touch Pad Pins
 --------------
 
-8 pins on the ESP32 can be used to detect touches. These are (in the default "raw" pin names):
+Below are the raw GPIO pin numbers that can be used as touch pads for each variant.
+
+ESP32
+*****
 
 -  ``GPIO0``
 -  ``GPIO2``
@@ -116,6 +119,25 @@ Touch Pad Pins
 -  ``GPIO27``
 -  ``GPIO32``
 -  ``GPIO33``
+
+ESP32-S2 & ESP32-S3
+*******************
+
+-  ``GPIO1``
+-  ``GPIO2``
+-  ``GPIO3``
+-  ``GPIO4``
+-  ``GPIO5``
+-  ``GPIO6``
+-  ``GPIO7``
+-  ``GPIO8``
+-  ``GPIO9``
+-  ``GPIO10``
+-  ``GPIO11``
+-  ``GPIO12``
+-  ``GPIO13``
+-  ``GPIO14``
+
 
 Finding thresholds
 ------------------


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#4571

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
