### PR TITLE
Update ld2410.rst - Typo 

### DIFF
--- a/components/sensor/ld2410.rst
+++ b/components/sensor/ld2410.rst
@@ -326,7 +326,7 @@ Configuration variables:
 Button
 ------
 
-The ``ld2410`` button allows you to perfrom actions on your :doc:`ld2410`.
+The ``ld2410`` button allows you to perform actions on your :doc:`ld2410`.
 
 .. code-block:: yaml
 


### PR DESCRIPTION
## Description:

Typo in documentation for LD2410 sensor under the button heading: perfrom -> perform (button heading)

## Checklist:
  - [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

