### PR TITLE
Fix pulse_counter example unit name

### DIFF
--- a/components/sensor/pulse_counter.rst
+++ b/components/sensor/pulse_counter.rst
@@ -93,7 +93,7 @@ measure the total consumed energy in kWh.
     sensor:
       - platform: pulse_counter
         pin: 12
-        unit_of_measurement: 'Wh'
+        unit_of_measurement: 'kW'
         name: 'Power Meter House'
         filters:
           - multiply: 0.06  # (60s/1000 pulses per kWh)


### PR DESCRIPTION
## Description:

The current value should be measured in 'W' rather than 'Wh' since pulse_counter averages it over 1 minute.

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
