### PR TITLE
[waveshare_epaper] Add support for 4.26inch display

### DIFF
--- a/components/display/waveshare_epaper.rst
+++ b/components/display/waveshare_epaper.rst
@@ -103,6 +103,7 @@ Configuration variables:
   - ``2.90in-bV3`` - B/W rendering only
   - ``4.20in``
   - ``4.20in-bV2`` - B/W rendering only
+  - ``4.26in``
   - ``5.83in``
   - ``5.83inv2``
   - ``7.50in``


### PR DESCRIPTION
## Description:

Add entry for the new display supported with the linked PR.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes:** esphome/esphome#6941

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
