### PR TITLE
Added Sensor Longevity and correction to PMSX003

### DIFF
--- a/components/sensor/pmsx003.rst
+++ b/components/sensor/pmsx003.rst
@@ -5,7 +5,7 @@ PMSX003 Particulate Matter Sensor
     :description: Instructions for setting up PMSX003 Particulate matter sensors
     :image: pmsx003.svg
 
-The ``pmsx003`` sensor platform allows you to use your PMS5003, PMS7003, ... particulate matter
+The ``pmsx003`` sensor platform allows you to use your Plantower PMS5003, PMS7003, ... laser based particulate matter sensors
 (`datasheet <http://www.aqmd.gov/docs/default-source/aq-spec/resources-page/plantower-pms5003-manual_v2-3.pdf>`__)
 sensors with ESPHome.
 
@@ -20,6 +20,13 @@ value:
 - ``PMS5003S`` for PMS5003S. These support ``pm_1_0``, ``pm_2_5`` and ``pm_10_0`` and ``formaldehyde``.
 - ``PMS5003T`` for PMS5003T. These support ``pm_1_0``, ``pm_2_5`` and ``pm_10_0``, ``temperature`` and ``humidity``.
 - ``PMS5003ST`` for PMS5003ST. These support ``pm_2_5``, ``temperature``, ``humidity`` and ``formaldehyde``.
+
+Sensor Longevity
+------------------------
+The laser diode inside the PMSX003 has a lifetime of about 8000 hours, nearly one year.
+
+If you wish to use the optional ``update_interval`` ensure you have a ``tx_pin`` set in the UART configuration and connected to the RECEIVE/RX pin
+(may also be called the TX pin, depending on the model) of the PMS. Setting ``update_interval`` to 120 seconds or higher may help extend the life span of the sensor.
 
 .. code-block:: yaml
 
@@ -38,34 +45,34 @@ value:
           name: "Particulate Matter <2.5µm Concentration"
         pm_10_0:
           name: "Particulate Matter <10.0µm Concentration"
-        update_interval: 60000ms
+        update_interval: 120s
 
 Configuration variables:
 ------------------------
 
-- **pm_1_0_std** (*Optional*): Use the concentration of particulates of size less than 1.0µm in µg per cubic meter at standard particle
+- **pm_1_0_std** (*Optional*): Use the concentration of particulates of size less than 1.0µm in µg per cubic meter at standard particle.
   All options from :ref:`Sensor <config-sensor>`.
-- **pm_2_5_std** (*Optional*): Use the concentration of particulates of size less than 2.5µm in µg per cubic meter at standard particle
+- **pm_2_5_std** (*Optional*): Use the concentration of particulates of size less than 2.5µm in µg per cubic meter at standard particle.
   All options from :ref:`Sensor <config-sensor>`.
-- **pm_10_0_std** (*Optional*): Use the concentration of particulates of size less than 10.0µm in µg per cubic meter at standard particle
+- **pm_10_0_std** (*Optional*): Use the concentration of particulates of size less than 10.0µm in µg per cubic meter at standard particle.
   All options from :ref:`Sensor <config-sensor>`.
-- **pm_1_0** (*Optional*): Use the concentration of particulates of size less than 1.0µm in µg per cubic meter under atmospheric environment
+- **pm_1_0** (*Optional*): Use the concentration of particulates of size less than 1.0µm in µg per cubic meter under atmospheric environment.
   All options from :ref:`Sensor <config-sensor>`.
-- **pm_2_5** (*Optional*): Use the concentration of particulates of size less than 2.5µm in µg per cubic meter under atmospheric environment
+- **pm_2_5** (*Optional*): Use the concentration of particulates of size less than 2.5µm in µg per cubic meter under atmospheric environment.
   All options from :ref:`Sensor <config-sensor>`.
-- **pm_10_0** (*Optional*): Use the concentration of particulates of size less than 10.0µm in µg per cubic meter under atmospheric environment
+- **pm_10_0** (*Optional*): Use the concentration of particulates of size less than 10.0µm in µg per cubic meter under atmospheric environment.
   All options from :ref:`Sensor <config-sensor>`.
-- **pm_0_3um** (*Optional*): Use the number of particles with diameter beyond 0.3um in 0.1L of air
+- **pm_0_3um** (*Optional*): Use the number of particles with diameter beyond 0.3um in 0.1L of air.
   All options from :ref:`Sensor <config-sensor>`.
-- **pm_0_5um** (*Optional*): Use the number of particles with diameter beyond 0.5um in 0.1L of air
+- **pm_0_5um** (*Optional*): Use the number of particles with diameter beyond 0.5um in 0.1L of air.
   All options from :ref:`Sensor <config-sensor>`.
-- **pm_1_0um** (*Optional*): Use the number of particles with diameter beyond 1.0um in 0.1L of air
+- **pm_1_0um** (*Optional*): Use the number of particles with diameter beyond 1.0um in 0.1L of air.
   All options from :ref:`Sensor <config-sensor>`.
-- **pm_2_5um** (*Optional*): Use the number of particles with diameter beyond 2.5um in 0.1L of air
+- **pm_2_5um** (*Optional*): Use the number of particles with diameter beyond 2.5um in 0.1L of air.
   All options from :ref:`Sensor <config-sensor>`.
-- **pm_5_0um** (*Optional*): Use the number of particles with diameter beyond 5.0um in 0.1L of air
+- **pm_5_0um** (*Optional*): Use the number of particles with diameter beyond 5.0um in 0.1L of air. Not supported by the ``PMS5003T`` type sensors.
   All options from :ref:`Sensor <config-sensor>`.
-- **pm_10_0um** (*Optional*): Use the number of particles with diameter beyond 10.0um in 0.1L of air
+- **pm_10_0um** (*Optional*): Use the number of particles with diameter beyond 10.0um in 0.1L of air. Not supported by the ``PMS5003T`` type sensors.
   All options from :ref:`Sensor <config-sensor>`.
 - **temperature** (*Optional*): Use the temperature value in °C for the ``PMS5003T`` and ``PMS5003ST`` type sensors.
   All options from :ref:`Sensor <config-sensor>`.


### PR DESCRIPTION
## Description:
Grammar improvements.
Correction for two values as per merged esphome patch.
Added Sensor Longevity wording.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#4560

## Checklist:

  - [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
