### PR TITLE
Comment that ZMPT101B sensor also works with this

### DIFF
--- a/components/sensor/ct_clamp.rst
+++ b/components/sensor/ct_clamp.rst
@@ -9,7 +9,7 @@ The Current Transformer Clamp (``ct_clamp``) sensor allows you to hook up a CT C
 voltage sensor (like the :doc:`ADC sensor <adc>`) and convert the readings to measured single phase AC current.
 
 First, you need to set up a voltage sensor source (:doc:`ADC sensor <adc>`, but for example also
-:doc:`ADS1115 <ads1115>`) and pass it to the CT clamp sensor with the ``sensor`` option.
+:doc:`ADS1115 <ads1115>`) and pass it to the CT clamp sensor with the ``sensor`` option. (Also works with ZMPT101B)
 
 Please also see `this guide <https://learn.openenergymonitor.org/electricity-monitoring/ct-sensors/introduction>`__
 as an introduction to the working principle of CT clamp sensors and how to hook them up to your device.


### PR DESCRIPTION
I originally wrote a custom component for ZMPT101B because I could find no reference to it. I didnt' realise ct_clamp was a workign solution. I published this on ESPHome forum and someone has pointed this option out to me, so I wanted to make it easy to find for new users. I have had several people contact me about my custom post. If there is a better way to achieve this, please let me know.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
