### PR TITLE
add ´water_delivered´ sensor to dsmr documentation

### DIFF
--- a/components/sensor/dsmr.rst
+++ b/components/sensor/dsmr.rst
@@ -231,6 +231,12 @@ Configuration variables:
   - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.
   - All other options from :ref:`Sensor <config-sensor>`.
 
+- **water_delivered** (*Optional*): Water Consumed.
+
+  - **name** (**Required**, string): The name for the water_delivered sensor.
+  - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.
+  - All other options from :ref:`Sensor <config-sensor>`.
+
 Belgium
 
 - **gas_delivered_be** (*Optional*): Gas Consumed Belgium.


### PR DESCRIPTION
## Description:

See https://github.com/esphome/esphome/pull/4237 for the linked code changes.

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
