### PR TITLE
microWakeWord: Add minimum_esphome_version as optional field

### DIFF
--- a/components/micro_wake_word.rst
+++ b/components/micro_wake_word.rst
@@ -75,6 +75,9 @@ The model JSON file contains the following fields that are all **required**:
     If the probability of the wake word is below this value, the wake word is not detected.
   - **sliding_window_average_size** (int): The size of the sliding window average for the wake word detection.
 
+The following **optional** fields can be added to the JSON file:
+
+- **minimum_esphome_version** (version): The minimum ESPHome version required to use this model.
 
 Automations
 -----------

--- a/components/micro_wake_word.rst
+++ b/components/micro_wake_word.rst
@@ -61,7 +61,7 @@ Model JSON
       }
     }
 
-The model JSON file contains the following fields that are all **required**:
+The model JSON file contains the following fields that are all **required** unless otherwise specified:
 
 - **type** (string): The type of the model. This should always be ``micro``.
 - **wake_word** (string): The wake word that the model is trained to detect.
@@ -74,10 +74,8 @@ The model JSON file contains the following fields that are all **required**:
   - **probability_cutoff** (float): The probability cutoff for the wake word detection.
     If the probability of the wake word is below this value, the wake word is not detected.
   - **sliding_window_average_size** (int): The size of the sliding window average for the wake word detection.
+  - **minimum_esphome_version** (*Optional* version): The minimum ESPHome version required to use this model.
 
-The following **optional** fields can be added to the JSON file:
-
-- **minimum_esphome_version** (version): The minimum ESPHome version required to use this model.
 
 Automations
 -----------


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#6240

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
