### PR TITLE
Extend i2s config options

### DIFF
--- a/components/microphone/i2s_audio.rst
+++ b/components/microphone/i2s_audio.rst
@@ -12,7 +12,7 @@ This platform only works on ESP32 based chips.
 .. warning::
 
     Audio and voice components consume a significant amount of resources (RAM, CPU) on the device.
-    
+
     **Crashes are likely to occur** if you include too many additional components in your device's
     configuration. In particular, Bluetooth/BLE components are known to cause issues when used in
     combination with Voice Assistant and/or other audio components.
@@ -41,9 +41,11 @@ Configuration variables:
   - ``internal``: Use the internal ADC of the ESP32. Only supported on ESP32, no variant support.
 
 - **channel** (*Optional*, enum): The channel of the microphone. One of ``left`` or ``right``. Defaults to ``right``.
+- **sample_rate** (*Optional*, positive integer): I2S sample rate. Defaults to ``16000``.
 - **bits_per_sample** (*Optional*, enum): The bit depth of the audio samples. Note that while set to ``32bit``, the samples
   will be scaled down to 16bit before being forwarded.
   One of ``16bit`` or ``32bit``. Defaults to ``16bit``.
+- **use_apll** (*Optional*, boolean): I2S using APLL as main I2S clock, enable it to get accurate clock. Defaults to ``false``.
 - **i2s_audio_id** (*Optional*, :ref:`config-id`): The ID of the :ref:`I²S Audio <i2s_audio>` you wish to use for this microphone.
 - All other options from :ref:`Microphone <config-microphone>`
 


### PR DESCRIPTION
- added sample_rate
- added use_apll

## Description:

This is minor change adding for my aplication crutial missing options sample rate and apll

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
