### PR TITLE
Update binary.rst / Add binary output component to use for fan

### DIFF
--- a/components/fan/binary.rst
+++ b/components/fan/binary.rst
@@ -14,10 +14,18 @@ The ``binary`` fan platform lets you represent any binary :ref:`output` as a fan
 .. code-block:: yaml
 
     # Example configuration entry
+    output:
+      - id: fan_output
+        platform: gpio
+        pin: GPIO16
+        
     fan:
       - platform: binary
-        output: my_output_1
+        output: fan_output
         name: "Living Room Fan"
+        
+        
+        
 
 Configuration variables:
 ------------------------


### PR DESCRIPTION
## Description:
Add binary output component to use for fan example

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
