### PR TITLE
Update ota.rst

### DIFF
--- a/components/ota.rst
+++ b/components/ota.rst
@@ -174,7 +174,7 @@ enum. These values are:
         then:
           - if:
               condition:
-                lambda: return state == ota::OTA_STARTED
+                lambda: return state == ota::OTA_STARTED;
               then:
                 - logger.log: "OTA start"
 


### PR DESCRIPTION
Fix for missing semicolon in example-code of ota: on_state_change

https://github.com/esphome/issues/issues/5362

## Description:


**Related issue (if applicable):** fixes [<link to issue>](https://github.com/esphome/issues/issues/5362)

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
