### PR TITLE
Fixed wikipedia link

### DIFF
--- a/cookbook/power_meter.rst
+++ b/cookbook/power_meter.rst
@@ -17,7 +17,7 @@ Hooking it all up is quite easy: Just buy a suitable photoresistor (make sure th
 
 .. note::
 
-    Some energy meters have an exposed `S0 port <https://en.wikipedia.org/wiki/S_interface/>`__ (which essentially just is a switch that closes), if that is the case the photodiode can be replaced with the following connection.
+    Some energy meters have an exposed `S0 port <https://en.wikipedia.org/wiki/S_interface>`__ (which essentially just is a switch that closes), if that is the case the photodiode can be replaced with the following connection.
 
     .. code-block::
 


### PR DESCRIPTION
## Description:
Just a broken Wikipedia link (trailing /):
![image](https://github.com/esphome/esphome-docs/assets/11625419/244a16ab-537a-45e4-b749-5150a1f1f089)


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
