### PR TITLE
Wireguard: add netmask caveat note

### DIFF
--- a/components/wireguard.rst
+++ b/components/wireguard.rst
@@ -47,7 +47,8 @@ adding the following to your configuration:
       peer_endpoint: wg.server.example
       peer_public_key: EeFfGgHh...=
 
-      # Optional netmask (this is the default if omitted)
+      # Optional netmask (this is the default, no outgoing traffic 
+      # will pass through the tunnel if omitted)
       netmask: 255.255.255.255
 
       # Optional endpoint port (WireGuard default if omitted)


### PR DESCRIPTION
With the default netmask no outgoing traffic will pass through the tunnel, so add a note about this in the sample configuration.

## Description:

The minimal sample configuration is not very useful: no outgoing traffic will pass though the tunnel. While this is documented elsewhere in the doc I think an inline note would be valuable. 

At least I often start with minimal example configurations, where things marked _optional_ should be either clearly commented or in fact be optional for a reasonable default functionality.

## Checklist:

  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.
