### PR TITLE
Update rpi_dpi_rgb.rst

### DIFF
--- a/components/display/rpi_dpi_rgb.rst
+++ b/components/display/rpi_dpi_rgb.rst
@@ -115,6 +115,9 @@ Example configurations
 Waveshare ESP32-S3 Touch 4.3
 ****************************
 
+  - LCD controller is the ST7262E43
+  - Touch controller is the GT911
+
 .. code-block:: yaml
 
     display:


### PR DESCRIPTION
## Description:

Addition of component references for the 'Waveshare ESP32-S3 Touch 4.3' board

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
