### PR TITLE
Fix incorrect naming of the AdaFruit MagTag display.

### DIFF
--- a/components/display/waveshare_epaper.rst
+++ b/components/display/waveshare_epaper.rst
@@ -112,7 +112,7 @@ Configuration variables:
   - ``7.50inV2`` - Can't use with an ESP8266 as it runs out of RAM
   - ``7.50inV2alt`` (alternative version to the above ``7.50inV2``)
   - ``7.50in-hd-b`` - Can't use with an ESP8266 as it runs out of RAM
-  - ``gdey029t94`` - GooDisplay GDEY029T94, as used on the AdaFruit MagTag
+  - ``gdew029t5`` - GooDisplay GDEW029T5, as used on the AdaFruit MagTag (previously incorrectly referred to as GDEY029T94)
   - ``1.54in-m5coreink-m09`` - GoodDisplay gdew0154m09, as used in the M5Stack Core Ink
 
 .. warning::


### PR DESCRIPTION
## Description:

After unsuccessfully trying to configure my GDEY029T94 e-paper display, I looked into the code, and realized, that the implemented display is a different model GDEW029T5. This was confirmed on Discord by the author of the original pull request, as well as in the [issue 3514](https://github.com/esphome/issues/issues/3514), whose author also owns the MagTag. This is a breaking change for anyone using the display, since it renames the config option, but the config option is misleading since the actual GDEY029T94 does not work with it.

**Related issue (if applicable):** /

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#6810

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
