### PR TITLE
Update bme280_environment.rst to reference bme280_i2c

### DIFF
--- a/cookbook/bme280_environment.rst
+++ b/cookbook/bme280_environment.rst
@@ -21,7 +21,7 @@ After validating the sensor is working, we can proceed and add some formulas.
 .. code-block:: yaml
 
     sensor:
-      - platform: bme280
+      - platform: bme280_i2c
         temperature:
           name: "BME280 Temperature"
           id: bme280_temperature


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
