### PR TITLE
include commit hash for ref:

### DIFF
--- a/components/external_components.rst
+++ b/components/external_components.rst
@@ -43,7 +43,7 @@ Configuration variables:
   git options:
 
   - **url** (**Required**, url): HTTP git repository url. See :ref:`external-components_git`.
-  - **ref** (*Optional*, string): Git ref (branch or tag). If not specified the default branch is used.
+  - **ref** (*Optional*, string): Git ref (branch, tag, or commit hash). If not specified the default branch is used.
   - **username** (*Optional*, string): Username for the Git server, if one is required
   - **password** (*Optional*, string): Password for the Git server, if one is required
 
@@ -163,7 +163,7 @@ HTTP git repositories in general are supported with this configuration:
       source:
         type: git
         url: http://repository_url/
-        ref: branch_or_tag
+        ref: branch_tag_commit
 
 The source field accepts a short hand **github://** resource:
 


### PR DESCRIPTION
## Description:
add reference to commit hash as valid value for `ref:`

**Related issue (if applicable):** fixes <link to issue>
https://github.com/esphome/feature-requests/issues/2507

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>
https://github.com/esphome/esphome/pull/6446

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
