### PR TITLE
Wireguard support for bk72

### DIFF
--- a/components/wireguard.rst
+++ b/components/wireguard.rst
@@ -11,7 +11,7 @@ WireGuard Component
 |wireguard|_ is an extremely simple yet fast and modern VPN that utilizes
 state-of-the-art cryptography. This component uses a **custom**
 implementation not developed by original authors and currently
-available for ESP32 and ESP8266 platforms *only*.
+available for ESP32, ESP8266 and BK72xx microcontrollers *only*.
 
   Please note that *"WireGuard" and the "WireGuard" logo are
   registered trademarks of Jason A. Donenfeld.* See


### PR DESCRIPTION
## Description:

Add support for bk72xx microcontrollers.

**Related issue (if applicable):** none

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#6842

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
