### PR TITLE
Rephrase log level inclusivity.

### DIFF
--- a/components/logger.rst
+++ b/components/logger.rst
@@ -9,9 +9,8 @@ Logger Component
 
 The logger component automatically logs all log messages through the
 serial port and through MQTT topics (if there is an MQTT client in the
-configuration). By default, all logs with a severity higher than
-``DEBUG`` will be shown. Decreasing the log level can help with the
-performance of the application and memory size.
+configuration). By default, all logs with a severity ``DEBUG`` or higher will be shown.
+Increasing the log level severity (to e.g ``INFO`` or ``WARNING``) can help with the performance of the application and memory size.
 
 .. code-block:: yaml
 


### PR DESCRIPTION
## Description:

Rephrases log level usage to be inclusive of the selected log level (instead of the current exclusive phrasing) as mentioned in the issue noted below. 
Also rephrases the increase / decrease to specifically mention the severity as to not seem contradictive to the `higher` mentioned in the line above.

**Related issue (if applicable):** fixes esphome/issues#4668

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
