### PR TITLE
Fix a typo in the text template documentation

### DIFF
--- a/components/text/template.rst
+++ b/components/text/template.rst
@@ -22,7 +22,7 @@ using :ref:`lambdas <config-lambda>`.
 Configuration variables:
 ------------------------
 
-- **min_lenngth** (**Required**, float): The minimum length this text can be.
+- **min_length** (**Required**, float): The minimum length this text can be.
 - **max_length** (**Required**, float): The maximum length this text can be.
 - **lambda** (*Optional*, :ref:`lambda <config-lambda>`):
   Lambda to be evaluated every update interval to get the current value of the text.


### PR DESCRIPTION
## Description:
There is a typo in the text template sensor documentation

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** N/A

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
