### PR TITLE
Datetime lambda call fix

### DIFF
--- a/components/datetime/index.rst
+++ b/components/datetime/index.rst
@@ -208,7 +208,7 @@ advanced stuff (see the full API Reference for more info).
 
       // Within lambda, set the time to 12:34:56
       auto call = id(my_time).make_call();
-      call.set_date("12:34:56");
+      call.set_time("12:34:56");
       call.perform();
 
   Check the API reference for information on the methods that are available for

--- a/components/datetime/index.rst
+++ b/components/datetime/index.rst
@@ -231,7 +231,7 @@ See Also
 - :apiref:`DateTimeBase <datetime/datetime_base.h>`
 - :apiref:`DateEntity <datetime/date_entity.h>`
 - :apiref:`DateCall <datetime/date_entity.h>`
-- :apiref:`TimeEntity <datetime/time_entity.h>`
+- :apiref:`TimeeEntity <datetime/time_entity.h>`
 - :apiref:`TimeCall <datetime/time_entity.h>`
 - :ghedit:`Edit`
 

--- a/components/datetime/index.rst
+++ b/components/datetime/index.rst
@@ -231,7 +231,7 @@ See Also
 - :apiref:`DateTimeBase <datetime/datetime_base.h>`
 - :apiref:`DateEntity <datetime/date_entity.h>`
 - :apiref:`DateCall <datetime/date_entity.h>`
-- :apiref:`TimeeEntity <datetime/time_entity.h>`
+- :apiref:`TimeEntity <datetime/time_entity.h>`
 - :apiref:`TimeCall <datetime/time_entity.h>`
 - :ghedit:`Edit`
 


### PR DESCRIPTION
## Description:
changes
`call.set_date("12:34:56");`
to
`call.set_time("12:34:56");`
in datetime.time lambda call example

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
