### PR TITLE
Updates links to device class list

### DIFF
--- a/components/binary_sensor/index.rst
+++ b/components/binary_sensor/index.rst
@@ -35,7 +35,7 @@ Configuration variables:
       you want the binary sensor to use that name, you can set ``name: None``.
 
 - **device_class** (*Optional*, string): The device class for the
-  sensor. See https://developers.home-assistant.io/docs/core/entity/binary-sensor/#available-device-classes
+  sensor. See https://www.home-assistant.io/integrations/binary_sensor/#device-class
   for a list of available options.
 - **icon** (*Optional*, icon): Manually set the icon to use for the binary sensor in the frontend.
 - **filters** (*Optional*, list): A list of filters to apply on the binary sensor values such as

--- a/components/button/index.rst
+++ b/components/button/index.rst
@@ -57,7 +57,7 @@ Configuration variables:
   See https://developers.home-assistant.io/docs/core/entity/#generic-properties
   for a list of available options. Set to ``""`` to remove the default entity category.
 - **device_class** (*Optional*, string): The device class for the button.
-  See https://developers.home-assistant.io/docs/core/entity/button/#available-device-classes
+  See https://www.home-assistant.io/integrations/button/#device-class
   for a list of available options.
 
 Automations:

--- a/components/cover/index.rst
+++ b/components/cover/index.rst
@@ -36,7 +36,7 @@ Configuration variables:
       you want the cover to use that name, you can set ``name: None``.
 
 - **device_class** (*Optional*, string): The device class for the
-  sensor. See https://www.home-assistant.io/components/cover/ for a list of available options.
+  sensor. See https://www.home-assistant.io/integrations/cover/#device-class for a list of available options.
 - **icon** (*Optional*, icon): Manually set the icon to use for the cover in the frontend.
 
 Advanced options:

--- a/components/number/index.rst
+++ b/components/number/index.rst
@@ -55,7 +55,7 @@ Configuration variables:
   for a list of available options. Requires Home Assistant Core 2021.12 or newer.
   Defaults to ``"auto"``.
 - **device_class** (*Optional*, string): The device class for the number.
-  See https://developers.home-assistant.io/docs/core/entity/number/#available-device-classes
+  See https://www.home-assistant.io/integrations/number/#device-class
   for a list of available options.
 
 Automations:

--- a/components/sensor/index.rst
+++ b/components/sensor/index.rst
@@ -50,7 +50,7 @@ Configuration variables:
   of measurement the sensor should advertise its values with. This does
   not actually do any maths (conversion between units).
 - **device_class** (*Optional*, string): The device class for the
-  sensor. See https://developers.home-assistant.io/docs/core/entity/sensor/#available-device-classes
+  sensor. See https://www.home-assistant.io/integrations/sensor/#device-class
   for a list of available options. Set to ``""`` to remove the default device class of a sensor.
 - **state_class** (*Optional*, string): The state class for the
   sensor. See https://developers.home-assistant.io/docs/core/entity/sensor/#available-state-classes

--- a/components/switch/index.rst
+++ b/components/switch/index.rst
@@ -65,7 +65,7 @@ Configuration variables:
   for a list of available options. Requires Home Assistant 2021.11 or newer.
   Set to ``""`` to remove the default entity category.
 - **device_class** (*Optional*, string): The device class for the switch.
-  See https://developers.home-assistant.io/docs/core/entity/switch/#available-device-classes
+  See https://www.home-assistant.io/integrations/switch/#device-class
   for a list of available options. Requires Home Assistant 2022.3 or newer.
 - If MQTT enabled, All other options from :ref:`MQTT Component <config-mqtt-component>`.
 


### PR DESCRIPTION
## Description:
Changes the links that list the possible device classes, as the developer documentation only presents the Python classes, not informing the user what to use in ESPHome.

In the user documentation there is a list of device classes for each platform.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
