### PR TITLE
docs: fix typoed default port in migrate_sonoff_tasmota.rst

### DIFF
--- a/guides/migrate_sonoff_tasmota.rst
+++ b/guides/migrate_sonoff_tasmota.rst
@@ -99,10 +99,10 @@ You may also use Tasmota console to invoke the upgrade with just two commands:
 
 :: 
 
-  OtaUrl http://<MY-ESPHOME:6502>/download.bin?configuration=<MY_DEVICE>.yaml&type=firmware-factory.bin&compressed=1
+  OtaUrl http://<MY-ESPHOME:6052>/download.bin?configuration=<MY_DEVICE>.yaml&type=firmware-factory.bin&compressed=1
   Upgrade 1
 
-replacing ``http://<MY-ESPHOME:6502>/`` with the host and port of your ESPHome installation and ``<MY_DEVICE>.yaml``
+replacing ``http://<MY-ESPHOME:6052>/`` with the host and port of your ESPHome installation and ``<MY_DEVICE>.yaml``
 with your device configuration file name.
 
 If you need to use the uncompressed image for any reason, just remove ``&compressed=1`` from the above url.


### PR DESCRIPTION
The port listed in the docs was 6502, while the default port is actually 6052. See https://esphome.io/guides/getting_started_command_line.html#bonus-esphome-dashboard

## Description:

I found a typo in the docs and I'd like to fix it. See above.

**Related issue (if applicable):** fixes na
**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** na

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
