### PR TITLE
Add ESP32 S3 box to ESPHome projects

### DIFF
--- a/projects/installer.html
+++ b/projects/installer.html
@@ -161,7 +161,7 @@
         alt="M5Stack Atom Echo Development Kit"
       />
     </label>
-    <!-- <label>
+    <label>
       <input
         type="radio"
         name="voice-device"
@@ -172,7 +172,7 @@
         src="/_static/projects/voice-assistant/esp32-s3-box-3.png"
         alt="ESP32-S3-BOX-3"
       />
-    </label> -->
+    </label>
   </div>
 
   <div class="hidden info esp32-s3-box-3">


### PR DESCRIPTION
## Description:
The ESP32 S3 box firmware is ready for the projects website after https://github.com/esphome/firmware/pull/98

<img width="850" alt="image" src="https://github.com/esphome/esphome-docs/assets/1444314/0d370af9-9ed3-49be-97c6-7eaf59b504c9">


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
