### PR TITLE
Add docs for addressable color wipe gradient feature

### DIFF
--- a/components/light/index.rst
+++ b/components/light/index.rst
@@ -721,7 +721,7 @@ Configuration variables:
   - **blue** (*Optional*, percentage): The percentage the blue color channel should be on. Defaults to ``100%``.
   - **random** (*Optional*, boolean): If set to ``true``, will overwrite the RGB colors by a new, randomly-chosen
     color each time. Defaults to ``false``.
-  - **num_leds** (**Required**, positive int): The number of leds of this type to have before moving on to the next color. If ``gradient`` is true, it's the number of leds to transition to the next color over.
+  - **num_leds** (**Required**, positive int): The number of LEDs of this type to have before transitioning to the next color. If ``gradient`` is true, this will be the number of LEDs over which the color transition will occur.
   - **gradient** (*Optional*, boolean): If ``true`` the current color will transition with a gradient over ``num_leds`` to the next color. Defaults to ``false``.
 
 - **add_led_interval** (*Optional*, :ref:`config-time`): The interval with which to shift in new leds at the

--- a/components/light/index.rst
+++ b/components/light/index.rst
@@ -721,8 +721,8 @@ Configuration variables:
   - **blue** (*Optional*, percentage): The percentage the blue color channel should be on. Defaults to ``100%``.
   - **random** (*Optional*, boolean): If set to ``true``, will overwrite the RGB colors by a new, randomly-chosen
     color each time. Defaults to ``false``.
-  - **num_leds** (*Optional*, int): The number of leds of this type to have before moving on to the next color. If ``gradient`` is true, it's the number of leds to transition to the next color over. Defaults to previous color's ``num_leds`` or ``1`` on first color.
-  - **gradient** (*Optional*, boolean): If ``true`` the current color will transition with a gradient over ``num_leds`` to the next color. Defaults to previous color's ``gradient`` setting, or for ``false`` first color.
+  - **num_leds** (**Required**, positive int): The number of leds of this type to have before moving on to the next color. If ``gradient`` is true, it's the number of leds to transition to the next color over.
+  - **gradient** (*Optional*, boolean): If ``true`` the current color will transition with a gradient over ``num_leds`` to the next color. Defaults to ``false``.
 
 - **add_led_interval** (*Optional*, :ref:`config-time`): The interval with which to shift in new leds at the
   beginning of the strip. Defaults to ``100ms``.

--- a/components/light/index.rst
+++ b/components/light/index.rst
@@ -708,6 +708,7 @@ the strip and shifts them forward every ``add_led_interval``.
                   num_leds: 1
               add_led_interval: 100ms
               reverse: false
+              gradient: false
 
 Configuration variables:
 
@@ -720,11 +721,12 @@ Configuration variables:
   - **blue** (*Optional*, percentage): The percentage the blue color channel should be on. Defaults to ``100%``.
   - **random** (*Optional*, boolean): If set to ``true``, will overwrite the RGB colors by a new, randomly-chosen
     color each time. Defaults to ``false``.
-  - **num_leds** (*Optional*, int): The number of leds of this type to have before moving on to the next color.
+  - **num_leds** (*Optional*, int): The number of leds of this type to have before moving on to the next color. If ``gradient`` is true, it's the number of leds to transition to the next color over. Defaults to previous ``num_leds`` or ``1`` on first.
 
 - **add_led_interval** (*Optional*, :ref:`config-time`): The interval with which to shift in new leds at the
   beginning of the strip. Defaults to ``100ms``.
 - **reverse** (*Optional*, boolean): Whether to reverse the direction of the color wipe. Defaults to ``false``.
+- **gradient** (*Optional*, boolean): If ``true`` new colors are a gradient from the current to next color. Defaults to ``false``.
 
 Addressable Scan Effect
 ***********************

--- a/components/light/index.rst
+++ b/components/light/index.rst
@@ -721,12 +721,12 @@ Configuration variables:
   - **blue** (*Optional*, percentage): The percentage the blue color channel should be on. Defaults to ``100%``.
   - **random** (*Optional*, boolean): If set to ``true``, will overwrite the RGB colors by a new, randomly-chosen
     color each time. Defaults to ``false``.
-  - **num_leds** (*Optional*, int): The number of leds of this type to have before moving on to the next color. If ``gradient`` is true, it's the number of leds to transition to the next color over. Defaults to previous ``num_leds`` or ``1`` on first.
+  - **num_leds** (*Optional*, int): The number of leds of this type to have before moving on to the next color. If ``gradient`` is true, it's the number of leds to transition to the next color over. Defaults to previous color's ``num_leds`` or ``1`` on first color.
+  - **gradient** (*Optional*, boolean): If ``true`` the current color will transition with a gradient over ``num_leds`` to the next color. Defaults to previous color's ``gradient`` setting, or for ``false`` first color.
 
 - **add_led_interval** (*Optional*, :ref:`config-time`): The interval with which to shift in new leds at the
   beginning of the strip. Defaults to ``100ms``.
 - **reverse** (*Optional*, boolean): Whether to reverse the direction of the color wipe. Defaults to ``false``.
-- **gradient** (*Optional*, boolean): If ``true`` new colors are a gradient from the current to next color. Defaults to ``false``.
 
 Addressable Scan Effect
 ***********************


### PR DESCRIPTION
## Description:

Add documentation for addressable color wipe gradient feature. Also addresses `num_leds` optional being inconsistent with the existing code.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#5689

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
