### PR TITLE
Fix usage of response in http_request.rst samples

### DIFF
--- a/components/http_request.rst
+++ b/components/http_request.rst
@@ -88,8 +88,8 @@ This :ref:`action <config-action>` sends a GET request.
               - logger.log:
                   format: 'Response status: %d, Duration: %u ms'
                   args:
-                    - status_code
-                    - duration_ms
+                    - response->status_code
+                    - response->duration_ms
       # Short form
       - http_request.get: https://esphome.io
 
@@ -174,8 +174,8 @@ The following variables are available for use in :ref:`lambdas <config-lambda>`:
                 - logger.log:
                     format: "Response status: %d, Duration: %u ms"
                     args:
-                      - response.status_code
-                      - response.duration_ms
+                      - response->status_code
+                      - response->duration_ms
 
 
 .. _http_request-examples:


### PR DESCRIPTION
## Description:

Simple fixes of http request samples as I'm testing now, the response object is in shared pointer so it needs the arrow operator

`` error: 'class std::shared_ptr<esphome::http_request::HttpContainer>' has no member named 'status_code'`` 