### PR TITLE
Update esp32_camera.rst to include M5CameraF New example

### DIFF
--- a/components/esp32_camera.rst
+++ b/components/esp32_camera.rst
@@ -257,6 +257,25 @@ Configuration for M5Stack Timer Camera X/F
       name: My Camera
       # ...
 
+Confguration for M5Stack M5CameraF New
+--------------------------------------
+
+.. code-block:: yaml
+
+    # Example configuration entry as per https://docs.m5stack.com/en/unit/m5camera_f_new
+    esp32_camera:
+      external_clock:
+        pin: GPIO27
+        frequency: 20MHz
+      i2c_pins:
+        sda: GPIO22
+        scl: GPIO23
+      data_pins: [GPIO32, GPIO35, GPIO34, GPIO5, GPIO39, GPIO18, GPIO36, GPIO19]
+      vsync_pin: GPIO25
+      href_pin: GPIO26
+      pixel_clock_pin: GPIO21
+      reset_pin: GPIO15
+
 Configuration for Wrover Kit Boards
 -----------------------------------
 


### PR DESCRIPTION
Existing m5stack examples were subtly different (vsync / i2c etc)

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
