### PR TITLE
Fix typos in pmsa003i.rst

### DIFF
--- a/components/sensor/pmsa003i.rst
+++ b/components/sensor/pmsa003i.rst
@@ -30,17 +30,17 @@ The :ref:`I²C Bus <i2c>` is required to be set up in your configuration for thi
         pm_10_0:
           name: "PM10.0"
         pmc_0_3:
-          name: "PMC <0.3µm"
+          name: "PMC >0.3µm"
         pmc_0_5:
-          name: "PMC <0.5µm"
+          name: "PMC >0.5µm"
         pmc_1_0:
-          name: "PMC <1µm"
+          name: "PMC >1µm"
         pmc_2_5:
-          name: "PMC <2.5µm"
+          name: "PMC >2.5µm"
         pmc_5_0:
-          name: "PMC <5µm"
+          name: "PMC >5µm"
         pmc_10_0:
-          name: "PMC <10µm"
+          name: "PMC >10µm"
 
 Configuration variables:
 ------------------------


### PR DESCRIPTION
## Description:

These values refer to "particulate matter count" > <particle size>, not less than.

The existing documentation at the bottom of the page:
https://esphome.io/components/sensor/pmsa003i.html
in the "Config" section is correct. For some reason, the example got the names mixed up. 

Another source for the same info:
https://cdn-shop.adafruit.com/product-files/4632/4505_PMSA003I_series_data_manual_English_V2.6.pdf
(page 13-14)

The same typos exist in the code (will cut another PR for that):
https://github.com/esphome/esphome/blob/0ca8dcd08e96b431f8034acc16a7f9c2ab64eb84/esphome/components/pmsa003i/pmsa003i.h#L25
https://github.com/esphome/esphome/blob/0ca8dcd08e96b431f8034acc16a7f9c2ab64eb84/esphome/components/pmsa003i/pmsa003i.cpp#L61
Fixed that is this PR: https://github.com/esphome/esphome/pull/5425

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
