### PR TITLE
Add speaker to VA docs

### DIFF
--- a/components/voice_assistant.rst
+++ b/components/voice_assistant.rst
@@ -23,7 +23,8 @@ Configuration:
     voice_assistant:
       microphone: mic_id
 
-- **microphone** (**Required**, :ref:`config-id`): The microphone to use for input.
+- **microphone** (**Required**, :ref:`config-id`): The :doc:`microphone </components/microphone/index>` to use for input.
+- **speaker** (*Optional*, :ref:`config-id`): The :doc:`speaker </components/speaker/index>` to use to output the response.
 - **on_start** (*Optional*, :ref:`Automation <automation>`): An automation to
   perform when the voice assistant starts listening.
 - **on_end** (*Optional*, :ref:`Automation <automation>`): An automation to perform


### PR DESCRIPTION
## Description:

Followup from #2892 where speaker can now be specified on the voice_assistant for direct playback instead of using the media player.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
