### PR TITLE
Nextion - Remove soft reset at start

### DIFF
--- a/components/display/nextion.rst
+++ b/components/display/nextion.rst
@@ -68,6 +68,7 @@ Configuration variables:
 - **wake_up_page** (*Optional*, int): Sets the page to display after waking up
 - **auto_wake_on_touch** (*Optional*, boolean): Sets if Nextion should auto-wake from sleep when touch press occurs.
 - **exit_reparse_on_start** (*Optional*, boolean): Request the Nextion exit Active Reparse Mode before setup of the display. Defaults to ``false``.
+- **soft_reset_on_start** (*Optional*, boolean): Force a soft restart to the Nextion when the component is starting. Defaults to ``true``.
 - **on_setup** (*Optional*, :ref:`Action <config-action>`): An action to be performed after ESPHome connects to the Nextion. See :ref:`Nextion Automation <nextion-on_setup>`.
 - **on_sleep** (*Optional*, :ref:`Action <config-action>`): An action to be performed when the Nextion goes to sleep. See :ref:`Nextion Automation <nextion-on_sleep>`.
 - **on_wake** (*Optional*, :ref:`Action <config-action>`): An action to be performed when the Nextion wakes up. See :ref:`Nextion Automation <nextion-on_sleep>`.


### PR DESCRIPTION
## Description:

This introduces a user configurable attribute to Nextion display which allows skipping the soft reset on displays during the component startup.
I don't know really why this reset was introduced from the beginning, so I've left as a configurable attribute to avoid a breaking change, but on my tests it always work without this command and it makes the startup process a bit faster (my main goal).

This is not a breaking change, as the previous behavior is the default.

**Related issue (if applicable):** solves esphome/feature-requests#2074

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#6134

## Checklist:

  - [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
