### PR TITLE
[ethernet] Adds documentation for setting PHY register values

### DIFF
--- a/components/ethernet.rst
+++ b/components/ethernet.rst
@@ -74,9 +74,9 @@ RMII configuration variables:
 - **phy_addr** (*Optional*, int): The PHY addr type of the Ethernet controller. Defaults to 0.
 - **phy_registers** (*Optional*, mapping): Arbitrary PHY register values to set after Ethernet initialization.
 
-  - **address** (**Required**, hex): The register address as a hex number (e.g. `0x10` for address 16)
-  - **value** (**Required**, hex): The value of the register to set as a hex number (e.g. `0x1FFA`)
-  - **page_id** (*Optional*, hex): (RTL8201 only) Register page number to select before writing (e.g. `0x07` for page 7)
+  - **address** (**Required**, hex): The register address as a hex number (e.g. ``0x10`` for address 16)
+  - **value** (**Required**, hex): The value of the register to set as a hex number (e.g. ``0x1FFA``)
+  - **page_id** (*Optional*, hex): (RTL8201 only) Register page number to select before writing (e.g. ``0x07`` for page 7)
 
 - **power_pin** (*Optional*, :ref:`Pin Schema <config-pin_schema>`): The pin controlling the
   power/reset status of the Ethernet controller. Leave unspecified for no power pin (default).

--- a/components/ethernet.rst
+++ b/components/ethernet.rst
@@ -73,9 +73,11 @@ RMII configuration variables:
 
 - **phy_addr** (*Optional*, int): The PHY addr type of the Ethernet controller. Defaults to 0.
 - **phy_registers** (*Optional*, mapping): Arbitrary PHY register values to set after Ethernet initialization.
-  - **address** (**Required**, hex): The register address as a hex number (e.g. 0x10)
-  - **value** (**Required**, hex): The value of the register to set as a hex number (e.g. 0x1FFA)
-  - **page_id** (*Optional*, hex): (RTL8201 only) Register page number to select before writing (e.g. 0x07)
+
+  - **address** (**Required**, hex): The register address as a hex number (e.g. `0x10` for address 16)
+  - **value** (**Required**, hex): The value of the register to set as a hex number (e.g. `0x1FFA`)
+  - **page_id** (*Optional*, hex): (RTL8201 only) Register page number to select before writing (e.g. `0x07` for page 7)
+
 - **power_pin** (*Optional*, :ref:`Pin Schema <config-pin_schema>`): The pin controlling the
   power/reset status of the Ethernet controller. Leave unspecified for no power pin (default).
 

--- a/components/ethernet.rst
+++ b/components/ethernet.rst
@@ -72,6 +72,10 @@ RMII configuration variables:
   - ``GPIO17_OUT`` - Internal clock
 
 - **phy_addr** (*Optional*, int): The PHY addr type of the Ethernet controller. Defaults to 0.
+- **phy_registers** (*Optional*, mapping): Arbitrary PHY register values to set after Ethernet initialization.
+  - **address** (**Required**, hex): The register address as a hex number (e.g. 0x10)
+  - **value** (**Required**, hex): The value of the register to set as a hex number (e.g. 0x1FFA)
+  - **page_id** (*Optional*, hex): (RTL8201 only) Register page number to select before writing (e.g. 0x07)
 - **power_pin** (*Optional*, :ref:`Pin Schema <config-pin_schema>`): The pin controlling the
   power/reset status of the Ethernet controller. Leave unspecified for no power pin (default).
 
@@ -230,6 +234,11 @@ Configuration examples
       mdio_pin: GPIO17
       clk_mode: GPIO0_IN
       phy_addr: 0
+      phy_registers:
+        - address: 0x10
+          value: 0x1FFA
+          page_id: 0x07
+
 
 .. note::
 


### PR DESCRIPTION
## Description:

Adds the ability to write to arbitrary PHY registers when configuring Ethernet.

**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/5798

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#6836

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
