### PR TITLE
Update index.rst

### DIFF
--- a/components/select/index.rst
+++ b/components/select/index.rst
@@ -357,7 +357,7 @@ Setting up three options and set component state to selected option value.
          - "Option1"
          - "Option2"
          - "Option3"
-        initial_option: "OFF"
+        initial_option: "Option1"
         optimistic: true
         set_action:
           - logger.log:


### PR DESCRIPTION
Fix bug with incorrect value for 'initial_option'

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
