### PR TITLE
Remove restore_state from template switch

### DIFF
--- a/components/switch/template.rst
+++ b/components/switch/template.rst
@@ -43,8 +43,6 @@ Configuration variables:
   be performed when the remote (like Home Assistant's frontend) requests the switch to be turned on.
 - **turn_off_action** (*Optional*, :ref:`Action <config-action>`): The action that should
   be performed when the remote (like Home Assistant's frontend) requests the switch to be turned off.
-- **restore_state** (*Optional*, boolean): Sets whether ESPHome should attempt to restore the
-  state on boot-up and call the turn on/off actions with the recovered values. Defaults to ``no``.
 - **optimistic** (*Optional*, boolean): Whether to operate in optimistic mode - when in this mode,
   any command sent to the template switch will immediately update the reported state.
   Defaults to ``false``.


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#5106

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
