### PR TITLE
Add area (zone) to esphome core config to be suggested through API and MQTT.

### DIFF
--- a/components/esphome.rst
+++ b/components/esphome.rst
@@ -15,6 +15,7 @@ where you specify the **name** of the node.
     esphome:
         name: livingroom
         comment: Living room ESP32 controller
+        area: Living Room
 
     esp32:
         board: nodemcu-32s
@@ -32,6 +33,8 @@ Configuration variables:
 - **friendly_name** (*Optional*, string): This is the name sent to the frontend. It is used
   by Home Assistant as the integration name, device name, and is automatically prefixed to entities
   where necessary.
+- **area** (*Optional*, string): This is the area sent to the frontend. It is used
+  by Home Assistant as the area / zone which the node belongs to.
 
 Advanced options:
 


### PR DESCRIPTION
## Description:
Add area (zone) to esphome core config to be suggested through API and MQTT.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#5602

## Checklist:

  - [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
