### PR TITLE
Update mics_4514.rst

### DIFF
--- a/components/sensor/mics_4514.rst
+++ b/components/sensor/mics_4514.rst
@@ -6,7 +6,7 @@ MiCS 4514 Gas Sensor
     :image: mics_4514.jpg
     :keywords: MiCS, 4514, MICS-4514
 
-This component exposes the different gas concentration sensors from the `MiCS-4514 <https://www.dfrobot.com/product-2417.html>`__.
+This component exposes the different gas concentration sensors from the `MiCS-4514 <https://www.dfrobot.com/product-2417.html>`__. This is a differnet sensor than the MICS-4514 being sold on AliExpress.
 
 .. note::
 


### PR DESCRIPTION
MICS-4514 being sold on AliExpress has the same model number, but is a different board that doesn't use I²C Bus.  Adding a note about this as a warning for anyone shopping for this sensor.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
