### PR TITLE
Honeywellabp2

### DIFF
--- a/components/sensor/honeywellabp2_i2c.rst
+++ b/components/sensor/honeywellabp2_i2c.rst
@@ -1,5 +1,5 @@
-Honeywell ABP Pressure Sensors
-==============================
+Honeywell ABP 2 Pressure Sensors
+================================
 
 .. seo::
     :description: Instructions for setting up Honeywell ABP2 Pressure sensors
@@ -22,11 +22,8 @@ required to be set up in your configuration for this sensor to work
 
     sensor:
       - platform: honeywellabp2_i2c
-        id: abp2
-        update_interval: never
         pressure:
           name: "Honeywell2 pressure"
-          unit_of_measurement: "Pa"
           min_pressure: 0
           max_pressure: 16000
           transfer_function: "A"
@@ -42,21 +39,16 @@ set ``min_pressure`` and ``max_pressure`` to the measurement range, ``transfer_f
 
 - **pressure** (*Optional*): The information for the pressure sensor.
 
-  - **name** (**Required**, string): The name for the pressure sensor.
   - **min_pressure** (**Required**, int or float): Minimum pressure for the pressure sensor.
   - **max_pressure** (**Required**, int or float): Maximum pressure for the pressure sensor.
   - **transfer_function** (**Required**, "A" or "B"): Transfer function used by the pressure sensor.
-  - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.
   - All other options from :ref:`Sensor <config-sensor>`.
 
 Some sensors do not have temperature sensing ability, see datasheet. In some cases the sensor may return a valid temperature even though the 
 datasheet indicates that the sensor does not measure temperature.
 
 - **temperature** (*Optional*): The information for the temperature sensor.
-
-  - **name** (**Required**, string): The name for the temperature sensor.
-  - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.
-  - All other options from :ref:`Sensor <config-sensor>`.
+  All options from :ref:`Sensor <config-sensor>`.
 
 
 - **update_interval** (*Optional*, :ref:`config-time`): The interval to check the

--- a/components/sensor/honeywellabp2_i2c.rst
+++ b/components/sensor/honeywellabp2_i2c.rst
@@ -1,0 +1,70 @@
+Honeywell ABP Pressure Sensors
+==============================
+
+.. seo::
+    :description: Instructions for setting up Honeywell ABP2 Pressure sensors
+    :image: honeywellabp.jpg
+    :keywords: Honeywell ABP2
+
+The ``honeywellabp2_i2c`` sensor platform allows you to use your Honeywell ABP 
+(`website <https://sps.honeywell.com/us/en/products/advanced-sensing-technologies/healthcare-sensing/board-mount-pressure-sensors/basic-abp2-series>`__,
+`datasheet <https://prod-edam.honeywell.com/content/dam/honeywell-edam/sps/siot/en-us/products/sensors/pressure-sensors/board-mount-pressure-sensors/basic-abp2-series/documents/sps-siot-abp2-series-datasheet-32350268-en.pdf?download=false>`_) 
+pressure and temperature sensors with ESPHome. The :ref:`I2C <i2c>` is
+required to be set up in your configuration for this sensor to work
+
+.. figure:: images/honeywellabp.jpg
+    :align: center
+    :width: 50.0%
+
+    Honeywell ABP Pressure and Temperature Sensor.
+
+.. code-block:: yaml
+
+    sensor:
+      - platform: honeywellabp2_i2c
+        id: abp2
+        update_interval: never
+        pressure:
+          name: "Honeywell2 pressure"
+          unit_of_measurement: "Pa"
+          min_pressure: 0
+          max_pressure: 16000
+          transfer_function: "A"
+        temperature:
+          name: "Honeywell2 temperature"
+
+Configuration variables:
+------------------------
+
+The values for ``min_pressure`` and ``max_pressure`` and ``transfer_function`` can be found in the device datasheet for the specific device. 
+These are used to calculate the pressure reading published by the sensor. Some sensors measure pressure in ``bar`` or ``Psi``; 
+set ``min_pressure`` and ``max_pressure`` to the measurement range, ``transfer_function`` to ``A`` or ``B`` and ``unit_of_measurement`` to the appropriate unit for your device.
+
+- **pressure** (*Optional*): The information for the pressure sensor.
+
+  - **name** (**Required**, string): The name for the pressure sensor.
+  - **min_pressure** (**Required**, int or float): Minimum pressure for the pressure sensor.
+  - **max_pressure** (**Required**, int or float): Maximum pressure for the pressure sensor.
+  - **transfer_function** (**Required**, "A" or "B"): Transfer function used by the pressure sensor.
+  - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.
+  - All other options from :ref:`Sensor <config-sensor>`.
+
+Some sensors do not have temperature sensing ability, see datasheet. In some cases the sensor may return a valid temperature even though the 
+datasheet indicates that the sensor does not measure temperature.
+
+- **temperature** (*Optional*): The information for the temperature sensor.
+
+  - **name** (**Required**, string): The name for the temperature sensor.
+  - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.
+  - All other options from :ref:`Sensor <config-sensor>`.
+
+
+- **update_interval** (*Optional*, :ref:`config-time`): The interval to check the
+  sensor. Defaults to ``60s``.
+
+See Also
+--------
+
+- :ref:`sensor-filters`
+- :apiref:`honeywellabp/honeywellabp2.h`
+- :ghedit:`Edit`

--- a/index.rst
+++ b/index.rst
@@ -305,6 +305,7 @@ Environmental
     HDC1080, components/sensor/hdc1080, hdc1080.jpg, Temperature & Humidity
     HTE501, components/sensor/hte501, HTE501.png, Temperature & Humidity
     Honeywell ABP, components/sensor/honeywellabp, honeywellabp.jpg, Pressure & Temperature
+    Honeywell ABP2 I2C, components/sensor/honeywellabp2_i2c, honeywellabp.jpg, Pressure & Temperature
     HTU21D / Si7021 / SHT21, components/sensor/htu21d, htu21d.jpg, Temperature & Humidity
     Hydreon Rain Sensor, components/sensor/hydreon_rgxx, hydreon_rg9.jpg, Rain
     Inkbird IBS-TH1 Mini, components/sensor/inkbird_ibsth1_mini, inkbird_isbth1_mini.jpg, Temperature & Humidity


### PR DESCRIPTION
## Description:
Adding documentation for honeywellabp2 i2c sensor component

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#5422

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
