### PR TITLE
Build Docker image for arm64

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,6 +22,9 @@ jobs:
         name: Checkout source code
         uses: actions/checkout@v4.1.0
       -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       -
@@ -43,6 +46,7 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: |
             esphome/esphome-docs:latest
             ghcr.io/esphome/esphome-docs:latest


### PR DESCRIPTION
This is needed in order for the esphome-docs Docker image to run on Docker Desktop on MacBook M1/2/3.

I built the image locally on my M2 MacBook via `git clone git@github.com/esphome/esphome-docs && cd esphome-docs && docker build .` and it worked great. This PR should be sufficient to get the arm64 build published to the GitHub container registry.

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
