### PR TITLE
GooDisplay GDEY029T94

### DIFF
--- a/components/display/waveshare_epaper.rst
+++ b/components/display/waveshare_epaper.rst
@@ -97,6 +97,7 @@ Configuration variables:
   - ``7.50inV2`` - Can't use with an ESP8266 as it runs out of RAM
   - ``7.50inV2alt`` (alternative version to the above ``7.50inV2``)
   - ``7.50in-hd-b`` - Can't use with an ESP8266 as it runs out of RAM
+  - ``gdey029t94`` - GooDisplay GDEY029T94, as used on the AdaFruit MagTag
 
 - **busy_pin** (*Optional*, :ref:`Pin Schema <config-pin_schema>`): The BUSY pin. Defaults to not connected.
 - **reset_pin** (*Optional*, :ref:`Pin Schema <config-pin_schema>`): The RESET pin. Defaults to not connected.


### PR DESCRIPTION
## Description:

Support for the GooDisplay GDEY029T94 is being merged into esphome:dev, this PR adds the name of the module to the waveshare display docu


**Related issue (if applicable):** fixes <link to issue>

https://github.com/esphome/esphome/pull/4222

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
