### PR TITLE
Expand custom I2C documentation

### DIFF
--- a/custom/i2c.rst
+++ b/custom/i2c.rst
@@ -47,7 +47,7 @@ It may be useful to write to a register via I²C using a numerical input. For ex
         id: input_1
         icon: "mdi:counter"
         
-We want to write this number to a ``REGISTER_ADDRESS`` via I²C. The Arduino-based looping code shown above is modified following the guidance in  `Custom Sensor Component <https://esphome.io/components/sensor/custom.html>`__:
+We want to write this number to a ``REGISTER_ADDRESS`` on the slave device via I²C. The Arduino-based looping code shown above is modified following the guidance in  `Custom Sensor Component <https://esphome.io/components/sensor/custom.html>`__:
  
 .. code-block:: cpp
  
@@ -56,7 +56,7 @@ We want to write this number to a ``REGISTER_ADDRESS`` via I²C. The Arduino-bas
  const uint16_t I2C_ADDRESS = 0x21;
  const uint16_t REGISTER_ADDRESS = 0x78; 
  const uint16_t POLLING_PERIOD = 15000; //milliseconds
- char temp1 = 20; //Initial value of the register
+ char temp = 20; //Initial value of the register
 
  class MyCustomComponent : public PollingComponent {
  public:
@@ -70,17 +70,17 @@ We want to write this number to a ``REGISTER_ADDRESS`` via I²C. The Arduino-bas
   void update() override {  
   char register_value = id(input_1).state; //Read the number set on the dashboard
   //Did the user change the input?
-  if(register_value != temp1){
+  if(register_value != temp){
     Wire.beginTransmission(I2C_ADDRESS);
     Wire.write(REGISTER_ADDRESS);
     Wire.write(register_value);
     Wire.endTransmission();
-    temp1 = register_value; //Swap in the new value
+    temp = register_value; //Swap in the new value
     }
   }
  };
         
-The ``Component`` class has been replaced with ``PollingComponent`` and the free-running ``loop()`` is changed to the  ``update()`` method with period set by ``POLLING_PERIOD``. The numerical value from the dashboard is accessed with its ``id`` tag and its state is set to the byte variable that we call ``register_value``.  To prevent an I²C write on every iteration, the contents of the register are stored in ``temp1`` and checked for a change. Configuring the hardware with ``get_setup_priority()`` is explained `here <https://esphome.io/components/sensor/custom.html#step-1-custom-sensor-definition>`__.
+The ``Component`` class has been replaced with ``PollingComponent`` and the free-running ``loop()`` is changed to the  ``update()`` method with period set by ``POLLING_PERIOD``. The numerical value from the dashboard is accessed with its ``id`` tag and its state is set to the byte variable that we call ``register_value``.  To prevent an I²C write on every iteration, the contents of the register are stored in ``temp`` and checked for a change. Configuring the hardware with ``get_setup_priority()`` is explained `here <https://esphome.io/components/sensor/custom.html#step-1-custom-sensor-definition>`__.
 
 
 

--- a/custom/i2c.rst
+++ b/custom/i2c.rst
@@ -47,9 +47,10 @@ It may be useful to write to a register via I²C using a numerical input. For ex
         id: input_1
         icon: "mdi:counter"
         
-We want to write this number to a ``REGISTER_ADDRESS`` on the slave device via I²C. The Arduino-based looping code shown above is modified following the guidance in  `Custom Sensor Component <https://esphome.io/components/sensor/custom.html>`__:
+We want to write this number to a ``REGISTER_ADDRESS`` on the slave device via I²C. The Arduino-based looping code shown above is modified following the guidance in :ref:`custom-sensor-component`.
  
 .. code-block:: cpp
+ 
  
  #include "esphome.h"
  
@@ -80,7 +81,7 @@ We want to write this number to a ``REGISTER_ADDRESS`` on the slave device via I
   }
  };
         
-The ``Component`` class has been replaced with ``PollingComponent`` and the free-running ``loop()`` is changed to the  ``update()`` method with period set by ``POLLING_PERIOD``. The numerical value from the dashboard is accessed with its ``id`` tag and its state is set to the byte variable that we call ``register_value``.  To prevent an I²C write on every iteration, the contents of the register are stored in ``temp`` and checked for a change. Configuring the hardware with ``get_setup_priority()`` is explained `here <https://esphome.io/components/sensor/custom.html#step-1-custom-sensor-definition>`__.
+The ``Component`` class has been replaced with ``PollingComponent`` and the free-running ``loop()`` is changed to the  ``update()`` method with period set by ``POLLING_PERIOD``. The numerical value from the dashboard is accessed with its ``id`` tag and its state is set to the byte variable that we call ``register_value``.  To prevent an I²C write on every iteration, the contents of the register are stored in ``temp`` and checked for a change. Configuring the hardware with ``get_setup_priority()`` is explained in :ref:`step-1-custom-sensor-definition`.
 
 
 


### PR DESCRIPTION
## Description:
As a ESPHome newbie, I really struggled understanding the link between yaml and device I2C operations. I added some information to the documentation that might be useful.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
