### PR TITLE
Note about st7789v being replaced by ili9xxx

### DIFF
--- a/components/display/ili9xxx.rst
+++ b/components/display/ili9xxx.rst
@@ -63,7 +63,7 @@ Configuration variables:
 
 - **model** (**Required**): The model of the display. Options are:
 
-  - ``M5STACK``, ``TFT 2.4``, ``TFT 2.4R``, ``S3BOX``, ``S3BOX_LITE``, ``ST7789V``
+  - ``M5STACK``, ``TFT 2.4``, ``TFT 2.4R``, ``S3BOX``, ``S3BOX_LITE``
   - ``ILI9341``, ``ILI9342``, ``ILI9486``, ``ILI9488``, ``ILI9488_A`` (alternative gamma configuration for ILI9488)
   - ``ILI9481``, ``ILI9481-18`` (18 bit mode)
   - ``ST7789V``, ``ST7796``

--- a/components/display/st7789v.rst
+++ b/components/display/st7789v.rst
@@ -25,6 +25,12 @@ The TTGO T-Display module shown has the display attached to the module's board a
 cannot be changed. Other display modules have pin headers or other connectors which must be connected appropriately
 to an ESP module.
 
+.. warning::
+
+    This component has been made redundant since the ST7789V is now supported by the :ref:`ILI9XXX component <ili9xxx>`. It is recommended
+    that you use the ``ili9xxx`` component as it will be maintained, whereas this component may not be, or may be removed completely
+    in the future.
+
 .. note::
 
     Displays larger than the 135x240 pixel display on the TTGO T-Display shown require a significant amount of RAM


### PR DESCRIPTION
## Description:

Note about st7789v being replaced by ili9xxx

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
