### PR TITLE
Fix typo in ble_presence.rst

### DIFF
--- a/components/binary_sensor/ble_presence.rst
+++ b/components/binary_sensor/ble_presence.rst
@@ -66,7 +66,7 @@ Configuration variables:
    to be tracked. Usually used to identify beacons within an iBeacon group.
 -  **id** (*Optional*, :ref:`config-id`): Manually specify
    the ID used for code generation.
--  **min_rssi** (*Optional*, int): at which minimum RSSI level would the component report the device be precent
+-  **min_rssi** (*Optional*, int): at which minimum RSSI level would the component report the device be present.
 -  All other options from :ref:`Binary Sensor <config-binary_sensor>`.
 
 .. _esp32_ble_tracker-setting_up_devices:


### PR DESCRIPTION
- "present" was misspelled as "precent"
- all other lines end with a period

## Description:


**Related issue (if applicable):** fixes n.a.
**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
