### PR TITLE
[web_server] Add documentation for Private Network Access support

### DIFF
--- a/components/web_server.rst
+++ b/components/web_server.rst
@@ -57,8 +57,8 @@ Configuration variables:
 - **include_internal** (*Optional*, boolean): Whether ``internal`` entities should be displayed on the
   web interface. Defaults to ``false``.
 - **enable_private_network_access** (*Optional*, boolean): Enables support for
-  [Private Network Access](https://wicg.github.io/private-network-access) and the 
-  [Private Network Access Permission Prompt](https://wicg.github.io/private-network-access/#permission-prompt).
+  `Private Network Access <https://wicg.github.io/private-network-access>`__ and the
+  `Private Network Access Permission Prompt <https://wicg.github.io/private-network-access/#permission-prompt>`__.
   Defaults to ``true``.
 - **log** (*Optional*, boolean): Turn on or off the log feature inside webserver. Defaults to ``true``.
 - **ota** (*Optional*, boolean): Turn on or off the OTA feature inside webserver. Strongly not suggested without enabled authentication settings. Defaults to ``true``. Cannot be used with the ``esp-idf`` framework.

--- a/components/web_server.rst
+++ b/components/web_server.rst
@@ -56,6 +56,10 @@ Configuration variables:
 
 - **include_internal** (*Optional*, boolean): Whether ``internal`` entities should be displayed on the
   web interface. Defaults to ``false``.
+- **enable_private_network_access** (*Optional*, boolean): Enables support for
+  [Private Network Access](https://wicg.github.io/private-network-access) and the 
+  [Private Network Access Permission Prompt](https://wicg.github.io/private-network-access/#permission-prompt).
+  Defaults to ``true``.
 - **log** (*Optional*, boolean): Turn on or off the log feature inside webserver. Defaults to ``true``.
 - **ota** (*Optional*, boolean): Turn on or off the OTA feature inside webserver. Strongly not suggested without enabled authentication settings. Defaults to ``true``. Cannot be used with the ``esp-idf`` framework.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.


### PR DESCRIPTION
## Description:
Adds documentation for the PR https://github.com/esphome/esphome/pull/5669

**Related issue (if applicable):** https://github.com/esphome/feature-requests/issues/2453

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** [esphome/esphome#<esphome PR number goes here>](https://github.com/esphome/esphome/pull/5669)

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
