### PR TITLE
Add a Binary Sensor Filter for state settling

### DIFF
--- a/components/binary_sensor/index.rst
+++ b/components/binary_sensor/index.rst
@@ -213,7 +213,7 @@ the filter chain.
 
 (**Required**, time, :ref:`templatable <config-templatable>`): When a signal is received, publish the state
 but wait for the received state to remain the same for specified time period before publishing any
-additional state changes. This filter complements the ``delay_on_off`` filter but publishes value changes at
+additional state changes. This filter complements the ``delayed_on_off`` filter but publishes value changes at
 the beginning of the delay period.
 When using a lambda call, you should return the delay value in milliseconds.
 **Useful for debouncing binary switches**.

--- a/components/binary_sensor/index.rst
+++ b/components/binary_sensor/index.rst
@@ -208,6 +208,16 @@ Specify any :ref:`lambda <config-lambda>` for more complex filters. The input va
 the binary sensor is ``x`` and you can return ``true`` for ON, ``false`` for OFF, and ``{}`` to stop
 the filter chain.
 
+``settle``
+**********
+
+(**Required**, time, :ref:`templatable <config-templatable>`): When a signal is received, publish the state
+but wait for the received state to remain the same for specified time period before publishing any
+additional state changes. This filter complements the ``delay_on_off`` filter but publishes value changes at
+the beginning of the delay period.
+When using a lambda call, you should return the delay value in milliseconds.
+**Useful for debouncing binary switches**.
+
 Binary Sensor Automation
 ------------------------
 


### PR DESCRIPTION
## Description:

This filter complements the `DelayedOnOff` filter, but instead of passing the value after stabilization, this filter publishes a change in state immediately and then waits to publish any additional changes until the state remains stable for a given delay period.

The primary motivation for this filter is to reduce the latency incurred by the `Delayed*` filter family while still debouncing the sensor, at the cost of removing the noise filtering provided by the `Delayed*` filters.

I'm absolutely open to suggestions for a better name for this behavior.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#5900

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
