### PR TITLE
Fix doc for template cover regarding position_action and has_position

### DIFF
--- a/components/cover/template.rst
+++ b/components/cover/template.rst
@@ -62,7 +62,6 @@ Configuration variables:
   of hiding one of them. Defaults to ``false``.
 - **has_position** (*Optional*, boolean): Whether this cover will publish its position as a floating point number.
   By default (``false``), the cover only publishes OPEN/CLOSED position.
-  Parameter useless if you set the POSITION_ACTION (is set to TRUE).
 - **tilt_action** (*Optional*, :ref:`Action <config-action>`): The action that should
   be performed when the remote (like Home Assistant's frontend) requests the cover be set to a specific
   tilt position. The desired tilt is available in the lambda in the ``tilt`` variable.
@@ -71,6 +70,7 @@ Configuration variables:
 - **position_action** (*Optional*, :ref:`Action <config-action>`): The action that should
   be performed when the remote (like Home Assistant's frontend) requests the cover be set to a specific
   position. The desired position is available in the lambda in the ``pos`` variable.
+  Requires has_position to be set to ``true``.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
 - All other options from :ref:`Cover <config-cover>`.
 

--- a/components/cover/template.rst
+++ b/components/cover/template.rst
@@ -70,7 +70,7 @@ Configuration variables:
 - **position_action** (*Optional*, :ref:`Action <config-action>`): The action that should
   be performed when the remote (like Home Assistant's frontend) requests the cover be set to a specific
   position. The desired position is available in the lambda in the ``pos`` variable.
-  Requires has_position to be set to ``true``.
+  Useless if `has_position` is not set to ``true``.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
 - All other options from :ref:`Cover <config-cover>`.
 


### PR DESCRIPTION
## Description:

Fix documentation to match implementation. An alternative would be to change https://github.com/esphome/esphome/blob/6876c65edada3710687260c91302ccfa432d4f08/esphome/components/template/cover/template_cover.cpp#L122 to take into account the `position_trigger_`.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
