### PR TITLE
optional output is temporary

### DIFF
--- a/components/fan/speed.rst
+++ b/components/fan/speed.rst
@@ -24,8 +24,8 @@ Configuration variables:
 ------------------------
 
 - **name** (*Optional*, string): The name for this fan.
-- **output** (*Optional*, :ref:`config-id`): The id of the
-  :ref:`float output <output>` to use for this fan.
+- **output** (*Optional*, :ref:`config-id`): The id of the :ref:`float output <output>` to use for this fan.
+(This is a temporary change until a template fan is available.)
 - **oscillation_output** (*Optional*, :ref:`config-id`): The id of the
   :ref:`output <output>` to use for the oscillation state of this fan. Default is empty.
 - **direction_output** (*Optional*, :ref:`config-id`): The id of the

--- a/components/fan/speed.rst
+++ b/components/fan/speed.rst
@@ -25,7 +25,7 @@ Configuration variables:
 
 - **name** (*Optional*, string): The name for this fan.
 - **output** (*Optional*, :ref:`config-id`): The id of the :ref:`float output <output>` to use for this fan.
-(This is a temporary change until a template fan is available.)
+  (This is a temporary change until a template fan is available.)
 - **oscillation_output** (*Optional*, :ref:`config-id`): The id of the
   :ref:`output <output>` to use for the oscillation state of this fan. Default is empty.
 - **direction_output** (*Optional*, :ref:`config-id`): The id of the


### PR DESCRIPTION
## Description:

Note that the optional output is a temporary change.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#6309

## Checklist:

  - [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
