### PR TITLE
Update alarm controller docs

### DIFF
--- a/components/alarm_control_panel/index.rst
+++ b/components/alarm_control_panel/index.rst
@@ -218,9 +218,9 @@ opens.
 
     alarm_control_panel:
       # ...
-      on_disarmed:
+      on_chime:
         then:
-          - logger.log: "Alarm Disarmed!"
+          - logger.log: "Alarm Chime!"
 
 .. _alarm_control_panel_arm_away_action:
 ``arm_away`` Action

--- a/components/alarm_control_panel/index.rst
+++ b/components/alarm_control_panel/index.rst
@@ -44,6 +44,11 @@ Configuration variables:
   when the alarm state changes to ``disarmed``. See :ref:`alarm_control_panel_on_disarmed_trigger`.
 - **on_cleared** (*Optional*, :ref:`Action <config-action>`): An automation to perform
   when the alarm clears. See :ref:`alarm_control_panel_on_cleared_trigger`.
+- **on_ready** (*Optional*, :ref:`Action <config-action>`): An automation to perform
+  when the logical 'and' of all the zone sensors change state. See :ref:`alarm_control_panel_on_ready_trigger`.
+- **on_chime** (*Optional*, :ref:`Action <config-action>`): An automation to perform
+  when a zone has been marked as chime in the configuration, and it changes from closed to open. 
+  See :ref:`alarm_control_panel_on_chime_trigger`.
 
 
 Automation:
@@ -184,8 +189,38 @@ This trigger is activated when the alarm changes from to disarmed.
         then:
           - logger.log: "Alarm Disarmed!"
 
-.. _alarm_control_panel_arm_away_action:
+.. _alarm_control_panel_on_ready_trigger:
+``on_ready`` Trigger
+***********************
 
+This trigger is activated when the logical 'and' of all the alarm sensors change state. This is useful for implementing alarm ready LED's.
+Once this trigger is called, you can get the ready state by calling get_all_sensors_ready() in a lambda block.
+
+.. code-block:: yaml
+
+    alarm_control_panel:
+      # ...
+      on_disarmed:
+        then:
+          - lambda: !lambda |-
+              ESP_LOGI("AlarmPanel", "Sensor ready change to: %s", ((id(acp1).get_all_sensors_ready()) ? (const char *) "True" : (const char *) "False"));
+
+.. _alarm_control_panel_on_chime_trigger:
+``on_chime`` Trigger
+***********************
+
+This trigger is activated when a zone sensor marked with chime:true changes from closed to open. This is useful for implementing keypad chimes when a zone
+opens.
+
+.. code-block:: yaml
+
+    alarm_control_panel:
+      # ...
+      on_disarmed:
+        then:
+          - logger.log: "Alarm Disarmed!"
+
+.. _alarm_control_panel_arm_away_action:
 ``arm_away`` Action
 *******************
 
@@ -296,6 +331,7 @@ From :ref:`lambdas <config-lambda>`, you can call the following methods:
 - ``arm_home(code)``
 - ``arm_night(code)``
 - ``disarm(code)``
+-- ``get_all_sensors_ready()``
 
 .. code-block:: cpp
 
@@ -303,6 +339,7 @@ From :ref:`lambdas <config-lambda>`, you can call the following methods:
     id(acp1).arm_home();
     id(acp1).arm_night();
     id(acp1).disarm(std::string("1234"));
+    bool all_sensors_ready = id(acp1).get_all_sensors_ready();
 
 
 Platforms

--- a/components/alarm_control_panel/index.rst
+++ b/components/alarm_control_panel/index.rst
@@ -190,6 +190,7 @@ This trigger is activated when the alarm changes from to disarmed.
           - logger.log: "Alarm Disarmed!"
 
 .. _alarm_control_panel_on_ready_trigger:
+
 ``on_ready`` Trigger
 ***********************
 
@@ -206,6 +207,7 @@ Once this trigger is called, you can get the ready state by calling get_all_sens
               ESP_LOGI("AlarmPanel", "Sensor ready change to: %s", ((id(acp1).get_all_sensors_ready()) ? (const char *) "True" : (const char *) "False"));
 
 .. _alarm_control_panel_on_chime_trigger:
+
 ``on_chime`` Trigger
 ***********************
 

--- a/components/alarm_control_panel/index.rst
+++ b/components/alarm_control_panel/index.rst
@@ -223,6 +223,7 @@ opens.
           - logger.log: "Alarm Chime!"
 
 .. _alarm_control_panel_arm_away_action:
+
 ``arm_away`` Action
 *******************
 

--- a/components/alarm_control_panel/index.rst
+++ b/components/alarm_control_panel/index.rst
@@ -333,7 +333,7 @@ From :ref:`lambdas <config-lambda>`, you can call the following methods:
 - ``arm_home(code)``
 - ``arm_night(code)``
 - ``disarm(code)``
--- ``get_all_sensors_ready()``
+- ``get_all_sensors_ready()``
 
 .. code-block:: cpp
 

--- a/components/alarm_control_panel/template.rst
+++ b/components/alarm_control_panel/template.rst
@@ -65,13 +65,17 @@ State Flow:
 
 3. When the alarm is tripped by a sensor state changing to ``on`` or ``alarm_control_panel_pending_action`` invoked
   1. If sensor_type is set to ``delayed``:
+
     1. ``pending_time`` greater than 0 the state is ``PENDING``
     2. ``pending_time`` is 0 or after the ``pending_time`` delay the state is ``TRIGGERED``
   2. If sensor_type is set to ``instant``:
+
     1. The state is set to ``TRIGGERED``
   3. If the sensor_type is set to ``interior_follower``:
+
     1. If the current state is ``ARMED_...`` the state will be set to ``TRIGGERED``
     2. If the current state is ``PENDING`` then nothing will happen and it will stay in the ``PENDING`` state.
+
 4. If ``trigger_time`` greater than 0 and no sensors are ``on`` after ``trigger_time`` delay
    the state returns to ``ARM_...``
 

--- a/components/alarm_control_panel/template.rst
+++ b/components/alarm_control_panel/template.rst
@@ -68,9 +68,11 @@ State Flow:
 
     1. ``pending_time`` greater than 0 the state is ``PENDING``
     2. ``pending_time`` is 0 or after the ``pending_time`` delay the state is ``TRIGGERED``
+
   2. If sensor_type is set to ``instant``:
 
     1. The state is set to ``TRIGGERED``
+
   3. If the sensor_type is set to ``interior_follower``:
 
     1. If the current state is ``ARMED_...`` the state will be set to ``TRIGGERED``

--- a/components/alarm_control_panel/template.rst
+++ b/components/alarm_control_panel/template.rst
@@ -64,6 +64,7 @@ State Flow:
   b. ``arming_..._time`` is 0 or after the delay the state is ``ARMED_...``
 
 3. When the alarm is tripped by a sensor state changing to ``on`` or ``alarm_control_panel_pending_action`` invoked
+
   1. If sensor_type is set to ``delayed``:
 
     1. ``pending_time`` greater than 0 the state is ``PENDING``

--- a/components/alarm_control_panel/template.rst
+++ b/components/alarm_control_panel/template.rst
@@ -36,6 +36,8 @@ Configuration variables:
   - **input** (**Required**, string): The id of the binary sensor component
   - **bypass_armed_home** (*Optional*, boolean): This binary sensor will not trigger the alarm when in ``armed_home`` state.
   - **bypass_armed_night** (*Optional*, boolean): This binary sensor will not trigger the alarm when in ``armed_night`` state.
+  - **sensor_type** (*Optional*, string): Sets the sensor type. One of ``delayed``, ``instant``, or ``interior_follower``. (``delayed`` is default if not specified)
+  - **chime** (*Optional*, boolean): When set ``true``, the chime callback will be called whenever the sensor goes from closed to open. (``false`` is the default if not specified)
 
 - **restore_mode** (*Optional*, enum):
 
@@ -62,10 +64,14 @@ State Flow:
   b. ``arming_..._time`` is 0 or after the delay the state is ``ARMED_...``
 
 3. When the alarm is tripped by a sensor state changing to ``on`` or ``alarm_control_panel_pending_action`` invoked
-
-  a. ``pending_time`` greater than 0 the state is ``PENDING``
-  b. ``pending_time`` is 0 or after the ``pending_time`` delay the state is ``TRIGGERED``
-
+  1. If sensor_type is set to ``delayed``:
+    1. ``pending_time`` greater than 0 the state is ``PENDING``
+    2. ``pending_time`` is 0 or after the ``pending_time`` delay the state is ``TRIGGERED``
+  2. If sensor_type is set to ``instant``:
+    1. The state is set to ``TRIGGERED``
+  3. If the sensor_type is set to ``interior_follower``:
+    1. If the current state is ``ARMED_...`` the state will be set to ``TRIGGERED``
+    2. If the current state is ``PENDING`` then nothing will happen and it will stay in the ``PENDING`` state.
 4. If ``trigger_time`` greater than 0 and no sensors are ``on`` after ``trigger_time`` delay
    the state returns to ``ARM_...``
 
@@ -95,8 +101,16 @@ Example:
       trigger_time: 5min
       binary_sensors:
         - input: zone_1
+          chime: true
+          sensor_type: delayed
         - input: zone_2
+          chime: true
+          sensor_type: delayed
+        - input: zone_3
           bypass_armed_home: true
+          sensor_type: interior_follower
+        - input: zone_4
+          sensor_type: instant
         - input: ha_test
       on_state:
         then:
@@ -108,6 +122,15 @@ Example:
       on_cleared:
         then:
           - switch.turn_off: siren
+      on_ready:
+        then:
+         - lambda: !lambda |-
+             ESP_LOGD("TEST", "Sensor ready change to: %s",
+               (id(acp1).get_all_sensors_ready())) ? (const char *) "True" : (const char *) "False");
+      on_chime:
+        then:
+         - lambda: !lambda |-
+             ESP_LOGD("TEST", "Zone with chime mode set opened");
 
     binary_sensor:
       - platform: gpio
@@ -121,14 +144,30 @@ Example:
       - platform: gpio
         id: zone_2
         name: Zone 2
-        device_class: motion
+        device_class: door
         pin:
           number: D2
           mode: INPUT_PULLUP
           inverted: True
+      - platform: gpio
+        id: zone_3
+        name: Zone 3
+        device_class: motion
+        pin:
+          number: D3
+          mode: INPUT_PULLUP
+          inverted: True
+      - platform: gpio
+        id: zone_4
+        name: Zone 4
+        device_class: door
+        pin:
+          number: D4
+          mode: INPUT_PULLUP
+          inverted: True
       - platform: homeassistant
         id: ha_test
-        name: Zone 3
+        name: HA Test
         entity_id: input_boolean.test_switch
 
     switch:


### PR DESCRIPTION
Add zone type, add chime.

## Description:
Adds documentation for new features in the alarm panel controller. The new features are support for sensor types, and chime attribute. 2 new callbacks have been added: on_ready, and on_chime.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#5671

## Checklist:

  - [ X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
