### PR TITLE
Add docs for passing the used wake word to the voice_assistant

### DIFF
--- a/components/micro_wake_word.rst
+++ b/components/micro_wake_word.rst
@@ -35,6 +35,7 @@ Configuration variables:
     e.g. ``https://github.com/esphome/micro-wake-word-models/raw/main/models/okay_nabu.json``.
 
 - **on_wake_word_detected** (*Optional*, Automation): An automation to perform when the wake word is detected.
+  The ``wake_word`` phrase from the model manifest is provided as a ``std::string`` to any actions in this automation.
 
 The below two options are provided by the JSON file, but can be overridden in YAML.
 
@@ -100,6 +101,7 @@ Example usage
       on_wake_word_detected:
         then:
           - voice_assistant.start:
+              wake_word: !lambda return wake_word;
 
 
 See Also

--- a/components/voice_assistant.rst
+++ b/components/voice_assistant.rst
@@ -97,6 +97,8 @@ Listens for one voice command then stops.
 Configuration variables:
 
 - **silence_detection** (*Optional*, boolean): Enable silence detection. Defaults to ``true``.
+- **wake_word** (*Optional*, string): The wake word that was used to trigger the voice assistant
+  when using on-device wake word such as :doc:`/components/micro_wake_word`.
 
 Call ``voice_assistant.stop`` to signal the end of the voice command if ``silence_detection`` is set to ``false``.
 


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#6290

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
