### PR TITLE
Add esphome platform to OTA sections in docs

### DIFF
--- a/components/bluetooth_proxy.rst
+++ b/components/bluetooth_proxy.rst
@@ -103,6 +103,7 @@ This configuration is for an Olimex ESP32-PoE-ISO board with an Ethernet connect
     api:
 
     ota:
+      platform: esphome
 
     esp32_ble_tracker:
       scan_parameters:

--- a/components/display/inkplate6.rst
+++ b/components/display/inkplate6.rst
@@ -144,6 +144,7 @@ Wi-Fi, API, and OTA configuration.
     captive_portal:
 
     ota:
+      platform: esphome
 
     api:
 

--- a/components/light/sonoff_d1.rst
+++ b/components/light/sonoff_d1.rst
@@ -71,6 +71,7 @@ This component is useless for devices other than Sonoff D1 dimmer.
 
     # Make sure you can upload new firmware OTA
     ota:
+      platform: esphome
 
     # D1 dimmer uses hardware serial port on the default pins @ 9600 bps
     uart:

--- a/components/output/my9231.rst
+++ b/components/output/my9231.rst
@@ -108,6 +108,7 @@ complete configuration for a Sonoff B1 looks like:
     logger:
 
     ota:
+      platform: esphome
 
     my9231:
       data_pin: GPIO12  # GPIO13 for AiLight
@@ -163,6 +164,7 @@ And here is a complete configuration for the AiThinker AiLight:
     logger:
 
     ota:
+      platform: esphome
 
     my9231:
       data_pin: GPIO13

--- a/components/output/sm16716.rst
+++ b/components/output/sm16716.rst
@@ -108,6 +108,7 @@ A complete configuration for a Feit Electric A19 looks like:
     logger:
 
     ota:
+      platform: esphome
 
     sm16716:
       data_pin: GPIO14

--- a/cookbook/arduino_port_extender.rst
+++ b/cookbook/arduino_port_extender.rst
@@ -203,6 +203,7 @@ spares I/Os.
     api:
 
     ota:
+      platform: esphome
 
     # define i2c device
     # for an ESP8266 SDA is D2 and goes to Arduino's A4

--- a/cookbook/leak-detector-m5stickC.rst
+++ b/cookbook/leak-detector-m5stickC.rst
@@ -129,6 +129,7 @@ ESPHome configuration
     # Enable Home Assistant API & OTA Updates
     api:
     ota:
+      platform: esphome
 
     status_led:
       pin:

--- a/cookbook/sonoff-fishpond-pump.rst
+++ b/cookbook/sonoff-fishpond-pump.rst
@@ -67,6 +67,7 @@ Here is the configuration with the basic operations outlined above.
     logger:
 
     ota:
+      platform: esphome
 
     api:
 

--- a/guides/creators.rst
+++ b/guides/creators.rst
@@ -43,6 +43,7 @@ Example configuration
 
     # OTA is required for Over-the-Air updating
     ota:
+      platform: esphome
 
     # This should point to the public location of this yaml file.
     dashboard_import:


### PR DESCRIPTION
## Description:
Add esphome platform to OTA sections in docs. I've searched for `ota:` and added the platform anywhere it seemed to be missing to ensure that example code is right.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
