### PR TITLE
Fix an embarrassing typo in the new mmc5983 docs

### DIFF
--- a/components/sensor/mmc5983.rst
+++ b/components/sensor/mmc5983.rst
@@ -8,7 +8,7 @@ MMC5983 Magnetometer
     :image: mmc5983.jpg
     :keywords: MMC5983
 
-The ``mmc5983`` integration allows you to use your MMC5603 triple-axis magnetometer
+The ``mmc5983`` integration allows you to use your MMC5983 triple-axis magnetometer
 (`datasheet`_, `SparkFun`_) with ESPHome.
 
 The :ref:`I²C Bus <i2c>` is required to be set up for this sensor to work. The device supports 400kHz


### PR DESCRIPTION
## Description:
Fix an embarrassing typo in the new mmc5983 docs. I accidentally referred to a different chip in the first line of the page.



## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
