### PR TITLE
Added hints about repetition of signals

### DIFF
--- a/components/remote_transmitter.rst
+++ b/components/remote_transmitter.rst
@@ -898,6 +898,10 @@ earlier, create a new template switch that sends the RF code when triggered:
           - remote_transmitter.transmit_rc_switch_raw:
               code: '100010000000000010111110'
               protocol: 2
+              repeat: 
+                times: 10
+                wait_time: 0s
+
 
     # Or for raw code
     switch:
@@ -911,6 +915,12 @@ earlier, create a new template switch that sends the RF code when triggered:
 
 Recompile again, when you power up the device the next time you will see a new switch
 in the frontend. Click on it and you should see the remote signal being transmitted. Done!
+
+.. note::
+
+Some devices require that the transmitted code be repeated for the signal to be picked up as valid. 
+Also the interval between repetitions can be important. You can adjust the `repeat:` settings 
+accordingly.
 
 See Also
 --------

--- a/components/remote_transmitter.rst
+++ b/components/remote_transmitter.rst
@@ -918,9 +918,12 @@ in the frontend. Click on it and you should see the remote signal being transmit
 
 .. note::
 
-Some devices require that the transmitted code be repeated for the signal to be picked up as valid. 
-Also the interval between repetitions can be important. You can adjust the `repeat:` settings 
-accordingly.
+    Some devices require that the transmitted code be repeated for the signal to be picked up 
+    as valid. Also the interval between repetitions can be important. Check that the pace of 
+    repetition logs are consistent between the remote controller and the transmitter node. 
+    You can adjust the ``repeat:`` settings accordingly.
+
+
 
 See Also
 --------


### PR DESCRIPTION
## Description:

While working on setting up me 433-power-outlets, I was easily getting them to work with plain Arduino-studio code using rc-switch library and examples. I was happy to see ESPHome uses the same library, but had problems getting this to work, since the standard RCSwitch.send doesn't match remote_transmitter behavior.
Finally this was due to the repetitions. This PR builds on an earlier PR, that was not merged. I tried to include OttoWinters original suggestions while keeping the documentation short and clear.
I hope this PR would help future users, since I saw the issue with the repetitions and wait_time on several forum posts.

Let me know what you think and if there is anything I could improve :)

**Related issue (if applicable):** fixes or updates PR https://github.com/esphome/esphome-docs/pull/290

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ x ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
