### PR TITLE
Update FAQ to speifically mention OpenWrt and pfSense for mDNS

### DIFF
--- a/guides/faq.rst
+++ b/guides/faq.rst
@@ -369,11 +369,11 @@ And a docker compose file looks like this:
     to have the online/offline stat (see below)
 
     mDNS might not work if your Home Assistant server and your ESPHome nodes are on different subnets.
-    If your router supports Avahi, you are able to get mDNS working over different subnets.
+    If your router supports Avahi (or you use OpenWrt or pfSense), you are able to get mDNS working over different subnets.
 
     Just follow the next steps:
 
-    1. Enable Avahi on both subnets.
+    1. Enable Avahi on both subnets (install Avahi modules on OpenWrt or pfSense).
     2. Enable UDP traffic from ESPHome node's subnet to 224.0.0.251/32 on port 5353.
 
     Alternatively, you can make esphome use ICMP pings to check the status of the device

--- a/guides/faq.rst
+++ b/guides/faq.rst
@@ -361,19 +361,16 @@ And a docker compose file looks like this:
 .. _docker-reference-notes:
 .. note::
 
-    By default ESPHome uses mDNS to show online/offline state in the dashboard view. So for that feature
-    to work you need to enable host networking mode
+    By default ESPHome uses mDNS to show online/offline state in the dashboard view. So for that feature to work you need to enable host networking mode. 
 
     On MacOS the networking mode ("-net=host" option) doesn't work as expected. You have to use
     another way to launch the dashboard with a port mapping option and use alternative to mDNS
     to have the online/offline stat (see below)
 
     mDNS might not work if your Home Assistant server and your ESPHome nodes are on different subnets.
-    If your router supports Avahi (or you use OpenWrt or pfSense), you are able to get mDNS working over different subnets.
+    If your router supports Avahi (eg. OpenWRT or pfSense), you are able to get mDNS working over different subnets following the steps below:
 
-    Just follow the next steps:
-
-    1. Enable Avahi on both subnets (install Avahi modules on OpenWrt or pfSense).
+    1. Enable Avahi on both subnets (install Avahi modules on OpenWRT or pfSense).
     2. Enable UDP traffic from ESPHome node's subnet to 224.0.0.251/32 on port 5353.
 
     Alternatively, you can make esphome use ICMP pings to check the status of the device


### PR DESCRIPTION
## Description:
Add a specific reference to OpenWrt and pfSense to fix mDNS across subnets so when searching for either term, the FAQ should appear and point the user in the direction of adding the Avahi module and enabling it (plenty of detailed instructions available).

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
