### PR TITLE
Deep sleep: example of getting wakeup cause

### DIFF
--- a/components/deep_sleep.rst
+++ b/components/deep_sleep.rst
@@ -87,6 +87,35 @@ when the deep sleep should start? There are three ways of handling this using th
   then re-configure deep sleep to wake up on a LOW signal and vice versa. Useful in situations when you want to
   use observe the state changes of a pin using deep sleep and the ON/OFF values last longer.
 
+ESP32 Wakeup Cause
+------------------
+
+On the ESP32, the ``esp_sleep_get_wakeup_cause()`` function can be used to check which wakeup source has triggered
+wakeup from sleep mode.
+
+.. code-block:: yaml
+
+    sensor:
+        - platform: template
+         id: wakeup_cause
+         name: "Wakeup Cause"
+         accuracy_decimals: 0
+         lambda: return esp_sleep_get_wakeup_cause();
+
+The following integers are the wakeup causes:
+- 0 - ``ESP_SLEEP_WAKEUP_UNDEFINED``: In case of deep sleep, reset was not caused by exit from deep sleep
+- 1 - ``ESP_SLEEP_WAKEUP_ALL``: Not a wakeup cause, used to disable all wakeup sources with esp_sleep_disable_wakeup_source
+- 2 - ``ESP_SLEEP_WAKEUP_EXT0``: Wakeup caused by external signal using RTC_IO
+- 3 - ``ESP_SLEEP_WAKEUP_EXT1``: Wakeup caused by external signal using RTC_CNTL
+- 4 - ``ESP_SLEEP_WAKEUP_TIMER``: Wakeup caused by timer
+- 5 - ``ESP_SLEEP_WAKEUP_TOUCHPAD``: Wakeup caused by touchpad
+- 6 - ``ESP_SLEEP_WAKEUP_ULP``: Wakeup caused by ULP program
+- 7 - ``ESP_SLEEP_WAKEUP_GPIO``: Wakeup caused by GPIO (light sleep only on ESP32, S2 and S3)
+- 8 - ``ESP_SLEEP_WAKEUP_UART``: Wakeup caused by UART (light sleep only)
+- 9 - ``ESP_SLEEP_WAKEUP_WIFI``: Wakeup caused by WIFI (light sleep only)
+- 10 - ``ESP_SLEEP_WAKEUP_COCPU``: Wakeup caused by COCPU int
+- 11 - ``ESP_SLEEP_WAKEUP_COCPU_TRAP_TRIG``: Wakeup caused by COCPU crash
+- 12 - ``ESP_SLEEP_WAKEUP_BT``: Wakeup caused by BT (light sleep only)
 
 .. _deep_sleep-enter_action:
 

--- a/components/deep_sleep.rst
+++ b/components/deep_sleep.rst
@@ -96,26 +96,25 @@ wakeup from sleep mode.
 .. code-block:: yaml
 
     sensor:
-        - platform: template
-         id: wakeup_cause
-         name: "Wakeup Cause"
-         accuracy_decimals: 0
-         lambda: return esp_sleep_get_wakeup_cause();
+      - platform: template
+        name: "Wakeup Cause"
+        accuracy_decimals: 0
+        lambda: return esp_sleep_get_wakeup_cause();
 
 The following integers are the wakeup causes:
-- 0 - ``ESP_SLEEP_WAKEUP_UNDEFINED``: In case of deep sleep, reset was not caused by exit from deep sleep
-- 1 - ``ESP_SLEEP_WAKEUP_ALL``: Not a wakeup cause, used to disable all wakeup sources with esp_sleep_disable_wakeup_source
-- 2 - ``ESP_SLEEP_WAKEUP_EXT0``: Wakeup caused by external signal using RTC_IO
-- 3 - ``ESP_SLEEP_WAKEUP_EXT1``: Wakeup caused by external signal using RTC_CNTL
-- 4 - ``ESP_SLEEP_WAKEUP_TIMER``: Wakeup caused by timer
-- 5 - ``ESP_SLEEP_WAKEUP_TOUCHPAD``: Wakeup caused by touchpad
-- 6 - ``ESP_SLEEP_WAKEUP_ULP``: Wakeup caused by ULP program
-- 7 - ``ESP_SLEEP_WAKEUP_GPIO``: Wakeup caused by GPIO (light sleep only on ESP32, S2 and S3)
-- 8 - ``ESP_SLEEP_WAKEUP_UART``: Wakeup caused by UART (light sleep only)
-- 9 - ``ESP_SLEEP_WAKEUP_WIFI``: Wakeup caused by WIFI (light sleep only)
-- 10 - ``ESP_SLEEP_WAKEUP_COCPU``: Wakeup caused by COCPU int
-- 11 - ``ESP_SLEEP_WAKEUP_COCPU_TRAP_TRIG``: Wakeup caused by COCPU crash
-- 12 - ``ESP_SLEEP_WAKEUP_BT``: Wakeup caused by BT (light sleep only)
+    - **0** - ``ESP_SLEEP_WAKEUP_UNDEFINED``: In case of deep sleep, reset was not caused by exit from deep sleep
+    - **1** - ``ESP_SLEEP_WAKEUP_ALL``: Not a wakeup cause, used to disable all wakeup sources with esp_sleep_disable_wakeup_source
+    - **2** - ``ESP_SLEEP_WAKEUP_EXT0``: Wakeup caused by external signal using RTC_IO
+    - **3** - ``ESP_SLEEP_WAKEUP_EXT1``: Wakeup caused by external signal using RTC_CNTL
+    - **4** - ``ESP_SLEEP_WAKEUP_TIMER``: Wakeup caused by timer
+    - **5** - ``ESP_SLEEP_WAKEUP_TOUCHPAD``: Wakeup caused by touchpad
+    - **6** - ``ESP_SLEEP_WAKEUP_ULP``: Wakeup caused by ULP program
+    - **7** - ``ESP_SLEEP_WAKEUP_GPIO``: Wakeup caused by GPIO (light sleep only on ESP32, S2 and S3)
+    - **8** - ``ESP_SLEEP_WAKEUP_UART``: Wakeup caused by UART (light sleep only)
+    - **9** - ``ESP_SLEEP_WAKEUP_WIFI``: Wakeup caused by WIFI (light sleep only)
+    - **10** - ``ESP_SLEEP_WAKEUP_COCPU``: Wakeup caused by COCPU int
+    - **11** - ``ESP_SLEEP_WAKEUP_COCPU_TRAP_TRIG``: Wakeup caused by COCPU crash
+    - **12** - ``ESP_SLEEP_WAKEUP_BT``: Wakeup caused by BT (light sleep only)
 
 .. _deep_sleep-enter_action:
 


### PR DESCRIPTION
## Description:
Addition of a useful example to get the reason that a device woke up from deep sleep via `esp_sleep_get_wakeup_cause`.
- Reference: https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/system/sleep_modes.html#checking-sleep-wakeup-cause
- Causes: https://github.com/espressif/esp-idf/blob/ea7cfc40ae4ec8f6c90b39085883119e33350e42/components/esp_hw_support/include/esp_sleep.h#L104

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
