### PR TITLE
Update safe_mode syntax in `ota` documentation

### DIFF
--- a/components/ota/esphome.rst
+++ b/components/ota/esphome.rst
@@ -20,9 +20,9 @@ expected. This is automatically enabled by this component, but it may be disable
 .. code-block:: yaml
 
     # Example configuration entry
+    safe_mode:
     ota:
       - platform: esphome
-        safe_mode: true
         password: !secret ota_password
 
 Configuration variables:


### PR DESCRIPTION
Update safe_mode syntax

## Description:

Documentation of `ota` use old `safe_mode` syntax.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
