### PR TITLE
Add shell auto-completion documentation

### DIFF
--- a/guides/cli.rst
+++ b/guides/cli.rst
@@ -240,3 +240,16 @@ The ``esphome logs <CONFIG>`` command validates the configuration and shows all 
 
     Manually specify a serial port/IP to use. For example ``/dev/cu.SLAB_USBtoUART``.
 
+Using Bash or ZSH auto-completion
+---------------------------------
+
+ESPHome's command line interface provides the ability to use auto-completion features provided by Bash or ZSH.
+
+You can register ESPHome for auto-completion by adding the following to your ~/.bashrc file:
+
+.. code-block:: console
+
+    eval "$(register-python-argcomplete esphome)"
+
+For more information, see `argcomplete <https://kislyuk.github.io/argcomplete/>`__ documentation.
+


### PR DESCRIPTION
## Description:
Add documentation about ESPHome shell auto-completion feature.
Explain how to register it for Bash and provide link to the argcomplete documentation.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#5618

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
