### PR TITLE
Add LILYGO T-ETH-Lite to ethernet.rst

### DIFF
--- a/components/ethernet.rst
+++ b/components/ethernet.rst
@@ -222,7 +222,17 @@ Configuration examples
       clk_mode: GPIO17_OUT
       phy_addr: 1
 
+**LILYGO T-ETH-Lite**:
 
+.. code-block:: yaml
+
+    ethernet:
+      type: RTL8201
+      mdc_pin: GPIO23
+      mdio_pin: GPIO18
+      clk_mode: GPIO0_IN
+      phy_addr: 0
+      power_pin: GPIO12
 
 See Also
 --------


### PR DESCRIPTION
Added config example for LILYGO T-ETH-Lite

## Description:
Add config example for LILYGO T-ETH-Lite

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
