### PR TITLE
Update ota.rst - added OTA port for Beken chips

### DIFF
--- a/components/ota.rst
+++ b/components/ota.rst
@@ -40,6 +40,7 @@ Configuration variables:
    - ``3232`` for the ESP32
    - ``8266`` for the ESP8266
    - ``2040`` for the RP2040
+   - ``8892`` for Beken chips
 -  **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
 -  **reboot_timeout** (*Optional*, :ref:`config-time`): The amount of time to wait before rebooting when in
    safe mode. Defaults to ``5min``.


### PR DESCRIPTION
## Description: 
Add OTA port information (port 8892) for Beken chips as used by libretiny

**Related issue (if applicable):** Not Applicable

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** Not Applicable

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
