### PR TITLE
Fix GPIO pins of 2nd and 3rd hardware UART

### DIFF
--- a/components/logger.rst
+++ b/components/logger.rst
@@ -1,4 +1,4 @@
-.. _logger:
+`.. _logger:
 
 Logger Component
 ================
@@ -83,8 +83,8 @@ Default UART GPIO Pins
     * - ESP32
       - TX: 1, RX: 3
       - N/A
-      - TX: 9, RX: 10
-      - TX: 16, RX: 17
+      - TX: 10, RX: 9
+      - TX: 17, RX: 16
       - N/A
       - N/A
     * - ESP32-C3

--- a/components/logger.rst
+++ b/components/logger.rst
@@ -1,4 +1,4 @@
-`.. _logger:
+.. _logger:
 
 Logger Component
 ================


### PR DESCRIPTION
TX and RX are swapped according to [ESP32 Series Datasheet v4.5][1] page 15

[1]: https://www.espressif.com/sites/default/files/documentation/esp32_datasheet_en.pdf

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
