### PR TITLE
Add Waveshare 1.47in 172x320 to ST7789v component

### DIFF
--- a/components/display/st7789v.rst
+++ b/components/display/st7789v.rst
@@ -72,6 +72,7 @@ If you do specify them they will override any default.
   - ``Adafruit RR 280x240`` (round-rectangular display -- some pixels are "deleted" from corners to form rounded shape)
   - ``Adafruit S2 TFT FEATHER 240X135``
   - ``LILYGO T-Embed 170X320``
+  - ``Waveshare 1.47in 172X320`` (round-rectangular display -- some pixels are "deleted" from corners to form rounded shape)
   - ``Custom`` For other displays not listed above
 
 - **height** (**Required**, int): Sets height of display in pixels. Defaults depends ``model``.
@@ -177,6 +178,16 @@ Items marked RQ are hardware dependent but required and not preset. Items marked
      - 46
      - 12
      - 11
+   * - Waveshare 1.47in 172X320
+     - 320/172
+     - 34/0
+     - 21
+     - 22
+     - 23
+     - 4
+     - 
+     - 18
+     - 19
    * - Custom
      - RQ
      - RQ


### PR DESCRIPTION
## Description:
Add new display -  Waveshare 1.47in 172x320

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#5884

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
