### PR TITLE
Document how to return 'no value' from a lambda filter

### DIFF
--- a/components/sensor/index.rst
+++ b/components/sensor/index.rst
@@ -493,6 +493,14 @@ the result of the lambda is used as the output (use ``return``).
 Make sure to add ``.0`` to all values in the lambda, otherwise divisions of integers will
 result in integers (not floating point values).
 
+To prevent values from being published, return ``{}``:
+
+.. code-block:: yaml
+
+    filters:
+      - lambda: "return (x > 10) ? x-10 : {};"
+
+
 Example: Converting Celsius to Fahrenheit
 -----------------------------------------
 

--- a/components/sensor/index.rst
+++ b/components/sensor/index.rst
@@ -498,7 +498,9 @@ To prevent values from being published, return ``{}``:
 .. code-block:: yaml
 
     filters:
-      - lambda: "return (x > 10) ? x-10 : {};"
+      - lambda: !lambda |-
+          if (x < 10) return {};
+          return x-10;
 
 
 Example: Converting Celsius to Fahrenheit


### PR DESCRIPTION
## Description:

Document how to return a 'no value' value from a `lambda` filter. This also serves as an example on how to write a multi-line lambda filter, as all the other examples limit themselves to single lines.

No related PRs, as this just documents what's already in ESPHome.

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
