### PR TITLE
Update documentation about `restore_mode` for valves

### DIFF
--- a/components/valve/template.rst
+++ b/components/valve/template.rst
@@ -52,6 +52,10 @@ Configuration variables:
   requests the valve to be stopped.
 - **optimistic** (*Optional*, boolean): Whether to operate in optimistic mode - when in this mode, any command sent to
   the template valve will immediately update the reported state and no lambda needs to be used. Defaults to ``false``.
+- **restore_mode** (*Optional*): Control how the valve attempts to restore state on bootup. Valid options are
+  ``NO_RESTORE``, ``RESTORE`` or ``RESTORE_AND_CALL``. Restore mode ``RESTORE`` attempts to restore the state on
+  startup, but doesn't instruct the valve to return to that state. ``RESTORE_AND_CALL`` additionally instructs the valve
+  to return to the restored state. Defaults to ``NO_RESTORE``
 - **assumed_state** (*Optional*, boolean): Whether the true state of the valve is not known. This will make the Home
   Assistant frontend show buttons for both OPEN and CLOSE actions, instead of hiding one of them. Defaults to ``false``.
 - **has_position** (*Optional*, boolean): Whether this valve will publish its position as a floating point number.

--- a/components/valve/template.rst
+++ b/components/valve/template.rst
@@ -52,10 +52,12 @@ Configuration variables:
   requests the valve to be stopped.
 - **optimistic** (*Optional*, boolean): Whether to operate in optimistic mode - when in this mode, any command sent to
   the template valve will immediately update the reported state and no lambda needs to be used. Defaults to ``false``.
-- **restore_mode** (*Optional*): Control how the valve attempts to restore state on bootup. Valid options are
-  ``NO_RESTORE``, ``RESTORE`` or ``RESTORE_AND_CALL``. Restore mode ``RESTORE`` attempts to restore the state on
-  startup, but doesn't instruct the valve to return to that state. ``RESTORE_AND_CALL`` additionally instructs the valve
-  to return to the restored state. Defaults to ``NO_RESTORE``
+- **restore_mode** (*Optional*, enum): Control how the valve attempts to restore state on bootup.
+
+  - ``NO_RESTORE`` (Default): Do not save or restore state.
+  - ``RESTORE``: Attempts to restore the state on startup, but doesn't instruct the valve to return to that state.
+  - ``RESTORE_AND_CALL``: Attempts to restore the state on startup and instructs the valve to return to the restored state.
+
 - **assumed_state** (*Optional*, boolean): Whether the true state of the valve is not known. This will make the Home
   Assistant frontend show buttons for both OPEN and CLOSE actions, instead of hiding one of them. Defaults to ``false``.
 - **has_position** (*Optional*, boolean): Whether this valve will publish its position as a floating point number.


### PR DESCRIPTION
## Description:
This PR updates the documentation to clarify the behavior of Valves, and particularly the `restore_mode`.

**Related issue (if applicable):** fixes https://github.com/esphome/feature-requests/issues/2739

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration option `restore_mode` for valves, allowing control over state restoration on bootup with options: `NO_RESTORE`, `RESTORE`, or `RESTORE_AND_CALL`. Default is `NO_RESTORE`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->