### PR TITLE
Install bluetooth proxies and media players from firmware.esphome.io

### DIFF
--- a/projects/installer.html
+++ b/projects/installer.html
@@ -688,7 +688,6 @@
       const manifestRoot = typeRoot.dataset.manifestRoot;
       if (manifestRoot) {
         const button = typeRoot.querySelector("esp-web-install-button");
-        // TODO this has to be adjusted for firmware repo.
         button.manifest = `${manifestRoot}/${radio.value}/manifest.json`;
       }
 

--- a/projects/installer.html
+++ b/projects/installer.html
@@ -699,6 +699,17 @@
     })
   );
 
+  // Check URL for type
+  if (window.location.search) {
+    const params = new URLSearchParams(window.location.search);
+    const type = params.get("type");
+    if (type) {
+      document.querySelector(
+        `input[name="type"][value="${type}"]`
+      ).checked = true;
+    }
+  }
+
   // Show current selection on page load
   document
     .querySelector('input[name="type"]:checked')

--- a/projects/installer.html
+++ b/projects/installer.html
@@ -398,7 +398,7 @@
 
 <div
   class="type type-media hidden"
-  data-manifest-root="https://firmware.esphome.io/media-players"
+  data-manifest-root="https://firmware.esphome.io/media-player"
 >
   <div class="question-prompt">
     Pick the device you want to turn into a media player:

--- a/projects/installer.html
+++ b/projects/installer.html
@@ -135,7 +135,7 @@
 
 <div
   class="type type-bluetooth"
-  data-manifest-root="https://esphome.github.io/bluetooth-proxies"
+  data-manifest-root="https://firmware.esphome.io/bluetooth-proxy"
 >
   <div class="question-prompt">
     Pick the device you want to turn into a Bluetooth proxy:
@@ -398,7 +398,7 @@
 
 <div
   class="type type-media hidden"
-  data-manifest-root="https://esphome.github.io/media-players"
+  data-manifest-root="https://firmware.esphome.io/media-players"
 >
   <div class="question-prompt">
     Pick the device you want to turn into a media player:
@@ -671,6 +671,7 @@
     document.body.appendChild(improv);
   }
 
+  // Handle selecting a project type
   document.querySelectorAll('input[name="type"]').forEach((radio) =>
     radio.addEventListener("change", () => {
       document.querySelectorAll(".type").forEach((info) => {
@@ -679,13 +680,16 @@
       document.querySelector(`.type-${radio.value}`).classList.remove("hidden");
     })
   );
+
+  // Handle selecting a device
   document.querySelectorAll("input.device-option").forEach((radio) =>
     radio.addEventListener("change", () => {
       const typeRoot = radio.closest(".type");
       const manifestRoot = typeRoot.dataset.manifestRoot;
       if (manifestRoot) {
         const button = typeRoot.querySelector("esp-web-install-button");
-        button.manifest = `${manifestRoot}/${radio.value}-manifest.json`;
+        // TODO this has to be adjusted for firmware repo.
+        button.manifest = `${manifestRoot}/${radio.value}/manifest.json`;
       }
 
       typeRoot.querySelectorAll(".info").forEach((info) => {
@@ -694,12 +698,16 @@
       typeRoot.querySelector(`.info.${radio.value}`).classList.remove("hidden");
     })
   );
+
+  // Show current selection on page load
   document
     .querySelector('input[name="type"]:checked')
     .dispatchEvent(new Event("change"));
   document
     .querySelectorAll("input.device-option:checked")
     .forEach((radio) => radio.dispatchEvent(new Event("change")));
+
+  // Check if web installation is supported
   customElements.whenDefined("esp-web-install-button").then((cls) => {
     if (cls.isSupported) {
       return;


### PR DESCRIPTION
## Description:
Point installation at firmware.esphome.io for bluetooth proxies and media players

Requires

- [x] bluetooth proxies https://github.com/esphome/firmware/pull/49
- [x] media players https://github.com/esphome/firmware/pull/52
- [x] build https://github.com/esphome/firmware/actions/runs/6413865996

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
