### PR TITLE
FAQ: unavailable entities during deep sleep

### DIFF
--- a/components/deep_sleep.rst
+++ b/components/deep_sleep.rst
@@ -21,7 +21,9 @@ to wake up on any RTC pin (``GPIO0``, ``GPIO2``, ``GPIO4``, ``GPIO12``, ``GPIO13
 ``GPIO15``, ``GPIO25``, ``GPIO26``, ``GPIO27``, ``GPIO32``, ``GPIO39``).
 
 While in deep sleep mode, the node will not do any work and not respond to any network traffic,
-even Over The Air updates.
+even Over The Air updates. If the device's entities are appearing as **Unavailable** while your device is actively
+sleeping, this component was likely added after the device was added to Home Assistant. To prevent this behavior,
+you can remove and re-add the device within ESPHome.
 
 .. code-block:: yaml
 
@@ -32,8 +34,8 @@ even Over The Air updates.
 
 .. note::
 
-    Some ESP8266s have an onboard USB chip (e.g. D1 mini) on the chips' control line that is connected to the RST pin. This enables the flasher to reboot the ESP when required. This may interfere with deep sleep on some devices and prevent the ESP from waking when it's powered through its USB connector. Powering the ESP from a separate 3.3V source connected to the 3.3V pin and GND will solve this issue. In these cases, using a USB to TTL adapter will allow you to log ESP activity. 
-    
+    Some ESP8266s have an onboard USB chip (e.g. D1 mini) on the chips' control line that is connected to the RST pin. This enables the flasher to reboot the ESP when required. This may interfere with deep sleep on some devices and prevent the ESP from waking when it's powered through its USB connector. Powering the ESP from a separate 3.3V source connected to the 3.3V pin and GND will solve this issue. In these cases, using a USB to TTL adapter will allow you to log ESP activity.
+
 Configuration variables:
 ------------------------
 

--- a/guides/faq.rst
+++ b/guides/faq.rst
@@ -361,7 +361,7 @@ And a docker compose file looks like this:
 .. _docker-reference-notes:
 .. note::
 
-    By default ESPHome uses mDNS to show online/offline state in the dashboard view. So for that feature to work you need to enable host networking mode. 
+    By default ESPHome uses mDNS to show online/offline state in the dashboard view. So for that feature to work you need to enable host networking mode.
 
     On MacOS the networking mode ("-net=host" option) doesn't work as expected. You have to use
     another way to launch the dashboard with a port mapping option and use alternative to mDNS
@@ -450,6 +450,13 @@ flash your device, the code from the Pull Request will be used for the component
 Note that this only works for Pull Requests that only change files within components. If any files outside
 ``esphome/components/`` are added or changed, this method unfortunately doesn't work. Those Pull Requests are labeled
 with the "core" label on GitHub.
+
+Why do entities show as Unavailable during deep sleep?
+------------------------------------------------------
+
+The :doc:`Deep Sleep </components/deep_sleep>` component needs to be present within the config when the device
+is first added to Home Assistant. To prevent entities from appearing as Unavailable, you can remove and re-add the
+device within ESPHome.
 
 See Also
 --------


### PR DESCRIPTION
## Description:
Whether or not you're just getting started with ESPHome, the addition of the deep sleep component after a device has been added to ESPHome/Home Assistant results in entities appearing as "Unavailable" while in deep sleep. Not only did I personally experience this, but I have observed several other people inquire in Discord about the same outcome and they may only be a portion of the people experiencing this out in the wild.

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
