### PR TITLE
Remove explanation that corresponding actions will be performed witho…

### DIFF
--- a/components/cover/time_based.rst
+++ b/components/cover/time_based.rst
@@ -50,8 +50,7 @@ Configuration variables:
   when the cover has been opening/closing for the given durations.
 - **has_built_in_endstop** (*Optional*, boolean): Indicates that the cover has built in end stop
   detectors. In this configuration the ``stop_action`` is not performed when the open or close
-  time is completed and if the cover is commanded to open or close the corresponding actions
-  will be performed without checking current state. Defaults to ``false``.
+  time is completed. Defaults to ``false``.
 - **manual_control** (*Optional*, boolean): For covers with manual external controls. With this 
   configuration if the cover is commanded to open or close the corresponding actions will be 
   performed even if the current state fully open or fully closed matches desired state, then 


### PR DESCRIPTION
…ut checking current state when has_build_in_endstop is enabled for time_based_cover.

## Description:

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#6969

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
