### PR TITLE
Fix reference error in tm1637.rst

### DIFF
--- a/components/display/tm1637.rst
+++ b/components/display/tm1637.rst
@@ -46,8 +46,6 @@ Configuration variables:
 - **update_interval** (*Optional*, :ref:`config-time`): The interval to re-draw the screen. Defaults to ``1s``.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
 
-.. _display-tm1637_lambda:
-
 Binary Sensor
 -------------
 
@@ -78,6 +76,8 @@ Configuration variables:
 - **key** (**Required**, integer): The keycode for the connected key (Seg0 = 0, Seg1 = 1 etc,). Range is from
   0 to 15.
 - All other options from :ref:`Binary Sensor <config-binary_sensor>`.
+
+.. _display-tm1637_lambda:
 
 Rendering Lambda
 ----------------


### PR DESCRIPTION
The reference to the render lambda was to the binary sensor. This fixes the reference.