### PR TITLE
Update pid.rst - Added information about the derivate_average_samples

### DIFF
--- a/components/climate/pid.rst
+++ b/components/climate/pid.rst
@@ -86,6 +86,8 @@ Configuration variables:
     By taking an average of the derivative term it might become more useful for you. Most PID controllers call
     this derivative filtering. The derivative term is used to pre-act so don't filter too much. Defaults to ``1``
     which is no sampling/averaging.
+    Note that averiging only takes place internally in the PIP regulator so you will still see fast variations
+    whenever monitoring the "pid_climate_derivate" entity in the master (e.g. home assistant) or in the logs.
 
 - **deadband_parameters** (*Optional*): Enables a deadband to stabilise and minimise changes in the
   output when the temperature is close to the target temperature. See `Deadband Setup`_.


### PR DESCRIPTION
## Description:
I realized that derivate_average_samples only reflects the internal PID component and not the derivate value the PID sends out. This was confusing until I understood how it works so I updated the documentation

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
