### PR TITLE
Fix method name for time-based cover last operation

### DIFF
--- a/components/cover/time_based.rst
+++ b/components/cover/time_based.rst
@@ -86,10 +86,10 @@ This can be handled at the **stop_action** by using the folling lamda function:
 
     stop_action: 
       - lambda: !lambda |-
-          if (id(cover).last_operation() == CoverOperation::COVER_OPERATION_OPENING) {
+          if (id(cover).get_last_operation() == CoverOperation::COVER_OPERATION_OPENING) {
             // Cover is currently opening
             id(cover_button_down).press();
-          } else if (id(cover).last_operation() == CoverOperation::COVER_OPERATION_CLOSING) {
+          } else if (id(cover).get_last_operation() == CoverOperation::COVER_OPERATION_CLOSING) {
             // Cover is currently closing
             id(cover_button_up).press();
           }


### PR DESCRIPTION
-------

## Description:

The method name is described as `last_operation()` in docs while it is `get_last_operation()` in code.

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.