### PR TITLE
LTR390 - Multiple fixes (sensor name, descriptions and notes)

### DIFF
--- a/components/sensor/ltr390.rst
+++ b/components/sensor/ltr390.rst
@@ -39,8 +39,8 @@ Configuration variables:
 - **uv** (*Optional*): Sensor counts for the UV sensor (#). All options from :ref:`Sensor <config-sensor>`.
 - **light** (*Optional*): Lux of ambient light (lx). All options from :ref:`Sensor <config-sensor>`.
 - **ambient_light** (*Optional*): Sensor counts for the Ambient light sensor (#). All options from :ref:`Sensor <config-sensor>`.
-- **gain** (*Optional*, string): Adjusts the sensitivity of the sensor. A larger value means higher sensitivity. See table below for details, valid options under "Gain Parameter". Default is ``"X18"``.
-- **resolution** (*Optional*, int): ADC resolution. Higher resolutions require longer sensor integration times. See table below for details, valid options under "Resolution Parameter". Default is ``20``.
+- **gain** (*Optional*, string): Adjusts the sensitivity of the sensor. A larger value means higher sensitivity. Default is ``"X18"``, see table below for options.
+- **resolution** (*Optional*, int): ADC resolution. Higher resolutions require longer sensor integration times. Default is ``20``, see table below for options. 
 - **window_correction_factor** (*Optional*, float): Window correction factor. Use larger values when using under tinted windows. Default is ``1.0``, must be ``>= 1.0``.
 - **address** (*Optional*, int): Manually specify the I²C address of the sensor. Default is ``0x53``.
 - **update_interval** (*Optional*, :ref:`config-time`): The interval to check the

--- a/components/sensor/ltr390.rst
+++ b/components/sensor/ltr390.rst
@@ -62,8 +62,8 @@ where:
 - ``als`` and ``uv`` are the sensor values
 - ``gain`` is the amount of gain, see the table below for details
 - ``int`` is the integration time in 100s of ms and is tied to the resolution, see the table below for details
-- ``sensitivity`` is given by $$2300 \times \frac{\text{gain}}{18} \times \frac{int}{400}$$, where $$2300$$ is the
-sensor's count per UVI at ``X18`` gain and a resolution of 20 bits (integration time of 400ms).
+- ``sensitivity`` is given by $$2300 \times \frac{\text{gain}}{18} \times \frac{\text{int}}{400}$$, where :math:`2300` is the
+sensor's count per UVI at ``X18`` gain and a resolution of 20 bits (integration time of 400ms)
 - ``wfac`` is the window correction factor
 
 Note that for UVI calculations it is recommended to use the defaults of ``X18`` gain and a resolution of 20 bits since

--- a/components/sensor/ltr390.rst
+++ b/components/sensor/ltr390.rst
@@ -23,7 +23,7 @@ The :ref:`I²C Bus <i2c>` is required to be set up in your configuration for thi
       - platform: ltr390
         uv_index:
           name: "UV Index"
-        uv_index:
+        uv:
           name: "UV Sensor Counts"
         light:
           name: "Light"

--- a/components/sensor/ltr390.rst
+++ b/components/sensor/ltr390.rst
@@ -62,8 +62,10 @@ where:
 - ``als`` and ``uv`` are the sensor values
 - ``gain`` is the amount of gain, see the table below for details
 - ``int`` is the integration time in 100s of ms and is tied to the resolution, see the table below for details
-- ``sensitivity`` has the value ``2300`` and is the sensor's count per UVI
+- ``sensitivity`` is given by $2300 \times \frac{\text{gain}}{18} \times \frac{int}{400}$, where $2300$ is the sensor's count per UVI at ``X18`` gain and an integration time of 400ms.
 - ``wfac`` is the window correction factor
+
+
 
 Gain
 ----

--- a/components/sensor/ltr390.rst
+++ b/components/sensor/ltr390.rst
@@ -62,12 +62,16 @@ where:
 - ``als`` and ``uv`` are the sensor values
 - ``gain`` is the amount of gain, see the table below for details
 - ``int`` is the integration time in 100s of ms and is tied to the resolution, see the table below for details
-- ``sensitivity`` is given by :math:`2300 \times \frac{\text{gain}}{18} \times \frac{\text{int}}{400}`, where :math:`2300` is the sensor's count per UVI at ``X18`` gain and a resolution of 20 bits (integration time of 400ms)
+- ``sensitivity`` is the sensor's count per UVI. See note below for details.
 - ``wfac`` is the window correction factor
 
 Note that for UVI calculations it is recommended to use the defaults of ``X18`` gain and a resolution of 20 bits since
 the datasheet only provides the sensor counts per UVI (sensitivity) for this configuration. When using different
-configurations, the counts per UVI are scaled with respect to the default configuration.
+configurations, the counts per UVI are scaled as follows:
+.. math::
+
+    \text{sensitivity} = 2300 \times \frac{\text{gain}}{18} \times \frac{\text{int}}{400}
+where :math:`2300` is the sensor count per UVI at the default configuration.
 
 Gain
 ----

--- a/components/sensor/ltr390.rst
+++ b/components/sensor/ltr390.rst
@@ -40,7 +40,7 @@ Configuration variables:
 - **light** (*Optional*): Lux of ambient light (lx). All options from :ref:`Sensor <config-sensor>`.
 - **ambient_light** (*Optional*): Sensor counts for the Ambient light sensor (#). All options from :ref:`Sensor <config-sensor>`.
 - **gain** (*Optional*, string): Adjusts the sensitivity of the sensor. A larger value means higher sensitivity. Default is ``"X18"``, see table below for options.
-- **resolution** (*Optional*, int): ADC resolution. Higher resolutions require longer sensor integration times. Default is ``20``, see table below for options. 
+- **resolution** (*Optional*, int): ADC resolution. Higher resolutions require longer sensor integration times. Default is ``20``, see table below for options.
 - **window_correction_factor** (*Optional*, float): Window correction factor. Use larger values when using under tinted windows. Default is ``1.0``, must be ``>= 1.0``.
 - **address** (*Optional*, int): Manually specify the I²C address of the sensor. Default is ``0x53``.
 - **update_interval** (*Optional*, :ref:`config-time`): The interval to check the
@@ -65,9 +65,10 @@ where:
 - ``sensitivity`` is the sensor's count per UVI. See note below for details.
 - ``wfac`` is the window correction factor.
 
-For UV Index sensing it is recommended to use the defaults of ``X18`` gain and a resolution of 20 bits since
-the datasheet only provides the sensor counts per UVI (sensitivity) for this configuration. When using different
-configurations, the counts per UVI are scaled as follows:
+It is recommended to use the defaults of ``X18`` gain and resolution of 20 bits when UV Index sensing is required since
+the data sheet only provides accurate conversion formula for this combination. The UVI value is linearly scaled from
+this reference point when using other combinations of gain and resolution, which may be slightly inaccurate. The scaling
+formula is:
 
 .. math::
 

--- a/components/sensor/ltr390.rst
+++ b/components/sensor/ltr390.rst
@@ -62,8 +62,7 @@ where:
 - ``als`` and ``uv`` are the sensor values
 - ``gain`` is the amount of gain, see the table below for details
 - ``int`` is the integration time in 100s of ms and is tied to the resolution, see the table below for details
-- ``sensitivity`` is given by $$2300 \times \frac{\text{gain}}{18} \times \frac{\text{int}}{400}$$, where :math:`2300` is the
-sensor's count per UVI at ``X18`` gain and a resolution of 20 bits (integration time of 400ms)
+- ``sensitivity`` is given by $$2300 \times \frac{\text{gain}}{18} \times \frac{\text{int}}{400}$$, where :math:`2300` is the sensor's count per UVI at ``X18`` gain and a resolution of 20 bits (integration time of 400ms)
 - ``wfac`` is the window correction factor
 
 Note that for UVI calculations it is recommended to use the defaults of ``X18`` gain and a resolution of 20 bits since

--- a/components/sensor/ltr390.rst
+++ b/components/sensor/ltr390.rst
@@ -39,8 +39,8 @@ Configuration variables:
 - **uv** (*Optional*): Sensor counts for the UV sensor (#). All options from :ref:`Sensor <config-sensor>`.
 - **light** (*Optional*): Lux of ambient light (lx). All options from :ref:`Sensor <config-sensor>`.
 - **ambient_light** (*Optional*): Sensor counts for the Ambient light sensor (#). All options from :ref:`Sensor <config-sensor>`.
-- **gain** (*Optional*, string): Adjusts the sensitivity of the sensor. A larger value means higher sensitivity. See table below for details, valid options under "Gain Parameter". Default is ``"X3"``.
-- **resolution** (*Optional*, int): ADC resolution. Higher resolutions require longer sensor integration times. See table below for details, valid options under "Resolution Parameter". Default is ``18``.
+- **gain** (*Optional*, string): Adjusts the sensitivity of the sensor. A larger value means higher sensitivity. See table below for details, valid options under "Gain Parameter". Default is ``"X18"``.
+- **resolution** (*Optional*, int): ADC resolution. Higher resolutions require longer sensor integration times. See table below for details, valid options under "Resolution Parameter". Default is ``20``.
 - **window_correction_factor** (*Optional*, float): Window correction factor. Use larger values when using under tinted windows. Default is ``1.0``, must be ``>= 1.0``.
 - **address** (*Optional*, int): Manually specify the I²C address of the sensor. Default is ``0x53``.
 - **update_interval** (*Optional*, :ref:`config-time`): The interval to check the

--- a/components/sensor/ltr390.rst
+++ b/components/sensor/ltr390.rst
@@ -21,6 +21,8 @@ The :ref:`I²C Bus <i2c>` is required to be set up in your configuration for thi
 
     sensor:
       - platform: ltr390
+        gain: "X18"
+        resolution: 20
         uv_index:
           name: "UV Index"
         uv:
@@ -36,8 +38,8 @@ Configuration variables:
 - **uv** (*Optional*): Sensor counts for the UV sensor (#). All options from :ref:`Sensor <config-sensor>`.
 - **light** (*Optional*): Lux of ambient light (lx). All options from :ref:`Sensor <config-sensor>`.
 - **ambient_light** (*Optional*): Sensor counts for the Ambient light sensor (#). All options from :ref:`Sensor <config-sensor>`.
-- **gain** (*Optional*, string): Adjusts the sensitivity of the sensor. A larger value means higher sensitivity. See table below for details. Default is ``"X3"``.
-- **resolution** (*Optional*, int): ADC resolution. Higher resolutions require longer sensor integration times. See table below for details. Default is ``18``.
+- **gain** (*Optional*, string): Adjusts the sensitivity of the sensor. A larger value means higher sensitivity. See table below for details, valid options under "Gain Parameter". Default is ``"X3"``.
+- **resolution** (*Optional*, int): ADC resolution. Higher resolutions require longer sensor integration times. See table below for details, valid options under "Resolution Parameter". Default is ``18``.
 - **window_correction_factor** (*Optional*, float): Window correction factor. Use larger values when using under tinted windows. Default is ``1.0``, must be ``>= 1.0``.
 - **address** (*Optional*, int): Manually specify the I²C address of the sensor. Default is ``0x53``.
 - **update_interval** (*Optional*, :ref:`config-time`): The interval to check the

--- a/components/sensor/ltr390.rst
+++ b/components/sensor/ltr390.rst
@@ -51,7 +51,7 @@ Lux and UVI Formulas
 
 .. math::
 
-    \text{lux} = \frac{0.6 \times \text{als}}{\text{gain} \times \text{int}} \times \text{wfac}
+    \text{lux} = \frac{0.6 \times \text{als}}{\text{gain} \times \frac{\text{int}}{100} } \times \text{wfac}
 
 .. math::
 
@@ -59,19 +59,19 @@ Lux and UVI Formulas
 
 where:
 
-- ``als`` and ``uv`` are the sensor values
-- ``gain`` is the amount of gain, see the table below for details
-- ``int`` is the integration time in 100s of ms and is tied to the resolution, see the table below for details
+- ``als`` and ``uv`` are the sensor values.
+- ``gain`` is the sensor gain, see the table below for details.
+- ``int`` is the integration time in ms and is tied to the resolution, see the table below for details.
 - ``sensitivity`` is the sensor's count per UVI. See note below for details.
-- ``wfac`` is the window correction factor
+- ``wfac`` is the window correction factor.
 
-Note that for UVI calculations it is recommended to use the defaults of ``X18`` gain and a resolution of 20 bits since
+For UV Index sensing it is recommended to use the defaults of ``X18`` gain and a resolution of 20 bits since
 the datasheet only provides the sensor counts per UVI (sensitivity) for this configuration. When using different
 configurations, the counts per UVI are scaled as follows:
 
 .. math::
 
-    \text{sensitivity} = 2300 \times \frac{\text{gain}}{18} \times \frac{\text{int}}{400}
+    \text{sensitivity} = 2300 \times \frac{\text{gain}}{18} \times \frac{\text{int}}{4}
 
 where :math:`2300` is the sensor count per UVI at the default configuration.
 
@@ -106,27 +106,21 @@ Resolution
     * - Configuration value
       - Resolution (bits)
       - Integration Time (ms)
-      - int
     * - 16
       - 16
       - 25
-      - 0.25
     * - 17
       - 17
       - 50
-      - 0.5
     * - 18
       - 18
       - 100
-      - 1
     * - 19
       - 19
       - 200
-      - 2
     * - 20
       - 20
       - 400
-      - 4
 
 See Also
 --------

--- a/components/sensor/ltr390.rst
+++ b/components/sensor/ltr390.rst
@@ -62,7 +62,7 @@ where:
 - ``als`` and ``uv`` are the sensor values
 - ``gain`` is the amount of gain, see the table below for details
 - ``int`` is the integration time in 100s of ms and is tied to the resolution, see the table below for details
-- ``sensitivity`` is given by $$2300 \times \frac{\text{gain}}{18} \times \frac{\text{int}}{400}$$, where :math:`2300` is the sensor's count per UVI at ``X18`` gain and a resolution of 20 bits (integration time of 400ms)
+- ``sensitivity`` is given by :math:`2300 \times \frac{\text{gain}}{18} \times \frac{\text{int}}{400}`, where :math:`2300` is the sensor's count per UVI at ``X18`` gain and a resolution of 20 bits (integration time of 400ms)
 - ``wfac`` is the window correction factor
 
 Note that for UVI calculations it is recommended to use the defaults of ``X18`` gain and a resolution of 20 bits since

--- a/components/sensor/ltr390.rst
+++ b/components/sensor/ltr390.rst
@@ -31,6 +31,7 @@ The :ref:`I²C Bus <i2c>` is required to be set up in your configuration for thi
           name: "Light"
         ambient_light:
           name: "Light Sensor Counts"
+
 Configuration variables:
 ------------------------
 

--- a/components/sensor/ltr390.rst
+++ b/components/sensor/ltr390.rst
@@ -72,7 +72,7 @@ formula is:
 
 .. math::
 
-    \text{sensitivity} = 2300 \times \frac{\text{gain}}{18} \times \frac{\text{int}}{4}
+    \text{sensitivity} = 2300 \times \frac{\text{gain}}{18} \times \frac{\text{int}}{400}
 
 where :math:`2300` is the sensor count per UVI at the default configuration.
 

--- a/components/sensor/ltr390.rst
+++ b/components/sensor/ltr390.rst
@@ -21,8 +21,6 @@ The :ref:`I²C Bus <i2c>` is required to be set up in your configuration for thi
 
     sensor:
       - platform: ltr390
-        gain: "X18"
-        resolution: 20
         uv_index:
           name: "UV Index"
         uv:

--- a/components/sensor/ltr390.rst
+++ b/components/sensor/ltr390.rst
@@ -82,7 +82,7 @@ Gain
     :widths: 25 25
     :header-rows: 1
 
-    * - Gain Parameter
+    * - Configuration value
       - gain
     * - X1
       - 1
@@ -103,22 +103,28 @@ Resolution
     :widths: 25 25 10
     :header-rows: 1
 
-    * - Resolution Parameter (bits)
+    * - Configuration value
+      - Resolution (bits)
       - Integration Time (ms)
       - int
     * - 16
+      - 16
       - 25
       - 0.25
     * - 17
+      - 17
       - 50
       - 0.5
     * - 18
+      - 18
       - 100
       - 1
     * - 19
+      - 19
       - 200
       - 2
     * - 20
+      - 20
       - 400
       - 4
 

--- a/components/sensor/ltr390.rst
+++ b/components/sensor/ltr390.rst
@@ -62,10 +62,13 @@ where:
 - ``als`` and ``uv`` are the sensor values
 - ``gain`` is the amount of gain, see the table below for details
 - ``int`` is the integration time in 100s of ms and is tied to the resolution, see the table below for details
-- ``sensitivity`` is given by $2300 \times \frac{\text{gain}}{18} \times \frac{int}{400}$, where $2300$ is the sensor's count per UVI at ``X18`` gain and an integration time of 400ms.
+- ``sensitivity`` is given by $$2300 \times \frac{\text{gain}}{18} \times \frac{int}{400}$$, where $$2300$$ is the
+sensor's count per UVI at ``X18`` gain and a resolution of 20 bits (integration time of 400ms).
 - ``wfac`` is the window correction factor
 
-
+Note that for UVI calculations it is recommended to use the defaults of ``X18`` gain and a resolution of 20 bits since
+the datasheet only provides the sensor counts per UVI (sensitivity) for this configuration. When using different
+configurations, the counts per UVI are scaled with respect to the default configuration.
 
 Gain
 ----

--- a/components/sensor/ltr390.rst
+++ b/components/sensor/ltr390.rst
@@ -68,9 +68,11 @@ where:
 Note that for UVI calculations it is recommended to use the defaults of ``X18`` gain and a resolution of 20 bits since
 the datasheet only provides the sensor counts per UVI (sensitivity) for this configuration. When using different
 configurations, the counts per UVI are scaled as follows:
+
 .. math::
 
     \text{sensitivity} = 2300 \times \frac{\text{gain}}{18} \times \frac{\text{int}}{400}
+
 where :math:`2300` is the sensor count per UVI at the default configuration.
 
 Gain

--- a/components/sensor/ltr390.rst
+++ b/components/sensor/ltr390.rst
@@ -21,11 +21,14 @@ The :ref:`I²C Bus <i2c>` is required to be set up in your configuration for thi
 
     sensor:
       - platform: ltr390
-        uv:
+        uv_index:
           name: "UV Index"
+        uv_index:
+          name: "UV Sensor Counts"
         light:
           name: "Light"
-
+        ambient_light:
+          name: "Light Sensor Counts"
 Configuration variables:
 ------------------------
 
@@ -83,7 +86,7 @@ Gain
 Resolution
 ----------
 
-.. list-table:: Resolution
+.. list-table::
     :widths: 25 25 10
     :header-rows: 1
 


### PR DESCRIPTION
## Description:

- Correct sensor name in example YAML
- Update UVI formula
- Add note about UVI calculations and relationship with gain and resolution
- Simplify tables

**Related issue (if applicable):** 

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** https://github.com/esphome/esphome/pull/6161

## Checklist:

  - [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
