### PR TITLE
Documentation for 6190 & 6193 (WLED Sync fix and BK72XX support)

### DIFF
--- a/components/light/index.rst
+++ b/components/light/index.rst
@@ -1099,7 +1099,7 @@ Configuration variables:
 
 - **port** (*Optional*, int): The port to run the UDP server on. Defaults to ``21324``.
 - **blank_on_start** (*Optional*, boolean): Whether or not to blank all LEDs when effect starts. Deaults to ``True``.
-- **sync_group_mask** (*Optional*, int): Used with WLED Notifier. The Sync Group mask value that specifies which WLED Sync Groups to listen to. Defaults to ``0`` (All Sync Groups). Sync Groups 1, 2, 3, 4, 5, 6, 7, 8 use masks 1, 2, 4, 8, 16, 32, 64. Combine mask values to listen to multiple Sync Groups.
+- **sync_group_mask** (*Optional*, int): Used with WLED Notifier. The Sync Group mask value that specifies which WLED Sync Groups to listen to. Defaults to ``0`` (All Sync Groups). Sync Groups 1, 2, 3, 4, 5, 6, 7, 8 use masks 1, 2, 4, 8, 16, 32, 64, 128. Combine mask values to listen to multiple Sync Groups.
 
 .. note::
 

--- a/components/light/index.rst
+++ b/components/light/index.rst
@@ -1092,10 +1092,14 @@ It is also possible to use LedFx_ to control the lights. Please use the connecti
         effects:
           - wled:
               # port: 21324
+              # blank_on_start: True
+              # sync_group_mask: 0
 
 Configuration variables:
 
 - **port** (*Optional*, int): The port to run the UDP server on. Defaults to ``21324``.
+- **blank_on_start** (*Optional*, boolean): Whether or not to blank all LEDs when effect starts. Deaults to ``True``.
+- **sync_group_mask** (*Optional*, int): Used with WLED Notifier. The Sync Group mask value that specifies which WLED Sync Groups to listen to. Defaults to ``0`` (All Sync Groups). Sync Groups 1, 2, 3, 4, 5, 6, 7, 8 use masks 1, 2, 4, 8, 16, 32, 64. Combine mask values to listen to multiple Sync Groups.
 
 .. note::
 


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#

https://github.com/esphome/esphome/pull/6190
https://github.com/esphome/esphome/pull/6193

## Checklist:

  - [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
