### PR TITLE
Update sps30.rst to include i2c sample

### DIFF
--- a/components/sensor/sps30.rst
+++ b/components/sensor/sps30.rst
@@ -19,6 +19,8 @@ This sensor supports both UART and I²C communication. However, at the moment on
 .. code-block:: yaml
 
     # Example configuration entry
+    i2c:
+
     sensor:
       - platform: sps30
         pm_1_0:


### PR DESCRIPTION
## Description:
Cannot use the example as it was as you must include i2c too.

## Checklist:

  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.
