### PR TITLE
Fan no off cycle action

### DIFF
--- a/components/fan/index.rst
+++ b/components/fan/index.rst
@@ -137,21 +137,22 @@ Configuration options:
 ``fan.cycle_speed`` Action
 --------------------------
 
-Increments through speed levels of the fan with the given ID when executed. If the fan's speed level is set to maximum when executed, fan will cycle off unless off_speed_cycle is set to ``false``.
+Increments through speed levels of the fan with the given ID when executed. If the fan's speed level is set to maximum when executed, fan will cycle off unless ``off_speed_cycle`` is set to ``false``.
 
 .. code-block:: yaml
 
     on_...:
       then:
         - fan.cycle_speed:
-            id: myFan
-            off_speed_cycle: true #default
+            id: fan_1
+            off_speed_cycle: true
+        # Shorthand:
+        - fan.cycle_speed:: fan_1
 
 Configuration options:
 
 - **id** (**Required**, :ref:`config-id`): The ID of the fan.
-- **off_speed_cycle** (*Optional*, boolean, :ref:`templatable <config-templatable>`):
-   Determines if the fan will cycle off after cycling though its highest speed. Can be ``true`` or ``false``. If ``false`` fan will cycle to its lowest speed instead of turning off.  Defaults to ``true``.
+- **off_speed_cycle** (*Optional*, boolean, :ref:`templatable <config-templatable>`): Determines if the fan will cycle off after cycling though its highest speed. Can be ``true`` or ``false``. If ``false`` fan will cycle to its lowest speed instead of turning off.  Defaults to ``true``.
 
 .. _fan-is_on_condition:
 .. _fan-is_off_condition:

--- a/components/fan/index.rst
+++ b/components/fan/index.rst
@@ -137,14 +137,21 @@ Configuration options:
 ``fan.cycle_speed`` Action
 --------------------------
 
-Increments through speed levels of the fan with the given ID when executed. If the fan's speed level is set to maximum when executed, turns fan off.
+Increments through speed levels of the fan with the given ID when executed. If the fan's speed level is set to maximum when executed, fan will cycle off unless off_speed_cycle is set to ``false``.
 
 .. code-block:: yaml
 
     on_...:
       then:
-        - fan.cycle_speed: fan_1
+        - fan.cycle_speed:
+            id: myFan
+            off_speed_cycle: true #default
 
+Configuration options:
+
+- **id** (**Required**, :ref:`config-id`): The ID of the fan.
+- **off_speed_cycle** (*Optional*, boolean, :ref:`templatable <config-templatable>`):
+   Determines if the fan will cycle off after cycling though its highest speed. Can be ``true`` or ``false``. If ``false`` fan will cycle to its lowest speed instead of turning off.  Defaults to ``true``.
 
 .. _fan-is_on_condition:
 .. _fan-is_off_condition:


### PR DESCRIPTION
## Description:
Adds an option to the fan cycle_speed action so that the fan will not turn off when calling the cycle_speed action if so desired by the user

**Related issue (if applicable):** fixes nothing.  Is new feature.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#5564

## Checklist:

  - [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
