### PR TITLE
Add documentation for WireGuard address text sensor

### DIFF
--- a/components/wireguard.rst
+++ b/components/wireguard.rst
@@ -241,6 +241,22 @@ This sensor reports the *timestamp* of the latest completed handshake.
 All options from :ref:`Sensor <config-sensor>` can be added to the
 above configuration.
 
+Address Text Sensor
+^^^^^^^^^^^^^^^^^^^
+
+This sensor exposes to the frontend the configured :ref:`address <wireguard-address>`.
+
+.. code-block:: yaml
+
+    # Example configuration entry
+    text_sensor:
+      - platform: wireguard
+        address:
+          name: 'WireGuard Address'
+
+All options from :ref:`Text Sensor <config-text_sensor>` can be added to the
+above configuration.
+
 .. _wireguard-installation:
 
 Remote peer setup

--- a/index.rst
+++ b/index.rst
@@ -697,6 +697,7 @@ Text Sensor Components
     Tuya Text Sensor, components/text_sensor/tuya, tuya.png
     WL-134 Pet Tag Sensor , components/text_sensor/wl_134, fingerprint.svg, dark-invert
     LibreTiny, components/text_sensor/libretiny, libretiny.svg
+    WireGuard, components/wireguard, wireguard_custom_logo.svg
 
 Climate Components
 ------------------


### PR DESCRIPTION
## Description:

Documentation for WireGuard address text sensor.

**Related issue (if applicable):** none

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#5576

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
