### PR TITLE
Update power_supply.rst

### DIFF
--- a/components/power_supply.rst
+++ b/components/power_supply.rst
@@ -33,7 +33,7 @@ Configuration variables:
 - **enable_time** (*Optional*, :ref:`config-time`): The time
   that the power supply needs for startup. The output component will
   wait for this period of time after turning on the PSU and before
-  switching the output on. Defaults to ``20ms``.
+  switching the output on. Defaults to ``20ms``. Maximum of less than ``5s``.
 - **keep_on_time** (*Optional*, :ref:`config-time`): The time the
   power supply should be kept enabled after the last output that used
   it has been switch off. Defaults to ``10s``.


### PR DESCRIPTION
Added maximum time for enable_time.
A delay() command of longer than 5 seconds triggers the watch dog timer and forces reset.


Since power_supply's enable_time uses delay() instead of set_timeout(), anything longer than the watchdog timer's timeout causes the device to reset. While there are many work arounds that could be done in the future to avoid this, for now it's easiest to just add a documentation note.