### PR TITLE
Fix strftime issue in max7219 doc

### DIFF
--- a/components/display/max7219.rst
+++ b/components/display/max7219.rst
@@ -104,7 +104,7 @@ segment of the previous position will be enabled.
 
           // Print the current time
           it.print("        ");
-          it.strftime("%H.%M.%S");
+          it.strftime("%H.%M.%S", id(esptime).now());
           // Result for 10:06:42 -> "10.06.42  "
 
           // Change the display intnsity based on another id.


### PR DESCRIPTION
## Description:
Fix strftime issue in max7219 doc.


**Related issue:** 
```
error: no matching function for call to 'esphome::max7219::MAX7219Component::strftime(const char [9])'
       it.strftime("%H.%M.%S");
```

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
