### PR TITLE
Update configuration-types.rst

### DIFF
--- a/guides/configuration-types.rst
+++ b/guides/configuration-types.rst
@@ -340,7 +340,8 @@ Another way to modularize and reuse your configuration is to use packages. This 
 you to put common pieces of configuration in separate files and keep only unique pieces of your
 config in the main yaml file. All definitions from packages will be merged with your main
 config in non-destructive way so you could always override some bits and pieces of package
-configuration.
+configuration. Substitutions in your main config will override substitutions with the same
+name in a package.
 
 Dictionaries are merged key-by-key. Lists of components are merged by component
 ID if specified. Other lists are merged by concatenation. All other config


### PR DESCRIPTION
## Description:
Added info about substitutions in packages will be overridden by substitutions in main config.

**Related issue (if applicable):** none

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**  -

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
