### PR TITLE
correct spelling of Revspace in link to wiki page Tiny nitpick: fix typo.

### DIFF
--- a/components/sensor/mhz19.rst
+++ b/components/sensor/mhz19.rst
@@ -7,7 +7,7 @@ MH-Z19 CO_2 and Temperature Sensor
     :keywords: mh-z19
 
 The ``mhz19`` sensor platform allows you to use MH-Z19 CO_2 and temperature sensors
-(`refspace`_) with ESPHome.
+(`Revspace`_) with ESPHome.
 The CO_2 measurement also works with the MH-Z16 and MH-Z14 sensors.
 
 .. figure:: images/mhz19-full.jpg
@@ -16,7 +16,7 @@ The CO_2 measurement also works with the MH-Z16 and MH-Z14 sensors.
 
     MH-Z19 CO_2 and Temperature Sensor.
 
-.. _refspace: https://revspace.nl/MHZ19
+.. _Revspace: https://revspace.nl/MHZ19
 
 As the communication with the MH-Z19 is done using UART, you need
 to have an :ref:`UART bus <uart>` in your configuration with the ``rx_pin`` connected to the TX pin of the


### PR DESCRIPTION
## Description:

Tiny nitpick: fix typo.

## Checklist:

  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.
  - ~Link added in `/index.rst` when creating new documents for new components or cookbook.~