### PR TITLE
Add block about component operation warning to changelog

### DIFF
--- a/changelog/2023.7.0.rst
+++ b/changelog/2023.7.0.rst
@@ -32,6 +32,22 @@ This release adds a few changes to the display core code to optimise and allow f
 improvements which are already in progress. This also may bring breaking changes to the internal APIs that ``external_components``
 may be relying on.
 
+A new warning in the logs
+-------------------------
+
+.. code:: text
+
+    [00:00:00][W][component:204]: Component xxxxxx took a long time for an operation (x.xx s).
+    [00:00:00][W][component:205]: Components should block for at most 20-30ms.
+
+
+These 2 log lines may show up in the most recent version of ESPHome due to the log level being changed from `verbose` to `warning`.
+I made this change because changing the device log level to verbose just to see if these lines show up significantly slowed down
+the device due to all the extra logging it had to do.
+
+Please do not report new issues for this, but `comment on this issue <https://github.com/esphome/issues/issues/4714>`__
+if someone has not already commented for that specific component.
+
 
 Full list of changes
 --------------------


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
