### PR TITLE
Add missing required attribute name

### DIFF
--- a/components/sensor/airthings_ble.rst
+++ b/components/sensor/airthings_ble.rst
@@ -53,6 +53,7 @@ Configuration example:
 
     sensor:
       - platform: airthings_wave_plus
+        name: wave_plus
         ble_client_id: airthings01
         update_interval: 5min # default
         battery_update_interval: 24h # default


### PR DESCRIPTION
airthings_wave_plug requires `id` or `name` attributes, but both were missing in the sample. Adding `name` into the sample to have a working sample.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
