### PR TITLE
Add i2s_audio_id to i2s speaker

### DIFF
--- a/components/speaker/i2s_audio.rst
+++ b/components/speaker/i2s_audio.rst
@@ -39,6 +39,7 @@ External DAC
 
 - **i2s_dout_pin** (**Required**, :ref:`Pin Schema <config-pin_schema>`): The GPIO pin to use for the I²S DOUT (Data Out) signal.
 - **mode** (*Optional*, string): The mode of the I²S bus. Can be ``mono`` or ``stereo``. Defaults to ``mono``.
+- **i2s_audio_id** (*Optional*, :ref:`config-id`): The ID of the :ref:`I²S Audio <i2s_audio>` you wish to use for this speaker.
 
 For best results, keep the wires as short as possible.
 


### PR DESCRIPTION
## Description:
`i2s_audio_id` was referenced in [microphone](https://esphome.io/components/microphone/i2s_audio) and [media_player](https://esphome.io/components/media_player/i2s_audio) but not in [speaker](https://esphome.io/components/speaker/i2s_audio).

This option exists and is important when building voice assistants with different i2s buses for the microphone and the speaker.

**Related issue (if applicable):** fixes <link to issue>
NOT APPLICABLE

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**
NOT APPLICABLE


## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
