### PR TITLE
Update ethernet.rst

### DIFF
--- a/components/ethernet.rst
+++ b/components/ethernet.rst
@@ -40,6 +40,8 @@ This component and the Wi-Fi component may **not** be used simultaneously, even 
       interrupt_pin: GPIOXX
       reset_pin: GPIOXX
 
+>> Support for W5500 is currently not working (see https://github.com/esphome/issues/issues/5781)  
+
 Configuration variables:
 ------------------------
 


### PR DESCRIPTION
Added ">> Support for W5500 is currently not working (see https://github.com/esphome/issues/issues/5781)"

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
