### PR TITLE
Update automations.rst doc page

### DIFF
--- a/guides/automations.rst
+++ b/guides/automations.rst
@@ -287,7 +287,7 @@ global variables can be used to store the state of a garage door.
              id(my_global_int) += 10;
            }
 
-           ESP_LOGD(TAG, "%s: %d", id(my_global_string), id(my_global_int));
+           ESP_LOGD(TAG, "%s: %d", id(my_global_string).c_str(), id(my_global_int));
 
 Configuration variables:
 


### PR DESCRIPTION
## Description:

Fixed mistake in documentation on Automations and Templates page. 
Added .c_str() for string output in logger example.  On line 290, changed:

ESP_LOGD(TAG, "%s: %d", id(my_global_string), id(my_global_int));

to:

ESP_LOGD(TAG, "%s: %d", id(my_global_string).c_str(), id(my_global_int));

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
