### PR TITLE
Update status_led.rst

### DIFF
--- a/components/status_led.rst
+++ b/components/status_led.rst
@@ -9,7 +9,8 @@ The ``status_led`` hooks into all ESPHome components and can indicate the status
 the device. Specifically, it will:
 
 - Blink slowly (about every second) when a **warning** is active. Warnings are active when for
-  example reading a sensor value fails temporarily or the WiFi/MQTT connections are disrupted.
+  example reading a sensor value fails temporarily, the WiFi/MQTT connections are disrupted, or 
+  if the native API component is included but no client is connected.
 - Blink quickly (multiple times per second) when an **error** is active. Errors indicate that
   ESPHome has found an error while setting up. In most cases, ESPHome will still try to
   recover from the error and continue with all other operations.


### PR DESCRIPTION
Update causes for led blinking slowly to include when native API is included in configuration but no api client is connected.  I discovered this by googling but figured it might save someone some confusion in the future by including in the docs.


## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.****

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
