### PR TITLE
Add Ethernet MAC address to ethernet_info

### DIFF
--- a/components/text_sensor/ethernet_info.rst
+++ b/components/text_sensor/ethernet_info.rst
@@ -27,6 +27,8 @@ via text sensors.
             name: ESP IP Address 4
         dns_address:
           name: ESP DNS Address
+        mac_address:
+          name: ESP MAC Address
 
 
 Configuration variables:
@@ -37,6 +39,8 @@ Configuration variables:
 - **address_0-address_4** (*Optional*): With dual stack (IPv4 and IPv6) the device will have at least two IP addresses -- often more. To report all addresses the configuration may have up to five sub-sensors. All options from
   :ref:`Text Sensor <config-text_sensor>`.
 - **dns_address** (*Optional*): Expose the DNS Address of the ESP as text sensor.
+  :ref:`Text Sensor <config-text_sensor>`.
+- **mac_address** (*Optional*): Expose the MAC Address of the ESP as text sensor.
   :ref:`Text Sensor <config-text_sensor>`.
 
 See Also


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes esphome/feature-requests#1326

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#6835

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
