### PR TITLE
ESP-IDF SPI LED strip (APA102/SK9822)

### DIFF
--- a/components/light/esp32_spi_led_strip.rst
+++ b/components/light/esp32_spi_led_strip.rst
@@ -1,0 +1,52 @@
+ESP32 SPI LED Strip
+===================
+
+.. seo::
+    :description: Instructions for setting up addressable lights like FASTLED on an ESP32 using the SPI bus.
+    :image: color_lens.svg
+
+This is a component using the ESP32 SPI bus to drive some addressable LED strips.
+
+.. code-block:: yaml
+
+    light:
+      - platform: esp32_spi_led_strip
+        name: "My Light"
+        data_pin: GPIO40
+        clock_pin: GPIO39
+        num_leds: 1
+        rgb_order: RGB
+        max_refresh_rate: 50us
+
+Configuration variables
+-----------------------
+
+- **data_pin** (**Required**, :ref:`config-pin`): The pin for the data line of the light.
+- **clock_pin** (**Required**, :ref:`config-pin`): The pin for the clock line of the light.
+- **num_leds** (**Required**, int): The number of LEDs in the strip.
+- **rgb_order** (**Optional**, string): The RGB order of the strip. Default: RGB
+    - ``RGB``
+    - ``RBG``
+    - ``GRB``
+    - ``GBR``
+    - ``BGR``
+    - ``BRG``
+- **max_refresh_rate** (*Optional*, :ref:`config-time`):
+  A time interval used to limit the number of commands a light can handle per second. For example
+  16ms will limit the light to a refresh rate of about 60Hz. Defaults to sending commands as quickly as
+  changes are made to the lights.
+
+
+Supported Chipsets
+******************
+
+- ``APA102``
+- ``SK9822``
+
+See Also
+--------
+
+- :doc:`/components/light/index`
+- :doc:`/components/power_supply`
+- :apiref:`esp32_spi_led_strip/led_strip.h`
+- :ghedit:`Edit`

--- a/components/light/fastled.rst
+++ b/components/light/fastled.rst
@@ -24,7 +24,7 @@ FastLED Light
 
     FastLED does **not** work with ESP-IDF.
 
-    For addressable lights, you can use :doc:`esp32_rmt_led_strip`.
+    For addressable lights, you can use :doc:`esp32_rmt_led_strip` or :doc:`esp32_spi_led_strip`.
 
 .. _fastled-clockless:
 

--- a/components/light/neopixelbus.rst
+++ b/components/light/neopixelbus.rst
@@ -9,7 +9,7 @@ NeoPixelBus Light
 
     NeoPixelBus does **not** work with ESP-IDF.
 
-    For addressable lights, you can use :doc:`esp32_rmt_led_strip`.
+    For addressable lights, you can use :doc:`esp32_rmt_led_strip` or :doc:`esp32_spi_led_strip`.
 
 The ``neopixelbus`` light platform allows you to create RGB lights
 in ESPHome for an individually addressable lights like NeoPixel or WS2812.

--- a/index.rst
+++ b/index.rst
@@ -533,6 +533,7 @@ Light Components
     RGBCT Light, components/light/rgbct, rgbw.png
 
     ESP32 RMT, components/light/esp32_rmt_led_strip, color_lens.svg, dark-invert
+    ESP32 SPI, components/light/esp32_spi_led_strip, color_lens.svg, dark-invert
     RP2040 PIO, components/light/rp2040_pio_led_strip, color_lens.svg, dark-invert
     FastLED Light, components/light/fastled, color_lens.svg, dark-invert
     NeoPixelBus Light, components/light/neopixelbus, color_lens.svg, dark-invert


### PR DESCRIPTION
## Description:

This is the documentation for ESP32 SPI LED Strip component.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#5101

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
