### PR TITLE
Make hut21d sensors optional

### DIFF
--- a/components/sensor/htu21d.rst
+++ b/components/sensor/htu21d.rst
@@ -31,25 +31,18 @@ Example sensors:
     sensor:
       - platform: htu21d
         temperature:
-          name: "Living Room Temperature"
+          name: "Temperature"
         humidity:
-          name: "Living Room Humidity"
-        update_interval: 60s
+          name: "Humidity"
 
 Configuration variables:
 ------------------------
 
-- **temperature** (**Required**): The information for the temperature sensor.
+- **temperature** (*Optional*): The information for the temperature sensor.
+  All options from :ref:`Sensor <config-sensor>`.
 
-  - **name** (**Required**, string): The name for the temperature sensor.
-  - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.
-  - All other options from :ref:`Sensor <config-sensor>`.
-
-- **humidity** (**Required**): The information for the humidity sensor.
-
-  - **name** (**Required**, string): The name for the humidity sensor.
-  - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.
-  - All other options from :ref:`Sensor <config-sensor>`.
+- **humidity** (*Optional*): The information for the humidity sensor.
+  All options from :ref:`Sensor <config-sensor>`.
 
 - **update_interval** (*Optional*, :ref:`config-time`): The interval to check the sensor. Defaults to ``60s``.
 


### PR DESCRIPTION
## Description:
Sensors are now marked as optional and I have tidied up the configuration variables block.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#5285

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
