### PR TITLE
Add documentation for flash size

### DIFF
--- a/components/esp32.rst
+++ b/components/esp32.rst
@@ -23,13 +23,16 @@ Configuration variables:
   choose a generic board from Espressif such as ``esp32dev``.
 - **framework** (*Optional*): Options for the underlying framework used by ESPHome.
   See :ref:`esp32-arduino_framework` and :ref:`esp32-espidf_framework`.
+- **flash_size** (*Optional*, string): The amount of flash memory available on the ESP32 board/module. One of ``4MB``,
+  ``8MB``, ``16MB`` or ``32MB``. Defaults to ``4MB``. **Warning: specifying a size larger than that available on your
+  board will cause the ESP32 to fail to boot.**
 - **variant** (*Optional*, string): The variant of the ESP32 that is used on this board. One of ``esp32``,
-  ``esp32s2``, ``esp32s3``, ``esp32c3`` and ``esp32h2``. Defaults to the variant that is detected from the board, if
+  ``esp32s2``, ``esp32s3``, ``esp32c3`` and ``esp32h2``. Defaults to the variant that is detected from the board; if
   a board that's unknown to ESPHome is used, this option is mandatory.
 
 .. note::
 
-    Support for the ESP32-S2 and ESP32-C3 is still in development and there could be issues.
+    Support for ESP32 variants such as the S2, S3 and C3 is still in development and there could be issues.
 
 GPIO Pin Numbering
 ------------------


### PR DESCRIPTION
## Description:

Documents esphome/esphome#5697

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#5697

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
