### PR TITLE
Correcting battery level UOM and adding "See Also" section

### DIFF
--- a/components/sensor/airthings_ble.rst
+++ b/components/sensor/airthings_ble.rst
@@ -154,7 +154,7 @@ the AirThings mobile app.
       - platform: copy
         source_id: bv
         name: "WaveMini Battery Level"
-        unit_of_measurement: percent
+        unit_of_measurement: "%"
         device_class: battery
         accuracy_decimals: 0
         filters:
@@ -173,10 +173,16 @@ the AirThings mobile app.
       - platform: copy
         source_id: bv
         name: "WavePlus Battery Level"
-        unit_of_measurement: percent
+        unit_of_measurement: "%"
         device_class: battery
         accuracy_decimals: 0
         filters:
           - calibrate_linear:
             - 2.2 -> 0
             - 3.1 -> 100
+
+See Also
+--------
+
+- :doc:`/components/esp32_ble_tracker`
+- :ghedit:`Edit`


### PR DESCRIPTION
## Description:
Current docs list "percent" as battery level UOM when HA uses "%" to indicate percentage. Also adding the "See Also" section that has the "Edit on GitHub" link since it was missing. Included the BLE Tracker section, as well, since it seemed relevant.

**Related issue (if applicable):** fixes <link to issue>
See Description

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>
Not applicable

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
