### PR TITLE
Update ssd1306.rst

### DIFF
--- a/components/display/ssd1306.rst
+++ b/components/display/ssd1306.rst
@@ -34,8 +34,8 @@ improve reliability.
 
     # Example configuration entry
     i2c:
-      sda: D1
-      scl: D2
+      scl: D1
+      sda: D2
 
     display:
       - platform: ssd1306_i2c


### PR DESCRIPTION
Invertir los pines de i2C, scl es D1 y sda es D2

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
