### PR TITLE
Olimex POE WROVER uses GPIO0 for clock

### DIFF
--- a/components/ethernet.rst
+++ b/components/ethernet.rst
@@ -98,6 +98,10 @@ Configuration examples
       phy_addr: 0
       power_pin: GPIO12
 
+.. note::
+
+    WROVER version of Olimex POE cards change CLK to ping GPIO0, configuration must be `clk_mode: GPIO0_OUT`.
+
 
 **Olimex ESP32-EVB**:
 


### PR DESCRIPTION
Update ethernet.rst

## Description:

Olimex POE WROVER uses GPIO0 for clock

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
