### PR TITLE
Update bme280_environment.rst

### DIFF
--- a/cookbook/bme280_environment.rst
+++ b/cookbook/bme280_environment.rst
@@ -6,7 +6,7 @@ BME280 Environment
     :image: bme280.jpg
     :keywords: BME280
 
-The :doc:`/components/sensor/bme280` is a simple temperature, humidity, and pressure sensor with communication over :ref:`I²C <i2c>`.
+The :doc:`/components/sensor/bme280` is a simple temperature, humidity, and pressure sensor with communication over :ref:`I²C <i2c>` or :ref:`SPI <spi>`.
 With some simple math it is possible to either determine the height of the sensor, or the current pressure at sea level.
 This guide can be applied to any sensor measuring temperature and pressure at the same time, like the
 :doc:`/components/sensor/bmp280`, or :doc:`/components/sensor/bme680`.
@@ -17,6 +17,7 @@ This guide can be applied to any sensor measuring temperature and pressure at th
 
 The first step is to connect the sensor as described :doc:`here </components/sensor/bme280>`.
 After validating the sensor is working, we can proceed and add some formulas.
+In the example below change - platform: bme280 to the relevant one for your installation (_i2c or _spi)
 
 .. code-block:: yaml
 

--- a/cookbook/bme280_environment.rst
+++ b/cookbook/bme280_environment.rst
@@ -17,7 +17,7 @@ This guide can be applied to any sensor measuring temperature and pressure at th
 
 The first step is to connect the sensor as described :doc:`here </components/sensor/bme280>`.
 After validating the sensor is working, we can proceed and add some formulas.
-In the example below change - platform: bme280 to the relevant one for your installation (_i2c or _spi)
+In the example below, modify ``platform: bme280`` as appropriate for your hardware (either ``bme280_i2c`` or ``bme280_spi``). See :doc:`/components/sensor/bme280` for specific details.
 
 .. code-block:: yaml
 


### PR DESCRIPTION
update to doc to include use of _i2c or _spi as per recent platform change

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
