### PR TITLE
update mcp4728 docs

### DIFF
--- a/components/output/mcp4728.rst
+++ b/components/output/mcp4728.rst
@@ -11,6 +11,9 @@ The MCP4728 output component allows to use `12bit external quad DAC
 <https://www.adafruit.com/product/4470>`__
 in order to have analog outputs on any board by using :ref:`I²C <i2c>`. Devices default address is ``0x60``.
 
+If you only have one, it is not necessary to explicitly specify the ``mcp4728:`` component in the config unless you need to change the parameters.
+It will be automatically created with the default settings if you use it.
+
 .. code-block:: yaml
 
     # Example configuration entry
@@ -23,13 +26,12 @@ in order to have analog outputs on any board by using :ref:`I²C <i2c>`. Devices
 
     # Set the component with default (address: 0x60 / global I²C)
     mcp4728:
-      - platform: mcp4728
-        id: dac_output
+      - id: dac_output
 
 Configuration variables:
 ------------------------
 
-- **id** (**Required**, :ref:`config-id`): The id to use for this output component.
+- **id** (*Optional*, :ref:`config-id`): The id to use for this output component.
 - **address** (*Optional*, int): Manually specify the I2C address of
   the DAC. Defaults to ``0x60``.
 - **store_in_eeprom** (*Optional*, boolean): Use SEQ_WRITE mode to also write to EEPROM sequentially. Defaults to ``false``.
@@ -57,14 +59,12 @@ The MCP4728 output component exposes 4 MCP4728 channels of a global :ref:`MCP472
       power_down: gnd_1k
     - platform: mcp4728
       id: ac_dimmer_3
-      mcp4728_id: dac_output
       channel: C
       vref: internal
       gain: X1
       power_down: normal # default
     - platform: mcp4728
       id: ac_dimmer_4
-      mcp4728_id: dac_output
       channel: D
       vref: internal
       gain: X2
@@ -96,5 +96,7 @@ When ``vref=internal``, output voltage will range from 0.000V to 2.048V with ``g
 See Also
 --------
 
+- :doc:`/components/output/index`
 - :doc:`/components/output/esp32_dac`
+- :apiref:`mcp4728/mcp4728.h`
 - :ghedit:`Edit`


### PR DESCRIPTION
## Description:
mcp4728 document updates to fix a bad example and match PR changes

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#5609

## Checklist:

  - [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
