### PR TITLE
OTA version documentation

### DIFF
--- a/components/ota.rst
+++ b/components/ota.rst
@@ -56,7 +56,7 @@ Configuration variables:
    performed when an OTA update state change happens. See :ref:`ota-on_state_change`.
 -  **version** (*Optional*, int): Version of OTA protocol to use. Version 2 is more stable.
    To downgrade to legacy ESPHome, the device should be updated with OTA version 1 first.
-   Defaults to ``1``.
+   Defaults to ``2``.
 
 .. note::
 

--- a/components/ota.rst
+++ b/components/ota.rst
@@ -54,7 +54,8 @@ Configuration variables:
    performed after a failed OTA update. See :ref:`ota-on_error`.
 -  **on_state_change** (*Optional*, :ref:`Automation<automation>`): An action to be
    performed when an OTA update state change happens. See :ref:`ota-on_state_change`.
--  **version** (*Optional*, int): Version of OTA protocol to use. Version 2 is more stable. To downgrate to legacy EPSHOME device should be updated with OTA version 1 first.
+-  **version** (*Optional*, int): Version of OTA protocol to use. Version 2 is more stable.
+   To downgrate to legacy ESPHome, the device should be updated with OTA version 1 first.
    Defaults to ``1``.
 
 .. note::

--- a/components/ota.rst
+++ b/components/ota.rst
@@ -55,7 +55,7 @@ Configuration variables:
 -  **on_state_change** (*Optional*, :ref:`Automation<automation>`): An action to be
    performed when an OTA update state change happens. See :ref:`ota-on_state_change`.
 -  **version** (*Optional*, int): Version of OTA protocol to use. Version 2 is more stable.
-   To downgrate to legacy ESPHome, the device should be updated with OTA version 1 first.
+   To downgrade to legacy ESPHome, the device should be updated with OTA version 1 first.
    Defaults to ``1``.
 
 .. note::

--- a/components/ota.rst
+++ b/components/ota.rst
@@ -54,6 +54,8 @@ Configuration variables:
    performed after a failed OTA update. See :ref:`ota-on_error`.
 -  **on_state_change** (*Optional*, :ref:`Automation<automation>`): An action to be
    performed when an OTA update state change happens. See :ref:`ota-on_state_change`.
+-  **version** (*Optional*, int): Version of OTA protocol to use. Version 2 is more stable. To downgrate to legacy EPSHOME device should be updated with OTA version 1 first.
+   Defaults to ``1``.
 
 .. note::
 


### PR DESCRIPTION
## Description:

OTA version documentation which allows user to select between OTA v1 and OTA v2.
OTA v1 is default.

**Related issue (if applicable):** fixes <link to issue>

https://github.com/esphome/issues/issues/3318

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

https://github.com/esphome/esphome/pull/6066

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
