### PR TITLE
remote_receiver: document using multiple with receiver_id

### DIFF
--- a/components/remote_receiver.rst
+++ b/components/remote_receiver.rst
@@ -23,6 +23,8 @@ which will trigger when they hear their own configured signal.
       pin: GPIO32
       dump: all
 
+Multiple remote receivers can be configured as a list of dict definitions in remote_receiver.
+
 Configuration variables:
 ------------------------
 
@@ -222,6 +224,8 @@ Configuration variables:
 
 - **name** (**Required**, string): The name for the binary sensor.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
+- **receiver_id** (*Optional*, :ref:`config-id`): The remote receiver to receive the
+  remote code with. Required if multiple receivers configured.
 - All other options from :ref:`Binary Sensor <config-binary_sensor>`.
 
 Remote code selection (exactly one of these has to be included):


### PR DESCRIPTION
## Description:

Having multiple remote_receiver requires them to being a list, otherwise they're silently merged.
When using them in binary_sensor, `receiver_id` is undocumented so far, but omitting it fails to compile with the error

~~~
binary_sensor.remote_receiver: [source IR_receiver.yml:59]

  Too many candidates found for 'receiver_id' type 'remote_base::RemoteReceiverBase' Some are 'F1000a_rx', 'TSOP31238'.
~~~


**Related issue (if applicable):** none

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** none

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
