### PR TITLE
Add 12MHz option to canbus docs.

### DIFF
--- a/components/canbus.rst
+++ b/components/canbus.rst
@@ -259,7 +259,7 @@ Configuration variables:
 - **cs_pin** (**Required**, :ref:`Pin Schema <config-pin_schema>`): Is used to tell the receiving SPI device
   when it should listen for data on the SPI bus. Each device has an individual ``CS`` line.
   Sometimes also called ``SS``.
-- **clock** (*Optional*): One of ``8MHZ``, ``16MHZ`` or ``20MHZ``. Clock crystal used on the MCP2515 device.
+- **clock** (*Optional*): One of ``8MHZ``, ``12MHz``, ``16MHZ`` or ``20MHZ``. Clock crystal used on the MCP2515 device.
   Defaults to ``8MHZ``.
 - **mode** (*Optional*): Operation mode. Default to ``NORMAL``
 

--- a/components/canbus.rst
+++ b/components/canbus.rst
@@ -269,6 +269,10 @@ Configuration variables:
 
 - All other options from :ref:`Canbus <config-canbus>`.
 
+Note that not all combinations of clock and bitrate are supported. An unsupported
+combination will not be flagged at compile time, check the runtime log for a message like
+``Invalid frequency/bitrate combination`` if you suspect this is an issue.
+
 Wiring options
 **************
 


### PR DESCRIPTION
## Description:


**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#5089

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
