### PR TITLE
Don't hide all hardware when webserial unsupported

### DIFF
--- a/projects/installer.html
+++ b/projects/installer.html
@@ -724,14 +724,5 @@
     }
     // show unsupported note
     document.querySelector(".unsupported").classList.remove("hidden");
-    // disable all radio
-    document
-      .querySelectorAll('input[name="type"]')
-      .forEach((radio) => radio.setAttribute("disabled", "disabled"));
-    // Hide all types
-    document.querySelectorAll(".type").forEach((info) => {
-      info.classList.add("hidden");
-    });
-    document.querySelector(".installer-footer").classList.add("hidden");
   });
 </script>


### PR DESCRIPTION
## Description:
When WebSerial was unsupported, ready-made projects would hide supported devices. That is a bad user experience. This shows it all again. 

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
