### PR TITLE
removed spelling error in neopixelbus documentation, line 16

### DIFF
--- a/components/light/neopixelbus.rst
+++ b/components/light/neopixelbus.rst
@@ -13,7 +13,7 @@ NeoPixelBus Light
 
 
 The ``neopixelbus`` light platform allows you to create RGB lights
-in ESPHome for an individually addressable lights like NeoPixel or WS2812.
+in ESPHome for individually addressable lights like NeoPixel or WS2812.
 
 It is very similar to the :doc:`fastled` platform.
 In fact, most addressable lights are supported through both light platforms. The


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ x ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
