### PR TITLE
extend ct_clamp doc

### DIFF
--- a/components/sensor/ct_clamp.rst
+++ b/components/sensor/ct_clamp.rst
@@ -72,6 +72,24 @@ a 4.0 A device is showing a value of 0.1333 in the logs. Now go into your config
 
 Recompile and upload, now your CT clamp sensor is calibrated!
 
+Using GPIO pins
+---------------
+
+If you try to use an ESP32 and hook the sensor up to a normal GPIO wire, you won't get any readings. This is because the ESP32 has an internal voltage divider.
+To counteract this, you must add some `attenuation` and a `multiply` filter. After that, you can use the sensor just like on an analog pin.
+
+.. code-block:: yaml
+
+    # Example configuration entry
+    sensor:
+      - platform: adc
+        pin: GPIO35 # or any other Analog to Digital Converter (ADC) capable pin
+        name: "Measured Current"
+        update_interval: 60s
+        attenuation: 11dB
+        filters:
+          - multiply: 2.0
+
 See Also
 --------
 


### PR DESCRIPTION
## Description:
I had real trouble, getting this sensor to work on an esp32 untill i found out the reaon for the low measurements. So i added some information, how to use this sensor with normal GPIO pins that are ADC capable.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
