### PR TITLE
pylontech: document voltage_low and voltage_high correctly

### DIFF
--- a/components/pylontech.rst
+++ b/components/pylontech.rst
@@ -112,8 +112,8 @@ Configuration variables:
 - **temperature** (*Optional*): Temperature. All options from :ref:`Sensor <config-sensor>`.
 - **temperature_low** (*Optional*): Historic minimum temperature. All options from :ref:`Sensor <config-sensor>`.
 - **temperature_high** (*Optional*): Historic maximum temperature. All options from :ref:`Sensor <config-sensor>`.
-- **voltage_low** (*Optional*): Historic minimum voltage. All options from :ref:`Sensor <config-sensor>`.
-- **voltage_high** (*Optional*): Historic maximum voltage. All options from :ref:`Sensor <config-sensor>`.
+- **voltage_low** (*Optional*): Voltage of the lowest cell. All options from :ref:`Sensor <config-sensor>`.
+- **voltage_high** (*Optional*): Voltage of the highest cell. All options from :ref:`Sensor <config-sensor>`.
 - **mos_temperature** (*Optional*): Temperature of the mosfets. All options from :ref:`Sensor <config-sensor>`.
 
 Text Sensor


### PR DESCRIPTION
## Description:

Fix documentation for `voltage_low` and `voltage_high` sensors.

**Related issue (if applicable):** partially addresses https://github.com/esphome/feature-requests/issues/2544

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#6060

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
