### PR TITLE
As3935 calibration

### DIFF
--- a/components/sensor/as3935.rst
+++ b/components/sensor/as3935.rst
@@ -99,14 +99,7 @@ Configuration variables:
   detection and distance sensing. It's possible to add up to 120pF in steps of 8pF to the antenna. Defaults to ``0``.
 - **watchdog_threshold** (*Optional*, int): Determines the threshold for events that trigger the IRQ pin.
   Defaults to ``2``.
-- **tune_antenna** (*Optional*, boolean): Start sensor in antenna tuning mode. It will emit oscillator
-  frequency to be read on the INT pin. Please follow AS3935 documentation. Note that while this mode is enabled,
-  lightings will not be detected. It should be used for initial calibration only, in order to determine correct value of
-  ``capacitance`` and/or ``div_ratio`` parameters.
-  Defaults to ``False``.
-- **calibration** (*Optional*, boolean): Enable/disable oscillator calibration on startup. It is recommended to perform
-  antenna tuning procedure first and adjust parameters, so that RLC antenna resonance is tuned within optimal range.
-  Defaults to ``True``.
+
 
 Over I²C
 --------
@@ -159,14 +152,7 @@ Configuration variables:
   detection and distance sensing. It's possible to add up to 120pF in steps of 8pF to the antenna. Defaults to ``0``.
 - **watchdog_threshold** (*Optional*, int): Determines the threshold for events that trigger the IRQ pin.
   Defaults to ``2``.
-**tune_antenna** (*Optional*, boolean): Start sensor in antenna tuning mode. It will emit oscillator
-  frequency to be read on the INT pin. Please follow AS3935 documentation. Note that while this mode is enabled,
-  lightings will not be detected. It should be used for initial calibration only, in order to determine correct value of
-  ``capacitance`` and/or ``div_ratio`` parameters.
-  Defaults to ``False``.
-- **calibration** (*Optional*, boolean): Enable/disable oscillator calibration on startup. It is recommended to perform
-  antenna tuning procedure first and adjust parameters, so that RLC antenna resonance is tuned within optimal range.
-  Defaults to ``True``.
+
 
 Sensor
 ------

--- a/components/sensor/as3935.rst
+++ b/components/sensor/as3935.rst
@@ -99,7 +99,14 @@ Configuration variables:
   detection and distance sensing. It's possible to add up to 120pF in steps of 8pF to the antenna. Defaults to ``0``.
 - **watchdog_threshold** (*Optional*, int): Determines the threshold for events that trigger the IRQ pin.
   Defaults to ``2``.
-
+- **tune_antenna** (*Optional*, boolean): Start sensor in antenna tuning mode. It will emit oscillator
+  frequency to be read on the INT pin. Please follow AS3935 documentation. Note that while this mode is enabled,
+  lightings will not be detected. It should be used for initial calibration only, in order to determine correct value of
+  ``capacitance`` and/or ``div_ratio`` parameters.
+  Defaults to ``False``.
+- **calibration** (*Optional*, boolean): Enable/disable oscillator calibration on startup. It is recommended to perform
+  antenna tuning procedure first and adjust parameters, so that RLC antenna resonance is tuned within optimal range.
+  Defaults to ``True``.
 
 Over I²C
 --------
@@ -152,7 +159,14 @@ Configuration variables:
   detection and distance sensing. It's possible to add up to 120pF in steps of 8pF to the antenna. Defaults to ``0``.
 - **watchdog_threshold** (*Optional*, int): Determines the threshold for events that trigger the IRQ pin.
   Defaults to ``2``.
-
+**tune_antenna** (*Optional*, boolean): Start sensor in antenna tuning mode. It will emit oscillator
+  frequency to be read on the INT pin. Please follow AS3935 documentation. Note that while this mode is enabled,
+  lightings will not be detected. It should be used for initial calibration only, in order to determine correct value of
+  ``capacitance`` and/or ``div_ratio`` parameters.
+  Defaults to ``False``.
+- **calibration** (*Optional*, boolean): Enable/disable oscillator calibration on startup. It is recommended to perform
+  antenna tuning procedure first and adjust parameters, so that RLC antenna resonance is tuned within optimal range.
+  Defaults to ``True``.
 
 Sensor
 ------

--- a/components/sensor/as3935.rst
+++ b/components/sensor/as3935.rst
@@ -159,7 +159,7 @@ Configuration variables:
   detection and distance sensing. It's possible to add up to 120pF in steps of 8pF to the antenna. Defaults to ``0``.
 - **watchdog_threshold** (*Optional*, int): Determines the threshold for events that trigger the IRQ pin.
   Defaults to ``2``.
-**tune_antenna** (*Optional*, boolean): Start sensor in antenna tuning mode. It will emit oscillator
+- **tune_antenna** (*Optional*, boolean): Start sensor in antenna tuning mode. It will emit oscillator
   frequency to be read on the INT pin. Please follow AS3935 documentation. Note that while this mode is enabled,
   lightings will not be detected. It should be used for initial calibration only, in order to determine correct value of
   ``capacitance`` and/or ``div_ratio`` parameters.


### PR DESCRIPTION
## Description:

Add documentation for proposed new configuration directives to enable antenna tuning and calibration for AS3935 (lightning detector)

https://github.com/esphome/esphome/pull/5366

## Checklist:

  - [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
