### PR TITLE
Typo in getting_started_hassio.rst

### DIFF
--- a/guides/getting_started_hassio.rst
+++ b/guides/getting_started_hassio.rst
@@ -82,7 +82,7 @@ in ``/config/esphome/garage-door.yaml``.
     command line is not very straightforward, but it's possible. To do that,
     install Home Assistant's SSH addon, configure a username and a password,
     and disable `Protection Mode` (please assess the risks you take with that).
-    Then, for example to access the logs form a device through an SSH client,
+    Then, for example to access the logs from a device through an SSH client,
     log in, and you can use a command like
     `docker exec -it addon_15ef4d2f_esphome esphome logs /config/esphome/garage-door.yaml`.
     See :doc:`getting_started_command_line` for more.


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
