### PR TITLE
implementing web_server local_fallback option

### DIFF
--- a/components/web_server.rst
+++ b/components/web_server.rst
@@ -64,6 +64,8 @@ Configuration variables:
 - **ota** (*Optional*, boolean): Turn on or off the OTA feature inside webserver. Strongly not suggested without enabled authentication settings. Defaults to ``true``. Cannot be used with the ``esp-idf`` framework.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
 - **local** (*Optional*, boolean): Include supporting javascript locally allowing it to work without internet access. Defaults to ``false``.
+- **local_fallback** (*Optional*, boolean): Enables support for minimal fallback webpage if internet is not available, yet local option is not used.
+  Defaults to ``false``.
 - **version** (*Optional*, string): ``1`` or ``2``. Version 1 displays as a table. Version 2 uses web components and has more functionality. Defaults to ``2``.
 
 To conserve flash size, the CSS and JS files used on the root page to show a simple user


### PR DESCRIPTION
## Description:
web_server component should have the right to work even if internet is not available for the the IoT network.
I have created a minimal implementation of a display only server.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#5853

## Checklist:

  - [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
