### PR TITLE
BP1658CJ - Fix power level defaults in configuration variables section.

### DIFF
--- a/components/output/bp1658cj.rst
+++ b/components/output/bp1658cj.rst
@@ -39,9 +39,9 @@ Configuration variables:
    this ``bp1658cj`` component. Use this if you have multiple BP1658CJ chains
    connected at the same time.
 -  **max_power_color_channels** (*Optional*, int 0-15): Adjusts the current supplied to the
-   color channels, higher is more power.  Default is 2 per BP1658CJ datasheet. See table below.
+   color channels, higher is more power.  Default is 4 per BP1658CJ datasheet. See table below.
 -  **max_power_white_channels** (*Optional*, int 0-15): Adjusts the current supplied to the
-   white channels, higher is more power.  Default is 4 per BP1658CJ datasheet. See table below.
+   white channels, higher is more power.  Default is 6 per BP1658CJ datasheet. See table below.
 
 .. note::
 


### PR DESCRIPTION
## Description:
Fix the defaults in the configuration variables section (already correct in examples and tables).

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
