### PR TITLE
Document clamp filter's ignore out of range option

### DIFF
--- a/components/sensor/index.rst
+++ b/components/sensor/index.rst
@@ -262,12 +262,26 @@ degree with a least squares solver.
 ``clamp``
 *********
 
-Limits the value to the range between ``min_value`` and ``max_value``. Sensor values outside these bounds will be set to ``min_value`` or ``max_value``, respectively. If ``min_value`` is not set, there is no lower bound, if ``max_value`` is not set there is no upper bound.
+Limits the value to the range between ``min_value`` and ``max_value``. By default, sensor values outside these bounds will be set to ``min_value`` or ``max_value``, respectively. If ``ignore_out_of_range`` is true, then sensor values outside those bounds will be ignored. If ``min_value`` is not set, there is no lower bound; if ``max_value`` is not set there is no upper bound.
 
 Configuration variables:
 
 - **min_value** (*Optional*, float): The lower bound of the range.
 - **max_value** (*Optional*, float): The upper bound of the range.
+- **ignore_out_of_range** (*Optional*, bool): If true, ignores all sensor values out of the range. Defaults to ``false``.
+
+.. code-block:: yaml
+
+    # Example configuration entry
+    - platform: wifi_signal
+      # ...
+      filters:
+        - clamp:
+            min_value: 10
+            max_value: 75
+            ignore_out_of_range: true
+
+
 
 ``quantile``
 ************


### PR DESCRIPTION
## Description:

Documents a new option for the clamp sensor filter that ignores values out of the configured range. It additionally adds an example configuration.

**Related issue (if applicable):** closes esphome/feature-requests#2298

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#5455

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
