### PR TITLE
Add support for ESP32 CAM 3MP and 5MP resolutions and arbitrary camera clock.

### DIFF
--- a/components/esp32_camera.rst
+++ b/components/esp32_camera.rst
@@ -53,8 +53,8 @@ Connection Options:
 - **external_clock** (**Required**): The configuration of the external clock to drive the camera.
 
   - **pin** (**Required**, pin): The pin the external clock line is connected to.
-  - **frequency** (*Optional*, float): The frequency of the external clock, must be either 20MHz
-    or 10MHz. Defaults to ``20MHz``.
+  - **frequency** (*Optional*, float): The frequency of the external clock, must be between 10
+    and 20MHz. Defaults to ``20MHz``.
 
 - **i2c_pins** (**Required**): The I²C control pins of the camera.
 
@@ -90,6 +90,15 @@ Image Settings:
     - ``1024x768`` (XGA)
     - ``1280x1024`` (SXGA)
     - ``1600x1200`` (UXGA)
+    - ``1920x1080`` (FHD)
+    - ``720x1280`` (Portrait HD)
+    - ``864x1536`` (Portrait 3MP)
+    - ``2048x1536`` (QXGA)
+    - ``2560x1440`` (QHD)
+    - ``2560x1600`` (WQXGA)
+    - ``1080x1920`` (Portrait FHD)
+    - ``2560x1920`` (QSXGA)
+
 
 - **jpeg_quality** (*Optional*, int): The JPEG quality that the camera should encode images with.
   From 10 (best) to 63 (worst). Defaults to ``10``.


### PR DESCRIPTION
Add support for ESP32 CAM resolutions for 3MP and 5MP sensors (OV5640 for example). Also support (almost) arbitrary camera clock, some cameras/ESP chips need slightly lower clock than 20MHz to avoid image corruption.

## Description:

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#4580

## Checklist:

  - [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
