### PR TITLE
Fix typo, double colon in fan action

### DIFF
--- a/components/fan/index.rst
+++ b/components/fan/index.rst
@@ -147,7 +147,7 @@ Increments through speed levels of the fan with the given ID when executed. If t
             id: fan_1
             off_speed_cycle: true
         # Shorthand:
-        - fan.cycle_speed:: fan_1
+        - fan.cycle_speed: fan_1
 
 Configuration options:
 


### PR DESCRIPTION
## Description:
Fix typo in fan action

**Related issue (if applicable): None

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
