### PR TITLE
Correct pulse_counter to pulse_meter

### DIFF
--- a/components/sensor/pulse_meter.rst
+++ b/components/sensor/pulse_meter.rst
@@ -94,7 +94,7 @@ trying to match.
           variables:
             new_total: int
           then:
-            - pulse_counter.set_total_pulses:
+            - pulse_meter.set_total_pulses:
                 id: sensor_pulse_meter
                 value: !lambda 'return new_total;'
 


### PR DESCRIPTION
The service pulse_counter.set_total_pulses does not exist. Instead it should be pulse_meter.

## Description:


**Related issue (if applicable):** fixes none

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
