### PR TITLE
Documentation for !extend

### DIFF
--- a/guides/configuration-types.rst
+++ b/guides/configuration-types.rst
@@ -323,6 +323,20 @@ your configuration file. This can be used to create generic 'template' configura
 files (like the ``example.yaml`` above) which can be used for multiple devices,
 using substitutions which are provided on the command line.
 
+Extend
+------
+
+To make changes or add additional configuration to included configurations ``!extend config_id`` can be used, where ``config_id`` is the ID of the configuration to modify.
+For example to set a specific update interval on a common uptime sensor that is shared between configurations:
+
+.. code-block:: yaml
+
+    <<: !include common.yaml
+
+    sensor:
+    - id: !extend uptime_sensor
+      update_interval: 10s
+
 .. _config-packages:
 
 Packages


### PR DESCRIPTION
## Description:

Adds missing example usage for `!extend` feature to ESPHome documentation.

**Related issue (if applicable):** fixes esphome/issues#4748

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
