### PR TITLE
cc1101 radio transmitter component documentation

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -1008,6 +1008,7 @@ Wireless communication that is **not Wi-Fi.**
     Remote Transmitter, components/remote_transmitter, remote.svg, dark-invert
     RF Bridge, components/rf_bridge, rf_bridge.jpg
     SIM800L, components/sim800l, sim800l.jpg
+    CC1101 Radio Transmitter, components/cc1101, cc1101.jpg
 
 Miscellaneous Components
 ------------------------


### PR DESCRIPTION
## Description:

New matching documentation, this time in a branch. Replacing https://github.com/esphome/esphome-docs/pull/3649

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#6300

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
