### PR TITLE
Hint for using 433Mhz transmitter

### DIFF
--- a/components/remote_transmitter.rst
+++ b/components/remote_transmitter.rst
@@ -936,6 +936,7 @@ earlier, create a new template switch that sends the RF code when triggered:
     switch:
       - platform: template
         name: RF Power Button
+        optimistic: true
         turn_on_action:
           - remote_transmitter.transmit_rc_switch_raw:
               code: '100010000000000010111110'


### PR DESCRIPTION
## Description:
Added a little parameter to an example from remote transmitter.
This has to be added in order for the example to work, otherwise homeassistant is expecting a feedback sensor (for 433 transmitters, there is usually no feedback from e.g. the RC-lightbulb) and therefore always assumes the switch is turned off (therefore making it impossible to actually switch it off).

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ x ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ x ] Link added in `/index.rst` when creating new documents for new components or cookbook.
