### PR TITLE
Made for ESPHome: Specify adopted configs must compile

### DIFF
--- a/guides/made_for_esphome.rst
+++ b/guides/made_for_esphome.rst
@@ -37,7 +37,9 @@ For all projects
 - Your project supports adoption via the ``dashboard_import`` feature of ESPHome (see :doc:`Sharing </guides/creators>`). In particular:
     - There are **no** references to secrets or passwords
     - Network configuration must assume defaults (no static IPs or DNS configured)
-    - All configuration is contained within a single YAML file
+    - It **must** compile successfully without any user changes after adopting it.
+    - All configuration is contained within a single YAML file. Fully remote packages are permitted if using ``import_full_config: true``.
+
 - Your product name cannot contain **ESPHome** except in the case of *ending with* **for ESPHome**
 
 When your project matches all requirements of the Made for ESPHome program,


### PR DESCRIPTION
## Description:

- Adds a rule that should be common sense about compilation.
- Allow remote packages for fully imported configs.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
