### PR TITLE
fix uart id in example

### DIFF
--- a/components/sensor/growatt_solar.rst
+++ b/components/sensor/growatt_solar.rst
@@ -22,13 +22,13 @@ to some pins on your board and the baud rate set to 9600.
 
     # Example configuration entry
     uart:
-      - id: uart1
+      - id: gw_uart
         baud_rate: 9600
         tx_pin: GPIO1
         rx_pin: GPIO3
 
     modbus:
-      uart_id: uart1
+      uart_id: gw_uart
       flow_control_pin: GPIO4
 
     sensor:


### PR DESCRIPTION
## Description:  `uart1` is a reserved id now.


**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/4428

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
