### PR TITLE
Add line for 13.3in-k in waveshare_epaper component

### DIFF
--- a/components/display/waveshare_epaper.rst
+++ b/components/display/waveshare_epaper.rst
@@ -114,6 +114,7 @@ Configuration variables:
   - ``7.50in-hd-b`` - Can't use with an ESP8266 as it runs out of RAM
   - ``gdew029t5`` - GooDisplay GDEW029T5, as used on the AdaFruit MagTag (previously incorrectly referred to as GDEY029T94)
   - ``1.54in-m5coreink-m09`` - GoodDisplay gdew0154m09, as used in the M5Stack Core Ink
+  - ``13.3in-k`` - 13.3in, with the K model, 960x680, B/W rendering only
 
 .. warning::
 


### PR DESCRIPTION
## Description:

Add line for Waveshare E-paper 13.3 in K version under display section

PR for the change in esphome
https://github.com/esphome/esphome/pull/6443

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
