### PR TITLE
Fix typos in time-based cover documentation

### DIFF
--- a/components/cover/time_based.rst
+++ b/components/cover/time_based.rst
@@ -80,7 +80,7 @@ Configuration variables:
 Handle stop_action:
 ------------------------
 For some cover controllers, separate switches for UP and DOWN action are used while a stop is issued when sending a counter command.
-This can be handled at the **stop_action** by using the folling lamda function:
+This can be handled at the **stop_action** by using the following lambda function:
 
 .. code-block:: yaml
 


### PR DESCRIPTION
-------

## Description:

Fix two typos in time-based cover documentation.

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.