### PR TITLE
Update for SHT85 support

### DIFF
--- a/components/sensor/sht3xd.rst
+++ b/components/sensor/sht3xd.rst
@@ -7,8 +7,8 @@ SHT3X-D Temperature+Humidity Sensor
 
 The ``sht3xd`` sensor platform Temperature+Humidity sensor allows you to use your Sensirion SHT31-D/SHT3x
 (`datasheet <https://cdn-shop.adafruit.com/product-files/2857/Sensirion_Humidity_SHT3x_Datasheet_digital-767294.pdf>`__,
-`Adafruit`_ ) and SHT85 (`datasheet <https://sensirion.com/media/documents/4B40CEF3/640B2346/Sensirion_Humidity_Sensors_SHT85_Datasheet.pdf>` __,
-`Sensirion`_ ), sensors with Esphome.
+`Adafruit`_ ) and SHT85 (`datasheet <https://sensirion.com/media/documents/4B40CEF3/640B2346/Sensirion_Humidity_Sensors_SHT85_Datasheet.pdf>`__,
+`Sensirion`_ ) sensors with Esphome.
 The :ref:`I²C Bus <i2c>` is required to be set up in your configuration for this sensor to work.
 
 .. _Adafruit: https://www.adafruit.com/product/2857
@@ -32,7 +32,7 @@ The :ref:`I²C Bus <i2c>` is required to be set up in your configuration for thi
 
 Configuration variables:
 ------------------------
-,
+
 - **temperature** (*Optional*): The information for the temperature sensor.
 
   - **name** (**Required**, string): The name for the temperature sensor.

--- a/components/sensor/sht3xd.rst
+++ b/components/sensor/sht3xd.rst
@@ -7,11 +7,12 @@ SHT3X-D Temperature+Humidity Sensor
 
 The ``sht3xd`` sensor platform Temperature+Humidity sensor allows you to use your Sensirion SHT31-D/SHT3x
 (`datasheet <https://cdn-shop.adafruit.com/product-files/2857/Sensirion_Humidity_SHT3x_Datasheet_digital-767294.pdf>`__,
-`Adafruit`_ ) sensors with
-ESPHome. The :ref:`I²C Bus <i2c>` is
-required to be set up in your configuration for this sensor to work.
+`Adafruit`_ ) and SHT85 (`datasheet <https://sensirion.com/media/documents/4B40CEF3/640B2346/Sensirion_Humidity_Sensors_SHT85_Datasheet.pdf>` __,
+`Sensirion`_ ), sensors with Esphome.
+The :ref:`I²C Bus <i2c>` is required to be set up in your configuration for this sensor to work.
 
 .. _Adafruit: https://www.adafruit.com/product/2857
+.. _Sensirion: https://sensirion.com/products/catalog/SHT85/
 
 .. figure:: images/temperature-humidity.png
     :align: center
@@ -31,21 +32,21 @@ required to be set up in your configuration for this sensor to work.
 
 Configuration variables:
 ------------------------
-
-- **temperature** (**Required**): The information for the temperature sensor.
+,
+- **temperature** (*Optional*): The information for the temperature sensor.
 
   - **name** (**Required**, string): The name for the temperature sensor.
   - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.
   - All other options from :ref:`Sensor <config-sensor>`.
 
-- **humidity** (**Required**): The information for the humidity sensor.
+- **humidity** (*Optional*): The information for the humidity sensor.
 
   - **name** (**Required**, string): The name for the humidity sensor.
   - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.
   - All other options from :ref:`Sensor <config-sensor>`.
 
 - **address** (*Optional*, int): Manually specify the I²C address of the sensor.
-  Defaults to ``0x44``.
+  Defaults to ``0x44``. For sht3xd, an alternate address can be ``0x45`` while SHT85 supports only address ``0x44``
 - **update_interval** (*Optional*, :ref:`config-time`): The interval to check the
   sensor. Defaults to ``60s``.
 - **heater_enabled** (*Optional*, bool): Turn on/off heater at boot.

--- a/components/sensor/sht3xd.rst
+++ b/components/sensor/sht3xd.rst
@@ -2,7 +2,7 @@ SHT3X-D Temperature+Humidity Sensor
 ===================================
 
 .. seo::
-    :description: Instructions for setting up SHT31-D/SHT3x temperature and humidity sensors
+    :description: Instructions for setting up SHT31-D/SHT3x and SHT85 temperature and humidity sensors
     :image: sht3xd.jpg
 
 The ``sht3xd`` sensor platform Temperature+Humidity sensor allows you to use your Sensirion SHT31-D/SHT3x
@@ -46,7 +46,7 @@ Configuration variables:
   - All other options from :ref:`Sensor <config-sensor>`.
 
 - **address** (*Optional*, int): Manually specify the I²C address of the sensor.
-  Defaults to ``0x44``. For sht3xd, an alternate address can be ``0x45`` while SHT85 supports only address ``0x44``
+  Defaults to ``0x44``. For SHT3x, an alternate address can be ``0x45`` while SHT85 supports only address ``0x44``
 - **update_interval** (*Optional*, :ref:`config-time`): The interval to check the
   sensor. Defaults to ``60s``.
 - **heater_enabled** (*Optional*, bool): Turn on/off heater at boot.


### PR DESCRIPTION
## Description:
Update so support for SHT85 is indicated and to reflect config change that Temperature and humidity sensors are optional

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#6415

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
