### PR TITLE
Allow components to be internal with respect to publishing via MQTT

### DIFF
--- a/components/mqtt.rst
+++ b/components/mqtt.rst
@@ -56,6 +56,10 @@ Configuration variables:
 - **discovery_object_id_generator** (*Optional*, string): The object_id generator
   to use. Can be one of ``none`` or ``device_name``. Defaults to ``none`` which
   does not generate object_id. ``device_name`` generator uses format ``<device_name>_<friendly_name>``.
+- **internal_mqtt_default** (*Optional*, enum): The default behavior for entities to be internal with respect to 
+  publishing via MQTT. Can be one of ``copy``, which follows the entity's regular ``internal`` setting; 
+  ``internal``, where entities by default do not publish their state over MQTT; or ``external``, where 
+  entities by default publish their state over MQTT. Defaults to ``copy``.
 - **use_abbreviations** (*Optional*, boolean): Whether to use
   `Abbreviations <https://www.home-assistant.io/docs/mqtt/discovery/>`__
   in discovery messages. Defaults to ``true``.
@@ -367,6 +371,10 @@ Configuration variables:
    be retained. Defaults to ``true``.
 -  **discovery** (*Optional*, boolean): Manually enable/disable
    discovery for a component. Defaults to the global default.
+-  **internal_mqtt** (*Optional*, boolean): Manually set whether the component is 
+   internal with respect to publishing via MQTT. Set to ``true`` to disable 
+   publishing over MQTT, and set to ``false`` to enable publishing over MQTT. If 
+   not configured, the component follows the global ``internal_mqtt_default`` setting.
 -  **availability** (*Optional*): Manually set what should be sent to
    Home Assistant for showing entity availability. Default derived from
    :ref:`global birth/last will message <mqtt-last_will_birth>`.


### PR DESCRIPTION
## Description:

When using the native API and MQTT, the ``internal`` setting makes no differentiation between the two. This PR documents the linked pull request which allows every MQTT component to be separately marked internal or not. If ``internal_mqtt`` is set to true, then the component will never publish its state via MQTT. If ``internal_mqtt`` is set to false, then the component will always publish its state via MQTT.

There is an additional configuration option for the base mqtt component called ``internal_mqtt_default``. If set to ``copy``, then all MQTT components will, by default, follow the regular ``internal`` setting. If set to ``internal``, all components, by default, do not publish their state via MQTT. If set to ``external``, all components, by default, publish their state via MQTT. Do note that setting the ``internal_mqtt`` on individual components overrides this default setting.

**Related issue (if applicable):** fixes esphome/feature-requests#375

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#5195
## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
