### PR TITLE
Fix missing platform for one_wire in changelog

### DIFF
--- a/changelog/2024.6.0.rst
+++ b/changelog/2024.6.0.rst
@@ -149,7 +149,8 @@ to allow for other Dallas sensors to be implemented that are not temperature sen
 
     # New
     one_wire:
-      - pin: GPIOXX
+      - platform: gpio
+        pin: GPIOXX
 
     sensor:
       - platform: dallas_temp


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
