### PR TITLE
Update time_based.rst - handle with last operation

### DIFF
--- a/components/cover/time_based.rst
+++ b/components/cover/time_based.rst
@@ -77,7 +77,22 @@ Configuration variables:
     ``esp8266_restore_from_flash: true`` option set. 
     See :doc:`esp8266_restore_from_flash </components/esphome>` for details.
 
+Handle stop_action:
+------------------------
+For some cover controllers, separate switches for UP and DOWN action are used while a stop is issued when sending a counter command.
+This can be handled at the **stop_action** by using the folling lamda function:
 
+.. code-block:: yaml
+
+    stop_action: 
+      - lambda: !lambda |-
+          if (id(cover).last_operation() == CoverOperation::COVER_OPERATION_OPENING) {
+            // Cover is currently opening
+            id(cover_button_down).press();
+          } else if (id(cover).last_operation() == CoverOperation::COVER_OPERATION_CLOSING) {
+            // Cover is currently closing
+            id(cover_button_up).press();
+          }
 
 See Also
 --------


### PR DESCRIPTION
## Description:
Added docs for handling of last_operation() function to handle cover STOP needed for some cover controllers.

**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/4252

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#6084

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
