### PR TITLE
Fix decay_mode comment in hbridge fan example configuration.

### DIFF
--- a/components/fan/hbridge.rst
+++ b/components/fan/hbridge.rst
@@ -38,7 +38,7 @@ The ``hbridge`` fan platform allows you to use a compatible *h-bridge* (L298N, D
         pin_a: motor_forward_pin
         pin_b: motor_reverse_pin
         # enable_pin: motor_enable
-        decay_mode: slow   # slow decay mode (braking) or fast decay (coasting).
+        decay_mode: slow   # slow decay mode (coasting) or fast decay (braking).
 
 Configuration variables:
 ------------------------


### PR DESCRIPTION
## Description:
The comment incorrectly described the slow decay mode as braking, and fast decay mode as coasting.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** N/A

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
