### PR TITLE
Add esp32_rmt_led_strip docs

### DIFF
--- a/components/light/esp32_rmt_led_strip.rst
+++ b/components/light/esp32_rmt_led_strip.rst
@@ -24,16 +24,16 @@ Configuration variables
 - **pin** (**Required**, :ref:`config-pin`): The pin for the data line of the light.
 - **num_leds** (**Required**, int): The number of LEDs in the strip.
 - **rmt_channel** (**Required**, int): The RMT channel to use. If using multiple strips, you need to use different channels.
-  - **ESP32**: ``0`` to ``7``
-  - **ESP32-S2**: ``0`` to ``3``
-  - **ESP32-S3**: ``0`` to ``3``
-  - **ESP32-C3**: ``0`` or ``1``
+    - **ESP32**: ``0`` to ``7``
+    - **ESP32-S2**: ``0`` to ``3``
+    - **ESP32-S3**: ``0`` to ``3``
+    - **ESP32-C3**: ``0`` or ``1``
 
 - **chipset** (**Required**, enum): The chipset to apply known timings from. Not used if specifying the timings manually, see below.
-  - ``WS2812``
-  - ``SK6812``
-  - ``APA106``
-  - ``SM16703``
+    - ``WS2812``
+    - ``SK6812``
+    - ``APA106``
+    - ``SM16703``
 
 - **rgb_order** (**Required**, string): The RGB order of the strip.
     - ``RGB``

--- a/components/light/esp32_rmt_led_strip.rst
+++ b/components/light/esp32_rmt_led_strip.rst
@@ -1,0 +1,72 @@
+ESP32 RMT LED Strip
+===================
+
+.. seo::
+    :description: Instructions for setting up addressable lights like NEOPIXEL on an ESP32 using the RMT peripheral.
+    :image: color_lens.svg
+
+This is a component using the ESP32 RMT peripheral to drive most addressable LED strips.
+
+.. code-block:: yaml
+
+    light:
+      - platform: esp32_rmt_led_strip
+        rgb_order: GRB
+        pin: REPLACEME
+        num_leds: 30
+        rmt_channel: 0
+        chipset: ws2812
+        name: "My Light"
+
+Configuration variables
+-----------------------
+
+- **pin** (**Required**, :ref:`config-pin`): The pin for the data line of the light.
+- **num_leds** (**Required**, int): The number of LEDs in the strip.
+- **rmt_channel** (**Required**, int): The RMT channel to use. If using multiple strips, you need to use different channels.
+
+  - **ESP32**: ``0`` to ``7``
+  - **ESP32-S2**: ``0`` to ``3``
+  - **ESP32-S3**: ``0`` to ``3``
+  - **ESP32-C3**: ``0`` or ``1``
+
+- **chipset** (**Required**, enum): The chipset to apply known timings from. Not used if specifying the timings manually, see below.
+
+  - ``WS2812``
+  - ``SK6812``
+  - ``APA106``
+  - ``SM16703``
+
+- **rgb_order** (**Required**, string): The RGB order of the strip.
+
+    - ``RGB``
+    - ``RBG``
+    - ``GRB``
+    - ``GBR``
+    - ``BGR``
+    - ``BRG``
+
+- **is_rgbw** (*Optional*, boolean): Set to ``true`` if the strip is RGBW. Defaults to ``false``.
+- **max_refresh_rate** (*Optional*, :ref:`config-time`):
+  A time interval used to limit the number of commands a light can handle per second. For example
+  16ms will limit the light to a refresh rate of about 60Hz. Defaults to sending commands as quickly as
+  changes are made to the lights.
+
+Manual Timings
+**************
+
+These can be used if you know the timings and your chipset is not set above. If you have a new specific chipset,
+please consider adding support to the codebase and add it to the list above.
+
+- **bit0_high** (*Optional*, :ref:`config-time`): The time to hold the data line high for a ``0`` bit.
+- **bit0_low** (*Optional*, :ref:`config-time`): The time to hold the data line low for a ``0`` bit.
+- **bit1_high** (*Optional*, :ref:`config-time`): The time to hold the data line high for a ``1`` bit.
+- **bit1_low** (*Optional*, :ref:`config-time`): The time to hold the data line low for a ``1`` bit.
+
+See Also
+--------
+
+- :doc:`/components/light/index`
+- :doc:`/components/power_supply`
+- :apiref:`esp32_rmt_led_strip/esp32_rmt_led_strip.h`
+- :ghedit:`Edit`

--- a/components/light/esp32_rmt_led_strip.rst
+++ b/components/light/esp32_rmt_led_strip.rst
@@ -12,7 +12,7 @@ This is a component using the ESP32 RMT peripheral to drive most addressable LED
     light:
       - platform: esp32_rmt_led_strip
         rgb_order: GRB
-        pin: REPLACEME
+        pin: GPIO13
         num_leds: 30
         rmt_channel: 0
         chipset: ws2812
@@ -24,21 +24,18 @@ Configuration variables
 - **pin** (**Required**, :ref:`config-pin`): The pin for the data line of the light.
 - **num_leds** (**Required**, int): The number of LEDs in the strip.
 - **rmt_channel** (**Required**, int): The RMT channel to use. If using multiple strips, you need to use different channels.
-
   - **ESP32**: ``0`` to ``7``
   - **ESP32-S2**: ``0`` to ``3``
   - **ESP32-S3**: ``0`` to ``3``
   - **ESP32-C3**: ``0`` or ``1``
 
 - **chipset** (**Required**, enum): The chipset to apply known timings from. Not used if specifying the timings manually, see below.
-
   - ``WS2812``
   - ``SK6812``
   - ``APA106``
   - ``SM16703``
 
 - **rgb_order** (**Required**, string): The RGB order of the strip.
-
     - ``RGB``
     - ``RBG``
     - ``GRB``

--- a/index.rst
+++ b/index.rst
@@ -523,6 +523,7 @@ Light Components
     RGBWW Light, components/light/rgbww, rgbw.png
     RGBCT Light, components/light/rgbct, rgbw.png
 
+    ESP32 RMT, components/light/esp32_rmt_led_strip, color_lens.svg
     FastLED Light, components/light/fastled, color_lens.svg
     NeoPixelBus Light, components/light/neopixelbus, color_lens.svg
     Light Partition, components/light/partition, color_lens.svg


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#4708

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
