### PR TITLE
Clarify NEC data length

### DIFF
--- a/components/remote_transmitter.rst
+++ b/components/remote_transmitter.rst
@@ -343,6 +343,8 @@ This :ref:`action <config-action>` sends an NEC infrared remote code to a remote
     In version 2021.12, the order of transferring bits was corrected from MSB to LSB in accordance with the NEC standard.
     Therefore, if the configuration file has come from an earlier version of ESPhome, it is necessary to reverse the order of the address and command bits when moving to 2021.12 or above.
     For example, address: 0x84ED, command: 0x13EC becomes 0xB721 and 0x37C8 respectively.
+    Additionally, ESPHome does not automatically generate parity bits or pad values to 2 bytes.
+    So, in order to send command 0x0, you need to use 0xFF00 (0x00 being the command and 0xFF being the logical inverse).
 
 .. code-block:: yaml
 
@@ -353,8 +355,8 @@ This :ref:`action <config-action>` sends an NEC infrared remote code to a remote
 
 Configuration variables:
 
-- **address** (**Required**, int): The address to send, see dumper output for more details.
-- **command** (**Required**, int): The NEC command to send.
+- **address** (**Required**, int): The 16-bit address to send, see dumper output for more details.
+- **command** (**Required**, int): The 16-bit NEC command to send.
 - All other options from :ref:`remote_transmitter-transmit_action`.
 
 ``remote_transmitter.transmit_nexa`` Action


### PR DESCRIPTION
## Description:

I used [this program](https://github.com/crankyoldgit/IRremoteESP8266/blob/master/examples/IRrecvDumpV3/IRrecvDumpV3.ino) to dump IR codes from my remote. I got the results: address 0xDE80 & command 0x0. When I loaded that into ESPHome, it didn't send the parity bits for the command, which made the command 0x0000 and was thus invalid. Turns out both values need to be 16-bit and the parity bits need to be included, but that wasn't in the documentation, so I added that. Hopefully that saves someone some troubleshooting.


## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.
