### PR TITLE
Fix mmc5603 example

### DIFF
--- a/components/sensor/mmc5603.rst
+++ b/components/sensor/mmc5603.rst
@@ -25,7 +25,7 @@ for this sensor to work.
 
     # Example configuration entry
     sensor:
-      - platform: MMC5603 
+      - platform: mmc5603 
         address: 0x30
         field_strength_x:
           name: "MMC5603 Field Strength X"


### PR DESCRIPTION
## Description:

Fixes a typo in the example configuration.
See https://community.home-assistant.io/t/platform-not-found-sensor-mmc5603/566173/26

**Related issue (if applicable):** fixes

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
