### PR TITLE
add note about default SPI pin usage for stability/performance

### DIFF
--- a/components/spi.rst
+++ b/components/spi.rst
@@ -44,6 +44,8 @@ Configuration variables:
 - **force_sw** (*Optional*, boolean): Whether software implementation should be used even if hardware one is available.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID for this SPI hub if you need multiple SPI hubs.
 
+**Please note:** while both ESP8266 and ESP32 support the reassignment of the default SPI pins to other GPIO pins, using the dedicated SPI pins can improve performance and stability for certain ESP/device combinations.
+
 See Also
 --------
 


### PR DESCRIPTION
The current SPI documentation doesn't mention that there is a difference in how ESPs work depending on which GPIOs are chosen for the SPI setup. While in theory all regular GPIOs can be used (and might work for a lot of people/setups), using the dedicated default SPI pins can be the missing puzzle piece for unstable ESP/device combinations

https://techoverflow.net/2021/07/26/what-is-the-spi-pinout-of-the-esp32-esp-wroom-32/

https://randomnerdtutorials.com/esp8266-pinout-reference-gpios/

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
