### PR TITLE
SHT3x heater_enabled defaults to false

### DIFF
--- a/components/sensor/sht3xd.rst
+++ b/components/sensor/sht3xd.rst
@@ -49,7 +49,7 @@ Configuration variables:
 - **update_interval** (*Optional*, :ref:`config-time`): The interval to check the
   sensor. Defaults to ``60s``.
 - **heater_enabled** (*Optional*, bool): Turn on/off heater at boot.
-  Defaults to ``true``.
+  Defaults to ``false``.
 
 See Also
 --------


### PR DESCRIPTION
## Description:
Update to reflect heater_enabled default to false as the normal operational use case of this temperature and humidity sensor is with the heater turned off.

**Related issue (if applicable):** fixes [#4886](https://github.com/esphome/issues/issues/4886)

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#5445

## Checklist:

  - [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
