### PR TITLE
Documentation for the `skip_initial` filter

### DIFF
--- a/components/sensor/index.rst
+++ b/components/sensor/index.rst
@@ -307,29 +307,6 @@ Configuration variables:
   Must be smaller than or equal to ``send_every``
   Defaults to ``1``.
 
-``skip``
-**********
-
-A simple skip filter, which skips the first **send_first_at** sensor readings and passes on the
-rest. This can be used when the sensor needs a few readings to 'warm up'. After the initial
-readings have been skipped, this filter does nothing.
-
-.. code-block:: yaml
-
-    # Example configuration entry
-    - platform: wifi_signal
-      # ...
-      filters:
-        - skip:
-            send_first_at: 3
-
-Configuration variables:
-
-- **send_first_at** (*Optional*, int): By default, the very first raw value on boot is immediately
-  published. With this parameter you can specify when the very first value is to be sent.
-  Must be smaller than or equal to ``send_every``
-  Defaults to ``1``.
-
 ``min``
 *******
 
@@ -428,6 +405,21 @@ Configuration variables:
 - **send_first_at** (*Optional*, int): By default, the very first raw value on boot is immediately
   published. With this parameter you can specify when the very first value is to be sent.
   Defaults to ``1``.
+
+``skip_initial``
+****************
+
+A simple skip filter; `skip_initial: N` skips the first **N** sensor readings and passes on the
+rest. This can be used when the sensor needs a few readings to 'warm up'. After the initial
+readings have been skipped, this filter does nothing.
+
+.. code-block:: yaml
+
+    # Example configuration entry
+    - platform: wifi_signal
+      # ...
+      filters:
+        - skip_initial: 3
 
 ``throttle``
 ************

--- a/components/sensor/index.rst
+++ b/components/sensor/index.rst
@@ -307,6 +307,29 @@ Configuration variables:
   Must be smaller than or equal to ``send_every``
   Defaults to ``1``.
 
+``skip``
+**********
+
+A simple skip filter, which skips the first **send_first_at** sensor readings and passes on the
+rest. This can be used when the sensor needs a few readings to 'warm up'. After the initial
+readings have been skipped, this filter does nothing.
+
+.. code-block:: yaml
+
+    # Example configuration entry
+    - platform: wifi_signal
+      # ...
+      filters:
+        - skip:
+            send_first_at: 3
+
+Configuration variables:
+
+- **send_first_at** (*Optional*, int): By default, the very first raw value on boot is immediately
+  published. With this parameter you can specify when the very first value is to be sent.
+  Must be smaller than or equal to ``send_every``
+  Defaults to ``1``.
+
 ``min``
 *******
 
@@ -650,7 +673,7 @@ From :ref:`lambdas <config-lambda>`, you can call several methods on all sensors
 advanced stuff (see the full API Reference for more info).
 
 - ``publish_state()``: Manually cause the sensor to push out a value. It will then
-  be processed by the sensor filters, and once filtered will propagate though ESPHome and though the API to Home Assistant or out via MQTT if configured. 
+  be processed by the sensor filters, and once filtered will propagate though ESPHome and though the API to Home Assistant or out via MQTT if configured.
 
   .. code-block:: cpp
 

--- a/components/sensor/index.rst
+++ b/components/sensor/index.rst
@@ -409,7 +409,7 @@ Configuration variables:
 ``skip_initial``
 ****************
 
-A simple skip filter; `skip_initial: N` skips the first **N** sensor readings and passes on the
+A simple skip filter; `skip_initial: N` skips the first `N` sensor readings and passes on the
 rest. This can be used when the sensor needs a few readings to 'warm up'. After the initial
 readings have been skipped, this filter does nothing.
 


### PR DESCRIPTION
## Description:

This is documentation for the `skip_initial` filter, see esphome/esphome#4582

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#4582

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
