### PR TITLE
[voice_assistant] Timer triggers

### DIFF
--- a/components/voice_assistant.rst
+++ b/components/voice_assistant.rst
@@ -89,7 +89,7 @@ Configuration:
 - **on_timer_cancelled** (*Optional*, :ref:`Automation <automation>`): An automation to perform when a voice assistant
   timer has been cancelled. The timer is available as ``timer`` of type :apistruct:`voice_assistant::Timer`.
 - **on_timer_updated** (*Optional*, :ref:`Automation <automation>`): An automation to perform when a voice assistant
-  timer has been updated. The timer is available as ``timer`` of type :apistruct:`voice_assistant::Timer`.
+  timer has been updated (paused/resumed/duration changed). The timer is available as ``timer`` of type :apistruct:`voice_assistant::Timer`.
 - **on_timer_tick** (*Optional*, :ref:`Automation <automation>`): An automation to perform when the voice assistant timers
   tick is triggered.
   This is called every **1 second** while there are timers on this device.

--- a/components/voice_assistant.rst
+++ b/components/voice_assistant.rst
@@ -82,6 +82,19 @@ Configuration:
 - **volume_multiplier** (*Optional*, float): Volume multiplier to apply to the assist pipeline.
   Must be larger than 0. Defaults to 1 (disabled).
 
+- **on_timer_started** (*Optional*, :ref:`Automation <automation>`): An automation to perform when a voice assistant
+  timer has started. The timer is available as ``timer`` of type :apistruct:`voice_assistant::Timer`.
+- **on_timer_finished** (*Optional*, :ref:`Automation <automation>`): An automation to perform when a voice assistant
+  timer has finished. The timer is available as ``timer`` of type :apistruct:`voice_assistant::Timer`.
+- **on_timer_cancelled** (*Optional*, :ref:`Automation <automation>`): An automation to perform when a voice assistant
+  timer has been cancelled. The timer is available as ``timer`` of type :apistruct:`voice_assistant::Timer`.
+- **on_timer_updated** (*Optional*, :ref:`Automation <automation>`): An automation to perform when a voice assistant
+  timer has been updated. The timer is available as ``timer`` of type :apistruct:`voice_assistant::Timer`.
+- **on_timer_tick** (*Optional*, :ref:`Automation <automation>`): An automation to perform when the voice assistant timers
+  tick is triggered.
+  This is called every **1 second** while there are timers on this device.
+  The timers are available as ``timers`` which is a ``std::vector`` (array) of type :apistruct:`voice_assistant::Timer`.
+
 .. _voice_assistant-actions:
 
 Voice Assistant Actions


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#6821

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced new automation triggers for voice assistant timers:
    - Timer start
    - Timer finish
    - Timer cancellation
    - Timer update
    - Timer tick (every 1 second while timers are active)

These features allow for custom actions to be executed based on various timer events, enhancing the flexibility and functionality of the voice assistant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->