### PR TITLE
Documentation for Home Assistant Number

### DIFF
--- a/components/number/home_assistant.rst
+++ b/components/number/home_assistant.rst
@@ -6,7 +6,7 @@ Home Assistant Number
         :image: description.svg
 
 The ``homeassistant`` number platform allows you to create a number that is synchronized
-with Home Assistant.
+with Home Assistant. Min, Max and Step are not configurable for this platform because they are taken from the Home Assistant entity.
 
 .. code-block:: yaml
 
@@ -14,19 +14,13 @@ with Home Assistant.
         number:
             - platform: homeassistant
                 name: "Home Assistant number"
-                optimistic: true
-                min_value: 0
-                max_value: 100
-                step: 1
+                entity_id: light.my_light
 
 Configuration variables:
 ------------------------
 
 - **name** (**Required**, string): The name of the number.
 - **entity_id** (**Required**, string): The Home Assistant entity ID of the number to synchronize with.
-- **min_value** (**Required**, float): The minimum value this number can be.
-- **max_value** (**Required**, float): The maximum value this number can be.
-- **step** (**Required**, float): The granularity with which the number can be set.
 - **lambda** (*Optional*, :ref:`lambda <config-lambda>`):
     Lambda to be evaluated every update interval to get the current value of the number.
 - **set_action** (*Optional*, :ref:`Action <config-action>`): The action that should
@@ -34,14 +28,6 @@ Configuration variables:
     number value. The new value is available to lambdas in the ``x`` variable.
 - **update_interval** (*Optional*, :ref:`config-time`): The interval on which to update the number
     by executing the ``lambda``. Defaults to ``60s``.
-- **optimistic** (*Optional*, boolean): Whether to operate in optimistic mode - when in this mode,
-    any command sent to the Home Assistant number will immediately update the reported state.
-    Cannot be used with ``lambda``. Defaults to ``false``.
-- **restore_value** (*Optional*, boolean): Saves and loads the state to RTC/Flash.
-    Cannot be used with ``lambda``. Defaults to ``false``.
-- **initial_value** (*Optional*, float): The value to set the state to on setup if not
-    restored with ``restore_value``.
-    Cannot be used with ``lambda``. Defaults to ``min_value``.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
 - All other options from :ref:`Number <config-number>`.
 

--- a/components/number/home_assistant.rst
+++ b/components/number/home_assistant.rst
@@ -23,7 +23,7 @@ Configuration variables:
 ------------------------
 
 - **name** (**Required**, string): The name of the number.
-- **entity_id** (*Optional*, string): The Home Assistant entity ID of the number to synchronize with.
+- **entity_id** (**Required**, string): The Home Assistant entity ID of the number to synchronize with.
 - **min_value** (**Required**, float): The minimum value this number can be.
 - **max_value** (**Required**, float): The maximum value this number can be.
 - **step** (**Required**, float): The granularity with which the number can be set.

--- a/components/number/home_assistant.rst
+++ b/components/number/home_assistant.rst
@@ -10,11 +10,11 @@ with Home Assistant. Min, Max and Step are not configurable for this platform be
 
 .. code-block:: yaml
 
-        # Example configuration entry
-        number:
-            - platform: homeassistant
-                name: "Home Assistant number"
-                entity_id: light.my_light
+    # Example configuration entry
+    number:
+        - platform: homeassistant
+            name: "Home Assistant number"
+            entity_id: light.my_light
 
 Configuration variables:
 ------------------------

--- a/components/number/home_assistant.rst
+++ b/components/number/home_assistant.rst
@@ -12,23 +12,14 @@ with Home Assistant. Min, Max and Step are not configurable for this platform be
 
     # Example configuration entry
     number:
-        - platform: homeassistant
-            name: "Home Assistant number"
-            entity_id: light.my_light
+      - platform: homeassistant
+        id: my_ha_number
+        entity_id: number.my_number
 
 Configuration variables:
 ------------------------
 
-- **name** (**Required**, string): The name of the number.
 - **entity_id** (**Required**, string): The Home Assistant entity ID of the number to synchronize with.
-- **lambda** (*Optional*, :ref:`lambda <config-lambda>`):
-    Lambda to be evaluated every update interval to get the current value of the number.
-- **set_action** (*Optional*, :ref:`Action <config-action>`): The action that should
-    be performed when the remote (like Home Assistant's frontend) requests to set the
-    number value. The new value is available to lambdas in the ``x`` variable.
-- **update_interval** (*Optional*, :ref:`config-time`): The interval on which to update the number
-    by executing the ``lambda``. Defaults to ``60s``.
-- **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
 - All other options from :ref:`Number <config-number>`.
 
 ``number.set`` Action

--- a/components/number/home_assistant.rst
+++ b/components/number/home_assistant.rst
@@ -1,0 +1,59 @@
+Home Assistant Number
+=====================
+
+.. seo::
+        :description: Instructions for setting up Home Assistant numbers with ESPHome.
+        :image: description.svg
+
+The ``homeassistant`` number platform allows you to create a number that is synchronized
+with Home Assistant.
+
+.. code-block:: yaml
+
+        # Example configuration entry
+        number:
+            - platform: homeassistant
+                name: "Home Assistant number"
+                optimistic: true
+                min_value: 0
+                max_value: 100
+                step: 1
+
+Configuration variables:
+------------------------
+
+- **name** (**Required**, string): The name of the number.
+- **entity_id** (*Optional*, string): The Home Assistant entity ID of the number to synchronize with.
+- **min_value** (**Required**, float): The minimum value this number can be.
+- **max_value** (**Required**, float): The maximum value this number can be.
+- **step** (**Required**, float): The granularity with which the number can be set.
+- **lambda** (*Optional*, :ref:`lambda <config-lambda>`):
+    Lambda to be evaluated every update interval to get the current value of the number.
+- **set_action** (*Optional*, :ref:`Action <config-action>`): The action that should
+    be performed when the remote (like Home Assistant's frontend) requests to set the
+    number value. The new value is available to lambdas in the ``x`` variable.
+- **update_interval** (*Optional*, :ref:`config-time`): The interval on which to update the number
+    by executing the ``lambda``. Defaults to ``60s``.
+- **optimistic** (*Optional*, boolean): Whether to operate in optimistic mode - when in this mode,
+    any command sent to the Home Assistant number will immediately update the reported state.
+    Cannot be used with ``lambda``. Defaults to ``false``.
+- **restore_value** (*Optional*, boolean): Saves and loads the state to RTC/Flash.
+    Cannot be used with ``lambda``. Defaults to ``false``.
+- **initial_value** (*Optional*, float): The value to set the state to on setup if not
+    restored with ``restore_value``.
+    Cannot be used with ``lambda``. Defaults to ``min_value``.
+- **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
+- All other options from :ref:`Number <config-number>`.
+
+``number.set`` Action
+---------------------
+
+You can also set the number for the Home Assistant number from elsewhere in your YAML file
+with the :ref:`number-set_action`.
+
+See Also
+--------
+
+- :ref:`automation`
+- :apiref:`homeassistant/number/homeassistant_number.h`
+- :ghedit:`Edit`


### PR DESCRIPTION
## Description:

Documentation for [Home Assistant Number PR](https://github.com/esphome/esphome/pull/6455). This component syncs it's value between a Number entity in Home Assistant

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  