### PR TITLE
add get_total_pulses() reference

### DIFF
--- a/components/sensor/pulse_counter.rst
+++ b/components/sensor/pulse_counter.rst
@@ -102,6 +102,38 @@ measure the total consumed energy in kWh.
           filters:
             - multiply: 0.001  # (1/1000 pulses per kWh)
 
+To get the total pulses at that very instant, we'll use get_total_pulses() to 
+achieve this.
+
+.. code-block:: yaml
+
+    # Example configuration entry
+    sensor:
+      - platform: gpio
+        pin: GPIO15
+        ...
+        ...
+        on_turn_on:
+          - pulse_counter.set_total_pulses:
+              id: icemaker_water_flow_rate
+              value: 0
+          - while:
+              condition:
+                - switch.is_on: icemaker_relay_water_on
+              then:
+                - component.update: icemaker_water_flow_rate
+                - component.update: icemaker_water_flow_pulses
+                - delay: 1s
+          - delay: 3s
+          - if:
+              condition:
+                - and:
+                  - switch.is_on: icemaker_relay_water_on
+                 # check if water is actually flowing
+                  - lambda: !lambda |-
+                      return id(icemaker_water_flow_rate).get_total_pulses() < 30;
+
+
 (Re)Setting the total pulse count
 ---------------------------------
 


### PR DESCRIPTION
## Description:

This commit refers to an implementation of a method in pulse_counter library to retrieve the latest pulse count.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#5698

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
