### PR TITLE
corrected indentation

### DIFF
--- a/guides/configuration-types.rst
+++ b/guides/configuration-types.rst
@@ -554,8 +554,8 @@ For example to set a specific update interval on a common uptime sensor that is 
       common: !include common.yaml
 
     sensor:
-    - id: !extend uptime_sensor
-      update_interval: 10s
+      - id: !extend uptime_sensor
+        update_interval: 10s
 
 Remove
 ------


### PR DESCRIPTION
from:
```
sensor:
- id: !extend uptime_sensor update_interval: 1s
```

to:
```
sensor:
  - id: !extend uptime_sensor update_interval: 1s
```

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
