### PR TITLE
Add info about logging parameters to a script

### DIFF
--- a/components/logger.rst
+++ b/components/logger.rst
@@ -242,16 +242,16 @@ Printing arguments to a script:
 
 .. code-block:: yaml
 
-  script:
-    - id: format
-      parameters:
-        offset: int
-        message: string
-      then:
-      - logger.log: "Format called"
-      - logger.log:
-          format: "The offset is %d and the message is %s"
-          args: [ 'offset', 'message.c_str()' ]
+    script:
+      - id: format
+        parameters:
+          offset: int
+          message: string
+        then:
+        - logger.log: "Format called"
+        - logger.log:
+            format: "The offset is %d and the message is %s"
+            args: [ 'offset', 'message.c_str()' ]
 
 Configuration options:
 

--- a/components/logger.rst
+++ b/components/logger.rst
@@ -238,6 +238,21 @@ In the ``format`` option, you can use ``printf``-style formatting (see :ref:`dis
             format: "The temperature sensor reports value %.1f and humidity %.1f"
             args: [ 'id(temperature_sensor).state', 'id(humidity_sensor).state' ]
 
+Printing arguments to a script:
+
+.. code-block:: yaml
+
+  script:
+    - id: format
+      parameters:
+        offset: int
+        message: string
+      then:
+      - logger.log: "Format called"
+      - logger.log:
+          format: "The offset is %d and the message is %s"
+          args: [ 'offset', 'message.c_str()' ]
+
 Configuration options:
 
 -  **format** (**Required**, string): The format for the message in :ref:`printf-style <display-printf>`.


### PR DESCRIPTION
I struggled getting arguments to a script printed, especially a string, so I wanted to put this in the manual for future reference.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
