### PR TITLE
Small Improvements to FS3000 Documentation

### DIFF
--- a/components/sensor/fs3000.rst
+++ b/components/sensor/fs3000.rst
@@ -16,9 +16,9 @@ sensors with ESPHome.
     :width: 30.0%
 
     FS3000 Air Velocity Sensor.
-    (Credit: `Sparkfun <https://www.sparkfun.com/products/18377>`__, image compressed)
+    (Credit: `SparkFun <https://www.sparkfun.com/products/18377>`__, image compressed)
 
-.. _Sparkfun: https://www.sparkfun.com/products/15805
+.. _SparkFun: https://www.sparkfun.com/products/18377
 
 The FS3000 is a solid state air velocity sensor that communicates over over I²C. It is based on a MEMS thermopile sensor. There are two subtypes available: the FS3000-1005 measures air velocities between 0 meters/second and 7.23 meters/second, and the FS3000-1015 measures air velocities between 0 meters/second and 15 meters/second.
 
@@ -44,4 +44,7 @@ Configuration variables:
 See Also
 --------
 
+- :ref:`sensor-filters`
+- :apiref:`fs3000/fs3000.h`
+- `SparkFun FS3000 Library <https://github.com/sparkfun/SparkFun_FS3000_Arduino_Library>`__ by `SparkFun <https://www.sparkfun.com/>`__
 - :ghedit:`Edit`


### PR DESCRIPTION
## Description:

This fixes a link in the FS3000 Sensor documentation. It also adds links to sensor filters, the API reference, and SparkFun's library implementation to the See Also section.

**Related issue (if applicable):** not applicable

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** not applicable

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
