### PR TITLE
transmit_aeha carrier frequency now adjustable

### DIFF
--- a/components/remote_transmitter.rst
+++ b/components/remote_transmitter.rst
@@ -148,6 +148,8 @@ Configuration variables:
 
 - **address** (**Required**, int): The address to send the command to, see dumper output for more details.
 - **data** (**Required**, list): The command to send, A length of 2-35 bytes can be specified for one packet.
+- **carrier_frequency** (*Optional*, float): Optionally set a frequency to send the signal
+  with for infrared signals. Defaults to ``38000Hz``.
 
 AEHA refers to the Association for Electric Home Appliances in Japan, a format used by Panasonic and many other companies.
 

--- a/components/remote_transmitter.rst
+++ b/components/remote_transmitter.rst
@@ -148,7 +148,7 @@ Configuration variables:
 
 - **address** (**Required**, int): The address to send the command to, see dumper output for more details.
 - **data** (**Required**, list): The command to send, A length of 2-35 bytes can be specified for one packet.
-- **carrier_frequency** (*Optional*, float): Optionally set a frequency to send the signal
+- **carrier_frequency** (*Optional*, float): Set a frequency to send the signal
   with for infrared signals. Defaults to ``38000Hz``.
 
 AEHA refers to the Association for Electric Home Appliances in Japan, a format used by Panasonic and many other companies.


### PR DESCRIPTION
## Description:

Adds documentation that `carrier_frequency` is now a valid option for `remote_transmitter.transmit_aeha`. Defaults to `38000Hz`, which is the previous value. No configuration changes are necessary for those who don't need the new functionality.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** [esphome/esphome#6792](https://github.com/esphome/esphome/pull/6792)

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
