### PR TITLE
wifi signal percent device class blank for HA log warning

### DIFF
--- a/components/sensor/wifi_signal.rst
+++ b/components/sensor/wifi_signal.rst
@@ -42,6 +42,7 @@ To additionally display signal strength in percentage use the :ref:`copy-sensor`
           - lambda: return min(max(2 * (x + 100.0), 0.0), 100.0);
         unit_of_measurement: "Signal %"
         entity_category: "diagnostic"
+        device_class: ""
 
 Configuration variables:
 ------------------------


### PR DESCRIPTION
## Description:
When applying the current example for WiFi Signal Strength https://esphome.io/components/sensor/wifi_signal you will get a warning in home assistant to the tune of:
`Entity sensor.<name>_wifi_signal_percent (<class 'homeassistant.components.esphome.sensor.EsphomeSensor'>) is using native unit of measurement '%' which is not a valid unit for the device class ('signal_strength') it is using; expected one of ['dBm', 'dB']; Please update your configuration if your entity is manually configured, otherwise create a bug report at https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue+label%3A%22integration%3A+esphome%22`

However, if you add device_class: "" to the template it will go away.

**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/4763

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
