### PR TITLE
Update esphome.rst docs for ESPHOME_BUILD_PATH environment variable

### DIFF
--- a/components/esphome.rst
+++ b/components/esphome.rst
@@ -37,8 +37,9 @@ Advanced options:
 
 - **build_path** (*Optional*, string): Customize where ESPHome will store the build files
   for your node. By default, ESPHome puts the PlatformIO project it uses to build the
-  firmware in the ``.esphome/build/<NODE>`` directory, but you can customize this
-  behavior using this option.
+  firmware in the ``.esphome/build/<NODE>`` (or into path from ``ESPHOME_BUILD_PATH`` environment variable if specified) directory,
+  but you can customize this behavior using this option. Official docker image automatically use `/build` folder
+  as default one in case it is mounted to it.
 - **platformio_options** (*Optional*, mapping): Additional options to pass over to PlatformIO in the
   platformio.ini file. See :ref:`esphome-platformio_options`.
 - **includes** (*Optional*, list of files): A list of C/C++ files to include in the main (auto-generated) sketch file


### PR DESCRIPTION
## Description:

Information about using `ESPHOME_BUILD_PATH` environment variable

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#5387

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
