### PR TITLE
Added missing indentation in example RP2040 PIO LED Strip

### DIFF
--- a/components/light/rp2040_pio_led_strip.rst
+++ b/components/light/rp2040_pio_led_strip.rst
@@ -10,7 +10,7 @@ This is a component using the RP2040 PIO peripheral to drive most addressable LE
 .. code-block:: yaml
 
     light:
-  - platform: rp2040_pio_led_strip
+      - platform: rp2040_pio_led_strip
         name: led_strip
         id: led_strip
         pin: GPIO13


### PR DESCRIPTION
## Description:

Currently there is an indentation missing in the example.

![image](https://github.com/esphome/esphome-docs/assets/33957974/d242021c-d5cb-46d0-9d85-683869533351)

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
