### PR TITLE
Flip configuration and command in example

### DIFF
--- a/guides/migrate_sonoff_tasmota.rst
+++ b/guides/migrate_sonoff_tasmota.rst
@@ -42,7 +42,7 @@ From your configuration files folder, run
 
 :: 
 
-  esphome <MY_DEVICE>.yaml compile
+  esphome compile <MY_DEVICE>.yaml
   
 replacing ``<MY_DEVICE>.yaml`` with your configuration file and navigate to the ``<MY_DEVICE>/.pioenvs/<MY_DEVICE>/`` folder. 
 


### PR DESCRIPTION
Since running `esphome <MY_DEVICE>.yaml compile` generates the warning 
```
WARNING Calling ESPHome with the configuration before the command is deprecated and will be removed in the future. 
WARNING Please instead use:
WARNING    esphome compile powerplug.yaml
```