### PR TITLE
Add Ginlong Solis Inverter

### DIFF
--- a/components/modbus_controller.rst
+++ b/components/modbus_controller.rst
@@ -530,5 +530,6 @@ See Also
 - :doc:`/components/number/modbus_controller`
 - :doc:`/components/output/modbus_controller`
 - `EPEVER MPPT Solar Charge Controller (Tracer-AN Series) <https://devices.esphome.io/devices/epever_mptt_tracer_an>`__
+- `Ginlong Solis Solar Inverter <https://github.com/hn/ginlong-solis#replacing-the-main-application>`__
 - `Modbus RTU Protocol Description <https://www.modbustools.com/modbus.html>`__
 - :ghedit:`Edit`


### PR DESCRIPTION
YAML for Ginlong Solis Inverter vendor S3 WiFi stick firmware replacement, using LibreTuya/ESPhome

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
