### PR TITLE
Allow Poller Component suspend / resume action

### DIFF
--- a/guides/automations.rst
+++ b/guides/automations.rst
@@ -675,10 +675,11 @@ Using this action you can manually call the ``stop_poller()`` method of a compon
 
 After this action the component will stop being refreshed.
 
+While the poller is suspendend, it's still possible to trigger on-demand updates by
+using :ref:`component.update <component-update_action>`
+
 Please note that this only works with PollingComponent types and others will result in a
 compile error.
-
-While the poller is suspendend, it's still possible to trigger on-demand updates by using :ref:`component.update <component-update_action>`
 
 .. code-block:: yaml
 
@@ -695,6 +696,8 @@ While the poller is suspendend, it's still possible to trigger on-demand updates
 ---------------------------
 
 Using this action you can manually call the ``start_poller()`` method of a component.
+
+After this action the component will refresh at the original update_interval rate
 
 This will allow the component to resume automatic update at the defined interval.
 

--- a/guides/automations.rst
+++ b/guides/automations.rst
@@ -665,6 +665,50 @@ compile error.
         # The same as:
         - lambda: 'id(my_component).update();'
 
+.. _component-suspend_action:
+
+``component.suspend`` Action
+---------------------------
+
+Using this action you can manually call the ``stop_poller()`` method of a component.
+
+After this action the component will stop being refreshed.
+
+Please note that this only works with PollingComponent types and others will result in a
+compile error.
+
+While the poller is supsendend, it's still possible to updata manually the component by using `component.update`
+
+.. code-block:: yaml
+
+    on_...:
+      then:
+        - component.suspend: my_component
+
+        # The same as:
+        - lambda: 'id(my_component).stop_poller();'
+
+.. _component-resume_action:
+
+``component.resume`` Action
+---------------------------
+
+Using this action you can manually call the ``start_poller()`` method of a component.
+
+This will allow the component to resume automatic update at the defined interval.
+
+Please note that this only works with PollingComponent types and others will result in a
+compile error.
+
+.. code-block:: yaml
+
+    on_...:
+      then:
+        - component.resume: my_component
+
+        # The same as:
+        - lambda: 'id(my_component).start_poller();'
+
 .. _globals-set_action:
 
 ``globals.set`` Action

--- a/guides/automations.rst
+++ b/guides/automations.rst
@@ -356,6 +356,8 @@ All Actions
 - :ref:`lambda <lambda_action>`
 - :ref:`if <if_action>` / :ref:`while <while_action>` / :ref:`wait_until <wait_until_action>`
 - :ref:`component.update <component-update_action>`
+- :ref:`component.suspend <component-suspend_action>`
+- :ref:`component.resume <component-resume_action>`
 - :ref:`script.execute <script-execute_action>` / :ref:`script.stop <script-stop_action>` / :ref:`script.wait <script-wait_action>`
 - :ref:`logger.log <logger-log_action>`
 - :ref:`homeassistant.service <api-homeassistant_service_action>`

--- a/guides/automations.rst
+++ b/guides/automations.rst
@@ -356,8 +356,7 @@ All Actions
 - :ref:`lambda <lambda_action>`
 - :ref:`if <if_action>` / :ref:`while <while_action>` / :ref:`wait_until <wait_until_action>`
 - :ref:`component.update <component-update_action>`
-- :ref:`component.suspend <component-suspend_action>`
-- :ref:`component.resume <component-resume_action>`
+- :ref:`component.suspend <component-suspend_action>` / :ref:`component.resume <component-resume_action>`
 - :ref:`script.execute <script-execute_action>` / :ref:`script.stop <script-stop_action>` / :ref:`script.wait <script-wait_action>`
 - :ref:`logger.log <logger-log_action>`
 - :ref:`homeassistant.service <api-homeassistant_service_action>`
@@ -679,7 +678,7 @@ After this action the component will stop being refreshed.
 Please note that this only works with PollingComponent types and others will result in a
 compile error.
 
-While the poller is supsendend, it's still possible to updata manually the component by using `component.update`
+While the poller is suspendend, it's still possible to trigger on-demand updates by using :ref:`component.update <component-update_action>`
 
 .. code-block:: yaml
 

--- a/guides/automations.rst
+++ b/guides/automations.rst
@@ -701,6 +701,9 @@ After this action the component will refresh at the original update_interval rat
 
 This will allow the component to resume automatic update at the defined interval.
 
+This action also allows to change the update interval, calling it without suspend, 
+replace the poller directly.
+
 Please note that this only works with PollingComponent types and others will result in a
 compile error.
 
@@ -712,6 +715,14 @@ compile error.
 
         # The same as:
         - lambda: 'id(my_component).start_poller();'
+
+    # Change the poller interval
+    on_...:
+      then:
+        - component.resume: 
+            id: my_component
+            update_interval: 15s
+
 
 .. _globals-set_action:
 

--- a/guides/automations.rst
+++ b/guides/automations.rst
@@ -670,7 +670,7 @@ compile error.
 .. _component-suspend_action:
 
 ``component.suspend`` Action
----------------------------
+----------------------------
 
 Using this action you can manually call the ``stop_poller()`` method of a component.
 


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes [https://github.com/esphome/feature-requests/issues/2301](https://github.com/esphome/feature-requests/issues/2301)

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#5423

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
