### PR TITLE
Add hint for activating new ESPHome devices in HA

### DIFF
--- a/components/api.rst
+++ b/components/api.rst
@@ -24,6 +24,12 @@ A Python library that implements this protocol is `aioesphomeapi <https://github
     # Example configuration entry
     api:
 
+.. note::
+
+    Before a new ESPHome device can use the Home Assistant API it needs to be allowed to communicate with HA. This is done in
+    the ESPHome integration (NOT in the Add-On) by clicking "CONFIGURE" for that device and check the "Allow device to make
+    service calls" option.
+
 Configuration variables:
 ------------------------
 

--- a/components/api.rst
+++ b/components/api.rst
@@ -24,12 +24,6 @@ A Python library that implements this protocol is `aioesphomeapi <https://github
     # Example configuration entry
     api:
 
-.. note::
-
-    Before a new ESPHome device can use the Home Assistant API it needs to be allowed to communicate with HA. This is done in
-    the ESPHome integration (NOT in the Add-On) by clicking "CONFIGURE" for that device and check the "Allow device to make
-    service calls" option.
-
 Configuration variables:
 ------------------------
 
@@ -80,6 +74,12 @@ Configuration variables:
   disconnects from the API. See :ref:`api-on_client_disconnected_trigger`.
 
 .. _api-actions:
+
+.. note::
+
+    Before a newly added ESPHome device can interact with the Home Assistant API it needs to be allowed to communicate
+    with it. This setting can be found in the ESPHome integration (NOT in the Add-On) by clicking "CONFIGURE" for
+    that device and enabling the "Allow device to make service calls" option.
 
 Actions
 -------


### PR DESCRIPTION
## Description:
This adds a hint for a crucial step when configuring a new ESPHome device and wanting it to use Home Assistant services.

Background: It took me a painful week to find out that I need to explicitly enable a new ESPHome device in Home Assistant before it can use the Native API. That information was nowhere and there are no debug hints in the docs.

The debug process has an additional complexity because there's the ESPHome integration and the ESPHome add-on, which have the same name but do totally different things, so it's difficult to understand where to look for error or debug messages, if you're not deeply familiar with Home Assistant (I'm using HA for more than four years now, but I still can't wrap my head around stuff like that).

**Related issue (if applicable):** _no issue_

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** _not related to an ESPHome change_

## Checklist:
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.
