### PR TITLE
Extends UART change at runtime to ESP8266

### DIFF
--- a/components/uart.rst
+++ b/components/uart.rst
@@ -205,7 +205,7 @@ Below are the methods to read current settings and modify them dynamically:
       id(my_uart).get_baud_rate();
 
 - **Modifying Settings at Runtime:** You can change certain UART parameters during runtime.
-  After setting new values, invoke ``load_settings()`` (ESP32 only) to apply these changes:
+  After setting new values, invoke ``load_settings()`` (ESP only) to apply these changes:
 
   .. code-block:: yaml
 


### PR DESCRIPTION
## Description:

This extends the changes made on https://github.com/esphome/esphome/pull/5909 to esp8266 devices.

This adds the method `load_settings()` to the UART component allowing the interface to reload with the new settings used by methods `set_baud_rate`, `set_parity`, `set_data_bits`, etc. without the assignment of a new software UART.

This can be useful for connecting to devices which supports multiple baud rates or for devices which changes it's serial communication at runtime, but also allows some logic for a user's configurable baud rate to be set at `on_boot` after the UART component is loaded.

**Related issue (if applicable):** N/A
Discord thread: https://discord.com/channels/429907082951524364/1180653963461275648

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#6019

## Checklist:

  - [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
