### PR TITLE
extend clamp sensor description

### DIFF
--- a/components/sensor/index.rst
+++ b/components/sensor/index.rst
@@ -262,8 +262,7 @@ degree with a least squares solver.
 ``clamp``
 *********
 
-Limits the value to the range between ``min_value`` and ``max_value``. If ``min_value`` is not set, there is
-no lower bound, if ``max_value`` is not set there is no upper bound.
+Limits the value to the range between ``min_value`` and ``max_value``. Sensor values outside these bounds will be set to ``min_value`` or ``max_value``, respectively. If ``min_value`` is not set, there is no lower bound, if ``max_value`` is not set there is no upper bound.
 
 Configuration variables:
 


### PR DESCRIPTION
## Description:
slight addition to clamp sensor filter documentation to make it clear that values outside the range are not filtered away but rather set to min_value/max_value.

**Related issue (if applicable):** fixes <link to issue>
n/a

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#
n/a

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
