### PR TITLE
doc: wifi reboot_timeout disabled if ap enabled

### DIFF
--- a/components/wifi.rst
+++ b/components/wifi.rst
@@ -75,7 +75,7 @@ Configuration variables:
   Defaults to ``.local``.
 - **reboot_timeout** (*Optional*, :ref:`config-time`): The amount of time to wait before rebooting when no
   WiFi connection exists. Can be disabled by setting this to ``0s``, but note that the low level IP stack currently
-  seems to have issues with WiFi where a full reboot is required to get the interface back working. Defaults to ``15min``. Disabled if AP is enabled.
+  seems to have issues with WiFi where a full reboot is required to get the interface back working. Defaults to ``15min``. Disabled if in access point mode.
 - **power_save_mode** (*Optional*, string): The power save mode for the WiFi interface.
   See :ref:`wifi-power_save_mode`
 

--- a/components/wifi.rst
+++ b/components/wifi.rst
@@ -75,7 +75,7 @@ Configuration variables:
   Defaults to ``.local``.
 - **reboot_timeout** (*Optional*, :ref:`config-time`): The amount of time to wait before rebooting when no
   WiFi connection exists. Can be disabled by setting this to ``0s``, but note that the low level IP stack currently
-  seems to have issues with WiFi where a full reboot is required to get the interface back working. Defaults to ``15min``.
+  seems to have issues with WiFi where a full reboot is required to get the interface back working. Defaults to ``15min``. Disabled if AP is enabled.
 - **power_save_mode** (*Optional*, string): The power save mode for the WiFi interface.
   See :ref:`wifi-power_save_mode`
 

--- a/components/wifi.rst
+++ b/components/wifi.rst
@@ -75,7 +75,7 @@ Configuration variables:
   Defaults to ``.local``.
 - **reboot_timeout** (*Optional*, :ref:`config-time`): The amount of time to wait before rebooting when no
   WiFi connection exists. Can be disabled by setting this to ``0s``, but note that the low level IP stack currently
-  seems to have issues with WiFi where a full reboot is required to get the interface back working. Defaults to ``15min``. Disabled if in access point mode.
+  seems to have issues with WiFi where a full reboot is required to get the interface back working. Defaults to ``15min``. Does not apply when in access point mode.
 - **power_save_mode** (*Optional*, string): The power save mode for the WiFi interface.
   See :ref:`wifi-power_save_mode`
 


### PR DESCRIPTION
## Description:
As per https://github.com/esphome/esphome/blob/c7c0d97a5ecbaa235636ba9e527f8c9ff7b4c4b0/esphome/components/wifi/wifi_component.cpp#L192C1-L192C57 update documentation.

**Related issue (if applicable):** fixes

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
