### PR TITLE
Fix the invalid URL for data sheet in gdk101.rst

### DIFF
--- a/components/sensor/gdk101.rst
+++ b/components/sensor/gdk101.rst
@@ -119,7 +119,7 @@ See Also
 
 - :ref:`sensor-filters`
 - :apiref:`gdk101/gdk101.h`
-- `Data Sheet <http://allsmartlab.com/eng/wp-content/uploads/sites/2/2017/01/GDK101datasheet_v1.6.pdf>`__
+- `Data Sheet <https://www.eleparts.co.kr/data/goods_old/design/product_file/Hoon/AN_GDK101_V1.0_I2C.pdf>`__
 - `Application Notes <https://merona.blob.core.windows.net/radonftlab-web/GDK101.zip>`__
 - `Arduino Sensors for Everyone blog post <https://arduino.steamedu123.com/entry/GDK101-Radiation-Sensor>`__
 - :ghedit:`Edit`


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** 

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
