### PR TITLE
devcontainer updates

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,6 +3,7 @@
   "name": "ESPHome - docs",
   "image": "mcr.microsoft.com/vscode/devcontainers/python:0-3.11",
   "postCreateCommand": "pip3 install -r requirements.txt -r requirements_test.txt",
+  "postAttachCommand": "make live-html",
   "forwardPorts": [8000],
   "features": {
     "ghcr.io/devcontainers/features/github-cli:1": {}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,27 +1,19 @@
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.183.0/containers/python-3
 {
-    "name": "ESPHome - docs",
-    "image": "mcr.microsoft.com/vscode/devcontainers/python:0-3.10",
-    "postCreateCommand": "pip3 install -r requirements.txt -r requirements_test.txt",
-    "forwardPorts": [8000],
-    "settings": {
-        "python.pythonPath": "/usr/local/bin/python",
-        "python.languageServer": "Pylance",
-        "python.linting.enabled": true,
-        "python.linting.pylintEnabled": true,
-        "python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
-        "python.formatting.blackPath": "/usr/local/py-utils/bin/black",
-        "python.formatting.yapfPath": "/usr/local/py-utils/bin/yapf",
-        "python.linting.banditPath": "/usr/local/py-utils/bin/bandit",
-        "python.linting.flake8Path": "/usr/local/py-utils/bin/flake8",
-        "python.linting.mypyPath": "/usr/local/py-utils/bin/mypy",
-        "python.linting.pycodestylePath": "/usr/local/py-utils/bin/pycodestyle",
-        "python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",
-        "python.linting.pylintPath": "/usr/local/py-utils/bin/pylint"
-    },
+  "name": "ESPHome - docs",
+  "image": "mcr.microsoft.com/vscode/devcontainers/python:0-3.11",
+  "postCreateCommand": "pip3 install -r requirements.txt -r requirements_test.txt",
+  "forwardPorts": [8000],
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "python.pythonPath": "/usr/local/bin/python"
+      },
 
-    "extensions": [
-        "ms-python.python",
-        "ms-python.vscode-pylance"
-    ]
+      "extensions": ["ms-python.python"]
+    }
+  }
 }


### PR DESCRIPTION
## Description:
- Update container image to python 3.11
- Move settings into customizations block
- Add `gh cli` to container
- Start live html build when connecting to container

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
