### PR TITLE
Change the URL of the YAML repository, as the old one is archived

### DIFF
--- a/projects/installer.html
+++ b/projects/installer.html
@@ -543,7 +543,7 @@
     </li>
     <li>
       The YAML configuration is on
-      <a href="https://github.com/esphome/bluetooth-proxies/">GitHub</a>
+      <a href="https://github.com/esphome/firmware/tree/main/bluetooth-proxy">GitHub</a>
     </li>
   </ul>
 </div>


### PR DESCRIPTION
The currently linked repository is deprecated.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
