### PR TITLE
Mention how to disable MQTT logging

### DIFF
--- a/components/mqtt.rst
+++ b/components/mqtt.rst
@@ -63,7 +63,7 @@ Configuration variables:
   messages. Should not contain trailing slash. Defaults to
   ``<APP_NAME>``.
 - **log_topic** (*Optional*, :ref:`mqtt-message`): The topic to send MQTT log
-  messages to.
+  messages to. Use `null` if you want to disable sending logs to MQTT.
 
   The ``log_topic`` has an additional configuration option:
 


### PR DESCRIPTION
Explicitly say how to disable logging to MQTT, as mentioned in https://github.com/esphome/issues/issues/3047#issuecomment-1040758180

## Description:
1-sentence mention of how to disable logging to MQTT, to help minimize MQTT traffic.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
