### PR TITLE
Update ufire_ise.rst

### DIFF
--- a/components/sensor/ufire_ise.rst
+++ b/components/sensor/ufire_ise.rst
@@ -127,4 +127,5 @@ See Also
 
 - :ref:`sensor-filters`
 - :apiref:`ufire_ise/ufire_ise.h`
+- [u-fire ESPHomeComponents](https://github.com/u-fire/ESPHomeComponents) and [Mod-pH for Home Assistant](https://www.microfire.co/develop/ha/mod-ph)
 - :ghedit:`Edit`

--- a/components/sensor/ufire_ise.rst
+++ b/components/sensor/ufire_ise.rst
@@ -127,5 +127,5 @@ See Also
 
 - :ref:`sensor-filters`
 - :apiref:`ufire_ise/ufire_ise.h`
-- [u-fire ESPHomeComponents](https://github.com/u-fire/ESPHomeComponents) and [Mod-pH for Home Assistant](https://www.microfire.co/develop/ha/mod-ph)
+- `u-fire ESPHomeComponents <https://github.com/u-fire/ESPHomeComponents>`_ and `Mod-pH for Home Assistant <https://www.microfire.co/develop/ha/mod-ph>`_
 - :ghedit:`Edit`


### PR DESCRIPTION
## Description:
Added "see also" links for u-fire ESPHome and Home Assistant docs and code. mod-ph worked for me when ufire_ise gave "Component ufire_ise.sensor is marked FAILED." Possibly because I was using https://microfire.co/buy/mod-ph instead of the sensor pictured in the ufire_ise doc?

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
