### PR TITLE
Document null MQTT topic behavior

### DIFF
--- a/components/mqtt.rst
+++ b/components/mqtt.rst
@@ -60,8 +60,9 @@ Configuration variables:
   `Abbreviations <https://www.home-assistant.io/docs/mqtt/discovery/>`__
   in discovery messages. Defaults to ``true``.
 - **topic_prefix** (*Optional*, string): The prefix used for all MQTT
-  messages. Should not contain trailing slash. Defaults to
-  ``<APP_NAME>``.
+  messages. Should not contain trailing slash. Defaults to ``<APP_NAME>``. 
+  Use ``null`` to disable publishing or subscribing of any MQTT topic unless
+  it is explicitly configured.
 - **log_topic** (*Optional*, :ref:`mqtt-message`): The topic to send MQTT log
   messages to. Use ``null`` if you want to disable sending logs to MQTT.
 
@@ -373,9 +374,17 @@ Configuration variables:
 -  **state_topic** (*Optional*, string): The topic to publish state
    updates to. Defaults to
    ``<TOPIC_PREFIX>/<COMPONENT_TYPE>/<COMPONENT_NAME>/state``.
+   
+   ESPHome will always publish a manually configured state topic, even if 
+   the component is internal. Use ``null`` to disable publishing the 
+   component's state.
 -  **command_topic** (*Optional*, string): The topic to subscribe to for
    commands from the remote. Defaults to
    ``<TOPIC_PREFIX>/<COMPONENT_TYPE>/<COMPONENT_NAME>/command``.
+   
+   ESPHome will always subscribe to a manually configured command topic, 
+   even if the component is internal. Use ``null`` to disable subscribing 
+   to the component's command topic.
 -  **command_retain** (*Optional*, boolean): Whether MQTT command messages
    sent to the device should be retained or not. Default to ``false``.
 


### PR DESCRIPTION
## Description:

This PR documents setting the ``state_topic`` or ``command_topic`` to null per esphome/esphome#5213. It also adds documentation for the behavior with the new linked PR for a null ``topic_prefix``.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#5644

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
