### PR TITLE
Document running dashboard with systemd socket activation

### DIFF
--- a/guides/cli.rst
+++ b/guides/cli.rst
@@ -210,6 +210,12 @@ single configuration file.
     Manually set the unix socket to bind to. If specified along with ``--address`` or ``--port`` the values
     for those parameters will be ignored. Cannot be used along with ``--systemd-socket``.
 
+.. option:: --systemd-socket
+
+    Have the dashboard bind to a unix socket that is passed in using systemd socket activation. If
+    specified along with ``--address`` or ``--port`` the values for those parameters will be ignored.
+    Cannot be used along with ``--socket``.
+
 .. option:: --username USERNAME
 
     The optional username to require for authentication.
@@ -221,7 +227,7 @@ single configuration file.
 .. option:: --open-ui
 
     If set, opens the dashboard UI in a browser once the server is up and running. Does not work when using
-    ``--socket``.
+    ``--socket`` or `--systemd-socket`.
 
 ``logs`` Command
 ---------------------


### PR DESCRIPTION
## Description:

Adds documentation for the systemd socket activation feature I'd like to contribute to ESPHome.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#6931

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
