### PR TITLE
Update spi_led_strip.rst

### DIFF
--- a/components/light/spi_led_strip.rst
+++ b/components/light/spi_led_strip.rst
@@ -8,8 +8,8 @@ SPI LED Strip Light
 The ``spi_led_strip`` light platform drives one or more SPI interfaced RGB LEDs. These LEDs are often used in strips, where
 each LED is individually addressable. This component requires an SPI interface to be configured.
 
-This component has been tested with APA102 LEDs and should also work with HD107 and SK9822 type LEDs, or any others
-with a similar interface - SPI, 8 bits per colour and BGR ordering.
+This component has been tested with APA102 LEDs and the P9813 LED driver. It should also work with HD107 and SK9822 type 
+LEDs, or any others with a similar interface - SPI, 8 bits per colour and BGR ordering.
 
 .. figure:: images/apa102.jpg
     :align: center


### PR DESCRIPTION
## Description:

Mention that the `spi_led_strip` component also supports the `P9813` LED driver.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** N/A

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
