### PR TITLE
Fix broken link to `CustomAPIDevice` documentation

### DIFF
--- a/custom/custom_component.rst
+++ b/custom/custom_component.rst
@@ -67,7 +67,7 @@ Native API Custom Component
 ---------------------------
 
 If you want to communicate directly with Home Assistant via the :doc:`native API </components/api>`
-you can use the :apiclass:`CustomAPIDevice` class to declare services that can be executed from
+you can use the :apiclass:`api::CustomAPIDevice` class to declare services that can be executed from
 Home Assistant, as well as starting services in Home Assistant.
 
 .. code-block:: cpp


### PR DESCRIPTION
## Description:

Fix broken link to `CustomAPIDevice` in `custom/custom_component.rst`.

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
