### PR TITLE
Fix empty espressif install

### DIFF
--- a/ready-made/installer.html
+++ b/ready-made/installer.html
@@ -599,7 +599,7 @@
   </div>
 
   <div class="hidden info raspberry">
-    <div class="question-prompt">Start the installation:</div>
+    <div class="question-prompt">Installation instructions:</div>
 
     <ol>
       <li>Disconnect your Raspberry Pi Pico from your computer</li>

--- a/ready-made/installer.html
+++ b/ready-made/installer.html
@@ -593,7 +593,9 @@
 
   <div class="hidden info espressif">
     <div class="question-prompt">Start the installation:</div>
-    <esp-web-install-button></esp-web-install-button>
+    <esp-web-install-button
+      manifest="https://firmware.esphome.io/esphome-web/manifest.json"
+    ></esp-web-install-button>
   </div>
 
   <div class="hidden info raspberry">
@@ -684,8 +686,10 @@
     radio.addEventListener("change", () => {
       const typeRoot = radio.closest(".type");
       const manifestRoot = typeRoot.dataset.manifestRoot;
-      const button = typeRoot.querySelector("esp-web-install-button");
-      button.manifest = `${manifestRoot}/${radio.value}-manifest.json`;
+      if (manifestRoot) {
+        const button = typeRoot.querySelector("esp-web-install-button");
+        button.manifest = `${manifestRoot}/${radio.value}-manifest.json`;
+      }
 
       typeRoot.querySelectorAll(".info").forEach((info) => {
         info.classList.add("hidden");


### PR DESCRIPTION
## Description:

Clicking empty device would empty out the manifest. Now it's fixed.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
