### PR TITLE
Update i2c.rst

### DIFF
--- a/components/i2c.rst
+++ b/components/i2c.rst
@@ -20,7 +20,7 @@ connecting the wires from each device back to the two I²C pins on the ESP.
 
     # Example configuration entry for ESP32
     i2c:
-      sda: 21
+      sda: 21  # 23 for Adafruit HUZZAH32 ESP32 Feather
       scl: 22
       scan: true
       id: bus_a


### PR DESCRIPTION
Added an divergent number for the i2c sda Port for a widely used Adafruit HUZZAH32 ESP32 Feather

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
