### PR TITLE
Update pca9685.rst

### DIFF
--- a/components/output/pca9685.rst
+++ b/components/output/pca9685.rst
@@ -58,7 +58,7 @@ Configuration variables:
 
 -  **frequency** (*Optional*, float): The frequency to let the
    component drive all PWM outputs at. Must be in range from 24Hz to
-   1525.88Hz. Default ``1000Hz``.
+   1525.88Hz. Defaults to ``1000Hz``.
 -  **external_clock_input** (*Optional*, bool): Enable external clock input. PRE_SCALE register will by set to 3. Default to ``false``.
 -  **address** (*Optional*, int): The I²C address of the driver.
    Defaults to ``0x40``.
@@ -96,7 +96,7 @@ Configuration variables:
 ************************
 
 - **id** (**Required**, :ref:`config-id`): The id to use for this output component.
-- **channel** (**Required**, int): Chose the channel of the PCA9685 of
+- **channel** (**Required**, int): Choose the channel of the PCA9685 of
   this output component. Must be in range from 0 to 15.
 - **pca9685_id** (*Optional*, :ref:`config-id`): Manually specify the ID of the
   :ref:`PCA9685 hub <pca9685-component>`.


### PR DESCRIPTION
## Description:

Fix typo, adjust wording to be common ("defaults to" instead of "default")

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
