### PR TITLE
Clarifications to pulse_width documentation

### DIFF
--- a/components/sensor/pulse_width.rst
+++ b/components/sensor/pulse_width.rst
@@ -7,7 +7,12 @@ Pulse Width Sensor
 
 The ``pulse_width`` sensor allows you to measure how long a given digital signal
 is HIGH. For example this can be used to measure PWM signals to transmit some
-value over a simple protocol.
+value over a simple protocol. The unit of measurement for this sensor is seconds.
+
+.. note::
+
+    This component is intended for measurements in the microsecond to seconds range! 
+    The largest period this component can measure is just over 70 minutes.
 
 .. code-block:: yaml
 


### PR DESCRIPTION
## Description:

Some additional clarification to the usecases for the pulse_width sensor.

**Related issue (if applicable):** fixes esphome/issues#4638

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
