### PR TITLE
Change default restore mode for fan/light/switch

### DIFF
--- a/components/fan/index.rst
+++ b/components/fan/index.rst
@@ -37,11 +37,11 @@ Configuration variables:
 - **restore_mode** (*Optional*): Control how the fan attempts to restore state on boot.
 
     - ``NO_RESTORE`` - Don't restore any state.
-    - ``RESTORE_DEFAULT_OFF`` - Attempt to restore state and default to OFF if not possible to restore (default).
+    - ``RESTORE_DEFAULT_OFF`` - Attempt to restore state and default to OFF if not possible to restore.
     - ``RESTORE_DEFAULT_ON`` - Attempt to restore state and default to ON.
     - ``RESTORE_INVERTED_DEFAULT_OFF`` - Attempt to restore state inverted from the previous state and default to OFF.
     - ``RESTORE_INVERTED_DEFAULT_ON`` - Attempt to restore state inverted from the previous state and default to ON.
-    - ``ALWAYS_OFF`` - Always initialize the fan as OFF on bootup.
+    - ``ALWAYS_OFF`` (Default) - Always initialize the fan as OFF on bootup.
     - ``ALWAYS_ON`` - Always initialize the fan as ON on bootup.
 
 - **internal** (*Optional*, boolean): Mark this component as internal. Internal components will

--- a/components/light/index.rst
+++ b/components/light/index.rst
@@ -46,13 +46,13 @@ Configuration variables:
   For restoring on ESP8266s, also see ``esp8266_restore_from_flash`` in the
   :doc:`esphome section </components/esphome>`.
 
-    - ``RESTORE_DEFAULT_OFF`` (Default) - Attempt to restore state and default to OFF if not possible to restore.
+    - ``RESTORE_DEFAULT_OFF`` - Attempt to restore state and default to OFF if not possible to restore.
     - ``RESTORE_DEFAULT_ON`` - Attempt to restore state and default to ON.
     - ``RESTORE_INVERTED_DEFAULT_OFF`` - Attempt to restore state inverted from the previous state and default to OFF.
     - ``RESTORE_INVERTED_DEFAULT_ON`` - Attempt to restore state inverted from the previous state and default to ON.
     - ``RESTORE_AND_OFF`` - Attempt to restore state but initialize the light as OFF.
     - ``RESTORE_AND_ON`` - Attempt to restore state but initialize the light as ON.
-    - ``ALWAYS_OFF`` - Always initialize the light as OFF on bootup.
+    - ``ALWAYS_OFF`` (Default) - Always initialize the light as OFF on bootup.
     - ``ALWAYS_ON`` - Always initialize the light as ON on bootup.
 
 - **on_turn_on** (*Optional*, :ref:`Action <config-action>`): An automation to perform

--- a/components/switch/index.rst
+++ b/components/switch/index.rst
@@ -47,11 +47,11 @@ Configuration variables:
     - ``RESTORE_DEFAULT_ON`` - Attempt to restore state and default to ON.
     - ``RESTORE_INVERTED_DEFAULT_OFF`` - Attempt to restore state inverted from the previous state and default to OFF.
     - ``RESTORE_INVERTED_DEFAULT_ON`` - Attempt to restore state inverted from the previous state and default to ON.
-    - ``ALWAYS_OFF`` - Always initialize the switch as OFF on bootup.
+    - ``ALWAYS_OFF`` (Default) - Always initialize the switch as OFF on bootup.
     - ``ALWAYS_ON`` - Always initialize the switch as ON on bootup.
     - ``DISABLED`` - Does nothing and leaves it up to the downstream platform component to decide. For example, the component could read hardware and determine the state, or have a specific configuration option to regulate initial state.
 
-  Unless a specific platform defines another default value, the default is ``RESTORE_DEFAULT_OFF``.
+  Unless a specific platform defines another default value, the default is ``ALWAYS_OFF``.
 
 - **on_turn_on** (*Optional*, :ref:`Action <config-action>`): An automation to perform
   when the switch is turned on. See :ref:`switch-on_turn_on_off_trigger`.


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#4655

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
