### PR TITLE
Tuya cover invert position report

### DIFF
--- a/components/cover/tuya.rst
+++ b/components/cover/tuya.rst
@@ -40,6 +40,7 @@ Configuration variables:
 - **min_value** (*Optional*, int): The lowest position value, meaning cover closed. Defaults to 0.
 - **max_value** (*Optional*, int): the highest position value, meaning cover opened. Defaults to 255.
 - **invert_position** (*Optional*, boolean): Sets the direction of travel to be inverted, if direction_datapoint is configured.
+- **invert_position_report** (*Optional*, boolean): Invert reported position percentages calculated from `min_value` and `max_value` i.e. 70% becomes 30%.
 - All other options from :ref:`Cover <config-cover>`.
 
 Supported devices

--- a/components/cover/tuya.rst
+++ b/components/cover/tuya.rst
@@ -40,7 +40,7 @@ Configuration variables:
 - **min_value** (*Optional*, int): The lowest position value, meaning cover closed. Defaults to 0.
 - **max_value** (*Optional*, int): the highest position value, meaning cover opened. Defaults to 255.
 - **invert_position** (*Optional*, boolean): Sets the direction of travel to be inverted, if direction_datapoint is configured.
-- **invert_position_report** (*Optional*, boolean): Invert reported position percentages calculated from `min_value` and `max_value` i.e. 70% becomes 30%.
+- **invert_position_report** (*Optional*, boolean): Invert reported position percentages calculated from `min_value` and `max_value` i.e. 70% becomes 30%.  Defaults to false.
 - All other options from :ref:`Cover <config-cover>`.
 
 Supported devices


### PR DESCRIPTION
## Description:

Add the new parameter for `tuya.cover` as implemented by the matching PR.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#6020

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
