### PR TITLE
Update hydreon_rgxx.rst

### DIFF
--- a/components/sensor/hydreon_rgxx.rst
+++ b/components/sensor/hydreon_rgxx.rst
@@ -66,7 +66,7 @@ required to be set up in your configuration for this sensor to work.
 Configuration variables:
 ------------------------
 
-- **model** (**Required**, int): Specify which rain sensor you have connected. Must be either ``RG_9`` or ``RG_15``.
+- **model** (**Required**, string): Specify which rain sensor you have connected. Must be either ``RG_9`` or ``RG_15``.
 
 - **uart_id** (*Optional*, :ref:`config-id`): Manually specify the ID of the :ref:`UART Component <uart>` if you want
   to use multiple UART buses.


### PR DESCRIPTION
I can't see how "RG_9" or "RG_15" are integers

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
