### PR TITLE
Organize main page better

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -121,41 +121,115 @@ ESPHome is a system to control your microcontrollers by simple yet powerful conf
 
 .. _devices:
 
-Platforms
----------
+Processor Components
+--------------------
+
+Processors ESPHome supports.
 
 .. imgtable::
 
-    ESP8266, components/esp8266, esp8266.svg
     ESP32, components/esp32, esp32.svg
+    ESP8266, components/esp8266, esp8266.svg
     RP2040, components/rp2040, rp2040.svg
     BK72xx, components/libretiny, bk72xx.svg
     RTL87xx, components/libretiny, rtl87xx.svg
 
-Core Components
----------------
+Processor Peripheral Components
+-------------------------------
+
+Peripherals which directly support the processor(s).
+
+.. imgtable::
+
+    PSRAM, components/psram, psram.svg
+    Deep Sleep, components/deep_sleep, hotel.svg, dark-invert
+
+ESPHome Components
+------------------
+
+ESPHome-specific components or components supporting ESPHome device provisioning post-installation.
 
 .. imgtable::
 
     Core, components/esphome, cloud-circle.svg, dark-invert
-    PSRAM, components/psram, psram.svg
-    WiFi, components/wifi, network-wifi.svg, dark-invert
-    Network, components/network, network-wifi.svg, dark-invert
-
-    I²C Bus, components/i2c, i2c.svg
-    SPI Bus, components/spi, spi.svg
-    UART Bus, components/uart, uart.svg
-    CAN Bus, components/canbus, canbus.svg
-
-    MQTT, components/mqtt, mqtt.png
-    OTA Updates, components/ota, system-update.svg, dark-invert
-    Logger, components/logger, file-document-box.svg, dark-invert
-    Web Server, components/web_server, http.svg, dark-invert
-
-    Native API, components/api, server-network.svg, dark-invert
-    Power Supply, components/power_supply, power.svg, dark-invert
-    Deep Sleep, components/deep_sleep, hotel.svg, dark-invert
+    Captive Portal, components/captive_portal, wifi-strength-alert-outline.svg, dark-invert
+    Copy, components/copy, content-copy.svg, dark-invert
+    Demo, components/demo, description.svg, dark-invert
     External Components, components/external_components, external_components.svg, dark-invert
+    Improv via BLE, components/esp32_improv, improv.svg, dark-invert
+    Improv via Serial, components/improv_serial, improv.svg, dark-invert
+
+Network Hardware Components
+---------------------------
+
+.. imgtable::
+
+    WiFi, components/wifi, network-wifi.svg, dark-invert
+    ESP32 Ethernet, components/ethernet, ethernet.svg, dark-invert
+
+Network Protocol Components
+---------------------------
+
+.. imgtable::
+
+    Network Core, components/network, server-network.svg, dark-invert
+    Native API, components/api, server-network.svg, dark-invert
+    MQTT, components/mqtt, mqtt.png
+    HTTP Request, components/http_request, connection.svg, dark-invert
+    mDNS, components/mdns, radio-tower.svg, dark-invert
+    WireGuard, components/wireguard, wireguard_custom_logo.svg
+
+Bluetooth Components
+--------------------
+
+.. imgtable::
+
+    ESP32 BLE Beacon, components/esp32_ble_beacon, bluetooth.svg, dark-invert
+    ESP32 BLE Client, components/ble_client, bluetooth.svg, dark-invert
+    ESP32 BLE Tracker, components/esp32_ble_tracker, bluetooth.svg, dark-invert
+    Bluetooth Proxy, components/bluetooth_proxy, bluetooth.svg, dark-invert
+    Improv via BLE, components/esp32_improv, improv.svg, dark-invert
+
+Management and Monitoring Components
+------------------------------------
+
+.. imgtable::
+
+    Debug, components/debug, bug-report.svg, dark-invert
+    Logger, components/logger, file-document-box.svg, dark-invert
+    OTA Updates, components/ota, system-update.svg, dark-invert
+    Prometheus, components/prometheus, prometheus.svg
+    Web Server, components/web_server, http.svg, dark-invert
+    ESP32 Camera Web Server, components/esp32_camera_web_server, camera.svg, dark-invert
+
+Hardware Peripheral Interface/Bus Components
+--------------------------------------------
+
+.. imgtable::
+
+    CAN Bus, components/canbus, canbus.svg
+    I²C Bus, components/i2c, i2c.svg
+    I²S Audio, components/i2s_audio, i2s_audio.svg
+    SPI Bus, components/spi, spi.svg
+    UART, components/uart, uart.svg
+    ESP32 Camera, components/esp32_camera, camera.svg, dark-invert
+
+Input/Output Expansion Interface Components
+-------------------------------------------
+
+.. imgtable::
+
+    MAX6956 I/O expander - I²C Bus, components/max6956, max6956.jpg
+    MCP230XX I/O Expander - I²C Bus, components/mcp230xx, mcp230xx.svg
+    MCP23SXX I/O Expander - SPI Bus, components/mcp23Sxx, mcp230xx.svg
+    PCA6416A I/O Expander, components/pca6416a, pca6416a.svg
+    PCA9554 I/O Expander, components/pca9554, pca9554a.jpg
+    PCF8574 I/O Expander, components/pcf8574, pcf8574.jpg
+    SN74HC165 I/O Expander, components/sn74hc165, sn74hc595.jpg
+    SN74HC595 I/O Expander, components/sn74hc595, sn74hc595.jpg
+    SX1509 I/O Expander, components/sx1509, sx1509.jpg
+    TCA9548A I²C Multiplexer, components/tca9548a, tca9548a.jpg
+    XL9535 I/O Expander, components/xl9535, xl9535.svg
 
 Sensor Components
 -----------------
@@ -164,19 +238,20 @@ Sensors are split into categories. If a sensor fits into more than one category,
 
 Core
 ****
+
 .. imgtable::
 
     Sensor Core, components/sensor/index, folder-open.svg, dark-invert
+    Template Sensor, components/sensor/template, description.svg, dark-invert
+    Custom Sensor, components/sensor/custom, language-cpp.svg, dark-invert
     Home Assistant, components/sensor/homeassistant, home-assistant.svg, dark-invert
     MQTT Subscribe, components/sensor/mqtt_subscribe, mqtt.png
     Uptime Sensor, components/sensor/uptime, timer.svg, dark-invert
     WiFi Signal Strength, components/sensor/wifi_signal, network-wifi.svg, dark-invert
-    Template Sensor, components/sensor/template, description.svg, dark-invert
-    Custom Sensor, components/sensor/custom, language-cpp.svg, dark-invert
-
 
 Air Quality
 ***********
+
 .. imgtable::
 
     AGS10, components/sensor/ags10, ags10.jpg, Volatile Organic Compound Sensor
@@ -186,18 +261,19 @@ Air Quality
     ENS160, components/sensor/ens160, ens160.jpg, CO2 & Air Quality
     GCJA5, components/sensor/gcja5, gcja5.svg, Particulate
     HM3301, components/sensor/hm3301, hm3301.jpg, Particulate
+    iAQ-Core, components/sensor/iaqcore, iaqcore.jpg, CO2 & Volatile organics
     MH-Z19, components/sensor/mhz19, mhz19.jpg, CO2 & Temperature
     MiCS-4514, components/sensor/mics_4514, mics_4514.jpg, Gas concentration
     PM1006 Sensor, components/sensor/pm1006, pm1006.jpg, Particulate
     PMSA003I, components/sensor/pmsa003i, pmsa003i.jpg, Particulate
     PMSX003, components/sensor/pmsx003, pmsx003.svg, Particulate
     RadonEye BLE, components/sensor/radon_eye_ble, radon_eye_logo.png, Radon
+    SCD30, components/sensor/scd30, scd30.jpg, CO2 & Temperature & Humidity
+    SCD4X, components/sensor/scd4x, scd4x.jpg, CO2 & Temperature & Humidity
     SDS011 Sensor, components/sensor/sds011, sds011.jpg, Particulate
     SEN0321, components/sensor/sen0321, sen0321.jpg, Ozone
     SEN5x, components/sensor/sen5x, sen54.jpg, Temperature & Humidity, Volatile organics and NOx
     SenseAir, components/sensor/senseair, senseair_s8.jpg, CO2
-    SCD30, components/sensor/scd30, scd30.jpg, CO2 & Temperature & Humidity
-    SCD4X, components/sensor/scd4x, scd4x.jpg, CO2 & Temperature & Humidity
     SFA30, components/sensor/sfa30, sfa30.jpg, Formaldehyde
     SGP30, components/sensor/sgp30, sgp30.jpg, CO2 & Volatile organics
     SGP4x, components/sensor/sgp4x, sgp40.jpg, Volatile organics and NOx
@@ -205,11 +281,10 @@ Air Quality
     SPS30, components/sensor/sps30, sps30.jpg, Particulate
     T6613/15, components/sensor/t6615, t6615.jpg, CO2
     ZyAura, components/sensor/zyaura, zgm053.jpg, CO2 & Temperature & Humidity
-    iAQ-Core, components/sensor/iaqcore, iaqcore.jpg, CO2 & Volatile organics
-
 
 Analogue
 ********
+
 .. imgtable::
 
     ADC, components/sensor/adc, flash.svg, ESP internal, dark-invert
@@ -221,25 +296,25 @@ Analogue
     MCP3204 / MCP3208, components/sensor/mcp3204, mcp3204.jpg, 4-channel ADC
     Resistance, components/sensor/resistance, omega.svg, dark-invert
 
-
 Bluetooth Low Energy (BLE)
 **************************
+
 .. imgtable::
 
+    Alpha3, components/sensor/alpha3, alpha3.jpg
     AM43, components/sensor/am43, am43.jpg, Lux & Battery level
     BLE Client Sensor, components/sensor/ble_client, bluetooth.svg, dark-invert
     BLE RSSI, components/sensor/ble_rssi, bluetooth.svg, dark-invert
+    HHCCJCY10 (MiFlora Pink), components/sensor/xiaomi_hhccjcy10, xiaomi_hhccjcy10.jpg, Soil moisture & Temperature & Light
     Inkbird IBS-TH1 Mini, components/sensor/inkbird_ibsth1_mini, inkbird_isbth1_mini.jpg, Temperature & Humidity
     Mopeka Pro Check LP, components/sensor/mopeka_pro_check, mopeka_pro_check.jpg, tank level
     Mopeka Standard Check LP, components/sensor/mopeka_std_check, mopeka_std_check.jpg, tank level
     RuuviTag, components/sensor/ruuvitag, ruuvitag.jpg, Temperature & Humidity & Accelerometer
     Xiaomi BLE, components/sensor/xiaomi_ble, xiaomi_mijia_logo.jpg, Various
-    HHCCJCY10 (MiFlora Pink), components/sensor/xiaomi_hhccjcy10, xiaomi_hhccjcy10.jpg, Soil moisture & Temperature & Light
-    Alpha3, components/sensor/alpha3, alpha3.jpg
-
 
 Digital Signals
 ***************
+
 .. imgtable::
 
     Duty Cycle, components/sensor/duty_cycle, percent.svg, dark-invert
@@ -247,22 +322,23 @@ Digital Signals
     Pulse Meter, components/sensor/pulse_meter, pulse.svg, dark-invert
     Pulse Width, components/sensor/pulse_width, pulse.svg, dark-invert
 
-
 Distance
 ********
+
 .. imgtable::
 
     A01NYUB, components/sensor/a01nyub, a01nyub.jpg, Acoustic distance
     A02YYUW, components/sensor/a02yyuw, a02yyuw.jpg, Acoustic distance
     HRXL MaxSonar WR, components/sensor/hrxl_maxsonar_wr, hrxl_maxsonar_wr.jpg, Acoustic distance
+    JSN-SR04T, components/sensor/jsn_sr04t, jsn-sr04t-v3.jpg, Acoustic distance
     TOF10120, components/sensor/tof10120, tof10120.jpg, IR optical distance
     Ultrasonic Sensor, components/sensor/ultrasonic, ultrasonic.jpg, Acoustic distance
     VL53L0x, components/sensor/vl53l0x, vl53l0x.jpg, IR optical distance
     Zio Ultrasonic Sensor, components/sensor/zio_ultrasonic, zio_ultrasonic.jpg, Acoustic distance
-    JSN-SR04T, components/sensor/jsn_sr04t, jsn-sr04t-v3.jpg, Acoustic distance
 
 Electricity
 ***********
+
 .. imgtable::
 
     ADE7880, components/sensor/ade7880, ade7880.svg, Voltage & Current & Power
@@ -293,7 +369,6 @@ Electricity
     Teleinfo, components/sensor/teleinfo, teleinfo.jpg, Electrical counter
     Total Daily Energy, components/sensor/total_daily_energy, sigma.svg, dark-invert
 
-
 Environmental
 *************
 
@@ -304,14 +379,14 @@ Environmental
     AirThings BLE, components/sensor/airthings_ble, airthings_logo.png, Temperature & Humidity & Pressure
     AM2315C, components/sensor/am2315c, am2315c.jpg, Temperature & Humidity
     AM2320, components/sensor/am2320, am2320.jpg, Temperature & Humidity
+    b-parasite, components/sensor/b_parasite, b_parasite.jpg, Moisture & Temperature & Humidity & Light
     BME280, components/sensor/bme280, bme280.jpg, Temperature & Humidity & Pressure
-    BME680, components/sensor/bme680, bme680.jpg, Temperature & Humidity & Pressure & Gas
     BME680 via BSEC, components/sensor/bme680_bsec, bme680.jpg, Temperature & Humidity & Pressure & Gas
+    BME680, components/sensor/bme680, bme680.jpg, Temperature & Humidity & Pressure & Gas
     BMP085, components/sensor/bmp085, bmp180.jpg, Temperature & Pressure
     BMP280, components/sensor/bmp280, bmp280.jpg, Temperature & Pressure
     BMP388 and BMP390, components/sensor/bmp3xx, bmp388.jpg, Temperature & Pressure
     BMP581, components/sensor/bmp581, bmp581.jpg, Temperature & Pressure
-    b-parasite, components/sensor/b_parasite, b_parasite.jpg, Moisture & Temperature & Humidity & Light
     Dallas DS18B20, components/sensor/dallas, dallas.jpg, Temperature
     DHT, components/sensor/dht, dht.jpg, Temperature & Humidity
     DHT12, components/sensor/dht12, dht12.jpg, Temperature & Humidity
@@ -321,13 +396,14 @@ Environmental
     ENS210, components/sensor/ens210, ens210.jpg, Temperature & Humidity
     HDC1080, components/sensor/hdc1080, hdc1080.jpg, Temperature & Humidity
     HHCCJCY10 (MiFlora Pink), components/sensor/xiaomi_hhccjcy10, xiaomi_hhccjcy10.jpg, Soil moisture & Temperature & Light
-    HTE501, components/sensor/hte501, HTE501.png, Temperature & Humidity
     Honeywell ABP, components/sensor/honeywellabp, honeywellabp.jpg, Pressure & Temperature
     Honeywell ABP2 I2C, components/sensor/honeywellabp2_i2c, honeywellabp.jpg, Pressure & Temperature
     Honeywell HIH I2C, components/sensor/honeywell_hih_i2c, honeywellhih.jpg, Temperature & Humidity
+    HTE501, components/sensor/hte501, HTE501.png, Temperature & Humidity
     HTU21D / Si7021 / SHT21, components/sensor/htu21d, htu21d.jpg, Temperature & Humidity
     HTU31D, components/sensor/htu31d, htu31d.jpg, Temperature & Humidity
     Hydreon Rain Sensor, components/sensor/hydreon_rgxx, hydreon_rg9.jpg, Rain
+    HYT271, components/sensor/hyt271, hyt271.jpg, Temperature & Humidity
     Inkbird IBS-TH1 Mini, components/sensor/inkbird_ibsth1_mini, inkbird_isbth1_mini.jpg, Temperature & Humidity
     Internal Temperature, components/sensor/internal_temperature, thermometer.svg, Temperature, dark-invert
     MCP9808, components/sensor/mcp9808, mcp9808.jpg, Temperature
@@ -352,14 +428,13 @@ Environmental
     STS3X, components/sensor/sts3x, sts3x.jpg, Temperature
     TEE501, components/sensor/tee501, TEE501.png, Temperature
     TMP102, components/sensor/tmp102, tmp102.jpg, Temperature
-    TMP117, components/sensor/tmp117, tmp117.jpg, Temperature
     TMP1075, components/sensor/tmp1075, tmp1075.jpg, Temperature
-    HYT271, components/sensor/hyt271, hyt271.jpg, Temperature & Humidity
+    TMP117, components/sensor/tmp117, tmp117.jpg, Temperature
     XGZP68xx Series, components/sensor/xgzp68xx, 6897d.jpg, Differential Pressure
-
 
 Light
 *****
+
 .. imgtable::
 
     AM43, components/sensor/am43, am43.jpg, Lux
@@ -375,65 +450,65 @@ Light
     VEML6030, components/sensor/veml7700, veml6030.jpg, Lux
     VEML7700, components/sensor/veml7700, veml7700.jpg, Lux
 
-
 Magnetic
 ********
+
 .. imgtable::
 
-    ESP32 Hall Sensor, components/sensor/esp32_hall, magnet.svg, ESP internal, dark-invert
     AS5600, components/sensor/as5600, as5600.jpg, 12-Bit Magnetic Position Sensor
+    ESP32 Hall Sensor, components/sensor/esp32_hall, magnet.svg, ESP internal, dark-invert
     HMC5883L, components/sensor/hmc5883l, hmc5883l.jpg, 3-Axis magnetometer
+    MLX90393, components/sensor/mlx90393, mlx90393.jpg, 3-Axis magnetometer
     MMC5603, components/sensor/mmc5603, mmc5603.jpg, 3-Axis magnetometer
     MMC5983, components/sensor/mmc5983, mmc5983.jpg, 3-Axis magnetometer
-    MLX90393, components/sensor/mlx90393, mlx90393.jpg, 3-Axis magnetometer
     QMC5883L, components/sensor/qmc5883l, qmc5883l.jpg, 3-Axis magnetometer
-
 
 Miscellaneous
 *************
+
 .. imgtable::
 
     AS3935, components/sensor/as3935, as3935.jpg, Storm lightning
-    Binary Sensor Map, components/sensor/binary_sensor_map, binary_sensor_map.jpg, Map binary to value
     b-parasite, components/sensor/b_parasite, b_parasite.jpg, Moisture & Temperature & Humidity & Light
+    Binary Sensor Map, components/sensor/binary_sensor_map, binary_sensor_map.jpg, Map binary to value
     Combination, components/sensor/combination, function.svg, dark-invert
     Duty Time, components/sensor/duty_time, timer-play-outline.svg, dark-invert
     EZO sensor circuits, components/sensor/ezo, ezo-ph-circuit.png, (pH)
     FS3000, components/sensor/fs3000, fs3000.jpg, Air velocity
+    Growatt Solar, components/sensor/growatt_solar, growatt.jpg, Solar rooftop
     Havells Solar, components/sensor/havells_solar, havellsgti5000d_s.jpg, Solar rooftop
     Integration, components/sensor/integration, sigma.svg, dark-invert
-    Growatt Solar, components/sensor/growatt_solar, growatt.jpg, Solar rooftop
+    Kuntze pool sensor, components/sensor/kuntze, kuntze.jpg
+    MicroNova pellet stove, components/micronova, pellet.svg
     Modbus Sensor, components/sensor/modbus_controller, modbus.png
     Nextion, components/sensor/nextion, nextion.jpg, Sensors from display
+    Person Sensor (SEN21231), components/sensor/sen21231, sen21231.png
+    Resol VBus, components/vbus, resol_deltasol_bs_plus.jpg
     Rotary Encoder, components/sensor/rotary_encoder, rotary_encoder.jpg
     SMT100, components/sensor/smt100, smt100.jpg, Moisture & Temperature
     Tuya Sensor, components/sensor/tuya, tuya.png
     TX20, components/sensor/tx20, tx20.jpg, Wind speed & Wind direction
     uFire EC sensor, components/sensor/ufire_ec, ufire_ec.png, EC & Temperature
     uFire ISE sensor, components/sensor/ufire_ise, ufire_ise.png, pH & Temperature
-    Resol VBus, components/vbus, resol_deltasol_bs_plus.jpg
-    Person Sensor (SEN21231), components/sensor/sen21231, sen21231.png
-    Kuntze pool sensor, components/sensor/kuntze, kuntze.jpg
     WireGuard, components/wireguard, wireguard_custom_logo.svg
-    MicroNova pellet stove, components/micronova, pellet.svg
-
 
 Motion
 ******
+
 .. imgtable::
 
     APDS9960, components/sensor/apds9960, apds9960.jpg, Colour & Gesture
     BMI160, components/sensor/bmi160, bmi160.jpg, Accelerometer & Gyroscope
     LD2410, components/sensor/ld2410, ld2410.jpg, Motion & Presence
     LD2420, components/sensor/ld2420, ld2420.jpg, Motion & Presence
-    Seeed Studio MR24HPC1 mmWave, components/seeed_mr24hpc1, seeed-mr24hpc1.jpg, Motion & Presence
     MPU6050, components/sensor/mpu6050, mpu6050.jpg, Accelerometer & Gyroscope
     MPU6886, components/sensor/mpu6886, mpu6886.jpg, Accelerometer & Gyroscope
     RuuviTag, components/sensor/ruuvitag, ruuvitag.jpg, Temperature & Humidity & Accelerometer
-
+    Seeed Studio MR24HPC1 mmWave, components/seeed_mr24hpc1, seeed-mr24hpc1.jpg, Motion & Presence
 
 Thermocouple
 ************
+
 .. imgtable::
 
     KMeterISO, components/sensor/kmeteriso, kmeteriso.jpg, K-Type,
@@ -443,9 +518,9 @@ Thermocouple
     MAX6675, components/sensor/max6675, max6675.jpg, K-Type,
     MCP9600, components/sensor/mcp9600, mcp9600.jpg, All types
 
-
 Weight
 ******
+
 .. imgtable::
 
     HX711, components/sensor/hx711, hx711.jpg, Load cell amplifier
@@ -464,6 +539,7 @@ Binary Sensors are split into categories. If a sensor fits into more than one ca
 
 Core
 ****
+
 .. imgtable::
 
     Binary Sensor Core, components/binary_sensor/index, folder-open.svg, dark-invert
@@ -475,6 +551,7 @@ Core
 
 Capacitive Touch
 ****************
+
 .. imgtable::
 
     CAP1188 Capacitive Touch Sensor, components/binary_sensor/cap1188, cap1188.jpg
@@ -484,6 +561,7 @@ Capacitive Touch
 
 Mechanical
 **********
+
 .. imgtable::
 
     Matrix Keypad, components/matrix_keypad, matrix_keypad.jpg
@@ -503,19 +581,22 @@ Often known as "tag" or "card" readers within the community.
     PN716X, components/pn7160, pn716x.jpg
     RC522, components/binary_sensor/rc522, rc522.jpg
     RDM6300, components/binary_sensor/rdm6300, rdm6300.jpg
+    Wiegand Reader, components/wiegand, wiegand.jpg
 
 Touchscreen
 ***********
+
 .. imgtable::
 
-    Nextion Binary Sensor, components/binary_sensor/nextion, nextion.jpg
-    Touchscreen, components/touchscreen/index, touch.svg, dark-invert
-    TT21100, components/touchscreen/tt21100, esp32-s3-korvo-2-lcd.png
+    Touchscreen Core, components/touchscreen/index, touch.svg, dark-invert
     FT5X06, components/touchscreen/ft5x06, indicator.jpg
     GT911, components/touchscreen/gt911, esp32_s3_box_3.png
+    Nextion Binary Sensor, components/binary_sensor/nextion, nextion.jpg
+    TT21100, components/touchscreen/tt21100, esp32-s3-korvo-2-lcd.png
 
 Presence Detection
 ******************
+
 .. imgtable::
 
     DFRobot mmWave Radar, components/dfrobot_sen0395, dfrobot_sen0395.jpg
@@ -526,6 +607,7 @@ Presence Detection
 
 Miscellaneous
 *************
+
 .. imgtable::
 
     Analog Threshold, components/binary_sensor/analog_threshold, analog_threshold.svg, dark-invert
@@ -546,36 +628,36 @@ Output Components
 .. imgtable::
 
     Output Core, components/output/index, folder-open.svg, dark-invert
-    ESP8266 Software PWM, components/output/esp8266_pwm, pwm.png
-    Slow PWM, components/output/slow_pwm, pwm.png
-    GPIO Output, components/output/gpio, pin.svg, dark-invert
+    Template Output, components/output/template, description.svg, dark-invert
+    Custom Output, components/output/custom, language-cpp.svg, dark-invert
+    AC Dimmer, components/output/ac_dimmer, ac_dimmer.svg, dark-invert
+    BLE Binary Output, components/output/ble_client, bluetooth.svg, dark-invert
+    BP1658CJ, components/output/bp1658cj, bp1658cj.svg
+    BP5758D, components/output/bp5758d, bp5758d.svg
+    DAC7678, components/output/dac7678, dac7678.svg
+    EMC2101, components/emc2101, emc2101.jpg
     ESP32 DAC, components/output/esp32_dac, dac.svg
     ESP32 LEDC, components/output/ledc, pwm.png
+    ESP8266 Software PWM, components/output/esp8266_pwm, pwm.png
+    GP8403, components/output/gp8403, gp8403.svg
+    GPIO Output, components/output/gpio, pin.svg, dark-invert
     LibreTiny PWM, components/output/libretiny_pwm, pwm.png
-    AC Dimmer, components/output/ac_dimmer, ac_dimmer.svg, dark-invert
-    PCA9685, components/output/pca9685, pca9685.jpg
-    TLC59208F, components/output/tlc59208f, tlc59208f.jpg
-    TLC5947, components/output/tlc5947, tlc5947.jpg
-    TLC5971, components/output/tlc5971, tlc5971.jpg
+    MCP4725, components/output/mcp4725, mcp4725.jpg
+    MCP4728, components/output/mcp4728, mcp4728.jpg
+    MCP47A1, components/output/mcp47a1, mcp47a1.svg
+    Modbus Output, components/output/modbus_controller, modbus.png
     MY9231/MY9291, components/output/my9231, my9231.svg
+    PCA9685, components/output/pca9685, pca9685.jpg
+    Sigma-Delta Output, components/output/sigma_delta_output, sigma-delta.svg, dark-invert
+    Slow PWM, components/output/slow_pwm, pwm.png
     SM16716, components/output/sm16716, sm16716.svg
     SM2135, components/output/sm2135, sm2135.svg
     SM2235, components/output/sm2235, sm2235.svg
     SM2335, components/output/sm2335, sm2335.svg
-    MCP4725, components/output/mcp4725, mcp4725.jpg
-    MCP4728, components/output/mcp4728, mcp4728.jpg
-    MCP47A1, components/output/mcp47a1, mcp47a1.svg
-    DAC7678, components/output/dac7678, dac7678.svg
-    BLE Binary Output, components/output/ble_client, bluetooth.svg, dark-invert
-    Modbus Output, components/output/modbus_controller, modbus.png
-    Custom Output, components/output/custom, language-cpp.svg, dark-invert
-    Sigma-Delta Output, components/output/sigma_delta_output, sigma-delta.svg, dark-invert
-    Template Output, components/output/template, description.svg, dark-invert
-    BP1658CJ, components/output/bp1658cj, bp1658cj.svg
-    BP5758D, components/output/bp5758d, bp5758d.svg
+    TLC59208F, components/output/tlc59208f, tlc59208f.jpg
+    TLC5947, components/output/tlc5947, tlc5947.jpg
+    TLC5971, components/output/tlc5971, tlc5971.jpg
     X9C Potentiometer, components/output/x9c, x9c.jpg
-    GP8403, components/output/gp8403, gp8403.svg
-    EMC2101, components/emc2101, emc2101.jpg
 
 Light Components
 ----------------
@@ -583,34 +665,31 @@ Light Components
 .. imgtable::
 
     Light Core, components/light/index, folder-open.svg, dark-invert
+    Custom Light, components/light/custom, language-cpp.svg, dark-invert
     Binary Light, components/light/binary, lightbulb.svg, dark-invert
-    Status Led, components/light/status_led, led-on.svg, dark-invert
-    Monochromatic Light, components/light/monochromatic, brightness-medium.svg, dark-invert
-
     Cold+Warm White Light, components/light/cwww, brightness-medium.svg, dark-invert
     Color Temperature Light, components/light/color_temperature, brightness-medium.svg, dark-invert
+    ESP32 RMT, components/light/esp32_rmt_led_strip, color_lens.svg, dark-invert
+    FastLED Light, components/light/fastled, color_lens.svg, dark-invert
+    H-bridge Light, components/light/hbridge, brightness-medium.svg, dark-invert
+    Light Partition, components/light/partition, color_lens.svg, dark-invert
+    LightWaveRF, components/lightwaverf, brightness-medium.svg
+    Monochromatic Light, components/light/monochromatic, brightness-medium.svg, dark-invert
+    NeoPixelBus Light, components/light/neopixelbus, color_lens.svg, dark-invert
     RGB Light, components/light/rgb, rgb.png
+    RGBCT Light, components/light/rgbct, rgbw.png
     RGBW Light, components/light/rgbw, rgbw.png
     RGBWW Light, components/light/rgbww, rgbw.png
-    RGBCT Light, components/light/rgbct, rgbw.png
-
-    ESP32 RMT, components/light/esp32_rmt_led_strip, color_lens.svg, dark-invert
     RP2040 PIO, components/light/rp2040_pio_led_strip, color_lens.svg, dark-invert
-    FastLED Light, components/light/fastled, color_lens.svg, dark-invert
-    NeoPixelBus Light, components/light/neopixelbus, color_lens.svg, dark-invert
-    Light Partition, components/light/partition, color_lens.svg, dark-invert
-    SPI LED Strips, components/light/spi_led_strip, apa102.jpg
-
-    Tuya Dimmer, components/light/tuya, tuya.png
     Shelly Dimmer, components/light/shelly_dimmer, shellydimmer2.jpg
-    Custom Light, components/light/custom, language-cpp.svg, dark-invert
-    LightWaveRF, components/lightwaverf, brightness-medium.svg
-
-    H-bridge Light, components/light/hbridge, brightness-medium.svg, dark-invert
     Sonoff D1 Dimmer, components/light/sonoff_d1, sonoff_d1.jpg
+    SPI LED Strips, components/light/spi_led_strip, apa102.jpg
+    Status Led, components/light/status_led, led-on.svg, dark-invert
+    Tuya Dimmer, components/light/tuya, tuya.png
 
-Looking for WS2811 and similar individually addressable lights? Have a look at the
-:doc:`FastLED Light </components/light/fastled>`.
+**Looking for WS2811 and similar individually addressable lights?** For the ESP32 and its variants, we
+recommend the :doc:`components/light/esp32_rmt_led_strip` or :doc:`components/light/spi_led_strip`; for
+other processors, have a look at the :doc:`FastLED Light </components/light/fastled>`.
 
 Switch Components
 -----------------
@@ -618,19 +697,19 @@ Switch Components
 .. imgtable::
 
     Switch Core, components/switch/index, folder-open.svg, dark-invert
+    Template Switch, components/switch/template, description.svg, dark-invert
+    Custom Switch, components/switch/custom, language-cpp.svg, dark-invert
     GPIO Switch, components/switch/gpio, pin.svg, dark-invert
+    BLE Client Switch, components/switch/ble_client, bluetooth.svg, dark-invert
+    Factory Reset Switch, components/switch/factory_reset, restart-alert.svg, dark-invert
+    Generic Output Switch, components/switch/output, upload.svg, dark-invert
+    Modbus Switch, components/switch/modbus_controller, modbus.png
+    Nextion Switch, components/switch/nextion, nextion.jpg
     Restart Switch, components/switch/restart, restart.svg, dark-invert
     Safe Mode Switch, components/switch/safe_mode, restart-alert.svg, dark-invert
     Shutdown Switch, components/switch/shutdown, power_settings.svg, dark-invert
-    Factory Reset Switch, components/switch/factory_reset, restart-alert.svg, dark-invert
-    Generic Output Switch, components/switch/output, upload.svg, dark-invert
-    Template Switch, components/switch/template, description.svg, dark-invert
-    UART Switch, components/switch/uart, uart.svg
-    Custom Switch, components/switch/custom, language-cpp.svg, dark-invert
     Tuya Switch, components/switch/tuya, tuya.png
-    Modbus Switch, components/switch/modbus_controller, modbus.png
-    BLE Client Switch, components/switch/ble_client, bluetooth.svg, dark-invert
-    Nextion Switch, components/switch/nextion, nextion.jpg
+    UART Switch, components/switch/uart, uart.svg
 
 Button Components
 -----------------
@@ -639,14 +718,13 @@ Button Components
 
     Button Core, components/button/index, folder-open.svg, dark-invert
     Template Button, components/button/template, description.svg, dark-invert
+    Factory Reset Button, components/button/factory_reset, restart-alert.svg, dark-invert
     Generic Output Button, components/button/output, upload.svg, dark-invert
     Restart Button, components/button/restart, restart.svg, dark-invert
     Safe Mode Button, components/button/safe_mode, restart-alert.svg, dark-invert
     Shutdown Button, components/button/shutdown, power_settings.svg, dark-invert
-    Factory Reset Button, components/button/factory_reset, restart-alert.svg, dark-invert
-    Wake-on-LAN, components/button/wake_on_lan, power_settings.svg, dark-invert
     UART Button, components/button/uart, uart.svg
-
+    Wake-on-LAN, components/button/wake_on_lan, power_settings.svg, dark-invert
 
 Fan Components
 --------------
@@ -654,11 +732,11 @@ Fan Components
 .. imgtable::
 
     Fan Core, components/fan/index, folder-open.svg, dark-invert
+    Template Fan, components/fan/template, description.svg, dark-invert
     Binary Fan, components/fan/binary, fan.svg, dark-invert
     H-bridge Fan, components/fan/hbridge, fan.svg, dark-invert
     Speed Fan, components/fan/speed, fan.svg, dark-invert
     Tuya Fan, components/fan/tuya, tuya.png
-    Template Fan, components/fan/template, description.svg, dark-invert
 
 Display Components
 ------------------
@@ -666,7 +744,17 @@ Display Components
 .. imgtable::
 
     Display Core, components/display/index, folder-open.svg, dark-invert
+    Display Menu Core, components/display_menu/index, folder-open.svg, dark-invert
     Font Renderer, components/display/fonts, format-font.svg, dark-invert
+
+    Graphical Display Menu, components/display_menu/graphical_display_menu, graphical_display_menu.jpg
+    LCD Menu, components/display_menu/lcd_menu, lcd_menu.png
+
+Display Hardware Platforms
+--------------------------
+
+.. imgtable::
+
     Addressable Light, components/display/addressable_light, addressable_light.jpg
     ILI9xxx, components/display/ili9xxx, ili9341.jpg
     ILI9341, components/display/ili9xxx, ili9341.svg
@@ -675,7 +763,6 @@ Display Components
     ILI9486, components/display/ili9xxx, ili9341.jpg
     ILI9488, components/display/ili9xxx, ili9488.svg
     WSPICOLCD, components/display/ili9xxx, ili9488.svg
-
     Inkplate, components/display/inkplate6, inkplate6.jpg
     LCD Display, components/display/lcd_display, lcd.jpg
     MAX7219, components/display/max7219, max7219.jpg
@@ -700,6 +787,7 @@ Display Components
     TM1621, components/display/tm1621, tm1621.jpg
     TM1637, components/display/tm1637, tm1637.jpg
     TM1638, components/display/tm1638, tm1638.jpg
+    TM1651 Battery Display, components/tm1651, tm1651_battery_display.jpg
     Waveshare E-Paper, components/display/waveshare_epaper, waveshare_epaper.jpg
 
 Touchscreen Components
@@ -708,14 +796,14 @@ Touchscreen Components
 .. imgtable::
 
     Touchscreen Core, components/touchscreen/index, folder-open.svg, dark-invert
+    CST226, components/touchscreen/cst226, t4-s3.jpg
     CST816, components/touchscreen/cst816, cst816.jpg
     EKTF2232, components/touchscreen/ektf2232, ektf2232.svg, Inkplate 6 Plus
+    FT63X6, components/touchscreen/ft63x6, wt32-sc01.png
+    GT911, components/touchscreen/gt911, esp32_s3_box_3.png
     Lilygo T5 4.7", components/touchscreen/lilygo_t5_47, lilygo_t5_47_touch.jpg
     TT21100, components/touchscreen/tt21100, esp32-s3-korvo-2-lcd.png
     XPT2046, components/touchscreen/xpt2046, xpt2046.jpg
-    CST226, components/touchscreen/cst226, t4-s3.jpg
-    GT911, components/touchscreen/gt911, esp32_s3_box_3.png
-    FT63X6, components/touchscreen/ft63x6, wt32-sc01.png
 
 Cover Components
 ----------------
@@ -724,14 +812,14 @@ Cover Components
 
     Cover Core, components/cover/index, folder-open.svg, dark-invert
     Template Cover, components/cover/template, description.svg, dark-invert
-    Feedback Cover, components/cover/feedback, feedback_cover.svg, dark-invert
-    Endstop Cover, components/cover/endstop, electric-switch.svg, dark-invert
-    Current-Based Cover, components/cover/current_based, flash.svg, dark-invert
-    Time-Based Cover, components/cover/time_based, timer.svg, dark-invert
     Custom Cover, components/cover/custom, language-cpp.svg, dark-invert
     AM43 Cover, components/cover/am43, am43.jpg
-    Tuya Cover, components/cover/tuya, tuya.png
+    Current-Based Cover, components/cover/current_based, flash.svg, dark-invert
+    Endstop Cover, components/cover/endstop, electric-switch.svg, dark-invert
+    Feedback Cover, components/cover/feedback, feedback_cover.svg, dark-invert
     HE60R Cover, components/cover/he60r, he60r.jpg
+    Time-Based Cover, components/cover/time_based, timer.svg, dark-invert
+    Tuya Cover, components/cover/tuya, tuya.png
 
 Text Sensor Components
 ----------------------
@@ -739,20 +827,20 @@ Text Sensor Components
 .. imgtable::
 
     Text Sensor Core, components/text_sensor/index, folder-open.svg, dark-invert
-    Home Assistant, components/text_sensor/homeassistant, home-assistant.svg, dark-invert
-    MQTT Subscribe Text, components/text_sensor/mqtt_subscribe, mqtt.png
-    Version, components/text_sensor/version, new-box.svg, dark-invert
-    WiFi Info, components/text_sensor/wifi_info, network-wifi.svg, dark-invert
-    Ethernet Info, components/text_sensor/ethernet_info, ethernet.svg, dark-invert
-    BLE Scanner, components/text_sensor/ble_scanner, bluetooth.svg, dark-invert
-    Modbus Text Sensor, components/text_sensor/modbus_controller, modbus.png
     Template Text Sensor, components/text_sensor/template, description.svg, dark-invert
     Custom Text Sensor, components/text_sensor/custom, language-cpp.svg, dark-invert
+    BLE Scanner, components/text_sensor/ble_scanner, bluetooth.svg, dark-invert
+    Ethernet Info, components/text_sensor/ethernet_info, ethernet.svg, dark-invert
+    Home Assistant, components/text_sensor/homeassistant, home-assistant.svg, dark-invert
+    LibreTiny, components/text_sensor/libretiny, libretiny.svg
+    Modbus Text Sensor, components/text_sensor/modbus_controller, modbus.png
+    MQTT Subscribe Text, components/text_sensor/mqtt_subscribe, mqtt.png
     Nextion Text Sensor, components/text_sensor/nextion, nextion.jpg
     Tuya Text Sensor, components/text_sensor/tuya, tuya.png
-    WL-134 Pet Tag Sensor , components/text_sensor/wl_134, fingerprint.svg, dark-invert
-    LibreTiny, components/text_sensor/libretiny, libretiny.svg
+    Version, components/text_sensor/version, new-box.svg, dark-invert
+    WiFi Info, components/text_sensor/wifi_info, network-wifi.svg, dark-invert
     WireGuard, components/wireguard, wireguard_custom_logo.svg
+    WL-134 Pet Tag Sensor , components/text_sensor/wl_134, fingerprint.svg, dark-invert
 
 Climate Components
 ------------------
@@ -760,16 +848,16 @@ Climate Components
 .. imgtable::
 
     Climate Core, components/climate/index, folder-open.svg, dark-invert
-    Bang Bang Controller, components/climate/bang_bang, air-conditioner.svg, dark-invert
-    Thermostat Controller, components/climate/thermostat, air-conditioner.svg, dark-invert
     Custom Climate, components/climate/custom, language-cpp.svg, dark-invert
-    PID Controller, components/climate/pid, function.svg, dark-invert
-    IR Remote Climate, components/climate/climate_ir, air-conditioner-ir.svg, dark-invert
-    Tuya Climate, components/climate/tuya, tuya.png
-    Midea, components/climate/midea, midea.svg
     Anova Cooker, components/climate/anova, anova.png
+    Bang Bang Controller, components/climate/bang_bang, air-conditioner.svg, dark-invert
     BedJet Climate System, components/climate/bedjet, bedjet.png
     Haier Climate, components/climate/haier, haier.svg
+    IR Remote Climate, components/climate/climate_ir, air-conditioner-ir.svg, dark-invert
+    Midea, components/climate/midea, midea.svg
+    PID Controller, components/climate/pid, function.svg, dark-invert
+    Thermostat Controller, components/climate/thermostat, air-conditioner.svg, dark-invert
+    Tuya Climate, components/climate/tuya, tuya.png
     Uponor Smatrix Base Pulse Underfloor Heating, components/uponor_smatrix, uponor.svg
 
 Number Components
@@ -798,8 +886,8 @@ Lock Components
 .. imgtable::
 
     Lock Core, components/lock/index, folder-open.svg, dark-invert
-    Generic Output Lock, components/lock/output, upload.svg, dark-invert
     Template Lock, components/lock/template, description.svg, dark-invert
+    Generic Output Lock, components/lock/output, upload.svg, dark-invert
 
 Text Components
 ---------------
@@ -815,6 +903,7 @@ Media Player Components
 .. imgtable::
 
     Media Player Core, components/media_player/index, folder-open.svg, dark-invert
+    DFPlayer, components/dfplayer, dfplayer.svg, dark-invert
     I2S Audio, components/media_player/i2s_audio, i2s_audio.svg
 
 Microphone Components
@@ -839,24 +928,24 @@ Time Components
 .. imgtable::
 
     Time Core, components/time/index, clock-outline.svg, dark-invert
-    Home Assistant Time, components/time/homeassistant, home-assistant.svg, dark-invert
-    SNTP, components/time/sntp, clock-outline.svg, dark-invert
-    GPS Time, components/time/gps, crosshairs-gps.svg, dark-invert
     DS1307 RTC, components/time/ds1307, clock-outline.svg, dark-invert
-    PCF8563 RTC, components/time/pcf8563, clock-outline.svg, dark-invert
+    GPS Time, components/time/gps, crosshairs-gps.svg, dark-invert
+    Home Assistant Time, components/time/homeassistant, home-assistant.svg, dark-invert
     PCF85063 RTC, components/time/pcf85063, clock-outline.svg, dark-invert
+    PCF8563 RTC, components/time/pcf8563, clock-outline.svg, dark-invert
+    SNTP, components/time/sntp, clock-outline.svg, dark-invert
 
 Home Assistant Companion Components
 -----------------------------------
 
 .. imgtable::
 
+    Binary Sensor, components/binary_sensor/homeassistant, home-assistant.svg, dark-invert
     Bluetooth Proxy, components/bluetooth_proxy, bluetooth.svg, dark-invert
-    Voice Assistant, components/voice_assistant, voice-assistant.svg, dark-invert
     micro Wake Word, components/micro_wake_word, voice-assistant.svg, dark-invert
     Sensor, components/sensor/homeassistant, home-assistant.svg, dark-invert
     Text Sensor, components/text_sensor/homeassistant, home-assistant.svg, dark-invert
-    Binary Sensor, components/binary_sensor/homeassistant, home-assistant.svg, dark-invert
+    Voice Assistant, components/voice_assistant, voice-assistant.svg, dark-invert
 
 
 Alarm Control Panel Components
@@ -875,77 +964,60 @@ Datetime Components
     Datetime Core, components/datetime/index, clock-outline.svg, dark-invert
     Template Datetime, components/datetime/template, description.svg, dark-invert
 
+Energy/Solar Management
+-----------------------
+
+.. imgtable::
+
+    PipSolar-compatible PV Inverter, components/pipsolar, pipsolar.jpg
+    Power Supply, components/power_supply, power.svg, dark-invert
+    Resol VBus, components/vbus, resol_deltasol_bs_plus.jpg
+    SML, components/sml, sml.svg
+    SUN-GTIL2 inverter, components/sun_gtil2, sun_1000g2.png
+
+Electromechanical Components
+----------------------------
+
+.. imgtable::
+
+    Atlas Scientific Peristaltic Pump, components/ezo_pmp, ezo-pmp.jpg
+    Grove TB6612FNG, components/grove_tb6612fng, motor.png
+    Matrix Keypad, components/matrix_keypad, matrix_keypad.jpg
+    RTTTL Buzzer, components/rtttl, buzzer.jpg
+    Servo, components/servo, servo.svg
+    Stepper, components/stepper/index, stepper.svg
+
+Wireless Communication Components
+---------------------------------
+
+Wireless communication that is **not Wi-Fi.**
+
+.. imgtable::
+
+    IR Remote Climate, components/climate/climate_ir, air-conditioner-ir.svg, dark-invert
+    Remote Receiver, components/remote_receiver, remote.svg, dark-invert
+    Remote Transmitter, components/remote_transmitter, remote.svg, dark-invert
+    RF Bridge, components/rf_bridge, rf_bridge.jpg
+    SIM800L, components/sim800l, sim800l.jpg
+
 Miscellaneous Components
 ------------------------
 
 .. imgtable::
 
-    Remote Receiver, components/remote_receiver, remote.svg, dark-invert
-    Remote Transmitter, components/remote_transmitter, remote.svg, dark-invert
-    Status LED, components/status_led, led-on.svg, dark-invert
-    Display Menu Core, components/display_menu/index, folder-open.svg, dark-invert
-    LCD Menu, components/display_menu/lcd_menu, lcd_menu.png
-    Graphical Display Menu, components/display_menu/graphical_display_menu, graphical_display_menu.png
-    Matrix Keypad, components/matrix_keypad, matrix_keypad.jpg
-    Wiegand Reader, components/wiegand, wiegand.jpg
-    HTTP Request, components/http_request, connection.svg, dark-invert
-    mDNS, components/mdns, radio-tower.svg, dark-invert
-
-    Sun, components/sun, weather-sunny.svg, dark-invert
-    GPS, components/gps, crosshairs-gps.svg, dark-invert
-
-    Bluetooth Proxy, components/bluetooth_proxy, bluetooth.svg, dark-invert
-    ESP32 BLE Client, components/ble_client, bluetooth.svg, dark-invert
-    ESP32 BLE Tracker, components/esp32_ble_tracker, bluetooth.svg, dark-invert
-    ESP32 BLE Beacon, components/esp32_ble_beacon, bluetooth.svg, dark-invert
-
-    ESP32 Ethernet, components/ethernet, ethernet.svg, dark-invert
-    ESP32 Camera, components/esp32_camera, camera.svg, dark-invert
-    ESP32 Camera Web Server, components/esp32_camera_web_server, camera.svg, dark-invert
-
-    I²S Audio, components/i2s_audio, i2s_audio.svg
-
-    Stepper, components/stepper/index, stepper.svg
-    Servo, components/servo, servo.svg
-    Sprinkler, components/sprinkler, sprinkler-variant.svg, dark-invert
-    Grove TB6612FNG, components/grove_tb6612fng, motor.png
-
-    PCA6416A I/O Expander, components/pca6416a, pca6416a.svg
-    PCA9554 I/O Expander, components/pca9554, pca9554a.jpg
-    PCF8574 I/O Expander, components/pcf8574, pcf8574.jpg
-    MAX6956 I/O expander - I²C Bus, components/max6956, max6956.jpg
-    MCP230XX I/O Expander - I²C Bus, components/mcp230xx, mcp230xx.svg
-    TCA9548A I²C Multiplexer, components/tca9548a, tca9548a.jpg
-    MCP23SXX I/O Expander - SPI Bus, components/mcp23Sxx, mcp230xx.svg
-    SX1509 I/O Expander, components/sx1509, sx1509.jpg
-    SN74HC165 I/O Expander, components/sn74hc165, sn74hc595.jpg
-    SN74HC595 I/O Expander, components/sn74hc595, sn74hc595.jpg
-    XL9535 I/O Expander, components/xl9535, xl9535.svg
-    SIM800L, components/sim800l, sim800l.jpg
-    DFPlayer, components/dfplayer, dfplayer.svg, dark-invert
-    Captive Portal, components/captive_portal, wifi-strength-alert-outline.svg, dark-invert
-    Improv via BLE, components/esp32_improv, improv.svg, dark-invert
-    Improv via Serial, components/improv_serial, improv.svg, dark-invert
-    Debug Component, components/debug, bug-report.svg, dark-invert
-    TM1651 Battery Display, components/tm1651, tm1651_battery_display.jpg
-    RF Bridge, components/rf_bridge, rf_bridge.jpg
-    Tuya MCU, components/tuya, tuya.png
-    Modbus Controller, components/modbus_controller, modbus.png
     Exposure Notifications, components/exposure_notifications, exposure_notifications.png
-    RTTTL Buzzer, components/rtttl, buzzer.jpg
-    Prometheus, components/prometheus, prometheus.svg
-    PipSolar - compatible PV Inverter, components/pipsolar, pipsolar.jpg
+    GPS, components/gps, crosshairs-gps.svg, dark-invert
     Grow Fingerprint Reader, components/fingerprint_grow, fingerprint.svg, dark-invert
-    SML, components/sml, sml.svg
-    SUN-GTIL2 inverter, components/sun_gtil2, sun_1000g2.png
-    Atlas Scientific Peristaltic Pump, components/ezo_pmp, ezo-pmp.jpg
-    Resol VBus, components/vbus, resol_deltasol_bs_plus.jpg
-    WireGuard, components/wireguard, wireguard_custom_logo.svg
-    Demo, components/demo, description.svg, dark-invert
-    Copy, components/copy, content-copy.svg, dark-invert
+    Modbus Controller, components/modbus_controller, modbus.png
+    Sprinkler, components/sprinkler, sprinkler-variant.svg, dark-invert
+    Status LED, components/status_led, led-on.svg, dark-invert
+    Sun, components/sun, weather-sunny.svg, dark-invert
+    Tuya MCU, components/tuya, tuya.png
 
 Additional Custom Components
 ----------------------------
+
+**Note: Custom Components have been deprecated in favor of** :doc:`components/external_components`!
 
 .. imgtable::
 

--- a/index.rst
+++ b/index.rst
@@ -241,7 +241,6 @@ Core
 
     Sensor Core, components/sensor/index, folder-open.svg, dark-invert
     Template Sensor, components/sensor/template, description.svg, dark-invert
-    Custom Sensor, components/sensor/custom, language-cpp.svg, dark-invert
     Home Assistant, components/sensor/homeassistant, home-assistant.svg, dark-invert
     MQTT Subscribe, components/sensor/mqtt_subscribe, mqtt.png
     Uptime Sensor, components/sensor/uptime, timer.svg, dark-invert
@@ -541,7 +540,6 @@ Core
 .. imgtable::
 
     Binary Sensor Core, components/binary_sensor/index, folder-open.svg, dark-invert
-    Custom Binary Sensor, components/binary_sensor/custom, language-cpp.svg, dark-invert
     GPIO, components/binary_sensor/gpio, pin.svg, dark-invert
     Home Assistant, components/binary_sensor/homeassistant, home-assistant.svg, dark-invert
     Status, components/binary_sensor/status, server-network.svg, dark-invert
@@ -597,8 +595,8 @@ Presence Detection
 
 .. imgtable::
 
-    DFRobot mmWave Radar, components/dfrobot_sen0395, dfrobot_sen0395.jpg
     AT581X, components/at581x, at581x.png
+    DFRobot mmWave Radar, components/dfrobot_sen0395, dfrobot_sen0395.jpg
     LD2410, components/sensor/ld2410, ld2410.jpg
     LD2420, components/sensor/ld2420, ld2420.jpg
     Seeed Studio MR24HPC1 mmWave, components/seeed_mr24hpc1, seeed-mr24hpc1.jpg
@@ -627,7 +625,6 @@ Output Components
 
     Output Core, components/output/index, folder-open.svg, dark-invert
     Template Output, components/output/template, description.svg, dark-invert
-    Custom Output, components/output/custom, language-cpp.svg, dark-invert
     AC Dimmer, components/output/ac_dimmer, ac_dimmer.svg, dark-invert
     BLE Binary Output, components/output/ble_client, bluetooth.svg, dark-invert
     BP1658CJ, components/output/bp1658cj, bp1658cj.svg
@@ -663,7 +660,6 @@ Light Components
 .. imgtable::
 
     Light Core, components/light/index, folder-open.svg, dark-invert
-    Custom Light, components/light/custom, language-cpp.svg, dark-invert
     Binary Light, components/light/binary, lightbulb.svg, dark-invert
     Cold+Warm White Light, components/light/cwww, brightness-medium.svg, dark-invert
     Color Temperature Light, components/light/color_temperature, brightness-medium.svg, dark-invert
@@ -696,11 +692,10 @@ Switch Components
 
     Switch Core, components/switch/index, folder-open.svg, dark-invert
     Template Switch, components/switch/template, description.svg, dark-invert
-    Custom Switch, components/switch/custom, language-cpp.svg, dark-invert
-    GPIO Switch, components/switch/gpio, pin.svg, dark-invert
     BLE Client Switch, components/switch/ble_client, bluetooth.svg, dark-invert
     Factory Reset Switch, components/switch/factory_reset, restart-alert.svg, dark-invert
     Generic Output Switch, components/switch/output, upload.svg, dark-invert
+    GPIO Switch, components/switch/gpio, pin.svg, dark-invert
     Modbus Switch, components/switch/modbus_controller, modbus.png
     Nextion Switch, components/switch/nextion, nextion.jpg
     Restart Switch, components/switch/restart, restart.svg, dark-invert
@@ -763,12 +758,12 @@ Display Hardware Platforms
     WSPICOLCD, components/display/ili9xxx, ili9488.svg
     Inkplate, components/display/inkplate6, inkplate6.jpg
     LCD Display, components/display/lcd_display, lcd.jpg
-    MAX7219, components/display/max7219, max7219.jpg
     MAX7219 Dot Matrix, components/display/max7219digit, max7219digit.jpg
+    MAX7219, components/display/max7219, max7219.jpg
     Nextion, components/display/nextion, nextion.jpg
     PCD8544 (Nokia 5110/ 3310), components/display/pcd8544, pcd8544.jpg
-    Quad SPI AMOLED, components/display/qspi_amoled, t4-s3.jpg
     PVVX MiThermometer, components/display/pvvx_mithermometer, ../components/sensor/images/xiaomi_lywsd03mmc.jpg
+    Quad SPI AMOLED, components/display/qspi_amoled, t4-s3.jpg
     RPI_DPI_RGB, components/display/rpi_dpi_rgb, waveshare_touch-s3.jpg
     SSD1306, components/display/ssd1306, ssd1306.jpg
     SSD1322, components/display/ssd1322, ssd1322.jpg
@@ -777,8 +772,8 @@ Display Hardware Platforms
     SSD1331, components/display/ssd1331, ssd1331.jpg
     SSD1351, components/display/ssd1351, ssd1351.jpg
     ST7567, components/display/st7567, st7567.jpg
-    ST7735, components/display/st7735, st7735.jpg
     ST7701S, components/display/st7701s, indicator.jpg
+    ST7735, components/display/st7735, st7735.jpg
     ST7789V, components/display/st7789v, st7789v.jpg
     ST7796, components/display/ili9xxx, st7796.svg
     ST7920, components/display/st7920, st7920.jpg
@@ -810,14 +805,12 @@ Cover Components
 
     Cover Core, components/cover/index, folder-open.svg, dark-invert
     Template Cover, components/cover/template, description.svg, dark-invert
-    Custom Cover, components/cover/custom, language-cpp.svg, dark-invert
+    AM43 Cover, components/cover/am43, am43.jpg
     Current-Based Cover, components/cover/current_based, flash.svg, dark-invert
     Endstop Cover, components/cover/endstop, electric-switch.svg, dark-invert
     Feedback Cover, components/cover/feedback, feedback_cover.svg, dark-invert
-    Time-Based Cover, components/cover/time_based, timer.svg, dark-invert
-
-    AM43 Cover, components/cover/am43, am43.jpg
     HE60R Cover, components/cover/he60r, he60r.jpg
+    Time-Based Cover, components/cover/time_based, timer.svg, dark-invert
     Tuya Cover, components/cover/tuya, tuya.png
 
 Text Components
@@ -835,7 +828,6 @@ Text Sensor Components
 
     Text Sensor Core, components/text_sensor/index, folder-open.svg, dark-invert
     Template Text Sensor, components/text_sensor/template, description.svg, dark-invert
-    Custom Text Sensor, components/text_sensor/custom, language-cpp.svg, dark-invert
     BLE Scanner, components/text_sensor/ble_scanner, bluetooth.svg, dark-invert
     Ethernet Info, components/text_sensor/ethernet_info, ethernet.svg, dark-invert
     Home Assistant, components/text_sensor/homeassistant, home-assistant.svg, dark-invert
@@ -855,16 +847,14 @@ Climate Components
 .. imgtable::
 
     Climate Core, components/climate/index, folder-open.svg, dark-invert
-    Custom Climate, components/climate/custom, language-cpp.svg, dark-invert
-    Bang Bang Controller, components/climate/bang_bang, air-conditioner.svg, dark-invert
-    PID Controller, components/climate/pid, function.svg, dark-invert
-    Thermostat Controller, components/climate/thermostat, air-conditioner.svg, dark-invert
-
     Anova Cooker, components/climate/anova, anova.png
+    Bang Bang Controller, components/climate/bang_bang, air-conditioner.svg, dark-invert
     BedJet Climate System, components/climate/bedjet, bedjet.png
     Haier Climate, components/climate/haier, haier.svg
     IR Remote Climate, components/climate/climate_ir, air-conditioner-ir.svg, dark-invert
     Midea, components/climate/midea, midea.svg
+    PID Controller, components/climate/pid, function.svg, dark-invert
+    Thermostat Controller, components/climate/thermostat, air-conditioner.svg, dark-invert
     Tuya Climate, components/climate/tuya, tuya.png
     Uponor Smatrix Base Pulse Underfloor Heating, components/uponor_smatrix, uponor.svg
 
@@ -874,8 +864,8 @@ Number Components
 .. imgtable::
 
     Number Core, components/number/index, folder-open.svg, dark-invert
-    Modbus Number, components/number/modbus_controller, modbus.png
     Template Number, components/number/template, description.svg, dark-invert
+    Modbus Number, components/number/modbus_controller, modbus.png
     Tuya Number, components/number/tuya, tuya.png
 
 Select Components
@@ -1014,14 +1004,24 @@ Miscellaneous Components
     Sun, components/sun, weather-sunny.svg, dark-invert
     Tuya MCU, components/tuya, tuya.png
 
-Additional Custom Components
-----------------------------
+Custom Components
+-----------------
 
-**Note: Custom Components have been deprecated in favor of** :doc:`components/external_components`!
+**Note: Custom Components are deprecated in favor of** :doc:`components/external_components`!
 
 .. imgtable::
 
     Generic Custom Component, custom/custom_component, language-cpp.svg, dark-invert
+
+    Custom Binary Sensor, components/binary_sensor/custom, language-cpp.svg, dark-invert
+    Custom Climate, components/climate/custom, language-cpp.svg, dark-invert
+    Custom Cover, components/cover/custom, language-cpp.svg, dark-invert
+    Custom Light, components/light/custom, language-cpp.svg, dark-invert
+    Custom Output, components/output/custom, language-cpp.svg, dark-invert
+    Custom Sensor, components/sensor/custom, language-cpp.svg, dark-invert
+    Custom Switch, components/switch/custom, language-cpp.svg, dark-invert
+    Custom Text Sensor, components/text_sensor/custom, language-cpp.svg, dark-invert
+
     Custom I²C Component, custom/i2c, language-cpp.svg, dark-invert
     Custom SPI Component, custom/spi, language-cpp.svg, dark-invert
     Custom UART Component, custom/uart, language-cpp.svg, dark-invert

--- a/index.rst
+++ b/index.rst
@@ -121,10 +121,8 @@ ESPHome is a system to control your microcontrollers by simple yet powerful conf
 
 .. _devices:
 
-Processor Components
+Supported Processors
 --------------------
-
-Processors ESPHome supports.
 
 .. imgtable::
 
@@ -134,10 +132,10 @@ Processors ESPHome supports.
     BK72xx, components/libretiny, bk72xx.svg
     RTL87xx, components/libretiny, rtl87xx.svg
 
-Processor Peripheral Components
--------------------------------
+Processor Peripherals
+---------------------
 
-Peripherals which directly support the processor(s).
+Peripherals which directly support the operation of the processor(s).
 
 .. imgtable::
 
@@ -159,16 +157,16 @@ ESPHome-specific components or components supporting ESPHome device provisioning
     Improv via BLE, components/esp32_improv, improv.svg, dark-invert
     Improv via Serial, components/improv_serial, improv.svg, dark-invert
 
-Network Hardware Components
----------------------------
+Network Hardware
+----------------
 
 .. imgtable::
 
     WiFi, components/wifi, network-wifi.svg, dark-invert
     ESP32 Ethernet, components/ethernet, ethernet.svg, dark-invert
 
-Network Protocol Components
----------------------------
+Network Protocols
+-----------------
 
 .. imgtable::
 
@@ -179,8 +177,8 @@ Network Protocol Components
     mDNS, components/mdns, radio-tower.svg, dark-invert
     WireGuard, components/wireguard, wireguard_custom_logo.svg
 
-Bluetooth Components
---------------------
+Bluetooth/BLE
+-------------
 
 .. imgtable::
 
@@ -190,8 +188,8 @@ Bluetooth Components
     Bluetooth Proxy, components/bluetooth_proxy, bluetooth.svg, dark-invert
     Improv via BLE, components/esp32_improv, improv.svg, dark-invert
 
-Management and Monitoring Components
-------------------------------------
+Management and Monitoring
+-------------------------
 
 .. imgtable::
 
@@ -202,8 +200,8 @@ Management and Monitoring Components
     Web Server, components/web_server, http.svg, dark-invert
     ESP32 Camera Web Server, components/esp32_camera_web_server, camera.svg, dark-invert
 
-Hardware Peripheral Interface/Bus Components
---------------------------------------------
+Hardware Peripheral Interfaces/Busses
+-------------------------------------
 
 .. imgtable::
 
@@ -214,8 +212,8 @@ Hardware Peripheral Interface/Bus Components
     UART, components/uart, uart.svg
     ESP32 Camera, components/esp32_camera, camera.svg, dark-invert
 
-Input/Output Expansion Interface Components
--------------------------------------------
+I/O Expanders
+-------------
 
 .. imgtable::
 
@@ -568,8 +566,8 @@ Mechanical
     TM1637, components/display/tm1637, tm1637.jpg
     TM1638, components/display/tm1638, tm1638.jpg
 
-NFC/RFID Components
-*******************
+NFC/RFID
+********
 
 Often known as "tag" or "card" readers within the community.
 
@@ -821,6 +819,14 @@ Cover Components
     Time-Based Cover, components/cover/time_based, timer.svg, dark-invert
     Tuya Cover, components/cover/tuya, tuya.png
 
+Text Components
+---------------
+
+.. imgtable::
+
+    Text Core, components/text/index, folder-open.svg, dark-invert
+    Template Text, components/text/template, description.svg, dark-invert
+
 Text Sensor Components
 ----------------------
 
@@ -888,14 +894,6 @@ Lock Components
     Lock Core, components/lock/index, folder-open.svg, dark-invert
     Template Lock, components/lock/template, description.svg, dark-invert
     Generic Output Lock, components/lock/output, upload.svg, dark-invert
-
-Text Components
----------------
-
-.. imgtable::
-
-    Text Core, components/text/index, folder-open.svg, dark-invert
-    Template Text, components/text/template, description.svg, dark-invert
 
 Media Player Components
 -----------------------
@@ -975,8 +973,8 @@ Energy/Solar Management
     SML, components/sml, sml.svg
     SUN-GTIL2 inverter, components/sun_gtil2, sun_1000g2.png
 
-Electromechanical Components
-----------------------------
+Electromechanical
+-----------------
 
 .. imgtable::
 
@@ -987,8 +985,8 @@ Electromechanical Components
     Servo, components/servo, servo.svg
     Stepper, components/stepper/index, stepper.svg
 
-Wireless Communication Components
----------------------------------
+Wireless Communication
+----------------------
 
 Wireless communication that is **not Wi-Fi.**
 

--- a/index.rst
+++ b/index.rst
@@ -121,8 +121,8 @@ ESPHome is a system to control your microcontrollers by simple yet powerful conf
 
 .. _devices:
 
-Supported Processors
---------------------
+Supported Microcontrollers
+--------------------------
 
 .. imgtable::
 
@@ -132,10 +132,10 @@ Supported Processors
     BK72xx, components/libretiny, bk72xx.svg
     RTL87xx, components/libretiny, rtl87xx.svg
 
-Processor Peripherals
----------------------
+Microcontroller Peripherals
+---------------------------
 
-Peripherals which directly support the operation of the processor(s).
+Peripherals which directly support the operation of the microcontroller's processor(s).
 
 .. imgtable::
 
@@ -210,24 +210,23 @@ Hardware Peripheral Interfaces/Busses
     I²S Audio, components/i2s_audio, i2s_audio.svg
     SPI Bus, components/spi, spi.svg
     UART, components/uart, uart.svg
-    ESP32 Camera, components/esp32_camera, camera.svg, dark-invert
 
-I/O Expanders
--------------
+I/O Expanders/Multiplexers
+--------------------------
 
 .. imgtable::
 
-    MAX6956 I/O expander - I²C Bus, components/max6956, max6956.jpg
-    MCP230XX I/O Expander - I²C Bus, components/mcp230xx, mcp230xx.svg
-    MCP23SXX I/O Expander - SPI Bus, components/mcp23Sxx, mcp230xx.svg
-    PCA6416A I/O Expander, components/pca6416a, pca6416a.svg
-    PCA9554 I/O Expander, components/pca9554, pca9554a.jpg
-    PCF8574 I/O Expander, components/pcf8574, pcf8574.jpg
-    SN74HC165 I/O Expander, components/sn74hc165, sn74hc595.jpg
-    SN74HC595 I/O Expander, components/sn74hc595, sn74hc595.jpg
-    SX1509 I/O Expander, components/sx1509, sx1509.jpg
+    MAX6956 - I²C Bus, components/max6956, max6956.jpg
+    MCP230XX - I²C Bus, components/mcp230xx, mcp230xx.svg
+    MCP23SXX - SPI Bus, components/mcp23Sxx, mcp230xx.svg
+    PCA6416A, components/pca6416a, pca6416a.svg
+    PCA9554, components/pca9554, pca9554a.jpg
+    PCF8574, components/pcf8574, pcf8574.jpg
+    SN74HC165, components/sn74hc165, sn74hc595.jpg
+    SN74HC595, components/sn74hc595, sn74hc595.jpg
+    SX1509, components/sx1509, sx1509.jpg
     TCA9548A I²C Multiplexer, components/tca9548a, tca9548a.jpg
-    XL9535 I/O Expander, components/xl9535, xl9535.svg
+    XL9535, components/xl9535, xl9535.svg
 
 Sensor Components
 -----------------
@@ -540,10 +539,10 @@ Core
 .. imgtable::
 
     Binary Sensor Core, components/binary_sensor/index, folder-open.svg, dark-invert
+    Template Binary Sensor, components/binary_sensor/template, description.svg, dark-invert
     GPIO, components/binary_sensor/gpio, pin.svg, dark-invert
     Home Assistant, components/binary_sensor/homeassistant, home-assistant.svg, dark-invert
     Status, components/binary_sensor/status, server-network.svg, dark-invert
-    Template Binary Sensor, components/binary_sensor/template, description.svg, dark-invert
 
 Capacitive Touch
 ****************
@@ -740,7 +739,7 @@ Display Components
     Display Menu Core, components/display_menu/index, folder-open.svg, dark-invert
     Font Renderer, components/display/fonts, format-font.svg, dark-invert
 
-    Graphical Display Menu, components/display_menu/graphical_display_menu, graphical_display_menu.jpg
+    Graphical Display Menu, components/display_menu/graphical_display_menu, graphical_display_menu.png
     LCD Menu, components/display_menu/lcd_menu, lcd_menu.png
 
 Display Hardware Platforms
@@ -925,8 +924,10 @@ Time Components
     PCF8563 RTC, components/time/pcf8563, clock-outline.svg, dark-invert
     SNTP, components/time/sntp, clock-outline.svg, dark-invert
 
-Home Assistant Companion Components
------------------------------------
+Home Assistant Components
+-------------------------
+
+Components specifically for interacting with Home Assistant.
 
 .. imgtable::
 
@@ -995,6 +996,7 @@ Miscellaneous Components
 
 .. imgtable::
 
+    ESP32 Camera, components/esp32_camera, camera.svg, dark-invert
     Exposure Notifications, components/exposure_notifications, exposure_notifications.png
     GPS, components/gps, crosshairs-gps.svg, dark-invert
     Grow Fingerprint Reader, components/fingerprint_grow, fingerprint.svg, dark-invert

--- a/index.rst
+++ b/index.rst
@@ -811,12 +811,13 @@ Cover Components
     Cover Core, components/cover/index, folder-open.svg, dark-invert
     Template Cover, components/cover/template, description.svg, dark-invert
     Custom Cover, components/cover/custom, language-cpp.svg, dark-invert
-    AM43 Cover, components/cover/am43, am43.jpg
     Current-Based Cover, components/cover/current_based, flash.svg, dark-invert
     Endstop Cover, components/cover/endstop, electric-switch.svg, dark-invert
     Feedback Cover, components/cover/feedback, feedback_cover.svg, dark-invert
-    HE60R Cover, components/cover/he60r, he60r.jpg
     Time-Based Cover, components/cover/time_based, timer.svg, dark-invert
+
+    AM43 Cover, components/cover/am43, am43.jpg
+    HE60R Cover, components/cover/he60r, he60r.jpg
     Tuya Cover, components/cover/tuya, tuya.png
 
 Text Components
@@ -855,14 +856,15 @@ Climate Components
 
     Climate Core, components/climate/index, folder-open.svg, dark-invert
     Custom Climate, components/climate/custom, language-cpp.svg, dark-invert
-    Anova Cooker, components/climate/anova, anova.png
     Bang Bang Controller, components/climate/bang_bang, air-conditioner.svg, dark-invert
+    PID Controller, components/climate/pid, function.svg, dark-invert
+    Thermostat Controller, components/climate/thermostat, air-conditioner.svg, dark-invert
+
+    Anova Cooker, components/climate/anova, anova.png
     BedJet Climate System, components/climate/bedjet, bedjet.png
     Haier Climate, components/climate/haier, haier.svg
     IR Remote Climate, components/climate/climate_ir, air-conditioner-ir.svg, dark-invert
     Midea, components/climate/midea, midea.svg
-    PID Controller, components/climate/pid, function.svg, dark-invert
-    Thermostat Controller, components/climate/thermostat, air-conditioner.svg, dark-invert
     Tuya Climate, components/climate/tuya, tuya.png
     Uponor Smatrix Base Pulse Underfloor Heating, components/uponor_smatrix, uponor.svg
 


### PR DESCRIPTION
## Description:

An attempt to better-organize the front page:

- We had wayyyyy too many components in the "Miscellaneous" category.
- Alphabetize more or less everything with strategic exceptions only where appropriate.
- Use clearer naming for some sections and add brief descriptions where appropriate.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
