### PR TITLE
Update pulse_meter.rst

### DIFF
--- a/components/sensor/pulse_meter.rst
+++ b/components/sensor/pulse_meter.rst
@@ -14,6 +14,7 @@ Here's a comparison of the two sensors; both are set to an update interval of 10
 .. figure:: /images/pulse-counter_vs_pulse-meter.png
     :align: center
     :width: 50.0%
+Please note that it is not possible to use both of these two sensors on the same pin.
 
 .. code-block:: yaml
 

--- a/components/sensor/pulse_meter.rst
+++ b/components/sensor/pulse_meter.rst
@@ -9,12 +9,13 @@ The pulse meter sensor allows you to count the number and frequency of pulses on
 for the :doc:`pulse counter integration </components/sensor/pulse_counter>`.
 Rather than counting pulses over a fixed time interval, the pulse meter sensor measures the time between pulses. The precise manner in which this is done depends on the ``internal_filter_mode`` option. This leads to a higher resolution, especially for low pulse rates, as the pulse counter sensor is limited by the number of pulses within a time interval.
 
-Here's a comparison of the two sensors; both are set to an update interval of 10 seconds (using the ``update_interval`` and the ``throttle_average`` option respectively):
+Here's a comparison of the two sensors.  The pulse meter is the smoother line.  Both are set to an update interval of 10 seconds (using the ``update_interval`` and the ``throttle_average`` option respectively):
 
 .. figure:: /images/pulse-counter_vs_pulse-meter.png
     :align: center
     :width: 50.0%
-Please note that it is not possible to use both of these two sensors on the same pin.
+
+Please note that it is not possible to use both of these two sensors on the same pin at the same time.
 
 .. code-block:: yaml
 


### PR DESCRIPTION


## Description:
Pulse meter and pulse counter do not work at the same time, in contrary to what the included picture made me believe. 

I've just spent a few hours debugging this to find out that there is no way to run both pulse meter and pulse counter at the same time. I hope this saves others some work.


**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
