### PR TITLE
CSE7766 Apparent Power & Power Factor calculations

### DIFF
--- a/components/sensor/cse7766.rst
+++ b/components/sensor/cse7766.rst
@@ -23,6 +23,9 @@ will probably want some sort of averaging or throttle filter on the sensors.
 .. code-block:: yaml
 
     # Example configuration entry
+    substitutions:
+      update_interval: 60s
+
     # Disable logging over USB
     logger:
       baud_rate: 0
@@ -36,15 +39,27 @@ will probably want some sort of averaging or throttle filter on the sensors.
         current:
           name: "Sonoff Pow R2 Current"
           filters:
-            - throttle_average: 60s
+            - throttle_average: ${update_interval}
         voltage:
           name: "Sonoff Pow R2 Voltage"
           filters:
-            - throttle: 60s
+            - throttle_average: ${update_interval}
         power:
           name: "Sonoff Pow R2 Power"
+          filters:
+            - throttle_average: ${update_interval}
         energy:
           name: "Sonoff Pow R2 Energy"
+          filters:
+            - throttle: ${update_interval}
+        apparent_power:
+          name: "Sonoff Pow R2 Apparent Power"
+          filters:
+            - throttle_average: ${update_interval}
+        power_factor:
+          name: "Sonoff Pow R2 Power Factor"
+          filters:
+            - throttle_average: ${update_interval}
 .. note::
 
     The configuration above should work for Sonoff POWs (R2).
@@ -59,6 +74,10 @@ Configuration variables:
 - **voltage** (*Optional*): Use the voltage value of the sensor in V (RMS).
   All options from :ref:`Sensor <config-sensor>`.
 - **energy** (*Optional*): Use the total energy value of the sensor in Wh.
+  All options from :ref:`Sensor <config-sensor>`.
+- **apparent_power** (*Optional*): Use the apparent power value of the sensor in volt amps.
+  All options from :ref:`Sensor <config-sensor>`.
+- **power_factor** (*Optional*): Use the power factor value of the sensor.
   All options from :ref:`Sensor <config-sensor>`.
 - **uart_id** (*Optional*, :ref:`config-id`): Manually specify the ID of the :ref:`UART Component <uart>` if you want
   to use multiple UART buses.


### PR DESCRIPTION
## Description:

Since moving the averaging out of cse7766, calculating power factor & apparent power is much easier and more accurate when done inside the component. This adds optional Power Factor and Apparent Power sensors.

**Related issue (if applicable):** fixes esphome/issues/5501

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#6292

## Checklist:

  - [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [X] Link added in `/index.rst` when creating new documents for new components or cookbook.
