### PR TITLE
QMC5883L: mention the connection between oversampling and update_interval

### DIFF
--- a/components/sensor/qmc5883l.rst
+++ b/components/sensor/qmc5883l.rst
@@ -50,7 +50,7 @@ Configuration variables:
 - **heading** (*Optional*): The heading of the sensor in degrees. All options from
   :ref:`Sensor <config-sensor>`.
 - **range** (*Optional*): The range parameter for the sensor.
-- **oversampling** (*Optional*): The oversampling parameter for the sensor.
+- **oversampling** (*Optional*): The oversampling parameter for the sensor. See Oversampling Options below.
 - **update_interval** (*Optional*, :ref:`config-time`): The interval to check the sensor. Defaults to ``60s``.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
 
@@ -67,12 +67,15 @@ Oversampling Options
 --------------------
 
 By default, the QMC5883L sensor measures each value 512 times when requesting a new value. You can, however,
-configure this amount. The result is the sensor will take the adverage of the x samples. Possible sampling values:
+configure this amount. The result is the sensor will take the adverage of the x samples.
+Oversampling affects the output data rate and thus the update interval. Possible sampling values:
 
--  ``512x`` (default)
--  ``256x``
--  ``128x``
--  ``64x``
+| Oversampling | Output date rate | interval_rate |
+| ------------------ | ---------- | ------------ |
+| ``512x`` (default) | ``10 Hz``  | ``>= 100ms`` |
+| ``256x``           | ``50 Hz``  | ``>= 20ms``  |
+| ``128x``           | ``100 Hz`` | ``>= 10ms``  |
+| ``64x``            | ``200 Hz`` | ``>= 5ms``   |
 
 See Also
 --------

--- a/components/sensor/qmc5883l.rst
+++ b/components/sensor/qmc5883l.rst
@@ -70,12 +70,26 @@ By default, the QMC5883L sensor measures each value 512 times when requesting a 
 configure this amount. The result is the sensor will take the adverage of the x samples.
 Oversampling affects the output data rate and thus the update interval. Possible sampling values:
 
-| Oversampling | Output date rate | interval_rate |
-| ------------------ | ---------- | ------------ |
-| ``512x`` (default) | ``10 Hz``  | ``>= 100ms`` |
-| ``256x``           | ``50 Hz``  | ``>= 20ms``  |
-| ``128x``           | ``100 Hz`` | ``>= 10ms``  |
-| ``64x``            | ``200 Hz`` | ``>= 5ms``   |
+.. list-table::
+    :widths: 25 25 25
+    :header-rows: 1
+
+    * - Oversampling:
+      - Output date rate:
+      - interval_rate:
+
+    * - ``512x`` (default)
+      - ``10 Hz``
+      - ``>= 100ms``
+    * - ``256x``
+      - ``50 Hz``
+      - ``>= 20ms``
+    * - ``128x``
+      - ``100 Hz``
+      - ``>= 10ms``
+    * - ``64x``
+      - ``200 Hz``
+      -  ``>= 5ms``
 
 See Also
 --------

--- a/components/sensor/qmc5883l.rst
+++ b/components/sensor/qmc5883l.rst
@@ -50,7 +50,7 @@ Configuration variables:
 - **heading** (*Optional*): The heading of the sensor in degrees. All options from
   :ref:`Sensor <config-sensor>`.
 - **range** (*Optional*): The range parameter for the sensor.
-- **oversampling** (*Optional*): The oversampling parameter for the sensor. See Oversampling Options below.
+- **oversampling** (*Optional*): The oversampling parameter for the sensor.
 - **update_interval** (*Optional*, :ref:`config-time`): The interval to check the sensor. Defaults to ``60s``.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
 

--- a/components/sensor/qmc5883l.rst
+++ b/components/sensor/qmc5883l.rst
@@ -67,7 +67,7 @@ Oversampling Options
 --------------------
 
 By default, the QMC5883L sensor measures each value 512 times when requesting a new value. You can, however,
-configure this amount. The result is the sensor will take the adverage of the x samples.
+configure this amount. The result is the sensor will take the average of the x samples.
 Oversampling affects the output data rate and thus the update interval. Possible sampling values:
 
 .. list-table::

--- a/components/sensor/qmc5883l.rst
+++ b/components/sensor/qmc5883l.rst
@@ -76,7 +76,7 @@ Oversampling affects the output data rate and thus the update interval. Possible
 
     * - Oversampling:
       - Output date rate:
-      - interval_rate:
+      - Interval rate:
 
     * - ``512x`` (default)
       - ``10 Hz``


### PR DESCRIPTION
## Description:
Mention the connection between oversampling and update_interval.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
