### PR TITLE
microWakeWord - cutoff probability is a percentage

### DIFF
--- a/components/micro_wake_word.rst
+++ b/components/micro_wake_word.rst
@@ -38,7 +38,7 @@ Configuration variables:
 
 The below two options are provided by the JSON file, but can be overridden in YAML.
 
-- **probability_cutoff** (*Optional*, float): The probability cutoff for the wake word detection.
+- **probability_cutoff** (*Optional*, percentage): The probability cutoff for the wake word detection.
   If the probability of the wake word is below this value, the wake word is not detected.
   A larger value reduces the number of false accepts but increases the number of false rejections.
 - **sliding_window_average_size** (*Optional*, int): The size of the sliding window average for the wake word detection. A small value lowers latency but may increase the number of false accepts.


### PR DESCRIPTION
## Description:

Small PR to change the type for ``probability_cutoff`` to a percentage.

**Related issue (if applicable):** not applicable

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#6238

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
