### PR TITLE
added note on NFS for container config volume

### DIFF
--- a/guides/getting_started_command_line.rst
+++ b/guides/getting_started_command_line.rst
@@ -40,6 +40,12 @@ If you want to use `docker-compose` instead, here's a sample file:
         privileged: true
         network_mode: host
 
+.. note::
+
+    If you are using NFS share to back your container's config volume, you may 
+    need to mount the volume with the `nolock` option, otherwise platformio may 
+    freeze on container startup as per `platformIO-core Issue 3089 <https://github.com/platformio/platformio-core/issues/3089>`__
+
 The project provides multiple docker tags; please pick the one that suits you
 better:
 


### PR DESCRIPTION
## Description:
Added note on NFS for container config volume that can otherwise freeze platformio open container startup.


## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
