### PR TITLE
output is optional

### DIFF
--- a/components/fan/speed.rst
+++ b/components/fan/speed.rst
@@ -23,9 +23,9 @@ supports speed settings.
 Configuration variables:
 ------------------------
 
-- **output** (**Required**, :ref:`config-id`): The id of the
+- **output** (*Optional*, :ref:`config-id`): The id of the
   :ref:`float output <output>` to use for this fan.
-- **name** (**Required**, string): The name for this fan.
+- **name** (*Optional*, string): The name for this fan.
 - **oscillation_output** (*Optional*, :ref:`config-id`): The id of the
   :ref:`output <output>` to use for the oscillation state of this fan. Default is empty.
 - **direction_output** (*Optional*, :ref:`config-id`): The id of the

--- a/components/fan/speed.rst
+++ b/components/fan/speed.rst
@@ -23,9 +23,9 @@ supports speed settings.
 Configuration variables:
 ------------------------
 
+- **name** (*Optional*, string): The name for this fan.
 - **output** (*Optional*, :ref:`config-id`): The id of the
   :ref:`float output <output>` to use for this fan.
-- **name** (*Optional*, string): The name for this fan.
 - **oscillation_output** (*Optional*, :ref:`config-id`): The id of the
   :ref:`output <output>` to use for the oscillation state of this fan. Default is empty.
 - **direction_output** (*Optional*, :ref:`config-id`): The id of the


### PR DESCRIPTION
## Description:
Make the output optional and also fix the name which is optional.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#6274

## Checklist:

  - [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
