### PR TITLE
Revert template sensor publish updates

### DIFF
--- a/components/sensor/template.rst
+++ b/components/sensor/template.rst
@@ -35,9 +35,8 @@ Configuration variables:
 - **name** (**Required**, string): The name of the sensor.
 - **lambda** (*Optional*, :ref:`lambda <config-lambda>`):
   Lambda to be evaluated every update interval to get the new value of the sensor
-- **update_interval** (*Optional*, :ref:`config-time`): The interval to publish the value of the
-  sensor, either the result of the lambda function or if no lambda function the last value
-  published using the publish action. Set to ``never`` to disable updates. Defaults to ``60s``.
+- **update_interval** (*Optional*, :ref:`config-time`): The interval to check the
+  sensor. Set to ``never`` to disable updates. Defaults to ``60s``.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
 - All other options from :ref:`Sensor <config-sensor>`.
 

--- a/components/text_sensor/template.rst
+++ b/components/text_sensor/template.rst
@@ -31,9 +31,8 @@ Configuration variables:
 - **name** (**Required**, string): The name of the text sensor.
 - **lambda** (*Optional*, :ref:`lambda <config-lambda>`):
   Lambda to be evaluated every update interval to get the new value of the text sensor
-- **update_interval** (*Optional*, :ref:`config-time`): The interval to publish the value of the
-  text sensor, either the result of the lambda function or if no lambda function the last value
-  published using the publish action. Defaults to ``60s``.
+- **update_interval** (*Optional*, :ref:`config-time`): The interval to check the
+  text sensor. Set to ``never`` to disable updates. Defaults to ``60s``.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
 - All other options from :ref:`Text Sensor <config-text_sensor>`.
 


### PR DESCRIPTION
## Description:
This reverts the updates to the documentation related to the code change that always published the value for template sensors on the update interval even if a lambda function was not provided.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#4774

## Checklist:

  - [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [N/A] Link added in `/index.rst` when creating new documents for new components or cookbook.
