### PR TITLE
Add Documentation for "on_XXXX" triggers for alarm_control_panel component

### DIFF
--- a/components/alarm_control_panel/index.rst
+++ b/components/alarm_control_panel/index.rst
@@ -28,8 +28,20 @@ Configuration variables:
 
 - **on_state** (*Optional*, :ref:`Action <config-action>`): An automation to perform
   when the alarm changes state. See :ref:`alarm_control_panel_on_state_trigger`.
+- **on_arming** (*Optional*, :ref:`Action <config-action>`): An automation to perform
+  when the alarm state changes to `arming`. See :ref:`alarm_control_panel_on_arming_trigger`.
+- **on_pending** (*Optional*, :ref:`Action <config-action>`): An automation to perform
+  when the alarm state changes to `pending`. See :ref:`alarm_control_panel_on_pending_trigger`.
+- **on_armed_home** (*Optional*, :ref:`Action <config-action>`): An automation to perform
+  when the alarm state changes to `armed_home`. See :ref:`alarm_control_panel_on_armed_home_trigger`.
+- **on_armed_night** (*Optional*, :ref:`Action <config-action>`): An automation to perform
+  when the alarm state changes to `armed_night`. See :ref:`alarm_control_panel_on_armed_night_trigger`.
+- **on_armed_away** (*Optional*, :ref:`Action <config-action>`): An automation to perform
+  when the alarm state changes to `armed_away`. See :ref:`alarm_control_panel_on_armed_away_trigger`.
 - **on_triggered** (*Optional*, :ref:`Action <config-action>`): An automation to perform
   when the alarm triggers. See :ref:`alarm_control_panel_on_triggered_trigger`.
+- **on_disarmed** (*Optional*, :ref:`Action <config-action>`): An automation to perform
+  when the alarm state changes to `disarmed`. See :ref:`alarm_control_panel_on_disarmed_trigger`.
 - **on_cleared** (*Optional*, :ref:`Action <config-action>`): An automation to perform
   when the alarm clears. See :ref:`alarm_control_panel_on_cleared_trigger`.
 

--- a/components/alarm_control_panel/index.rst
+++ b/components/alarm_control_panel/index.rst
@@ -55,7 +55,7 @@ This trigger is activated each time the alarm changes state.
 .. _alarm_control_panel_on_pending_trigger:
 
 ``on_pending`` Trigger
-********************
+**********************
 
 This trigger is activated when the alarm changes to pending state.
 
@@ -70,7 +70,7 @@ This trigger is activated when the alarm changes to pending state.
 .. _alarm_control_panel_on_arming_trigger:
 
 ``on_arming`` Trigger
-********************
+*********************
 
 This trigger is activated when the alarm changes to arming state.
 
@@ -85,7 +85,7 @@ This trigger is activated when the alarm changes to arming state.
 .. _alarm_control_panel_on_armed_home_trigger:
 
 ``on_armed_home`` Trigger
-********************
+*************************
 
 This trigger is activated when the alarm changes to armed_home state.
 
@@ -100,7 +100,7 @@ This trigger is activated when the alarm changes to armed_home state.
 .. _alarm_control_panel_on_armed_night_trigger:
 
 ``on_armed_night`` Trigger
-********************
+**************************
 
 This trigger is activated when the alarm changes to armed_night state.
 
@@ -115,7 +115,7 @@ This trigger is activated when the alarm changes to armed_night state.
 .. _alarm_control_panel_on_armed_away_trigger:
 
 ``on_armed_away`` Trigger
-********************
+*************************
 
 This trigger is activated when the alarm changes to armed_away state.
 
@@ -160,7 +160,7 @@ This trigger is activated when the alarm changes from triggered back to either t
 .. _alarm_control_panel_on_disarmed_trigger:
 
 ``on_disarmed`` Trigger
-**********************
+***********************
 
 This trigger is activated when the alarm changes from to disarmed.
 

--- a/components/alarm_control_panel/index.rst
+++ b/components/alarm_control_panel/index.rst
@@ -52,6 +52,81 @@ This trigger is activated each time the alarm changes state.
         then:
           - logger.log: "Alarm Panel State Changed!"
 
+.. _alarm_control_panel_on_pending_trigger:
+
+``on_pending`` Trigger
+********************
+
+This trigger is activated when the alarm changes to pending state.
+
+.. code-block:: yaml
+
+    alarm_control_panel:
+      # ...
+      on_pending:
+        then:
+          - logger.log: "Alarm Pending!"
+
+.. _alarm_control_panel_on_arming_trigger:
+
+``on_arming`` Trigger
+********************
+
+This trigger is activated when the alarm changes to arming state.
+
+.. code-block:: yaml
+
+    alarm_control_panel:
+      # ...
+      on_arming:
+        then:
+          - logger.log: "Alarm Arming!"
+
+.. _alarm_control_panel_on_armed_home_trigger:
+
+``on_armed_home`` Trigger
+********************
+
+This trigger is activated when the alarm changes to armed_home state.
+
+.. code-block:: yaml
+
+    alarm_control_panel:
+      # ...
+      on_armed_home:
+        then:
+          - logger.log: "Alarm armed_home!"
+
+.. _alarm_control_panel_on_armed_night_trigger:
+
+``on_armed_night`` Trigger
+********************
+
+This trigger is activated when the alarm changes to armed_night state.
+
+.. code-block:: yaml
+
+    alarm_control_panel:
+      # ...
+      on_armed_night:
+        then:
+          - logger.log: "Alarm armed_night!"
+
+.. _alarm_control_panel_on_armed_away_trigger:
+
+``on_armed_away`` Trigger
+********************
+
+This trigger is activated when the alarm changes to armed_away state.
+
+.. code-block:: yaml
+
+    alarm_control_panel:
+      # ...
+      on_armed_away:
+        then:
+          - logger.log: "Alarm armed_away!"
+
 .. _alarm_control_panel_on_triggered_trigger:
 
 ``on_triggered`` Trigger
@@ -81,6 +156,21 @@ This trigger is activated when the alarm changes from triggered back to either t
       on_cleared:
         then:
           - logger.log: "Alarm Cleared!"
+
+.. _alarm_control_panel_on_disarmed_trigger:
+
+``on_disarmed`` Trigger
+**********************
+
+This trigger is activated when the alarm changes from to disarmed.
+
+.. code-block:: yaml
+
+    alarm_control_panel:
+      # ...
+      on_disarmed:
+        then:
+          - logger.log: "Alarm Disarmed!"
 
 .. _alarm_control_panel_arm_away_action:
 


### PR DESCRIPTION
- Add Documentation for `on_XXXX` triggers for alarm_conttrol_panel

## Description:



**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#5219

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
