### PR TITLE
Remove enable_ipv6 restricted to ESP32 with ESP-IDF

### DIFF
--- a/components/network.rst
+++ b/components/network.rst
@@ -18,7 +18,7 @@ networks (WiFi, Ethernet).
 Configuration variables:
 ------------------------
 
-- **enable_ipv6** (*Optional*, boolean): Enables IPv6 support. Defaults to ``false``. Only available on ESP32 with ESP-IDF framework.
+- **enable_ipv6** (*Optional*, boolean): Enables IPv6 support. Defaults to ``false``.
 
 See Also
 --------


### PR DESCRIPTION
## Description:

Now esphome/esphome#4759, esphome/esphome#4865 and esphome/esphome#4976 are merged, enable_ipv6 should be used without restriction.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
