### PR TITLE
Update custom.rst to include changes made in CoverTraits

### DIFF
--- a/components/cover/custom.rst
+++ b/components/cover/custom.rst
@@ -30,6 +30,7 @@ two methods:
         traits.set_is_assumed_state(false);
         traits.set_supports_position(true);
         traits.set_supports_tilt(false);
+        traits.set_supports_stop(true);
         return traits;
       }
       void control(const CoverCall &call) override {


### PR DESCRIPTION
Update documentation to add changes made in https://github.com/esphome/esphome/pull/3897

traits.set_supports_stop(true) required now in the custom cover for stop button to be exposed.

## Description:


**Related issue (if applicable):** fixes [https://github.com/esphome/issues/issues/4516]

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
