### PR TITLE
Update index.rst

### DIFF
--- a/components/sensor/index.rst
+++ b/components/sensor/index.rst
@@ -128,6 +128,7 @@ Filters are processed in the order they are defined in your configuration.
       - offset: 2.0
       - multiply: 1.2
       - calibrate_linear:
+          datapoints:
           - 0.0 -> 0.0
           - 40.0 -> 45.0
           - 100.0 -> 102.5


### PR DESCRIPTION
Updated filters example.   '- calibrate_linear:'  so it has required '  - calibrate_linear:'

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
