### PR TITLE
Add clarity for use of multiplier

### DIFF
--- a/components/sprinkler.rst
+++ b/components/sprinkler.rst
@@ -461,10 +461,13 @@ section below for more detail and examples.
 ***********************************
 
 Sets the multiplier value used to proportionally increase or decrease the run duration for all valves/zones.
-When a given valve is activated, this value is multiplied by the valve's run duration (see below) to determine the
-valve's actual run duration. *Note that a multiplier value of zero is allowed; if the multiplier value is zero, the
-sprinkler controller will not start any valves.* **This can result in confusing/unexpected behavior if a visual
-indication of this condition is not available!**
+For seasonal changes, it’s easier to use the multiplier to adjust the watering time instead of adjusting the
+run durations directly. Set your run duration to the time you want for ‘mild’ weather (spring/autumn) and then
+use the multiplier to increase (summer) or decrease (winter) the calculated run times. When a given valve is
+activated, this value is multiplied by the valve's run duration (see below) to determine the valve's actual
+run duration. *Note that a multiplier value of zero is allowed; if the multiplier value is zero, the
+sprinkler controller will not start any valves.* **This can result in confusing/unexpected behavior if
+a visual indication of this condition is not available!**
 
 .. code-block:: yaml
 


### PR DESCRIPTION
The use of multiplier wasn't really clear to me until explained as described below. I suggest, and have added to the document the following description for consideration;

## Description:

For seasonal changes, it’s easier to use the multiplier to adjust the watering time instead of adjusting the run durations directly. Set your run duration to the time you want for ‘mild’ weather (spring/autumn) and then use the multiplier to increase (summer) or decrease (winter) the calculated run times.