### PR TITLE
min_integral and max_integral had transposed minimum & maximum

### DIFF
--- a/components/climate/pid.rst
+++ b/components/climate/pid.rst
@@ -68,9 +68,9 @@ Configuration variables:
     Defaults to ``0``.
   - **kd** (*Optional*, float): The factor for the derivative term of the PID controller.
     Defaults to ``0``.
-  - **min_integral** (*Optional*, float): The maximum value of the integral term multiplied by
+  - **min_integral** (*Optional*, float): The minimum value of the integral term multiplied by
     ``ki`` to prevent windup. Defaults to ``-1``.
-  - **max_integral** (*Optional*, float): The minimum value of the integral term multiplied by
+  - **max_integral** (*Optional*, float): The maximum value of the integral term multiplied by
     ``ki`` to prevent windup. Defaults to ``1``.
   - **starting_integral_term** (*Optional*, float): Set the initial output, by priming the integral
     term. This is useful for when your system is rebooted and you don't want to wait


### PR DESCRIPTION
## Description:

Small edit to min_integral & max_integral descriptions - the use of minimum and maximum had been transposed.

