### PR TITLE
Add documentation for Dooya RF

### DIFF
--- a/components/remote_receiver.rst
+++ b/components/remote_receiver.rst
@@ -36,6 +36,7 @@ Configuration variables:
   - **canalsatld**: Decode and dump CanalSatLD infrared codes.
   - **coolix**: Decode and dump Coolix infrared codes.
   - **dish**: Decode and dump Dish infrared codes.
+  - **dooya**: Decode and dump Dooya RF codes.
   - **drayton**: Decode and dump Drayton Digistat RF codes.
   - **jvc**: Decode and dump JVC infrared codes.
   - **keeloq**: Decode and dump KeeLoq RF codes.
@@ -98,6 +99,9 @@ Automations:
   dish network remote code has been decoded. A variable ``x`` of type :apistruct:`remote_base::DishData`
   is passed to the automation for use in lambdas.
   Beware that Dish remotes use a different carrier frequency (57.6kHz) that many receiver hardware don't decode.
+- **on_dooya** (*Optional*, :ref:`Automation <automation>`): An automation to perform when a
+  Dooya RF remote code has been decoded. A variable ``x`` of type :apistruct:`remote_base::DooyaData`
+  is passed to the automation for use in lambdas.
 - **on_drayton** (*Optional*, :ref:`Automation <automation>`): An automation to perform when a
   Drayton Digistat RF code has been decoded. A variable ``x`` of type :apistruct:`remote_base::DraytonData`
   is passed to the automation for use in lambdas.
@@ -242,6 +246,13 @@ Remote code selection (exactly one of these has to be included):
 
   - **address** (*Optional*, int): The number of the receiver to target, between 1 and 16 inclusive. Defaults to ``1``.
   - **command** (**Required**, int): The Dish command to listen for, between 0 and 63 inclusive.
+
+- **dooya**: Trigger on a decoded Dooya RF remote code with the given data.
+
+  - **id** (**Required**, int): The 24-bit ID code to trigger on.
+  - **channel** (**Required**, int): The 8-bit channel to listen for.
+  - **button** (**Required**, int): The 4-bit button to listen for.
+  - **check** (**Required**, int): The 4-bit check to listen for. Includes an indication that a button is being held down.
 
 - **drayton**: Trigger on a decoded Drayton Digistat RF remote code with the given data.
 
@@ -434,3 +445,4 @@ See Also
 - `IRRemoteESP8266 <https://github.com/markszabo/IRremoteESP8266/>`__ by `Mark Szabo-Simon <https://github.com/markszabo>`__
 - :apiref:`remote/remote_receiver.h`
 - :ghedit:`Edit`
+

--- a/components/remote_transmitter.rst
+++ b/components/remote_transmitter.rst
@@ -212,6 +212,30 @@ Configuration variables:
 
 You can find a list of commands in the `LIRC project <https://sourceforge.net/p/lirc-remotes/code/ci/master/tree/remotes/dishnet/Dish_Network.lircd.conf>`__.
 
+.. _remote_transmitter-transmit_dooya:
+
+``remote_transmitter.transmit_dooya`` Action
+**********************************************
+
+This :ref:`action <config-action>` sends a Dooya RF remote code to a remote transmitter.
+
+.. code-block:: yaml
+
+    on_...:
+      - remote_transmitter.transmit_dooya:
+          id: 0x001612E5
+          channel: 142
+          button: 12
+          check: 3
+
+Configuration variables:
+
+- **id** (**Required**, int): The 24-bit ID to send. Each remote has a unique one.
+- **channel** (**Required**, int): The 8-bit channel to send, between 0 and 255 inclusive.
+- **button** (**Required**, int): The 4-bit button to send, between 0 and 15 inclusive. 
+- **check** (**Required**, int): The 4-bit check to send. Includes an indication that a button is being held down. See dumper output for more info.
+- All other options from :ref:`remote_transmitter-transmit_action`.
+
 .. _remote_transmitter-transmit_drayton:
 
 ``remote_transmitter.transmit_drayton`` Action


### PR DESCRIPTION
## Description:
Add documentation for Dooya RF remote receiver and transmitter.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#6488

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
