### PR TITLE
Tuya number scaling

### DIFF
--- a/components/number/tuya.rst
+++ b/components/number/tuya.rst
@@ -53,6 +53,7 @@ The value for ``step`` is used as the scaling factor for the Number. All numbers
 For instance, assume we have a pH sensor that reads from 0.00 to 15.00 with a scaling of 0.01. By setting `step` to 0.01, on the Tuya side (not visible to the user) the number will be reported as an integer from 0 to 1500. The following configuration could be used:
 
 .. code-block:: yaml
+
     - platform: "tuya"
       name: "pH Sensor"
       number_datapoint: 106

--- a/components/number/tuya.rst
+++ b/components/number/tuya.rst
@@ -48,6 +48,18 @@ Based on this, you can create a number as follows:
       max_value: 2
       step: 1
 
+The value for ``step`` is used as the scaling factor for the Number. All numbers in Tuya are integers, so a scaling factor is sometimes needed to convert the Tuya reported value into floating point.
+
+For instance, assume we have a pH sensor that reads from 0.00 to 15.00 with a scaling of 0.01. By setting `step` to 0.01, on the Tuya side (not visible to the user) the number will be reported as an integer from 0 to 1500. The following configuration could be used:
+
+.. code-block:: yaml
+    - platform: "tuya"
+      name: "pH Sensor"
+      number_datapoint: 106
+      min_value: 0.00
+      max_value: 15.00
+      step: 0.01
+
 Configuration variables:
 ------------------------
 


### PR DESCRIPTION
## Description:

In the Tuya ecosystem, all numeric datapoints are integers. Therefore, if the value needs to include floating point precision, the value has a scaling factor applied. For example, a pH reading from 0.00 to 15.00 is reported as integers from 0 to 1500 with a scaling of 0.01 applied.

Currently in ESPHome the Tuya Number component has no support for scaling. However, this concept is effectively already built into the Number component with the Step parameter capturing the intent.

This PR changes the behavior of Tuya Number to use the Step parameter as the scaling for the displayed number.

**Related issue (if applicable):** fixes esphome/issues#4309

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#5108

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
