### PR TITLE
Pulse light effect transition updates

### DIFF
--- a/components/light/index.rst
+++ b/components/light/index.rst
@@ -492,11 +492,21 @@ This effect makes a pulsating light. The period can be defined by ``update_inter
               name: "Slow Pulse"
               # transition_length: 1s      # defaults to 1s
               update_interval: 2s
+          - pulse:
+              name: "Asymmetrical Pulse"
+              transition_length:
+                on_length: 1s
+                off_length: 500ms
+              update_interval: 1.5s
 
 Configuration variables:
 
 - **name** (*Optional*, string): The name of the effect. Defaults to ``Pulse``.
-- **transition_length** (*Optional*, :ref:`config-time`): The duration of each transition. Defaults to ``1s``.
+- **transition_length** (*Optional*, :ref:`config-time`): The duration of each transition.
+  Defaults to ``1s``. Can be a single time or split for on and off using these nested options.
+
+  - **on_length** (*Optional*, :ref:`config-time`): The duration of the transition when the light is turned on.
+  - **off_length** (*Optional*, :ref:`config-time`): The duration of the transition when the light is turned off.
 - **update_interval** (*Optional*, :ref:`config-time`): The interval when the new transition is started. Defaults to ``1s``.
 - **min_brightness** (*Optional*, percentage): The minimum brightness value. Defaults to ``0%``
 - **max_brightness** (*Optional*, percentage): The maximum brightness value. Defaults to ``100%``


### PR DESCRIPTION
## Description:

Adding the nested transition length times for pulse effect


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#5659

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
