### PR TITLE
Adding documentation for idle mode for SPS30 sensor

### DIFF
--- a/components/climate/climate_ir.rst
+++ b/components/climate/climate_ir.rst
@@ -44,7 +44,7 @@ submit a feature request (see FAQ).
 +---------------------------------------+---------------------+----------------------+
 | :ref:`LG<climate_ir_lg>`              | ``climate_ir_lg``   | yes                  |
 +---------------------------------------+---------------------+----------------------+
-| Midea                                 | ``midea_ir``        | yes                  |
+| :ref:`Midea<midea_ir>`                | ``midea_ir``        | yes                  |
 +---------------------------------------+---------------------+----------------------+
 | :ref:`Mitsubishi<mitsubishi>`         | ``mitsubishi``      | yes                  |
 +---------------------------------------+---------------------+----------------------+
@@ -169,35 +169,6 @@ IR receiver.
         name: "Living Room AC"
         receiver_id: rcvr
 
-.. _midea_ir:
-
-``midea_ir`` Climate
--------------------------
-
-These air conditioners support two protocols: Midea and Coolix. Therefore, when using an IR receiver, it considers both protocols and publishes the received states.
-
-Additional configuration is available for this platform
-
-
-Configuration variables:
-
-- **use_fahrenheit** (*Optional*, boolean): Allows you to transfer the temperature to the air conditioner in degrees Fahrenheit. The air conditioner display also shows the temperature in Fahrenheit. Defaults to ``false``.
-
-.. code-block:: yaml
-
-    # Example configuration entry
-    climate:
-      - platform: midea_ir
-        name: "AC"
-        sensor: room_temperature
-        use_fahrenheit: true
-
-.. note::
-
-    - See :ref:`Transmit Midea<remote_transmitter-transmit_midea>` to send custom commands, including Follow Me mode.
-    - See :ref:`Toshiba<toshiba>` below if you are looking for compatibility with Midea model MAP14HS1TBL or similar.
-
-
 .. _climate_ir_lg:
 
 ``climate_ir_lg`` Climate
@@ -271,6 +242,34 @@ Currently supports the protocol used by some Delonghi portable units
 Known working with:
 
 - Delonghi PAC WE 120HP
+
+.. _midea_ir:
+
+``midea_ir`` Climate
+-------------------------
+
+These air conditioners support two protocols: Midea and Coolix. Therefore, when using an IR receiver, it considers both protocols and publishes the received states.
+
+Additional configuration is available for this platform
+
+
+Configuration variables:
+
+- **use_fahrenheit** (*Optional*, boolean): Allows you to transfer the temperature to the air conditioner in degrees Fahrenheit. The air conditioner display also shows the temperature in Fahrenheit. Defaults to ``false``.
+
+.. code-block:: yaml
+
+    # Example configuration entry
+    climate:
+      - platform: midea_ir
+        name: "AC"
+        sensor: room_temperature
+        use_fahrenheit: true
+
+.. note::
+
+    - See :ref:`Transmit Midea<remote_transmitter-transmit_midea>` to send custom commands, including Follow Me mode.
+    - See :ref:`Toshiba<toshiba>` below if you are looking for compatibility with Midea model MAP14HS1TBL or similar.
 
 .. _mitsubishi:
 

--- a/components/cover/template.rst
+++ b/components/cover/template.rst
@@ -62,7 +62,6 @@ Configuration variables:
   of hiding one of them. Defaults to ``false``.
 - **has_position** (*Optional*, boolean): Whether this cover will publish its position as a floating point number.
   By default (``false``), the cover only publishes OPEN/CLOSED position.
-  Parameter useless if you set the POSITION_ACTION (is set to TRUE).
 - **tilt_action** (*Optional*, :ref:`Action <config-action>`): The action that should
   be performed when the remote (like Home Assistant's frontend) requests the cover be set to a specific
   tilt position. The desired tilt is available in the lambda in the ``tilt`` variable.
@@ -71,6 +70,7 @@ Configuration variables:
 - **position_action** (*Optional*, :ref:`Action <config-action>`): The action that should
   be performed when the remote (like Home Assistant's frontend) requests the cover be set to a specific
   position. The desired position is available in the lambda in the ``pos`` variable.
+  Useless if `has_position` is not set to ``true``.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
 - All other options from :ref:`Cover <config-cover>`.
 

--- a/components/cover/time_based.rst
+++ b/components/cover/time_based.rst
@@ -86,13 +86,16 @@ This can be handled at the **stop_action** by using the following lambda functio
 
     stop_action: 
       - lambda: !lambda |-
-          if (id(cover).last_operation() == CoverOperation::COVER_OPERATION_OPENING) {
+          if (id(cover).get_last_operation() == CoverOperation::COVER_OPERATION_OPENING) {
             // Cover is currently opening
             id(cover_button_down).press();
-          } else if (id(cover).last_operation() == CoverOperation::COVER_OPERATION_CLOSING) {
+          } else if (id(cover).get_last_operation() == CoverOperation::COVER_OPERATION_CLOSING) {
             // Cover is currently closing
             id(cover_button_up).press();
           }
+
+Be aware that ``get_last_operation`` will only return the last opening or closing operation, but not the last idle operation. 
+This issue is tracked `here <https://github.com/esphome/issues/issues/4252#issuecomment-2132727377>`_.
 
 See Also
 --------

--- a/components/esp32_camera.rst
+++ b/components/esp32_camera.rst
@@ -174,8 +174,10 @@ Test Setting:
     Camera uses PWM timer #1. If you need PWM (via the ``ledc`` platform) you need to manually specify
     a channel there (with the ``channel: 2``  parameter)
 
-Configuration for Ai-Thinker Camera
------------------------------------
+Configuration examples
+----------------------
+
+**Ai-Thinker Camera**:
 
 .. warning::
 
@@ -203,8 +205,7 @@ Configuration for Ai-Thinker Camera
       name: My Camera
       # ...
 
-Configuration for M5Stack Camera
---------------------------------
+**M5Stack Camera**:
 
 .. warning::
 
@@ -235,8 +236,7 @@ Configuration for M5Stack Camera
       name: My Camera
       # ...
 
-Configuration for M5Stack Timer Camera X/F
-------------------------------------------
+**M5Stack Timer Camera X/F**:
 
 .. code-block:: yaml
 
@@ -258,8 +258,7 @@ Configuration for M5Stack Timer Camera X/F
       name: My Camera
       # ...
 
-Confguration for M5Stack M5CameraF New
---------------------------------------
+**M5Stack M5CameraF New**:
 
 .. code-block:: yaml
 
@@ -277,8 +276,7 @@ Confguration for M5Stack M5CameraF New
       pixel_clock_pin: GPIO21
       reset_pin: GPIO15
 
-Configuration for Wrover Kit Boards
------------------------------------
+**Wrover Kit Boards**:
 
 .. code-block:: yaml
 
@@ -299,8 +297,7 @@ Configuration for Wrover Kit Boards
       name: My Camera
       # ...
 
-Configuration for TTGO T-Camera V05
------------------------------------
+**TTGO T-Camera V05**:
 
 .. code-block:: yaml
 
@@ -322,8 +319,7 @@ Configuration for TTGO T-Camera V05
       name: My Camera
       # ...
 
-Configuration for TTGO T-Camera V162
-------------------------------------
+**TTGO T-Camera V162**:
 
 .. code-block:: yaml
 
@@ -346,8 +342,7 @@ Configuration for TTGO T-Camera V162
       name: My Camera
       # ...
 
-Configuration for TTGO T-Camera V17
------------------------------------
+**TTGO T-Camera V17**:
 
 .. code-block:: yaml
 
@@ -371,8 +366,7 @@ Configuration for TTGO T-Camera V17
       name: My Camera
       # ...
 
-Configuration for TTGO T-Journal
---------------------------------
+**TTGO T-Journal**:
 
 .. code-block:: yaml
 
@@ -394,8 +388,7 @@ Configuration for TTGO T-Journal
       # ...
 
 
-Configuration for TTGO-Camera Plus
-----------------------------------
+**TTGO-Camera Plus**:
 
 .. code-block:: yaml
 
@@ -418,8 +411,7 @@ Configuration for TTGO-Camera Plus
       name: My Camera
       # ...
 
-Configuration for TTGO-Camera Mini
-----------------------------------
+**TTGO-Camera Mini**:
 
 .. code-block:: yaml
 
@@ -440,8 +432,7 @@ Configuration for TTGO-Camera Mini
       name: My Camera
       # ...
 
-Configuration for ESP-EYE
-----------------------------------
+**ESP-EYE**:
 
 .. code-block:: yaml
 
@@ -462,8 +453,7 @@ Configuration for ESP-EYE
       name: My Camera
       # ...
 
-Configuration for ESP32S3_EYE on `Freenove ESP32-S3-DevKitC-1 <https://github.com/Freenove/Freenove_ESP32_S3_WROOM_Board>`_
----------------------------------------------------------------------------------------------------------------------------
+**ESP32S3_EYE** on `Freenove ESP32-S3-DevKitC-1 <https://github.com/Freenove/Freenove_ESP32_S3_WROOM_Board>`__:
 
 .. code-block:: yaml
 
@@ -484,6 +474,26 @@ Configuration for ESP32S3_EYE on `Freenove ESP32-S3-DevKitC-1 <https://github.co
       data_pins: [GPIO11, GPIO9, GPIO8, GPIO10, GPIO12, GPIO18, GPIO17, GPIO16]
       vsync_pin: GPIO6
       href_pin: GPIO7
+      pixel_clock_pin: GPIO13
+
+      # Image settings
+      name: My Camera
+      # ...
+
+**Seeed Studio XIAO ESP32S3 Sense**:
+
+.. code-block:: yaml
+
+    esp32_camera:
+      external_clock:
+        pin: GPIO10
+        frequency: 20MHz
+      i2c_pins:
+        sda: GPIO40
+        scl: GPIO39
+      data_pins: [GPIO15, GPIO17, GPIO18, GPIO16, GPIO14, GPIO12, GPIO11, GPIO48]
+      vsync_pin: GPIO38
+      href_pin: GPIO47
       pixel_clock_pin: GPIO13
 
       # Image settings

--- a/components/light/index.rst
+++ b/components/light/index.rst
@@ -702,14 +702,14 @@ the strip and shifts them forward every ``add_led_interval``.
                 - red: 100%
                   green: 100%
                   blue: 100%
-                  num_leds: 1
+                  num_leds: 5
+                  gradient: true
                 - red: 0%
                   green: 0%
                   blue: 0%
                   num_leds: 1
               add_led_interval: 100ms
               reverse: false
-              gradient: false
 
 Configuration variables:
 

--- a/components/sensor/ens160.rst
+++ b/components/sensor/ens160.rst
@@ -31,6 +31,7 @@ required to be set up in your configuration for this sensor to work.
         tvoc:
           name: "ENS160 Total Volatile Organic Compounds"
         aqi:
+          id: ens160_air_quality_index
           name: "ENS160 Air Quality Index"
         update_interval: 60s  
         address: 0x53

--- a/components/sensor/sgp30.rst
+++ b/components/sensor/sgp30.rst
@@ -72,12 +72,12 @@ Advanced:
   - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.
   - All other options from :ref:`Sensor <config-sensor>`.
 
-- **compensation** (*Optional*): The block containing sensors used for compensation.
+- **compensation** (*Optional*): The block containing sensors used for compensation. Both values must be supplied in order to be able to generate the absolute humidity to be reported to the sensor.
 
   - **temperature_source** (*Optional*, :ref:`config-id`): Give an external temperature sensor ID
-    here. This can improve the sensor's internal calculations.
+    here. The data must be in Celsius. This can improve the sensor's internal calculations.
 
-  - **humidity_source** (*Optional*, :ref:`config-id`): Give an external humidity sensor ID
+  - **humidity_source** (*Optional*, :ref:`config-id`): Give an external relative humidity sensor ID
     here. This can improve the sensor's internal calculations.
 
 .. _sgp30-calibrating:

--- a/components/sensor/sps30.rst
+++ b/components/sensor/sps30.rst
@@ -53,6 +53,7 @@ This sensor supports both UART and I²C communication. However, at the moment on
           id: "pm_size"
         address: 0x69
         update_interval: 10s
+        idle_interval: 5min
 
 Configuration variables:
 ------------------------
@@ -123,6 +124,7 @@ Configuration variables:
   Defaults to ``0x69``.
 - **update_interval** (*Optional*, :ref:`config-time`): The interval to check the
   sensor. Defaults to ``60s``.
+- **idle_interval** (*Optional*, :ref:`config-time`): If specified, will put the sensor into an idle mode between readings for the specified amount of time.
 
 Wiring:
 -------
@@ -157,6 +159,45 @@ This :ref:`action <config-action>` manually starts fan-cleaning.
       then:
         - sps30.start_fan_autoclean: my_sps30
 
+Idle Operation Mode:
+--------------------
+
+The SPS30 sensor can go into an idle operation mode where most internal electronics are switched off, including the fan and laser.  This greatly reduces power consumption as well
+as can prolong the life of the sensor.
+
+Specifying an ``idle_interval`` configuration parameter will automatically stop the sensor for that interval, wake it when it is time, allow the sensor to warm up, and take a reading
+before putting it back into idle state.
+
+The start and stop actions below allow users to manually take the sensor in and out of idle mode.  Note that after the sensor is started, it does have a warm-up period of 30 seconds
+prior to outputting measurements.
+
+See `low power documentation <https://sensirion.com/media/documents/188A2C3C/6166F165/Sensirion_Particulate_Matter_AppNotes_SPS30_Low_Power_Operation_D1.pdf>`__ for more information.
+
+.. _sps30_start_measurement_action:
+
+``sps30.start_measurement`` Action
+------------------------------------
+
+This :ref:`action <config-action>` manually puts the sensor into measurement mode.
+
+.. code-block:: yaml
+
+    on_...:
+      then:
+        - sps30.start_measurement: my_sps30
+
+.. _sps30_stop_measurement_action:
+
+``sps30.stop_measurement`` Action
+------------------------------------
+
+This :ref:`action <config-action>` manually puts the sensor into sleep mode.
+
+.. code-block:: yaml
+
+    on_...:
+      then:
+        - sps30.stop_measurement: my_sps30
 
 See Also
 --------

--- a/components/sn74hc165.rst
+++ b/components/sn74hc165.rst
@@ -11,7 +11,6 @@ Once configured, you can use any of the 8 pins for your projects. Up-to 256 shif
 to provide more pins, without using more GPIO pins on the controller. They are linked by connecting pin Q of the closer
 shift register to the pin QH of the next shift register.
 
-
 .. code-block:: yaml
 
     # Example configuration entry
@@ -28,11 +27,10 @@ Configuration variables:
 
 - **id** (**Required**, :ref:`config-id`): The id to use for this SN74HC165 component.
 - **data_pin** (**Required**, :ref:`Pin Schema <config-pin_schema>`): Pin connected to SN74HC165 Serial Output (QH) input.
-- **clock_pin** (**Required**, :ref:`Pin Schema <config-pin_schema>`): Pin connected to SN74HC165 Clock (CLK) pin
-- **load_pin** (**Required**, :ref:`Pin Schema <config-pin_schema>`): Pin connected to SN74HC165 Load input (SH/LD) pin
-- **clock_inhibit_pin** (**Required**, :ref:`Pin Schema <config-pin_schema>`): Pin connected to SN74HC165 Clock Inhibit (CLK INH) pin
+- **clock_pin** (**Required**, :ref:`Pin Schema <config-pin_schema>`): Pin connected to SN74HC165 Clock (CLK) pin.
+- **load_pin** (**Required**, :ref:`Pin Schema <config-pin_schema>`): Pin connected to SN74HC165 Load input (SH/LD) pin.
+- **clock_inhibit_pin** (*Optional*, :ref:`Pin Schema <config-pin_schema>`): Pin connected to SN74HC165 Clock Inhibit (CLK INH) pin. The use of it is optional, as it can be directly connected to ground.
 - **sr_count** (*Optional*, int): Number of daisy-chained shift registers, up-to 256. Defaults to ``1``.
-
 
 Pin configuration variables:
 ****************************
@@ -61,7 +59,6 @@ Pin configuration variables:
 
 See Also
 --------
-
 
 - :doc:`binary_sensor/gpio`
 - :apiref:`SN74HC165/SN74HC165.h`

--- a/components/time/index.rst
+++ b/components/time/index.rst
@@ -181,6 +181,15 @@ In the ``seconds:``, ``minutes:``, ... fields you can use the following operator
                 then:
                   - switch.toggle: my_switch
 
+.. note::
+
+    ``on_time`` does not re-schedule events for times that are skipped or duplicated due to local Daylight
+    Saving Time or other local time-adjustments like leap seconds. In regions with Daylight Saving Time, this
+    means that events located between 01:00 - 02:00 may trigger twice, and events scheduled between 02:00 - 03:00 may
+    be skipped once a year. This differs from `cron <https://man7.org/linux/man-pages/man8/cron.8.html>`__ behavior
+    despite allowing the use of similar `crontab` syntax. Similarly, triggers on days of the month that do not exist
+    ("every 31st of the month") will be skipped when those dates do not exist.
+
 .. _time-on_time_sync:
 
 ``on_time_sync`` Trigger

--- a/components/wifi.rst
+++ b/components/wifi.rst
@@ -75,7 +75,7 @@ Configuration variables:
   Defaults to ``.local``.
 - **reboot_timeout** (*Optional*, :ref:`config-time`): The amount of time to wait before rebooting when no
   WiFi connection exists. Can be disabled by setting this to ``0s``, but note that the low level IP stack currently
-  seems to have issues with WiFi where a full reboot is required to get the interface back working. Defaults to ``15min``.
+  seems to have issues with WiFi where a full reboot is required to get the interface back working. Defaults to ``15min``. Does not apply when in access point mode.
 - **power_save_mode** (*Optional*, string): The power save mode for the WiFi interface.
   See :ref:`wifi-power_save_mode`
 

--- a/guides/made_for_esphome.rst
+++ b/guides/made_for_esphome.rst
@@ -39,8 +39,7 @@ For all projects
     - Network configuration must assume defaults (no static IPs or DNS configured)
     - It **must** compile successfully without any user changes after adopting it.
     - All configuration is contained within a single YAML file. Fully remote packages are permitted if using ``import_full_config: true``.
-
-- Your product name cannot contain **ESPHome** except in the case of *ending with* **for ESPHome**
+- Your product name cannot contain "**ESPHome**" except in the case of *ending with* "**for ESPHome**"
 
 When your project matches all requirements of the Made for ESPHome program,
 you can apply for permission to carry the logo by emailing esphome@nabucasa.com

--- a/index.rst
+++ b/index.rst
@@ -131,7 +131,7 @@ Supported Microcontrollers
     RP2040, components/rp2040, rp2040.svg
     BK72xx, components/libretiny, bk72xx.svg
     RTL87xx, components/libretiny, rtl87xx.svg
-    host, components/host, host.svg
+    host, components/host, host.svg, dark-invert
 
 Microcontroller Peripherals
 ---------------------------


### PR DESCRIPTION
## Description:
Adding documentation for idle mode for SPS30 sensor.

**Related issue (if applicable):** fixes https://github.com/esphome/feature-requests/issues/2133

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#6828

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
