### PR TITLE
Warn users about ESP32 Tasmota v12 incompatibility

### DIFF
--- a/guides/migrate_sonoff_tasmota.rst
+++ b/guides/migrate_sonoff_tasmota.rst
@@ -9,7 +9,7 @@ Migrating from previous Tasmota setups is very easy. You just need to have
 ESPHome create a binary for you and then upload that in the Tasmota web interface.
 
 Incompatible versions
-------------------
+---------------------
 WARNING! Migrating via OTA on ESP32, from Tasmota v12 (with boot partition) and up is currently not possible! Trying it could soft-brick your device!
 
 

--- a/guides/migrate_sonoff_tasmota.rst
+++ b/guides/migrate_sonoff_tasmota.rst
@@ -8,6 +8,11 @@ Migrating from Tasmota
 Migrating from previous Tasmota setups is very easy. You just need to have
 ESPHome create a binary for you and then upload that in the Tasmota web interface.
 
+Incompatible versions
+------------------
+WARNING! Migrating via OTA on ESP32, from Tasmota v12 (with boot partition) and up is currently not possible! Trying it could soft-brick your device!
+
+
 Getting the Binary
 ------------------
 


### PR DESCRIPTION
## Description:
The guide for migration from Tasmota is missing a very important piece of information: it's not possible if you're on ESP32, Tasmota version 12 (and up) with a boot partition (which seems to be mandatory in v13).

The HA community has stumbled upon this problem, see [here](https://community.home-assistant.io/t/error-flashing-esphome-after-migration-from-tasmota-on-esp32-sonoff-dualr3/515987). Had I known this earlier, I wouldn't now have bricked devices...
Let's prevent this from happening to other people's devices...

**Related issue (if applicable):** fixes N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** N/A

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
