### PR TITLE
SHT3xd component - Provide example i2c configuration for >50-100Khz i2c frequencies on IDF

### DIFF
--- a/components/sensor/sht3xd.rst
+++ b/components/sensor/sht3xd.rst
@@ -54,6 +54,24 @@ Configuration variables:
   but can also increase temperature readings and decrease humidity readings as a side effect.
   Defaults to ``false``.
 
+Configuration using Higher I²C Frequencies
+------------------------------------------
+
+When using the **IDF framework** and **I²C Frequencies greater than 50-100kHz**, the I²C configuration needs to include a **timeout** option.
+On an ESP32, the Arduino framework has a default I²C timeout of 50ms whereas on IDF framework, the default timeout is 100us.
+At these higher I²C Frequencies, the default I²C timeout on IDF framework causes a "Communication with SHT3xD failed" error on setup.
+A solution that has been tested on ESP32 at 800kHz, is to increase the I²C timeout to 10ms as per the following example.
+
+.. code-block:: yaml
+
+    # Example I²C configuration entry
+    i2c:
+      sda: 21
+      scl: 22
+      scan: true
+      frequency: 800khz
+      timeout: 10ms
+
 See Also
 --------
 

--- a/components/sensor/sht3xd.rst
+++ b/components/sensor/sht3xd.rst
@@ -54,17 +54,17 @@ Configuration variables:
   but can also increase temperature readings and decrease humidity readings as a side effect.
   Defaults to ``false``.
 
-Configuration using Higher I²C Frequencies
-------------------------------------------
+I²C Configuration when using Higher I²C Frequencies
+---------------------------------------------------
 
-When using the **IDF framework** and **I²C Frequencies greater than 50-100kHz**, the I²C configuration needs to include a **timeout** option.
+When using the **IDF framework** and **I²C frequencies greater than 50-100kHz**, the I²C configuration needs to include a **timeout** option.
 On an ESP32, the Arduino framework has a default I²C timeout of 50ms whereas on IDF framework, the default timeout is 100us.
-At these higher I²C Frequencies, the default I²C timeout on IDF framework causes a "Communication with SHT3xD failed" error on setup.
+At these higher I²C frequencies, the default I²C timeout on IDF framework causes a "Communication with SHT3xD failed" error on setup.
 A solution that has been tested on ESP32 at 800kHz, is to increase the I²C timeout to 10ms as per the following example.
 
 .. code-block:: yaml
 
-    # Example I²C configuration entry
+    # Example I²C configuration
     i2c:
       sda: 21
       scl: 22


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/5303 and
and also https://github.com/esphome/issues/issues/5294 should be able to be closed.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable): NA

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
