### PR TITLE
Updated Image reference to be correct

### DIFF
--- a/components/binary_sensor/rc522.rst
+++ b/components/binary_sensor/rc522.rst
@@ -18,7 +18,7 @@ The RC522 supports SPI, I²C and UART communication protocols, ESPHome can use e
 Component/Hub
 -------------
 
-* If you have a module like the image above, it can only be used in SPI mode (`unless hacked <https://forum.arduino.cc/index.php?topic=442750.0>`__)
+* If you have a module like the image below, it can only be used in SPI mode (`unless hacked <https://forum.arduino.cc/index.php?topic=442750.0>`__)
   and you need to have an :ref:`SPI bus <spi>` in your configuration with both the **miso_pin** and **mosi_pin** set.
 
 * If you have a RC522 which communicates via I²C like in the M5 Stack then you need to have an :ref:`I²C <i2c>` bus configured.


### PR DESCRIPTION
## Description:

Minor documentation update to fix reference to image in `rc522`

**Related issue (if applicable):** None

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook. (Not Needed)
