### PR TITLE
Insert Europe Tank Types from mopeka_std_check

### DIFF
--- a/components/sensor/mopeka_pro_check.rst
+++ b/components/sensor/mopeka_pro_check.rst
@@ -105,6 +105,9 @@ Currently supported Tank types are:
 - ``20LB_V`` - 20 LB vertical tank
 - ``30LB_V`` - 30 LB vertical tank
 - ``40LB_V`` - 40 LB vertical tank
+- ``EUROPE_6KG`` - 6kg vertical tank
+- ``EUROPE_11KG`` - 11kg vertical tank
+- ``EUROPE_14KG`` - 14kg vertical tank
 - ``CUSTOM`` - Allows you to define your own full and empty points
 
 Setting Up Devices


### PR DESCRIPTION
## Description:
Make Europe Tank Types useable with mopeka pro

Needed for Pull Request #4757: Insert Europe Tank Types from mopeka_std_check

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#4757

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
