### PR TITLE
Update ens160.rst

### DIFF
--- a/components/sensor/ens160.rst
+++ b/components/sensor/ens160.rst
@@ -6,7 +6,7 @@ ENS160 Sensor
     :keywords: ENS160
 
 The ``ens160`` sensor platform allows you to use your ENS160
-(`datasheet <https://www.sciosense.com/wp-content/uploads/documents/SC-001224-DS-7-ENS160-Datasheet.pdf>`__) air-quality sensors with ESPHome. The :ref:`I²C <i2c>` component is
+(`https://www.sciosense.com/wp-content/uploads/documents/SC-001224-DS-9-ENS160-Datasheet.pdf>`__) air-quality sensors with ESPHome. The :ref:`I²C <i2c>` component is
 required to be set up in your configuration for this sensor to work.
 
 .. note::

--- a/components/sensor/ens160.rst
+++ b/components/sensor/ens160.rst
@@ -6,7 +6,7 @@ ENS160 Sensor
     :keywords: ENS160
 
 The ``ens160`` sensor platform allows you to use your ENS160
-(`https://www.sciosense.com/wp-content/uploads/documents/SC-001224-DS-9-ENS160-Datasheet.pdf>`__) air-quality sensors with ESPHome. The :ref:`I²C <i2c>` component is
+(`datasheet <https://www.sciosense.com/wp-content/uploads/documents/SC-001224-DS-9-ENS160-Datasheet.pdf>`__) air-quality sensors with ESPHome. The :ref:`I²C <i2c>` component is
 required to be set up in your configuration for this sensor to work.
 
 .. note::


### PR DESCRIPTION
update datasheet link. pervious one is broken

## Description:

Datasheet link is broken, fixed it. 
**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
