### PR TITLE
remove serial command text

### DIFF
--- a/components/sensor/pm1006.rst
+++ b/components/sensor/pm1006.rst
@@ -70,21 +70,6 @@ Example config:
         update_interval: 20s
 
 
-If you run the PM1006 (2.5µm) or PM1006K (1, 2.5, 10µm) independent from the original MCU you need to send a serial command in the first 5 seconds after power is applied to the sensor. Otherwise the sensor will switch to PWM mode and does not repond to UART requests. A possibility to do this in ESPhome is to use an automation. `Source <https://community.home-assistant.io/t/ikea-vindriktning-air-quality-sensor/324599/300>`_
-
-Example config:
-
-.. code-block:: yaml
-
-    # Example configuration entry
-    on_boot:
-      priority: 240
-      then:
-        - uart.write:
-            id: ikea #id of the uart bus used for the PM1006
-            data: [0x11, 0x02, 0x0B, 0x01, 0xE1]
-
-
 See Also
 --------
 


### PR DESCRIPTION
## Description:
The serial command text at the end is not needed anymore becaus of: https://github.com/esphome/esphome/pull/2214

Was probably forgotten to remove

**Related issue (if applicable):**
./.

**Pull request in [esphome]:**
./.

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.   or
  - [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
