### PR TITLE
Update ethernet.rst. Added more details.

### DIFF
--- a/components/ethernet.rst
+++ b/components/ethernet.rst
@@ -264,7 +264,7 @@ Configuration examples
       clk_mode: GPIO17_OUT
       phy_addr: 1
 
-**LILYGO T-ETH-Lite**:
+**LILYGO T-ETH-Lite ESP32**:
 
 .. code-block:: yaml
 


### PR DESCRIPTION
Added details about the specific board. There is a ESP32 and a ESP32-S3 variant which uses a different network chip.

## Description:
There is a T-ETH-Lite ESP32 and a T-ETH-Lite ESP32 S3 version of this board.  
The T-ETH-Lite ESP32 **S3** uses a W5500 which is not supported yet.  
I think it is important to point out that the configuration just appies to the non-S3 variant.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
