### PR TITLE
ili9xxx: add list of models on top of the document. 

### DIFF
--- a/components/display/ili9xxx.rst
+++ b/components/display/ili9xxx.rst
@@ -11,8 +11,17 @@ ILI9xxx TFT LCD Series
 Models
 ------
 With this display driver you can control the following displays:
-  - ``M5STACK``, ``TFT 2.4``, ``TFT 2.4R``, ``S3BOX``, ``S3BOX_LITE``
-  - ``ILI9341``, ``ILI9342``, ``ILI9481``, ``ILI9486``, ``ILI9488``, ``ST7796``
+  - ILI9341
+  - ILI9342
+  - ILI9481
+  - ILI9486
+  - ILI9488
+  - M5STACK
+  - S3BOX
+  - S3BOX_LITE
+  - ST7796
+  - TFT 2.4
+  - TFT 2.4R
 
 More display drivers will come in the future.
 

--- a/components/display/ili9xxx.rst
+++ b/components/display/ili9xxx.rst
@@ -3,10 +3,18 @@ ILI9xxx TFT LCD Series
 ======================
 
 .. seo::
-    :description: Instructions for setting up ILI9xxx TFT LCD display drivers.
+    :description: Instructions for setting up ILI9xxx like TFT LCD display drivers.
     :image: ili9341.jpg
 
 .. _ili9xxx:
+
+Models
+------
+With this display driver you can control the following displays:
+  - ``M5STACK``, ``TFT 2.4``, ``TFT 2.4R``, ``S3BOX``, ``S3BOX_LITE``
+  - ``ILI9341``, ``ILI9342``, ``ILI9481``, ``ILI9486``, ``ILI9488``, ``ST7796``
+
+More display drivers will come in the future.
 
 Usage
 -----

--- a/index.rst
+++ b/index.rst
@@ -609,6 +609,7 @@ Display Components
     ST7735, components/display/st7735, st7735.jpg
     ST7789V, components/display/st7789v, st7789v.jpg
     ST7920, components/display/st7920, st7920.jpg
+    ILI9xxx, components/display/ili9xxx, ili9341.jpg
     ILI9341, components/display/ili9xxx, ili9341.jpg
     ILI9342, components/display/ili9xxx, ili9341.jpg
     ILI9481, components/display/ili9xxx, ili9341.jpg 

--- a/index.rst
+++ b/index.rst
@@ -609,7 +609,13 @@ Display Components
     ST7735, components/display/st7735, st7735.jpg
     ST7789V, components/display/st7789v, st7789v.jpg
     ST7920, components/display/st7920, st7920.jpg
-    ILI9xxx, components/display/ili9xxx, ili9341.jpg
+    ILI9341, components/display/ili9xxx, ili9341.jpg
+    ILI9342, components/display/ili9xxx, ili9341.jpg
+    ILI9481, components/display/ili9xxx, ili9341.jpg 
+    ILI9486, components/display/ili9xxx, ili9341.jpg 
+    ILI9488, components/display/ili9xxx, ili9341.jpg 
+    ST7796, components/display/ili9xxx, ili9341.jpg
+
     Waveshare E-Paper, components/display/waveshare_epaper, waveshare_epaper.jpg
     Inkplate, components/display/inkplate6, inkplate6.jpg
     PCD8544 (Nokia 5110/ 3310), components/display/pcd8544, pcd8544.jpg

--- a/index.rst
+++ b/index.rst
@@ -616,6 +616,11 @@ Display Components
     ILI9486, components/display/ili9xxx, ili9341.jpg 
     ILI9488, components/display/ili9xxx, ili9341.jpg 
     ST7796, components/display/ili9xxx, ili9341.jpg
+    M5STACK, components/display/ili9xxx, ili9341.jpg
+    TFT 2.4, components/display/ili9xxx, ili9341.jpg
+    TFT 2.4R, components/display/ili9xxx, ili9341.jpg
+    S3BOX, components/display/ili9xxx, ili9341.jpg
+    S3BOX_LITE, components/display/ili9xxx, ili9341.jpg
 
     Waveshare E-Paper, components/display/waveshare_epaper, waveshare_epaper.jpg
     Inkplate, components/display/inkplate6, inkplate6.jpg

--- a/index.rst
+++ b/index.rst
@@ -616,11 +616,6 @@ Display Components
     ILI9486, components/display/ili9xxx, ili9341.jpg 
     ILI9488, components/display/ili9xxx, ili9341.jpg 
     ST7796, components/display/ili9xxx, ili9341.jpg
-    M5STACK, components/display/ili9xxx, ili9341.jpg
-    TFT 2.4, components/display/ili9xxx, ili9341.jpg
-    TFT 2.4R, components/display/ili9xxx, ili9341.jpg
-    S3BOX, components/display/ili9xxx, ili9341.jpg
-    S3BOX_LITE, components/display/ili9xxx, ili9341.jpg
 
     Waveshare E-Paper, components/display/waveshare_epaper, waveshare_epaper.jpg
     Inkplate, components/display/inkplate6, inkplate6.jpg


### PR DESCRIPTION
Pleasing the list of allowed display models on top of the page. As suggested on the discord #documention channel.

## Description:
add list of models on top of the document. 

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
