### PR TITLE
`HLW8012`: add `"never"` option to `change_mode_every`

### DIFF
--- a/components/sensor/hlw8012.rst
+++ b/components/sensor/hlw8012.rst
@@ -71,7 +71,8 @@ Advanced Options:
   Possible values are ``HLW8012``, ``CSE7759``, ``BL0937``. Defaults to ``HLW8012``. 
   CSE7759 uses same constants and it also works with default. Must be set for BL0937 to be able to calibrate all three measurements at the same time.
 - **change_mode_every** (*Optional*, int): After how many updates to cycle between the current/voltage measurement mode.
-  Note that the first value after switching is discarded because it is often inaccurate. Defaults to ``8``.
+  Note that the first value after switching is discarded because it is often inaccurate. When set to ``"never"`` the measurement mode will stay at the 
+  set ``initial_mode``. Defaults to ``8``.
 - **initial_mode** (*Optional*, string): The initial measurement mode. Defaults to ``VOLTAGE``.
   Possible initial measurement modes are ``VOLTAGE`` or ``CURRENT``.
 
@@ -97,7 +98,7 @@ the initial measurement mode to match whichever mode the device uses, and disabl
           name: "HLW8012 Power"
         update_interval: 60s
         initial_mode: CURRENT
-        change_mode_every: 4294967295
+        change_mode_every: "never"
 
 SEL Pin Inversion
 -----------------


### PR DESCRIPTION
## Description:

Adds documentation for the `"never"` option for `change_mode_every` entry.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#5924

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
