### PR TITLE
Add new esp32 bt classic & bt classic presence components.

### DIFF
--- a/components/binary_sensor/bt_classic_presence.rst
+++ b/components/binary_sensor/bt_classic_presence.rst
@@ -1,0 +1,40 @@
+ESP32 Bluetooth Classic Presence
+================================
+
+.. seo::
+    :description: Instructions for setting up BT Classic binary sensors for the ESP32.
+    :image: bluetooth.svg
+
+The ``bt_classic_presence`` binary sensor platform lets you poll the presence of a Bluetooth Classic device.
+
+.. code-block:: yaml
+
+    # Example configuration entry
+    esp32_bt_classic:
+
+    binary_sensor:
+      - platform: bt_classic_presence
+        mac_address: 61:73:9f:ca:16:e9
+        name: "Smartwatch Presence"
+        num_scans: 5
+        update_interval: 60s
+
+
+Configuration variables:
+------------------------
+
+-  **name** (**Required**, string): The name of the binary sensor.
+-  **mac_address** (**Required**, MAC Address): The MAC address to track for this binary sensor.
+-  **num_scans** (*optional*, int): Number of scans performed to find the device. When not found after these attemtpts the device is marked absent. Defaults to ``1``.
+-  **update_interval** (*Optional*, :ref:`config-time`): Interval at which presence for this device is scanned. Defaults to ``5min``.
+-  **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
+-  All other options from :ref:`Binary Sensor <config-binary_sensor>`.
+
+
+See Also
+--------
+
+- :doc:`/components/esp32_bt_classic`
+- :doc:`/components/binary_sensor/index`
+- :apiref:`bt_classic_presence/bt_classic_presence_device.h`
+- :ghedit:`Edit`

--- a/components/esp32_bt_classic.rst
+++ b/components/esp32_bt_classic.rst
@@ -1,0 +1,120 @@
+ESP32 Bluetooth Classic Component
+=================================
+
+.. seo::
+    :description: Instructions for setting up Bluetooth Classic in ESPHome.
+    :image: bluetooth.svg
+
+The ``esp32_bt_classic`` component in ESPHome sets up the Bluetooth Classic stack on the device as a backend for :doc:`/components/binary_sensor/bt_classic_presence` sensors.
+
+.. code-block:: yaml
+
+    # Example configuration
+
+    esp32_bt_classic:
+      on_scan_start:
+        # Enable LED while scanning for BT devices
+        - light.turn_on:
+            id: state_led
+      on_scan_result:
+        # Can listen for ANY scan result:
+        - then:
+          # Send custom event to HomeAssistant
+          - homeassistant.event:
+              event: esphome.bt_scan_result
+              data:
+                node: "ESP32-Hallway"
+                status: !lambda "return status.str();"
+                name: !lambda "return name;"
+                address: !lambda "return address.str();"
+          - light.turn_off:
+              id: state_led
+       # Can listen for specific MAC addresses:
+       - mac_address:
+           - AA:BB:CC:DD:EE:F0
+           - AA:BB:CC:DD:EE:F2
+         then:
+           lambda: |-
+             ESP_LOGI("BT_SCAN_RESULT", "Result for one of the Watches!\n  address: %s\n  name: %s\n  status: %s (%d)", address.c_str(), name, status.c_str(), status.bt_status());
+
+
+.. _config-esp32_bt_classic:
+
+Configuration variables:
+------------------------
+
+Automations:
+
+- **on_scan_start** (*Optional*, :ref:`Automation <automation>`): An automation to perform when a Bluetooth scan has started.
+- **on_scan_result** (*Optional*, :ref:`Automation <automation>`): An automation to perform when a Bluetooth scan result arrives. See :ref:`esp32_bt_classic-on_scan_result`.
+
+
+ESP32 Bluetooth Classic Automations
+---------------------------------------------
+
+.. _esp32_bt_classic-on_scan_result:
+
+``on_scan_result`` Trigger
+************************************************
+
+This automation will be triggered when a Bluetooth scan result arrives. The following variables are passed to the automation for use in lambdas: ``address`` of type :apiclass:`esp32_bt_classic::BtAddress`, ``status`` of type :apiclass:`esp32_bt_classic::BtStatus`, and ``name`` of type ``const char*``.
+
+.. code-block:: yaml
+
+    esp32_bt_classic:
+      on_scan_result:
+        - then:
+            - lambda: |-
+                ESP_LOGD("BT_SCAN_RESULT", "This is not the device you're looking for:\n  address: %s\n  name: %s\n  status: %s (%d)", address.c_str(), name, status.c_str(), status.bt_status());
+        - mac_address: 11:22:33:44:55:66
+          then:
+            - lambda: |-
+                ESP_LOGD("BT_SCAN_RESULT", "Found the device you're looking for!");
+                ESP_LOGD("BT_SCAN_RESULT", "  address: %s", address.c_str());
+                ESP_LOGD("BT_SCAN_RESULT", "  name: %s", name);
+                ESP_LOGD("BT_SCAN_RESULT", "  status: %s (%d)", status.c_str(), status.bt_status());
+
+Configuration variables:
+
+- **mac_address** (*Optional*, MAC Address): The MAC address to filter for this automation.
+- See :ref:`Automation <automation>`.
+
+
+``bt_classic.bt_classic_scan`` Action
+************************************************
+
+Start a Bluetooth scan. If there is a scan already in progress, then the scan request is queued. 
+This Action may be particularly useful as a user-defined service (See :ref:`api-services`), in combination with a :ref:`homeassistant.event <api-homeassistant_event_action>` hooked up to an ``on_scan_result`` trigger.
+
+
+.. code-block:: yaml
+
+    esp32_bt_classic:
+
+    # Use with any generic Trigger: 
+    on_...:
+      - bt_classic.bt_classic_scan:
+
+    # Home assistant service example:
+    api:
+      services:
+        - service: scan_bt_devices
+          variables:
+            addresses: string[]
+            num_scans: int
+          then:
+            - bt_classic.bt_classic_scan:
+                mac_address: !lambda "return addresses;"
+                num_scans: !lambda "return num_scans;"
+
+Configuration variables:
+
+- **mac_address** (**Required**, List of MAC Addresses, :ref:`templatable <config-templatable>`): The MAC addresses to scan. For templates accepts a ``std::vector<std::string>``. Any non MAC address entry is ignored.
+- **num_scans** (*optional*, int, :ref:`templatable <config-templatable>`): Number of scans performed to find the device. Defaults to ``1``.
+
+See Also
+--------
+
+- :doc:`/components/binary_sensor/bt_classic_presence`
+- :apiref:`esp32_bt_classic/bt_classic.h`
+- :ghedit:`Edit`

--- a/index.rst
+++ b/index.rst
@@ -462,6 +462,7 @@ Miscellaneous
 
     Analog Threshold, components/binary_sensor/analog_threshold, analog_threshold.svg
     ESP32 BLE Presence, components/binary_sensor/ble_presence, bluetooth.svg
+    ESP32 BT Classic Presence, components/binary_sensor/bt_classic_presence, bluetooth.svg
     Hydreon Rain Sensor Binary Sensor, components/binary_sensor/hydreon_rgxx, hydreon_rg9.jpg
     LD2410, components/sensor/ld2410, ld2410.jpg
     Modbus Binary Sensor, components/binary_sensor/modbus_controller, modbus.png
@@ -758,6 +759,7 @@ Miscellaneous Components
     ESP32 BLE Client, components/ble_client, bluetooth.svg
     ESP32 BLE Tracker, components/esp32_ble_tracker, bluetooth.svg
     ESP32 BLE Beacon, components/esp32_ble_beacon, bluetooth.svg
+    ESP32 BT Classic, components/esp32_bt_classic, bluetooth.svg
 
     ESP32 Ethernet, components/ethernet, ethernet.svg
     ESP32 Camera, components/esp32_camera, camera.svg


### PR DESCRIPTION
## Description:

Documentation for new components: ESP32 BT Classic & BT Classic Presence.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#4736

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
