### PR TITLE
[CST816] Add support for Hynitron Microelectronics CST826 capacitive touch

### DIFF
--- a/components/touchscreen/cst816.rst
+++ b/components/touchscreen/cst816.rst
@@ -9,7 +9,7 @@ cst816 Touch Screen Controller
 The ``cst816`` touchscreen platform allows using the touch screen controllers based on the CST816 series of chips with ESPHome.
 The :ref:`I²C <i2c>` is required to be set up in your configuration for this touchscreen to work.
 
-This controller is used in the Lilygo T-Display S3 AMOLED. The component should work with CST816T, CST816S, CST820 and CST716
+This controller is used in the Lilygo T-Display S3 AMOLED. The component should work with CST816T, CST816S, CST820, CST826 and CST716
 controller chips.
 
 


### PR DESCRIPTION
## Description:
Update doc to add Hynitron Microelectronics CST826 capacitive touch support

**Related issue (if applicable):** fixes [#2715](https://github.com/esphome/feature-requests/issues/2715)

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#6682

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
