### PR TITLE
Adding play_mp3 action documentation to dfplayer component

### DIFF
--- a/components/dfplayer.rst
+++ b/components/dfplayer.rst
@@ -112,7 +112,7 @@ Configuration options:
   the same track. Defaults to ``false``.
 
 ``dfplayer.play_mp3`` Action
-------------------------
+----------------------------
 
 Plays a track inside the folder ``MP3``. Files inside the folder must be numbered from 1 
 to 65535, like ``001.mp3``, ``002.mp3``, ... etc.

--- a/components/dfplayer.rst
+++ b/components/dfplayer.rst
@@ -118,13 +118,15 @@ Plays a track inside the folder ``mp3``. Files inside the folder must be numbere
 to 65535, like ``0001.mp3``, ``0002.mp3``, ... etc.
 The folder name needs to be ``mp3``, placed under the SD card root directory, and the 
 mp3 file name needs to be 4 digits, for example, "0001.mp3", placed under the mp3 folder. 
-If you want to name it, you can add it after the number, for example, "0001hello.mp3".
+If you want, you can add additional text after the number in the filename, for example, 
+``0001hello.mp3``, but must always reference it by number only in yaml.
 
 .. code-block:: bash
 
     /mp3
-      /0001.mp3
+      /0001hello.mp3
       /0002.mp3
+      /0003_thisistheway.mp3
       ..
 
 .. code-block:: yaml
@@ -132,14 +134,14 @@ If you want to name it, you can add it after the number, for example, "0001hello
     on_...:
       then:
         - dfplayer.play_mp3:
-            file: 23
+            file: 1
         # Shorthand
-        - dfplayer.play_mp3: 23
+        - dfplayer.play_mp3: 1
 
 Configuration options:
 
 - **file** (**Required**, int, :ref:`templatable <config-templatable>`): The file number
-  inside the folder to play.
+  inside the ``mp3`` folder to play.
 
 
 ``dfplayer.play_folder`` Action

--- a/components/dfplayer.rst
+++ b/components/dfplayer.rst
@@ -115,11 +115,11 @@ Configuration options:
 ----------------------------
 
 Plays a track inside the folder ``mp3``. Files inside the folder must be numbered from 1 
-to 65535, like ``0001.mp3``, ``0002.mp3``, ... etc.
+to 9999, like ``0001.mp3``, ``0002.mp3``, ... etc.
 The folder name needs to be ``mp3``, placed under the SD card root directory, and the 
 mp3 file name needs to be 4 digits, for example, "0001.mp3", placed under the mp3 folder. 
 If you want, you can add additional text after the number in the filename, for example, 
-``0001hello.mp3``, but must always reference it by number only in yaml.
+``0001hello.mp3``, but must always be referenced by number only in yaml.
 
 .. code-block:: bash
 

--- a/components/dfplayer.rst
+++ b/components/dfplayer.rst
@@ -111,6 +111,34 @@ Configuration options:
 - **loop** (*Optional*, boolean, :ref:`templatable <config-templatable>`): Repeats playing
   the same track. Defaults to ``false``.
 
+``dfplayer.play_mp3`` Action
+------------------------
+
+Plays a track inside the folder ``MP3``. Files inside the folder must be numbered from 1 
+to 65535, like ``001.mp3``, ``002.mp3``, ... etc.
+
+.. code-block:: bash
+
+    /MP3
+      /001.mp3
+      /002.mp3
+      ..
+
+.. code-block:: yaml
+
+    on_...:
+      then:
+        - dfplayer.play_mp3:
+            file: 23
+        # Shorthand
+        - dfplayer.play_mp3: 23
+
+Configuration options:
+
+- **file** (**Required**, int, :ref:`templatable <config-templatable>`): The file number
+  inside the folder to play.
+
+
 ``dfplayer.play_folder`` Action
 -------------------------------
 

--- a/components/dfplayer.rst
+++ b/components/dfplayer.rst
@@ -114,14 +114,17 @@ Configuration options:
 ``dfplayer.play_mp3`` Action
 ----------------------------
 
-Plays a track inside the folder ``MP3``. Files inside the folder must be numbered from 1 
-to 65535, like ``001.mp3``, ``002.mp3``, ... etc.
+Plays a track inside the folder ``mp3``. Files inside the folder must be numbered from 1 
+to 65535, like ``0001.mp3``, ``0002.mp3``, ... etc.
+The folder name needs to be ``mp3``, placed under the SD card root directory, and the 
+mp3 file name needs to be 4 digits, for example, "0001.mp3", placed under the mp3 folder. 
+If you want to name it, you can add it after the number, for example, "0001hello.mp3".
 
 .. code-block:: bash
 
-    /MP3
-      /001.mp3
-      /002.mp3
+    /mp3
+      /0001.mp3
+      /0002.mp3
       ..
 
 .. code-block:: yaml


### PR DESCRIPTION
## Description:

Documentation for a new action on dfplayer component: play_mp3

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#4758

## Checklist:

  - [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
