### PR TITLE
Template cover toggle

### DIFF
--- a/components/cover/template.rst
+++ b/components/cover/template.rst
@@ -52,6 +52,8 @@ Configuration variables:
   be performed when the remote requests the cover to be closed.
 - **stop_action** (*Optional*, :ref:`Action <config-action>`): The action that should
   be performed when the remote requests the cover to be stopped.
+- **toggle_action** (*Optional*, :ref:`Action <config-action>`): The action that should
+  be performed when the remote requests to toggle the the cover.
 - **optimistic** (*Optional*, boolean): Whether to operate in optimistic mode - when in this mode,
   any command sent to the template cover will immediately update the reported state and no lambda
   needs to be used. Defaults to ``false``.


### PR DESCRIPTION
## Description:

The template cover component does not have "toggle" capability, in contrast with other cover components.
This PR adds a toggle_action configuration entry to the template cover allowing the user to implement that.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#5917

## Checklist:

  - [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
