### PR TITLE
Update ota.rst

### DIFF
--- a/components/ota.rst
+++ b/components/ota.rst
@@ -22,7 +22,6 @@ expected. This is automatically enabled by this component, but it may be disable
     # Example configuration entry
     ota:
       - platform: esphome
-        safe_mode: true
         password: !secret ota_password
 
 Configuration variables:


### PR DESCRIPTION
## Description:
Removed invalid safe mode option from esphome ota platform example.

Safe mode is not configured in the ota platform. It has it's own top level component as described in the paragraph above the example.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
