### PR TITLE
The event type is accesible using the event_type variable.

### DIFF
--- a/components/event/index.rst
+++ b/components/event/index.rst
@@ -92,6 +92,7 @@ Event Automation
 ************
 
 This automation will be triggered when an event of the specified types is triggered.
+In :ref:`Lambdas <config-lambda>` you can get the event type from the trigger with ``event_type``.
 
 .. code-block:: yaml
 
@@ -100,7 +101,8 @@ This automation will be triggered when an event of the specified types is trigge
         # ...
         on_event:
           then:
-            - logger.log: "Event Triggered"
+            - lambda: |-
+                ESP_LOGD("main", "Event %s triggered.", event_type.c_str());
 
 Configuration variables: see :ref:`Automation <automation>`.
 


### PR DESCRIPTION
## Description:
Document that in the event.on_event automation, the event type that triggered the event is accesible using the event_type variable.

**Related issue (if applicable):** none

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** N/A

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
