### PR TITLE
Add skip_validation_for_pins documentation

### DIFF
--- a/components/esp32.rst
+++ b/components/esp32.rst
@@ -85,6 +85,7 @@ Configuration variables:
 
 - **source** (*Optional*, string): The PlatformIO package or repository to use for framework. This can be used to use a custom or patched version of the framework.
 - **platform_version** (*Optional*, string): The version of the `platformio/espressif32 <https://github.com/platformio/platform-espressif32/releases/>`__ package to use.
+- **skip_validation_for_pins** (*Optional*, list[string]): List of pins to skip validation; for custom boards, this allows reuse of pins that are otherwise not allowed. Use carefully!
 
 .. _esp32-espidf_framework:
 


### PR DESCRIPTION
Adds documentation for usage of `skip_validation_for_pins`

## Description:



**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#5615

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
