### PR TITLE
Olimex POE ISO WROVER configuration

### DIFF
--- a/components/ethernet.rst
+++ b/components/ethernet.rst
@@ -98,6 +98,9 @@ Configuration examples
       phy_addr: 0
       power_pin: GPIO12
 
+.. note::
+
+    Olimex ESP-POE-ISO WROVER needs `clk_mode: GPIO17_OUT`
 
 **Olimex ESP32-EVB**:
 


### PR DESCRIPTION
Update ethernet.rst reflecting Olimex POE ISO WROVER configuration

## Description:

Simple change of documentation to reflect Olimex POE *wrover* cards using a different clock.

## Checklist:

  - [] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
