### PR TITLE
Fix caution and search style in dark mode

### DIFF
--- a/_static/custom.css
+++ b/_static/custom.css
@@ -331,8 +331,12 @@ div.body p, div.body dd, div.body li, div.body blockquote {
     border: 1px solid #808080;
   }
 
-  div.warning {
+  div.warning, div.caution {
     background-color: #5d1616;
+  }
+
+  dt:target, span.highlighted {
+    background-color: #8e8129;
   }
 
 }


### PR DESCRIPTION
## Description:

Fix caution and search style in dark mode

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
