### PR TITLE
FAQ: fixed location of re-add when unavailable

### DIFF
--- a/components/deep_sleep.rst
+++ b/components/deep_sleep.rst
@@ -23,7 +23,7 @@ to wake up on any RTC pin (``GPIO0``, ``GPIO2``, ``GPIO4``, ``GPIO12``, ``GPIO13
 While in deep sleep mode, the node will not do any work and not respond to any network traffic,
 even Over The Air updates. If the device's entities are appearing as **Unavailable** while your device is actively
 sleeping, this component was likely added after the device was added to Home Assistant. To prevent this behavior,
-you can remove and re-add the device within ESPHome.
+you can remove and re-add the device in Home Assistant.
 
 .. code-block:: yaml
 

--- a/guides/faq.rst
+++ b/guides/faq.rst
@@ -456,7 +456,7 @@ Why do entities show as Unavailable during deep sleep?
 
 The :doc:`Deep Sleep </components/deep_sleep>` component needs to be present within the config when the device
 is first added to Home Assistant. To prevent entities from appearing as Unavailable, you can remove and re-add the
-device within ESPHome.
+device in Home Assistant.
 
 See Also
 --------


### PR DESCRIPTION
## Description:
In #3648 it was mentioned that you can re-add devices in ESPHome to prevent unavailable entities resulting from post-config `deep_sleep` component addition. This should actually say remove/re-add in Home Assistant as opposed to ESPHome.

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
