### PR TITLE
Update logger.rst

### DIFF
--- a/components/logger.rst
+++ b/components/logger.rst
@@ -10,7 +10,7 @@ Logger Component
 The logger component automatically logs all log messages through the
 serial port and through MQTT topics (if there is an MQTT client in the
 configuration). By default, all logs with a severity ``DEBUG`` or higher will be shown.
-Increasing the log level severity (to e.g ``INFO`` or ``WARNING``) can help with the performance of the application and memory size.
+Increasing the log level severity (to e.g ``INFO`` or ``WARN``) can help with the performance of the application and memory size.
 
 .. code-block:: yaml
 


### PR DESCRIPTION
## Description:
No logger level "WARNING" in [available levels](https://esphome.io/components/logger.html#log-levels). Should be "WARN". Fixed.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
