### PR TITLE
Update modbus_controller.rst

### DIFF
--- a/components/modbus_controller.rst
+++ b/components/modbus_controller.rst
@@ -53,7 +53,7 @@ Configuration variables:
 - **address** (**Required**, :ref:`config-id`): The modbus address of the device
   Specify the modbus device address of the.
 
-- **command_throttle** (*Optional*, int): minimum time in milliseconds between 2 requests to the device. Default is 0ms
+- **command_throttle** (*Optional*, :ref:`config-time`): minimum time in between 2 requests to the device. Default is 0ms
   Because some modbus devices limit the rate of requests the interval between sending requests to the device can be modified.
 
 - **update_interval** (*Optional*, :ref:`config-time`): The interval that the sensors should be checked.


### PR DESCRIPTION
## Description:

I think at some time in the past the 'command_throttle' parameter changed from a unit of 'milliseconds' to the unit of 'time'.

If you try to compile with a value of 1000 (supposedly milliseconds), compilation fails with the following error:
```
    Don't know what '1000' means as it has no time *unit*! Did you mean '1000s'?.
    command_throttle: 1000
```
If I put a value of '1s' then compilation works and also this is the time I see that is being used.

**Related issue (if applicable):** no issue has been raised yet

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
