### PR TITLE
Fix ACP Header

### DIFF
--- a/components/alarm_control_panel/index.rst
+++ b/components/alarm_control_panel/index.rst
@@ -7,7 +7,7 @@ Alarm Control Panel Component
 
 .. _config-alarm_control_panel:
 
-Base Alarm COntrol Panel Configuration
+Base Alarm Control Panel Configuration
 --------------------------------------
 
 .. code-block:: yaml


### PR DESCRIPTION
## Description:
Just fixing the header there was an uppercase O where it should've been lowercase 😄 

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
