### PR TITLE
Update internal_temperature.rst - Clarify 53.3/128 value

### DIFF
--- a/components/sensor/internal_temperature.rst
+++ b/components/sensor/internal_temperature.rst
@@ -12,7 +12,7 @@ temperature sensor of the ESP32 and RP2040 chip.
 .. note::
 
     Some ESP32 variants return a large amount of invalid temperature
-    values. Invalid measurements are ignored by this component.
+    values, including 53.3°C which equates to a raw value of 128. Invalid measurements are ignored by this component.
 
 .. figure:: images/internal_temperature-ui.png
     :align: center


### PR DESCRIPTION
## Description:

Updates Note to clarify a value of 53.3°C is an error value.

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
