### PR TITLE
sht3xd: document the reason & effects for `heater_enabled`

### DIFF
--- a/components/sensor/sht3xd.rst
+++ b/components/sensor/sht3xd.rst
@@ -48,7 +48,7 @@ Configuration variables:
   Defaults to ``0x44``.
 - **update_interval** (*Optional*, :ref:`config-time`): The interval to check the
   sensor. Defaults to ``60s``.
-- **heater_enabled** (*Optional*, bool): Turn on/off heater at boot.
+- **heater_enabled** (*Optional*, bool): Turn on/off heater at boot. This may help provide `more accurate readings in condensing conditions <https://forum.arduino.cc/t/atmospheric-sensors-in-condensing-conditions/412167>`_, but can also increase temperature readings and decrease humidity readings as a side effect.
   Defaults to ``true``.
 
 See Also


### PR DESCRIPTION
From a report here: https://github.com/esphome/issues/issues/2887#issuecomment-1741934563 as well as my own personal experience. 

This was introduced in this change: https://github.com/esphome/esphome-docs/pull/3149

I am not really sure changing the default is the right path or not, but this should help folks debug. 

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
