### PR TITLE
Added documentation for id and uart_id variables of modbus

### DIFF
--- a/components/modbus.rst
+++ b/components/modbus.rst
@@ -23,6 +23,11 @@ ModBUS requires a :ref:`UART Bus <uart>` to communicate.
 Configuration variables:
 ------------------------
 
+- **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
+
+- **uart_id** (*Optional*, :ref:`config-id`): Manually specify the ID of the :ref:`UART Component <uart>` if you want
+  to use multiple UART buses.
+
 - **flow_control_pin** (*Optional*, :ref:`config-pin`): The pin used to switch flow control.
   This is useful for RS485 transceivers that do not have automatic flow control switching,
   like the common MAX485.


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
