### PR TITLE
Document added I2S audio configuration options and action

### DIFF
--- a/components/i2s_audio.rst
+++ b/components/i2s_audio.rst
@@ -23,6 +23,7 @@ Configuration variables:
 - **i2s_lrclk_pin** (**Required**, :ref:`config-pin`): The GPIO pin to use for the I²S ``LRCLK`` *(Left/Right Clock)* signal, also referred to as ``WS`` *(Word Select)* or ``FS`` *(Frame Sync)*.
 - **i2s_bclk_pin** (*Optional*, :ref:`config-pin`): The GPIO pin to use for the I²S ``BCLK`` *(Bit Clock)* signal, also referred to as ``SCK`` *(Serial Clock)*.
 - **i2s_mclk_pin** (*Optional*, :ref:`config-pin`): The GPIO pin to use for the I²S ``MCLK`` *(Master Clock)* signal.
+- **i2s_mode** (*Optional*, enum): The role of the I²S controller. One of ``primary`` or ``secondary``. In ``primary`` mode, the ESP device generates the clock signals. In ``secondary`` mode, another device generates the clock signals. Defaults to ``primary``.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID for this I²S bus if you need multiple.
 
 See also

--- a/components/speaker/i2s_audio.rst
+++ b/components/speaker/i2s_audio.rst
@@ -32,13 +32,14 @@ Configuration variables:
 - **dac_type** (**Required**, enum):
 
   - ``external``: Use an external DAC, for example the NS4168, or UDA1334A.
-  - ``internal``: Use the internal DAC
+  - ``internal``: Use the internal DAC.
 
 External DAC
 ************
 
 - **i2s_dout_pin** (**Required**, :ref:`Pin Schema <config-pin_schema>`): The GPIO pin to use for the I²S DOUT (Data Out) signal.
 - **mode** (*Optional*, string): The mode of the I²S bus. Can be ``mono`` or ``stereo``. Defaults to ``mono``.
+- **bits_per_sample** (*Optional*, enum): The bit depth of the audio samples. One of ``16bit`` or ``32bit``. Note that if set to ``32bit``, the 16 bit audio samples are automatically scaled. Defaults to ``16bit``.
 - **i2s_audio_id** (*Optional*, :ref:`config-id`): The ID of the :ref:`I²S Audio <i2s_audio>` you wish to use for this speaker.
 
 For best results, keep the wires as short as possible.

--- a/components/speaker/index.rst
+++ b/components/speaker/index.rst
@@ -28,7 +28,7 @@ your configuration YAML.
 ``speaker.play`` Action
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-This action will start playing raw audio data from the speaker.
+This action will start playing raw audio data (mono channel, 16000 kHz sample rate, 16 bits per sample) from the speaker.
 
 .. code-block:: yaml
 
@@ -59,6 +59,31 @@ This action will stop playing audio data from the speaker and discard the unplay
 Configuration variables:
 
 - **id** (*Optional*, :ref:`config-id`): The speaker to control. Defaults to the only one in YAML.
+
+.. _speaker-volume_set:
+
+``speaker.volume_set`` Action
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This action will set the volume of the speaker.
+
+.. code-block::
+
+    on_...:
+      # Simple
+      - speaker.volume_set: 50%
+
+      # Full
+      - speaker.volume_set:
+          id: speaker_id
+          volume: 50%
+
+      # Simple with lambda
+      - speaker.volume_set: !lambda "return 0.5;"
+
+Configuration variables:
+
+**volume** (**Required**, percentage): The volume to set the speaker to.
 
 .. _speaker-conditions:
 

--- a/guides/automations.rst
+++ b/guides/automations.rst
@@ -409,6 +409,7 @@ All Actions
 - :ref:`select.set <select-set_action>` / :ref:`select.set_index <select-set_index_action>` / :ref:`select.first <select-first_action>` / :ref:`select.last <select-last_action>` / :ref:`select.previous <select-previous_action>`  / :ref:`select.next <select-next_action>`  / :ref:`select.operation <select-operation_action>`
 - :ref:`media_player.play <media_player-play>` / :ref:`media_player.pause <media_player-pause>` / :ref:`media_player.stop <media_player-stop>` / :ref:`media_player.toggle <media_player-toggle>`
   / :ref:`media_player.volume_up <media_player-volume_up>` / :ref:`media_player.volume_down <media_player-volume_down>` / :ref:`media_player.volume_set <media_player-volume_set>`
+- :ref:`speaker.play <speaker-play>` / :ref:`speaker.stop <speaker-stop>` / :ref:`speaker.volume_set <speaker-volume_set>`
 - :ref:`ble_client.ble_write <ble_client-ble_write_action>`
 - :ref:`wireguard.disable <wireguard-actions>` / :ref:`wireguard.enable <wireguard-actions>`
 


### PR DESCRIPTION
## Description:

Adds documentation for linked esphome/esphome#6463.

- Documents ``i2s_mode`` parameter for parent I2S interfaces.
- Documents``bits_per_sample`` parameter for an I2S speaker.
- Clarifies that the speaker's audio format is mono channel, 16000 kHz sample rate with 16 bits per sample.
- Documents the new ``speaker.volume_set`` action.
- Adds links to all the speaker actions in the automations guide.

**Related issue (if applicable):** not applicable

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#6463

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
