### PR TITLE
Add thermocouple type, autoconversion, averaging, and has_fault to max31856

### DIFF
--- a/components/sensor/max31856.rst
+++ b/components/sensor/max31856.rst
@@ -7,7 +7,6 @@ MAX31856 Thermocouple Temperature Sensor
 
 The ``MAX31856`` temperature sensor allows you to use your MAX31856 Thermocouple
 temperature sensor (`datasheet <https://datasheets.maximintegrated.com/en/ds/MAX31856.pdf>`__) with ESPHome.
-Although the chip supports multiple thermocouple types, this component only implements the ``K`` type.
 
 .. figure:: images/max31856-full.jpg
     :align: center
@@ -28,7 +27,7 @@ to have an :ref:`spi bus <spi>` in your configuration with both **miso_pin** and
 - ``SDI`` connects to the SPI **mosi_pin**
 - ``CS`` connects to a free GPIO pin
 - ``FLT`` not used by ESPHome
-- ``DRDY`` not used by ESPHome
+- ``DRDY`` connects to a free GPIO pin (*Optional*)
 
 .. code:: yaml
 
@@ -49,10 +48,15 @@ Configuration variables:
 
 - **name** (**Required**, string): The name for the temperature sensor.
 - **cs_pin** (**Required**, :ref:`Pin Schema <config-pin_schema>`): The Chip Select pin of the SPI interface.
-- **update_interval** (*Optional*, :ref:`config-time`): The interval to check the sensor. Defaults to ``60s``.
+- **data_ready_pin** (*Optional*, :ref:`Pin Schema <config-pin_schema>`): The Data Ready pin of the MAX31856. If this pin is configured, the MAX31856 will use autoconversion mode and ``update_interval`` cannot be configured and will not be used.
+- **update_interval** (*Optional*, :ref:`config-time`): The interval to check the sensor. Defaults to ``60s``. Only one of ``data_ready_pin`` and ``update_interval`` may be set in the configuration.
+- **type** (*Optional*, string): The thermocouple type. One of the following values: ``B``, ``E``, ``J``, ``K``, ``N``, ``R``, ``S``, ``T``. Defaults to ``K``.
 - **mains_filter** (*Optional*, string): The mains power frequency to reject (``50 Hz`` or ``60 Hz``). Defaults to ``60 Hz``.
+- **samples_per_value** (*Optional*, int): The number of samples to average for each conversion. One of the following values: ``1``, ``2``, ``4``, ``8``, ``16``. Defaults to ``1``.
 - **spi_id** (*Optional*, :ref:`config-id`): Manually specify the ID of the :ref:`SPI Component <spi>` if you want to use multiple SPI buses.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
+- **has_fault** (*Optional*): If true the sensor has a fault. The fault condition can be obtained by viewing the logs.
+  All options from :ref:`Binary Sensor <config-binary_sensor>`.
 - All other options from :ref:`Sensor <config-sensor>`.
 
 See Also


### PR DESCRIPTION
## Description:

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#6659

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
