### PR TITLE
Document non-numeric Wiegand keys

### DIFF
--- a/components/wiegand.rst
+++ b/components/wiegand.rst
@@ -69,6 +69,9 @@ Automations:
     Automatic handling of multiple keys (e.g. PIN code entry) is possible with the 
     the :ref:`Key Collector <key_collector>` component.
 
+    Keys 10 and 11 are ``*`` and ``#``.  They might be labelled as ``ENT`` or ``ESC``,
+    but check the logs to see which key code you get and use the corresponding character.
+
 
 See Also
 --------


### PR DESCRIPTION
## Description:
Document how to use the non-numeric keys if they exist.

**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/5138

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
