### PR TITLE
Fix typo in canbus.rst

### DIFF
--- a/components/canbus.rst
+++ b/components/canbus.rst
@@ -352,7 +352,7 @@ Standard IDs and Extended IDs can coexist on the same segment.
                   data: [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]
               - canbus.send:
                   # Standard ID by default
-                  can_id: 0y100
+                  can_id: 0x100
                   data: [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]
 
     canbus:


### PR DESCRIPTION
## Description:

Just a mistyped constant.

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
