### PR TITLE
Fix datasheet link for PCA9685 component

### DIFF
--- a/components/output/pca9685.rst
+++ b/components/output/pca9685.rst
@@ -12,7 +12,7 @@ Component/Hub
 -------------
 
 The PCA9685 component represents a PCA9685 12-bit PWM driver
-(`datasheet <https://docs.espressif.com/projects/esp-idf/en/latest/api-reference/peripherals/ledc.html#configure-channel>`__,
+(`datasheet <https://www.nxp.com/docs/en/data-sheet/PCA9685.pdf>`__,
 `adafruit <https://www.adafruit.com/product/815>`__) in ESPHome. It
 uses :ref:`I²C Bus <i2c>` for communication.
 


### PR DESCRIPTION
The link for the PCA9685 pointed to LEDC Espressif documentation. Updated with the proper NXP datasheet URL.