### PR TITLE
Fix typo

### DIFF
--- a/components/light/index.rst
+++ b/components/light/index.rst
@@ -908,7 +908,7 @@ Available variables in the lambda:
               // stopping and starting the effect again
               static uint16_t progress = 0;
 
-              // normal variables lost their value after each
+              // normal variables lose their value after each
               // execution - basically after each update_interval
               uint16_t changes = 0;
 


### PR DESCRIPTION
## Description:

This fixes a typo in a comment in a lambda example.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
