### PR TITLE
Update i2s_audio.rst

### DIFF
--- a/components/i2s_audio.rst
+++ b/components/i2s_audio.rst
@@ -22,6 +22,7 @@ Configuration variables:
 
 - **i2s_lrclk_pin** (**Required**, :ref:`Pin Schema <config-pin_schema>`): The GPIO pin to use for the I²S ``LRCLK`` *(Left/Right Clock)* signal, also referred to as ``WS`` *(Word Select)* or ``FS`` *(Frame Sync)*.
 - **i2s_bclk_pin** (*Optional*, :ref:`Pin Schema <config-pin_schema>`): The GPIO pin to use for the I²S ``BCLK`` *(Bit Clock)* signal, also referred to as ``SCK`` *(Serial Clock)*.
+- **i2s_mclk_pin** (*Optional*, :ref:`<config-pin>`): The GPIO pin to use for the I²S ``MCLK`` *(Master Clock)* signal.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID for this I²S bus if you need multiple.
 
 See also

--- a/components/i2s_audio.rst
+++ b/components/i2s_audio.rst
@@ -20,9 +20,9 @@ This component only works on ESP32 based chips.
 Configuration variables:
 ------------------------
 
-- **i2s_lrclk_pin** (**Required**, :ref:`Pin Schema <config-pin_schema>`): The GPIO pin to use for the I²S ``LRCLK`` *(Left/Right Clock)* signal, also referred to as ``WS`` *(Word Select)* or ``FS`` *(Frame Sync)*.
-- **i2s_bclk_pin** (*Optional*, :ref:`Pin Schema <config-pin_schema>`): The GPIO pin to use for the I²S ``BCLK`` *(Bit Clock)* signal, also referred to as ``SCK`` *(Serial Clock)*.
-- **i2s_mclk_pin** (*Optional*, :ref:`<config-pin>`): The GPIO pin to use for the I²S ``MCLK`` *(Master Clock)* signal.
+- **i2s_lrclk_pin** (**Required**, :ref:`config-pin`): The GPIO pin to use for the I²S ``LRCLK`` *(Left/Right Clock)* signal, also referred to as ``WS`` *(Word Select)* or ``FS`` *(Frame Sync)*.
+- **i2s_bclk_pin** (*Optional*, :ref:`config-pin`): The GPIO pin to use for the I²S ``BCLK`` *(Bit Clock)* signal, also referred to as ``SCK`` *(Serial Clock)*.
+- **i2s_mclk_pin** (*Optional*, :ref:`config-pin`): The GPIO pin to use for the I²S ``MCLK`` *(Master Clock)* signal.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID for this I²S bus if you need multiple.
 
 See also


### PR DESCRIPTION
## Description:
Add MCLK to i2s_audio, also fix bclk and lrclk to be regular Pins not Pin Schemas

**Related issue (if applicable):** fixes https://github.com/esphome/feature-requests/issues/1786

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** https://github.com/esphome/esphome/pull/4885

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
