### PR TITLE
Add SVG support

### DIFF
--- a/components/display/index.rst
+++ b/components/display/index.rst
@@ -700,11 +700,8 @@ Configuration variables:
     To use images you will need to have the python ``pillow`` package installed.
     If you're running this as a Home Assistant add-on or with the official ESPHome docker image, it should already be
     installed. Otherwise you need to install it using ``pip install pillow``.
-
-.. note::
-
-    To use mdi images you will additionally need to have the python ``cairosvg`` package installed.
-    If you're running this as a Home Assistant add-on or with the official ESPHome docker image, it should already be
+    Additionally, if you want to use SVG images (including MDI images), you will additionally need to have the python ``cairosvg`` package installed.
+    If you're running this as a Home Assistant add-on or with the official ESPHome docker image, it should also already be
     installed. Otherwise you need to install it using ``pip install cairosvg``.
 
 And then later in code:


### PR DESCRIPTION
## Description:

SVG image support requires an additional dependency `cairosvg`. This dependency is also needed by MDI images; this PR rephrases the note to also mention the SVG support.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#4922

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
