### PR TITLE
Document variables available to new API triggers

### DIFF
--- a/components/api.rst
+++ b/components/api.rst
@@ -227,8 +227,8 @@ type ``string`` are available for use by actions called from within this trigger
 This trigger is activated each time the API disconnects from the API. Two variables of
 type ``string`` are available for use by actions called from within this trigger:
 
-- ``client_address``: the IP address of the client that connected
-- ``client_info``: the name of the client that connected
+- ``client_address``: the IP address of the client that disconnected
+- ``client_info``: the name of the client that disconnected
 
 .. code-block:: yaml
 

--- a/components/api.rst
+++ b/components/api.rst
@@ -207,7 +207,7 @@ Triggers
 *******************************
 
 This trigger is activated each time a client connects to the API. Two variables of
-type ``string`` are available for use by actions called from within this trigger:
+type ``std::string`` are available for use by actions called from within this trigger:
 
 - ``client_address``: the IP address of the client that connected
 - ``client_info``: the name of the client that connected
@@ -217,7 +217,10 @@ type ``string`` are available for use by actions called from within this trigger
     api:
       # ...
       on_client_connected:
-        - logger.log: "API client connected!"
+        - logger.log:
+            format: "Client %s connected to API with IP %s"
+            args: ["client_info.c_str()", "client_address.c_str()"]
+
 
 .. _api-on_client_disconnected_trigger:
 
@@ -225,7 +228,7 @@ type ``string`` are available for use by actions called from within this trigger
 **********************************
 
 This trigger is activated each time the API disconnects from the API. Two variables of
-type ``string`` are available for use by actions called from within this trigger:
+type ``std::string`` are available for use by actions called from within this trigger:
 
 - ``client_address``: the IP address of the client that disconnected
 - ``client_info``: the name of the client that disconnected

--- a/components/api.rst
+++ b/components/api.rst
@@ -206,7 +206,11 @@ Triggers
 ``on_client_connected`` Trigger
 *******************************
 
-This trigger is activated each time a client connects to the API.
+This trigger is activated each time a client connects to the API. Two variables of
+type ``string`` are available for use by actions called from within this trigger:
+
+- ``client_address``: the IP address of the client that connected
+- ``client_info``: the name of the client that connected
 
 .. code-block:: yaml
 
@@ -220,7 +224,11 @@ This trigger is activated each time a client connects to the API.
 ``on_client_disconnected`` Trigger
 **********************************
 
-This trigger is activated each time the API disconnects from the API.
+This trigger is activated each time the API disconnects from the API. Two variables of
+type ``string`` are available for use by actions called from within this trigger:
+
+- ``client_address``: the IP address of the client that connected
+- ``client_info``: the name of the client that connected
 
 .. code-block:: yaml
 


### PR DESCRIPTION
## Description:

Expands on #3308

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#5628

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
