### PR TITLE
[Fingerprint_grow] Add description for on_finger_scan_misplaced and on_finger_scan_start triggers

### DIFF
--- a/components/fingerprint_grow.rst
+++ b/components/fingerprint_grow.rst
@@ -46,6 +46,8 @@ If available on your reader model, it's recommended to connect 3.3VT (touch indu
         ...
       on_finger_scan_misplaced:
         ...
+      on_finger_scan_invalid:
+        ...
       on_enrollment_scan:
         ...
       on_enrollment_done:
@@ -70,6 +72,7 @@ Base Configuration:
 - **on_finger_scan_matched** (*Optional*, :ref:`Automation <automation>`): An action to be performed when an enrolled fingerprint is scanned. See :ref:`fingerprint_grow-on_finger_scan_matched`.
 - **on_finger_scan_unmatched** (*Optional*, :ref:`Automation <automation>`): An action to be performed when an unknown fingerprint is scanned. See :ref:`fingerprint_grow-on_finger_scan_unmatched`.
 - **on_finger_scan_misplaced** (*Optional*, :ref:`Automation <automation>`): An action to be performed when the finger is not entirely touching the sensor. See :ref:`fingerprint_grow-on_finger_scan_misplaced`.
+- **on_finger_scan_invalid** (*Optional*, :ref:`Automation <automation>`): An action to be performed when the scan of a fingerprint failed. See :ref:`fingerprint_grow-on_finger_scan_invalid`.
 - **on_enrollment_scan** (*Optional*, :ref:`Automation <automation>`): An action to be performed when a fingerprint is scanned during enrollment. See :ref:`fingerprint_grow-on_enrollment_scan`.
 - **on_enrollment_done** (*Optional*, :ref:`Automation <automation>`): An action to be performed when a fingerprint is enrolled. See :ref:`fingerprint_grow-on_enrollment_done`.
 - **on_enrollment_failed** (*Optional*, :ref:`Automation <automation>`): An action to be performed when a fingerprint enrollment failed. See :ref:`fingerprint_grow-on_enrollment_failed`.
@@ -165,6 +168,20 @@ With this configuration option, you can trigger an automation when a finger is d
           color: GREEN
           speed: 0
           count: 0
+
+.. _fingerprint_grow-on_finger_scan_invalid:
+
+``on_finger_scan_invalid`` Trigger
+----------------------------------
+
+With this configuration option you can write complex automations whenever a scan fails, e.g. when the finger is not placed correctly on the reader. This is different from ``on_finger_scan_unmatched`` which is triggered when an unknown fingerprint is scanned. This option works best with the ``sensing_pin`` option defined.
+
+.. code-block:: yaml
+
+    on_finger_scan_invalid:
+      - text_sensor.template.publish:
+          id: fingerprint_state
+          state: "Invalid finger"
 
 .. _fingerprint_grow-on_finger_scan_matched:
 
@@ -469,6 +486,9 @@ Sample code
 
     fingerprint_grow:
       sensing_pin: GPIO12
+      on_finger_scan_invalid:
+        - homeassistant.event:
+            event: esphome.test_node_finger_scan_invalid
       on_finger_scan_matched:
         - homeassistant.event:
             event: esphome.test_node_finger_scan_matched

--- a/components/fingerprint_grow.rst
+++ b/components/fingerprint_grow.rst
@@ -38,11 +38,13 @@ If available on your reader model, it's recommended to connect 3.3VT (touch indu
     # Declare Grow Fingerprint Reader
     fingerprint_grow:
       sensing_pin: GPIO12
+      on_finger_scan_start:
+        ...
       on_finger_scan_matched:
         ...
       on_finger_scan_unmatched:
         ...
-      on_finger_scan_invalid:
+      on_finger_scan_misplaced:
         ...
       on_enrollment_scan:
         ...
@@ -64,9 +66,10 @@ Base Configuration:
 - **sensing_pin** (*Optional*, :ref:`Pin Schema <config-pin_schema>`): Pin connected to the reader's finger detection signal (WAKEUP) output.
 - **password** (*Optional*, int): Password to use for authentication. Defaults to ``0x00``.
 - **new_password** (*Optional*, int): Sets a new password to use for authentication. See :ref:`fingerprint_grow-set_new_password` for more information.
+- **on_finger_scan_start** (*Optional*, :ref:`Automation <automation>`): An action to be performed when the finger touches the sensor. See :ref:`fingerprint_grow-on_finger_scan_start`.
 - **on_finger_scan_matched** (*Optional*, :ref:`Automation <automation>`): An action to be performed when an enrolled fingerprint is scanned. See :ref:`fingerprint_grow-on_finger_scan_matched`.
 - **on_finger_scan_unmatched** (*Optional*, :ref:`Automation <automation>`): An action to be performed when an unknown fingerprint is scanned. See :ref:`fingerprint_grow-on_finger_scan_unmatched`.
-- **on_finger_scan_invalid** (*Optional*, :ref:`Automation <automation>`): An action to be performed when the scan of a fingerprint failed. See :ref:`fingerprint_grow-on_finger_scan_invalid`.
+- **on_finger_scan_misplaced** (*Optional*, :ref:`Automation <automation>`): An action to be performed when the finger is not entirely touching the sensor. See :ref:`fingerprint_grow-on_finger_scan_misplaced`.
 - **on_enrollment_scan** (*Optional*, :ref:`Automation <automation>`): An action to be performed when a fingerprint is scanned during enrollment. See :ref:`fingerprint_grow-on_enrollment_scan`.
 - **on_enrollment_done** (*Optional*, :ref:`Automation <automation>`): An action to be performed when a fingerprint is enrolled. See :ref:`fingerprint_grow-on_enrollment_done`.
 - **on_enrollment_failed** (*Optional*, :ref:`Automation <automation>`): An action to be performed when a fingerprint enrollment failed. See :ref:`fingerprint_grow-on_enrollment_failed`.
@@ -147,19 +150,21 @@ The ``new_password:`` configuration option is meant to be compiled, flashed to t
       password: 0x72AB96CD      # Update the existing password with the new one
 
 
-.. _fingerprint_grow-on_finger_scan_invalid:
+.. _fingerprint_grow-on_finger_scan_start:
 
-``on_finger_scan_invalid`` Trigger
-----------------------------------
+``on_finger_scan_start`` Trigger
+------------------------------------
 
-With this configuration option you can write complex automations whenever a scan fails, e.g. when the finger is not placed correctly on the reader. This is different from ``on_finger_scan_unmatched`` which is triggered when an unknown fingerprint is scanned. This option works best with the ``sensing_pin`` option defined.
+With this configuration option, you can trigger an automation when a finger is detected touching the sensor. Very useful to indicate to the user via AuraLed that the sensor has detected the finger touch and will perform the scan. This trigger will **only** activate if your fingerprint sensor is configured with the ``sensing_pin`` option. 
 
 .. code-block:: yaml
 
-    on_finger_scan_invalid:
-      - text_sensor.template.publish:
-          id: fingerprint_state
-          state: "Invalid finger"
+    on_finger_scan_start:
+      - fingerprint_grow.aura_led_control:
+          state: ALWAYS_ON
+          color: GREEN
+          speed: 0
+          count: 0
 
 .. _fingerprint_grow-on_finger_scan_matched:
 
@@ -204,6 +209,21 @@ With this configuration option you can write complex automations whenever an unk
       - text_sensor.template.publish:
           id: fingerprint_state
           state: "Unauthorized finger"
+
+.. _fingerprint_grow-on_finger_scan_misplaced:
+
+``on_finger_scan_misplaced`` Trigger
+------------------------------------
+
+With this configuration option, you can create automations for situations when the finger is in contact with the sensor but not fully covering it, enabling you to perform a successful scan.
+This trigger will **only** activate if your fingerprint sensor is configured with the ``sensing_pin`` option. It serves as a useful indicator to alert the user when their touch on the sensor is insufficient.
+
+.. code-block:: yaml
+
+    on_finger_scan_misplaced:
+      - text_sensor.template.publish:
+          id: fingerprint_state
+          state: "Misplaced finger"
 
 .. _fingerprint_grow-on_enrollment_scan:
 
@@ -358,6 +378,12 @@ Controls the Aura LED on the reader. Only available on select models.  NOTE: The
             count: 2
     # Sample Aura LED config for all reader triggers
     fingerprint_grow:
+      on_finger_scan_start:
+        - fingerprint_grow.aura_led_control:
+            state: ALWAYS_ON
+            color: GREEN
+            speed: 0
+            count: 0
       on_finger_scan_matched:
         - fingerprint_grow.aura_led_control:
             state: BREATHING
@@ -369,6 +395,12 @@ Controls the Aura LED on the reader. Only available on select models.  NOTE: The
             state: FLASHING
             speed: 25
             color: RED
+            count: 2
+      on_finger_scan_misplaced:
+        - fingerprint_grow.aura_led_control:
+            state: FLASHING
+            speed: 25
+            color: PURPLE
             count: 2
       on_enrollment_scan:
         - fingerprint_grow.aura_led_control:
@@ -437,9 +469,6 @@ Sample code
 
     fingerprint_grow:
       sensing_pin: GPIO12
-      on_finger_scan_invalid:
-        - homeassistant.event:
-            event: esphome.test_node_finger_scan_invalid
       on_finger_scan_matched:
         - homeassistant.event:
             event: esphome.test_node_finger_scan_matched
@@ -449,6 +478,9 @@ Sample code
       on_finger_scan_unmatched:
         - homeassistant.event:
             event: esphome.test_node_finger_scan_unmatched
+      on_finger_scan_misplaced:
+        - homeassistant.event:
+            event: esphome.frontdoor_finger_scan_misplaced
       on_enrollment_scan:
         - homeassistant.event:
             event: esphome.test_node_enrollment_scan


### PR DESCRIPTION
## Description:

Add instructions and description for triggers `on_finger_scan_start` and `on_finger_scan_misplaced` introduced by PR mentioned below.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#6003

## Checklist:

  - [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
