### PR TITLE
New i2s_comm_fmt parameter for i2c_audio media_player

### DIFF
--- a/components/media_player/i2s_audio.rst
+++ b/components/media_player/i2s_audio.rst
@@ -16,7 +16,6 @@ via the :doc:`/components/i2s_audio`. This platform only works on ESP32 based ch
         name: ESPHome I2S Media Player
         dac_type: external
         i2s_dout_pin: GPIO22
-        i2s_comm_fmt: false
         mode: mono
 
 Configuration variables:
@@ -36,7 +35,9 @@ External DAC
 - **mute_pin** (*Optional*, :ref:`Pin Schema <config-pin_schema>`): The GPIO pin to use to mute the media player.
 - **mode** (*Optional*, string): The mode of the I²S bus. Can be ``mono`` or ``stereo``. Defaults to ``mono``.
 - **i2s_audio_id** (*Optional*, :ref:`config-id`): The ID of the :ref:`I²S Audio <i2s_audio>` you wish to use for this media player.
-- **i2s_comm_fmt** (*Optional*, string): I2S communication format. By default MSB format is used (AC101, PCM5102A). Set to ``lsb`` if using an external DAC that uses Japanese (Least Significant Bit Justified) format (like PT8211). Can be ``msb`` or ``lsb``. Defaults to ``msb``.
+- **i2s_comm_fmt** (*Optional*, string): I2S communication format. By default MSB format is used (AC101, PCM5102A). 
+  Set to ``lsb`` if using an external DAC that uses Japanese (Least Significant Bit Justified) format (like PT8211). 
+  Can be ``msb`` or ``lsb``. Defaults to ``msb``.
 
 For best results, keep the wires as short as possible.
 

--- a/components/media_player/i2s_audio.rst
+++ b/components/media_player/i2s_audio.rst
@@ -36,7 +36,7 @@ External DAC
 - **mute_pin** (*Optional*, :ref:`Pin Schema <config-pin_schema>`): The GPIO pin to use to mute the media player.
 - **mode** (*Optional*, string): The mode of the I²S bus. Can be ``mono`` or ``stereo``. Defaults to ``mono``.
 - **i2s_audio_id** (*Optional*, :ref:`config-id`): The ID of the :ref:`I²S Audio <i2s_audio>` you wish to use for this media player.
-- **i2s_comm_fmt** (*Optional*, boolean): I2S communication format. By default I2S_COMM_FORMAT_I2S_MSB (AC101, PCM5102A). Set to true if using an external DAC that uses Japanese (Least Significant Bit Justified) format (like PT8211) . Defaults to ``false``.
+- **i2s_comm_fmt** (*Optional*, boolean): I2S communication format. By default MSB format is used (AC101, PCM5102A). Set to true if using an external DAC that uses Japanese (Least Significant Bit Justified) format (like PT8211). Defaults to ``false``.
 
 For best results, keep the wires as short as possible.
 

--- a/components/media_player/i2s_audio.rst
+++ b/components/media_player/i2s_audio.rst
@@ -36,7 +36,7 @@ External DAC
 - **mute_pin** (*Optional*, :ref:`Pin Schema <config-pin_schema>`): The GPIO pin to use to mute the media player.
 - **mode** (*Optional*, string): The mode of the I²S bus. Can be ``mono`` or ``stereo``. Defaults to ``mono``.
 - **i2s_audio_id** (*Optional*, :ref:`config-id`): The ID of the :ref:`I²S Audio <i2s_audio>` you wish to use for this media player.
-- **i2s_comm_fmt** (*Optional*, boolean): I2S communication format. By default MSB format is used (AC101, PCM5102A). Set to true if using an external DAC that uses Japanese (Least Significant Bit Justified) format (like PT8211). Defaults to ``false``.
+- **i2s_comm_fmt** (*Optional*, string): I2S communication format. By default MSB format is used (AC101, PCM5102A). Set to ``lsb`` if using an external DAC that uses Japanese (Least Significant Bit Justified) format (like PT8211). Can be ``msb`` or ``lsb``. Defaults to ``msb``.
 
 For best results, keep the wires as short as possible.
 

--- a/components/media_player/i2s_audio.rst
+++ b/components/media_player/i2s_audio.rst
@@ -16,6 +16,7 @@ via the :doc:`/components/i2s_audio`. This platform only works on ESP32 based ch
         name: ESPHome I2S Media Player
         dac_type: external
         i2s_dout_pin: GPIO22
+        i2s_comm_fmt: false
         mode: mono
 
 Configuration variables:
@@ -35,6 +36,7 @@ External DAC
 - **mute_pin** (*Optional*, :ref:`Pin Schema <config-pin_schema>`): The GPIO pin to use to mute the media player.
 - **mode** (*Optional*, string): The mode of the I²S bus. Can be ``mono`` or ``stereo``. Defaults to ``mono``.
 - **i2s_audio_id** (*Optional*, :ref:`config-id`): The ID of the :ref:`I²S Audio <i2s_audio>` you wish to use for this media player.
+- **i2s_comm_fmt** (*Optional*, boolean): I2S communication format. By default I2S_COMM_FORMAT_I2S_MSB (AC101, PCM5102A). Set to true if using an external DAC that uses Japanese (Least Significant Bit Justified) format (like PT8211) . Defaults to ``false``.
 
 For best results, keep the wires as short as possible.
 


### PR DESCRIPTION
## Description:

I2S communication format parameter for external DACs that use LSBJ format

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#4918

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
