### PR TITLE
Mode AUTO replaced with HEAT_COOL in documentation

### DIFF
--- a/components/climate/haier.rst
+++ b/components/climate/haier.rst
@@ -82,7 +82,7 @@ This component requires a :ref:`uart` to be setup.
           temperature_step: 1 °C
         supported_modes:
         - 'OFF'
-        - AUTO
+        - HEAT_COOL
         - COOL
         - HEAT
         - DRY
@@ -114,7 +114,7 @@ Configuration variables:
   - **name** (**Required**, string): The name of the sensor.
   - **id** (*Optional*, :ref:`config-id`): ID of the sensor, can be used for code generation
   - All other options from :ref:`Sensor <config-sensor>`.
-- **supported_modes** (*Optional*, list): Can be used to disable some of AC modes. Possible values: 'OFF', AUTO, COOL, HEAT, DRY, FAN_ONLY
+- **supported_modes** (*Optional*, list): Can be used to disable some of AC modes. Possible values: 'OFF', HEAT_COOL, COOL, HEAT, DRY, FAN_ONLY
 - **supported_swing_modes** (*Optional*, list): Can be used to disable some swing modes if your AC does not support it. Possible values: 'OFF', VERTICAL, HORIZONTAL, BOTH
 - **supported_presets** (*Optional*, list): Can be used to disable some presets. Possible values for smartair2 are: BOOST, COMFORT. Possible values for hOn are: ECO, BOOST, SLEEP
 - All other options from :ref:`Climate <config-climate>`.


### PR DESCRIPTION
## Description:
Replace in documentation mode AUTO for Haier climate with HEAT_COOL to reflect code changes.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
