### PR TITLE
Add note about fake RP2040 unsupported

### DIFF
--- a/components/rp2040.rst
+++ b/components/rp2040.rst
@@ -11,7 +11,7 @@ This component contains platform-specific options for the RP2040 platform.
 
     Support for all aspects of ESPHome on the RP2040 is still in development.
     
-    Only the original model of Raspberry Pi Pico W board is supported, which has the Cypress **CYW43455** chip providing wireless connectivity. It can be identified by a metalic shield encapsulating the radio circuitry. Pico W boards having as radio modules chips like ESP8285 or similar (labelled as ``RP2040 Pico W-2023`` etc.), are not supported.
+    Only the original model of Raspberry Pi Pico W board is supported, which has the Cypress **CYW43455** chip providing wireless connectivity. It can be identified by a metallic shield encapsulating the radio circuitry. Pico W boards with radio module chips like ESP8285 or similar (labelled as ``RP2040 Pico W-2023`` etc.), are not supported.
 
     Please search for or create an `issue <https://github.com/esphome/issues/issues/new?assignees=&labels=&template=bug_report.yml>`__ if you encounter an unknown problem.
 

--- a/components/rp2040.rst
+++ b/components/rp2040.rst
@@ -10,6 +10,9 @@ This component contains platform-specific options for the RP2040 platform.
 .. note::
 
     Support for all aspects of ESPHome on the RP2040 is still in development.
+    
+    The RP2040 platform in ESPHome supports only the original model of Raspberry Pi Pico W board, which has the Cypress CYW43455 chip providing wireless connectivity. It can be identified by a metalic shield encapsulating the radio circuitry. Pico W boards having an ESP8285 as the radio module (labelled as ``RP2040 Pico W-2023`` or similar), are not currently supported.
+
     Please search for or create an `issue <https://github.com/esphome/issues/issues/new?assignees=&labels=&template=bug_report.yml>`__ if you encounter an unknown problem.
 
 .. code-block:: yaml

--- a/components/rp2040.rst
+++ b/components/rp2040.rst
@@ -11,7 +11,7 @@ This component contains platform-specific options for the RP2040 platform.
 
     Support for all aspects of ESPHome on the RP2040 is still in development.
     
-    The RP2040 platform in ESPHome supports only the original model of Raspberry Pi Pico W board, which has the Cypress **CYW43455** chip providing wireless connectivity. It can be identified by a metalic shield encapsulating the radio circuitry. Pico W boards having as radio modules chips like ESP8285 or similar (labelled as ``RP2040 Pico W-2023`` or similar), are not supported.
+    Only the original model of Raspberry Pi Pico W board is supported, which has the Cypress **CYW43455** chip providing wireless connectivity. It can be identified by a metalic shield encapsulating the radio circuitry. Pico W boards having as radio modules chips like ESP8285 or similar (labelled as ``RP2040 Pico W-2023`` etc.), are not supported.
 
     Please search for or create an `issue <https://github.com/esphome/issues/issues/new?assignees=&labels=&template=bug_report.yml>`__ if you encounter an unknown problem.
 

--- a/components/rp2040.rst
+++ b/components/rp2040.rst
@@ -11,7 +11,7 @@ This component contains platform-specific options for the RP2040 platform.
 
     Support for all aspects of ESPHome on the RP2040 is still in development.
     
-    The RP2040 platform in ESPHome supports only the original model of Raspberry Pi Pico W board, which has the Cypress CYW43455 chip providing wireless connectivity. It can be identified by a metalic shield encapsulating the radio circuitry. Pico W boards having an ESP8285 as the radio module (labelled as ``RP2040 Pico W-2023`` or similar), are not currently supported.
+    The RP2040 platform in ESPHome supports only the original model of Raspberry Pi Pico W board, which has the Cypress **CYW43455** chip providing wireless connectivity. It can be identified by a metalic shield encapsulating the radio circuitry. Pico W boards having as radio modules chips like ESP8285 or similar (labelled as ``RP2040 Pico W-2023`` or similar), are not supported.
 
     Please search for or create an `issue <https://github.com/esphome/issues/issues/new?assignees=&labels=&template=bug_report.yml>`__ if you encounter an unknown problem.
 


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes <link to issue>
Stores are overwhelmed by a new `RP2040 Pico W-2023` board, sold with the same name _Raspberry Pi Pico W_ which is unfortunate because of a fundamental difference: the radio module is not CYW43455, but an ESP8285(!). Naturally, ESPHome firmware uploaded to such a board will cause failure.

![rp2040](https://github.com/esphome/esphome-docs/assets/1550668/aeb14e1b-8a72-4a6a-9058-0cae778fd9a4)

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
