### PR TITLE
Fix SN-GCJA5 markdown

### DIFF
--- a/components/sensor/gcja5.rst
+++ b/components/sensor/gcja5.rst
@@ -11,7 +11,7 @@ sensors with ESPHome.
 
 As the communication with the GCJA5 is done using UART, you need
 to have an :ref:`UART bus <uart>` in your configuration with the ``rx_pin`` connected to the SEND/TX. Additionally, you need to set the baud rate to 9600, and you
-MUST have `EVEN`` parity.
+MUST have ``EVEN`` parity.
 
 The sensor itself will push values every second. You may wish to :ref:`filter <sensor-filters>` this value to reduce the amount of data you are ingesting.
 The sensor will internally track changes to the Laser Diode and Photo Diode over time to adjust and ensure accuracy.


### PR DESCRIPTION
## Description:

Added a missing `` ` `` to the UART settings description for [Panasonic SN-GCJA5](https://esphome.io/components/sensor/gcja5.html).

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** N/A

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.

