### PR TITLE
WireGuard for esp8266

### DIFF
--- a/components/wireguard.rst
+++ b/components/wireguard.rst
@@ -6,12 +6,12 @@ WireGuard Component
 
 .. seo::
     :description: Instructions to setup WireGuard for your ESP board.
-    :keywords: WireGuard, VPN, ESP32
+    :keywords: WireGuard, VPN
 
 |wireguard|_ is an extremely simple yet fast and modern VPN that utilizes
 state-of-the-art cryptography. This component uses a **custom**
 implementation not developed by original authors and currently
-available for **ESP32 platform only**.
+available for ESP32 and ESP8266 platforms *only*.
 
   Please note that *"WireGuard" and the "WireGuard" logo are
   registered trademarks of Jason A. Donenfeld.* See
@@ -145,7 +145,7 @@ Configuration variables
 Static routes and outgoing connections
 --------------------------------------
 
-Currently there is no way on ESP32 devices to configure static routes for
+Currently there is no way on ESP devices to configure static routes for
 network interfaces, so the ``peer_allowed_ips`` list is used only to allow
 (or drop) packets that pass through the VPN tunnel, not to define static
 routes for remote hosts.


### PR DESCRIPTION
## Description:
Change platforms restriction for WireGuard because the mathing PR in esphome adds support for esp8266 boards too.

I'm merging into next even if there is no new documentation because the matching PR has a new "feature".

**Related issue (if applicable):** none

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#6365

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
