### PR TITLE
Update to Addressable Color Wipe Example

### DIFF
--- a/components/light/index.rst
+++ b/components/light/index.rst
@@ -702,14 +702,14 @@ the strip and shifts them forward every ``add_led_interval``.
                 - red: 100%
                   green: 100%
                   blue: 100%
-                  num_leds: 1
+                  num_leds: 5
+                  gradient: true
                 - red: 0%
                   green: 0%
                   blue: 0%
                   num_leds: 1
               add_led_interval: 100ms
               reverse: false
-              gradient: false
 
 Configuration variables:
 


### PR DESCRIPTION
Update to the Addressable Color Wipe Example to correctly include gradient as an option of the color rather than the entire effect. The current documentation shows an example that is not valid as gradient is an option on the color and not the effect as a whole

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
