### PR TITLE
Fix typo

### DIFF
--- a/components/uart.rst
+++ b/components/uart.rst
@@ -82,7 +82,7 @@ use ``tx_pin: GPIO2``. Any other combination of pins will result in use of a sof
 
 .. note::
 
-    The the Software UART is only available on the ESP8266. It is not available on ESP32 and variants.
+    The Software UART is only available on the ESP8266. It is not available on ESP32 and variants.
 
 .. _uart-write_action:
 


### PR DESCRIPTION
## Description:

Fix very minor typo in the documentation

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
