### PR TITLE
Add status indicator information to esp32 improv

### DIFF
--- a/components/esp32_improv.rst
+++ b/components/esp32_improv.rst
@@ -31,6 +31,17 @@ Configuration variables:
 - **status_indicator** (*Optional*, :ref:`config-id`): An :doc:`output <output/index>` to display feedback to the user.
 - **identify_duration** (*Optional*, :ref:`config-time`): The amount of time to identify for. Defaults to ``10s``.
 
+Status Indicator
+----------------
+
+The ``status_indicator`` has the following patterns:
+
+- solid: The improv service is active and waiting to be authorized.
+- blinking once per second: The improv service is awaiting credentials.
+- blinking 3 times per second with a break in between: The identify command has been used by the client.
+- blinking 5 times per second: Credentials are being verified and saved to the device.
+- off: The improv service is not running.
+
 See Also
 --------
 


### PR DESCRIPTION
## Description:

Adding the status indicator patterns to the documentation


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
