### PR TITLE
doc: describe the IPv6 address generation

### DIFF
--- a/components/network.rst
+++ b/components/network.rst
@@ -22,6 +22,12 @@ Configuration variables:
 - **enable_ipv6** (*Optional*, boolean): Enables IPv6 support. Defaults to ``false``.
 - **min_ipv6_addr_count** (*Optional*, integer): ESPHome considers the network to be connected when it has one IPv4 address and this number of IPv6 addresses. Defaults to ``0`` so as to not hang on boot with networks where IPv6 is not enabled. ``2`` is typically a reasonable value for configurations requiring IPv6.
 
+Note
+----
+The `lwIP <https://savannah.nongnu.org/projects/lwip/>`_ library used for the network component currently only implements IPv6 SLAAC according to `RFC4862 <https://datatracker.ietf.org/doc/rfc4862/>`_. The interface identifier IID it directly generated from the device MAC address.
+This has various security and privacy implications decribed in `RFC7721 <https://datatracker.ietf.org/doc/rfc7721/>`_, as this might leak outside of the smart home network and makes the device uniquely identifiable.
+Therefore, the address generation does not comply to `RFC7217 <https://datatracker.ietf.org/doc/rfc7217/>`_.
+
 See Also
 --------
 

--- a/components/network.rst
+++ b/components/network.rst
@@ -22,11 +22,11 @@ Configuration variables:
 - **enable_ipv6** (*Optional*, boolean): Enables IPv6 support. Defaults to ``false``.
 - **min_ipv6_addr_count** (*Optional*, integer): ESPHome considers the network to be connected when it has one IPv4 address and this number of IPv6 addresses. Defaults to ``0`` so as to not hang on boot with networks where IPv6 is not enabled. ``2`` is typically a reasonable value for configurations requiring IPv6.
 
-Note
-----
-The `lwIP <https://savannah.nongnu.org/projects/lwip/>`_ library used for the network component currently only implements IPv6 SLAAC according to `RFC4862 <https://datatracker.ietf.org/doc/rfc4862/>`_. The interface identifier IID it directly generated from the device MAC address.
-This has various security and privacy implications decribed in `RFC7721 <https://datatracker.ietf.org/doc/rfc7721/>`_, as this might leak outside of the smart home network and makes the device uniquely identifiable.
-Therefore, the address generation does not comply to `RFC7217 <https://datatracker.ietf.org/doc/rfc7217/>`_.
+.. note::
+
+    The `lwIP <https://savannah.nongnu.org/projects/lwip/>`_ library used for the network component currently only implements IPv6 SLAAC according to `RFC4862 <https://datatracker.ietf.org/doc/rfc4862/>`_. The interface identifier (IID) is directly generated from the device MAC address.
+    This has various security and privacy implications decribed in `RFC7721 <https://datatracker.ietf.org/doc/rfc7721/>`_, as this might leak outside of the smart home network and makes the device uniquely identifiable.
+    Therefore, the address generation does not comply to `RFC7217 <https://datatracker.ietf.org/doc/rfc7217/>`_.
 
 See Also
 --------


### PR DESCRIPTION
## Description:
version 2024.3.0 enables IPv6
due to the limitiation of lwIP, the address generation does not comply to RFC7217.
This PR adds a note to the network component to clarify this.

* fixes https://github.com/esphome/issues/issues/5618


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
