### PR TITLE
[Ethernet] Add PHY KSZ8081 support

### DIFF
--- a/components/ethernet.rst
+++ b/components/ethernet.rst
@@ -40,6 +40,7 @@ Configuration variables:
   - ``DP83848``
   - ``IP101``
   - ``JL1101``
+  - ``KSZ8081``
 
 - **mdc_pin** (**Required**, :ref:`config-pin`): The MDC pin of the board.
   Usually this is ``GPIO23``.


### PR DESCRIPTION
## Description:

Add support for KSZ8081 ethernet phy.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#4668

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
