### PR TITLE
Fix Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN useradd -ms /bin/bash esphome
 USER esphome
 
 WORKDIR /workspaces/esphome-docs
+ENV PATH="${PATH}:/home/esphome/.local/bin"
 
 COPY requirements.txt ./
 RUN pip3 install --no-cache-dir --no-binary :all: -r requirements.txt

--- a/guides/contributing.rst
+++ b/guides/contributing.rst
@@ -98,7 +98,7 @@ Build
 
     .. code-block:: bash
 
-        docker run --rm -v "${PWD}/":/data/esphomedocs -p 8000:8000 -it ghcr.io/esphome/esphome-docs
+        docker run --rm -v "${PWD}/":/workspaces/esphome-docs -p 8000:8000 -it ghcr.io/esphome/esphome-docs
 
     With ``PWD`` referring to the root of the ``esphome-docs`` git repository. Then go to ``<CONTAINER_IP>:8000`` in your browser.
 


### PR DESCRIPTION
Context at https://discord.com/channels/429907082951524364/524177279270780928/1232999412100235315.

- Update instructions to volume mount `esphome-docs` from `/data/esphomedocs` to where https://github.com/esphome/esphome-docs/pull/3785 now expects it to be, `/workspaces/esphome-docs`
- Add `/home/esphome/.local/bin` to the `PATH`, which is where `pip3 install` drops `sphinx-autobuild` and friends now that the build is being run as the `esphome` user instead of as root

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
