### PR TITLE
fix canbus send config docs

### DIFF
--- a/components/canbus.rst
+++ b/components/canbus.rst
@@ -171,12 +171,11 @@ There are several forms to use it:
       - canbus.send: 'hello'
 
       # Templated, return type is std::vector<uint8_t>
-      - canbus.send: !lambda
-          return {0x00, 0x20, 0x42};
+      - canbus.send: !lambda return {0x00, 0x20, 0x42};
 
 Configuration variables:
 
-- **data** (**Required**, binary data): Data to transmit, up to 8 bytes or
+- **data** (**Required**, binary data, :ref:`templatable <config-templatable>`): Data to transmit, up to 8 bytes or
   characters are supported by can bus per frame.
 - **canbus_id** (*Optional*): Optionally set the can bus id to use for transmitting
   the frame. Not needed if you are using only 1 can bus.


### PR DESCRIPTION
## Description:
config description wasn't complete

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
