### PR TITLE
Added more configuration examples

### DIFF
--- a/components/ethernet.rst
+++ b/components/ethernet.rst
@@ -215,12 +215,12 @@ Configuration examples
 
 .. code-block:: yaml
 
-  ethernet:
-    type: LAN8720
-    mdc_pin: GPIO23
-    mdio_pin: GPIO18
-    clk_mode: GPIO17_OUT
-    phy_addr: 1
+    ethernet:
+      type: LAN8720
+      mdc_pin: GPIO23
+      mdio_pin: GPIO18
+      clk_mode: GPIO17_OUT
+      phy_addr: 1
 
 
 

--- a/components/ethernet.rst
+++ b/components/ethernet.rst
@@ -214,6 +214,7 @@ Configuration examples
 **Esp32-Stick-Eth** and **Esp32-Stick-PoE-P** and **Esp32-Stick-PoE-A**:
 
 .. code-block:: yaml
+
   ethernet:
     type: LAN8720
     mdc_pin: GPIO23

--- a/components/ethernet.rst
+++ b/components/ethernet.rst
@@ -193,6 +193,7 @@ Configuration examples
 
     Revision 5 and below of the wESP32 board use the LAN8720 Ethernet PHY. Revision 7 and newer of it use the RTL8201 Ethernet PHY. Support for RTL8201 is available from ESPHome version 2022.12 upwards.
 
+
 **OpenHacks LAN8720**:
 
 .. code-block:: yaml
@@ -208,6 +209,17 @@ Configuration examples
     This board has an issue that might cause the ESP32 to boot in program mode. When testing, make sure
     you are monitoring the serial output and reboot the device several times to see if it boots into the
     program properly.
+
+
+**Esp32-Stick-Eth** and **Esp32-Stick-PoE-P** and **Esp32-Stick-PoE-A**:
+
+.. code-block:: yaml
+  ethernet:
+    type: LAN8720
+    mdc_pin: GPIO23
+    mdio_pin: GPIO18
+    clk_mode: GPIO17_OUT
+    phy_addr: 1
 
 
 


### PR DESCRIPTION
Added configuration examples for ESP32-Stick Boards (Esp32-Stick-Eth, Esp32-Stick-PoE-P, Esp32-Stick-PoE-A)

## Description:
Added Ethernet configuration examples for newly released ethernet-enabled boards:
kickstarter.com/projects/esp32-stick/esp32-stick-boards

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
