### PR TITLE
Update links to voice control

### DIFF
--- a/changelog/2023.4.0.rst
+++ b/changelog/2023.4.0.rst
@@ -22,7 +22,7 @@ Voice Assistant
 
 This year is the Year of the Voice for Home Assistant, and ESPHome is charging ahead with this in mind.
 We've added a new :doc:`/components/voice_assistant` component that allows you to use ESPHome devices as an input
-for `assist <https://www.home-assistant.io/docs/assist/>`__ in Home Assistant **2023.5 or later**.
+for `assist <https://www.home-assistant.io/voice_control/>`__ in Home Assistant **2023.5 or later**.
 
 With this also comes preliminary :doc:`microphone </components/microphone/index>` support, which has been built in a way that multiple
 components, like ``voice_assistant`` can request start / stop of the microphone and get the data. We

--- a/components/voice_assistant.rst
+++ b/components/voice_assistant.rst
@@ -5,7 +5,7 @@ Voice Assistant
     :description: Instructions for setting up a Voice Assistant in ESPHome.
     :image: voice-assistant.svg
 
-ESPHome devices with a microphone are able to stream the audio to Home Assistant and be processed there by `assist <https://www.home-assistant.io/docs/assist/>`__.
+ESPHome devices with a microphone are able to stream the audio to Home Assistant and be processed there by `assist <https://www.home-assistant.io/voice_control/>`__.
 
 .. note::
 


### PR DESCRIPTION
## Description:
- Voice control pages were moved on home-assistant.io. 
- Update links to point to new location

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
