### PR TITLE
Reflect speed fan requirements in docs

### DIFF
--- a/components/fan/speed.rst
+++ b/components/fan/speed.rst
@@ -24,7 +24,7 @@ Configuration variables:
 ------------------------
 
 - **name** (*Optional*, string): The name for this fan.
-- **output** (*Optional*, :ref:`config-id`): The id of the
+- **output** (**Required**, :ref:`config-id`): The id of the
   :ref:`float output <output>` to use for this fan.
 - **oscillation_output** (*Optional*, :ref:`config-id`): The id of the
   :ref:`output <output>` to use for the oscillation state of this fan. Default is empty.


### PR DESCRIPTION
## Description:

*Output* is not an optional field according to yaml validation. Docs updated to reflect this behavior.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
