### PR TITLE
missing change directory directive

### DIFF
--- a/guides/contributing.rst
+++ b/guides/contributing.rst
@@ -373,6 +373,10 @@ a fork of the repository that you can modify and create git branches on.
     git clone https://github.com/<YOUR_GITHUB_USERNAME>/<REPO_NAME>.git
     # For example: git clone https://github.com/OttoWinter/esphome.git
 
+    # To continue you now need to enter the directory you created above
+    cd <REPRO_NAME>
+    # For example: cd esphome
+
     # Add "upstream" remote
     git remote add upstream https://github.com/esphome/<REPO_NAME>.git
     # For example: git remote add upstream https://github.com/esphome/esphome.git

--- a/guides/contributing.rst
+++ b/guides/contributing.rst
@@ -374,7 +374,7 @@ a fork of the repository that you can modify and create git branches on.
     # For example: git clone https://github.com/OttoWinter/esphome.git
 
     # To continue you now need to enter the directory you created above
-    cd <REPRO_NAME>
+    cd <REPO_NAME>
     # For example: cd esphome
 
     # Add "upstream" remote


### PR DESCRIPTION
I added the "cd esphome" command in the GIT section to make it easier for users not that familiar with GIT

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
