### PR TITLE
Add documentation for the color_temp light POST query parameter

### DIFF
--- a/web-api/index.rst
+++ b/web-api/index.rst
@@ -182,6 +182,7 @@ creating a POST request at ``/light/<id>/turn_on?brightness=128&transition=2`` w
 -  **flash**: Flash the color provided by the other properties for a duration in seconds.
 -  **transition**: Transition to the specified color values in this duration in seconds.
 -  **effect**: Set an effect for the light.
+-  ***color_temp***: Set the color temperature of the light, in mireds.
 
 ``turn_off`` optional URL parameters:
 


### PR DESCRIPTION
## Description:
The code for the webserver API clearly allows for setting of the color temperature, but the documentation does not mention this specific query parameter.

See https://github.com/esphome/esphome/blob/7ddcdab35130ab54ba4735623df2aab95dcf3ce6/esphome/components/web_server/web_server.cpp#L618-L623

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
