### PR TITLE
fix "cycle: !lambda:"

### DIFF
--- a/components/number/index.rst
+++ b/components/number/index.rst
@@ -278,7 +278,7 @@ using a generic templatable action call.
     - number.operation:
         id: my_number
         operation: !lambda "return NUMBER_OP_INCREMENT;"
-        cycle: !lambda: "return true;"
+        cycle: !lambda "return true;"
 
 Configuration variables:
 


### PR DESCRIPTION
the double ":" is not valid

## Description:

Invalid code example in documentation. 

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
