### PR TITLE
Add a bunch of missing supporters

### DIFF
--- a/guides/supporters.rst
+++ b/guides/supporters.rst
@@ -18,6 +18,7 @@ Contributors
 
 - `007hacky007 (@007hacky007) <https://github.com/007hacky007>`__
 - `0hax (@0hax) <https://github.com/0hax>`__
+- `Nikola (@0nikola1) <https://github.com/0nikola1>`__
 - `0x0a11c0de (@0x0a11c0de) <https://github.com/0x0a11c0de>`__
 - `Tercio Filho (@0x3333) <https://github.com/0x3333>`__
 - `Denis Bodor (aka Lefinnois) (@0xDRRB) <https://github.com/0xDRRB>`__
@@ -41,12 +42,17 @@ Contributors
 - `Avula Chandra Kiran Reddy (@ackr-8) <https://github.com/ackr-8>`__
 - `acshef (@acshef) <https://github.com/acshef>`__
 - `Zhenyu Wu (@Adam5Wu) <https://github.com/Adam5Wu>`__
+- `adamgreg (@adamgreg) <https://github.com/adamgreg>`__
 - `Chris Byrne (@adapt0) <https://github.com/adapt0>`__
 - `Attila Darazs (@adarazs) <https://github.com/adarazs>`__
 - `ADeadPixel (@ADeadPixel) <https://github.com/ADeadPixel>`__
+- `adezerega (@adezerega) <https://github.com/adezerega>`__
 - `Andrea Donno (@adonno) <https://github.com/adonno>`__
+- `Adrian Cuzman (@adriancuzman) <https://github.com/adriancuzman>`__
 - `Adrian Fretwell (@AdrianFretwell) <https://github.com/AdrianFretwell>`__
 - `Adrien Brault (@adrienbrault) <https://github.com/adrienbrault>`__
+- `Ian Blais (@aeonsablaze) <https://github.com/aeonsablaze>`__
+- `Johan Bloemberg (@aequitas) <https://github.com/aequitas>`__
 - `Attila Farago (@afarago) <https://github.com/afarago>`__
 - `Kjell Braden (@afflux) <https://github.com/afflux>`__
 - `Alejandro Galfrascoli (@AGalfra) <https://github.com/AGalfra>`__
@@ -75,12 +81,15 @@ Contributors
 - `AlexCPU (@AlexCPU) <https://github.com/AlexCPU>`__
 - `Alexandre Danault (@AlexDanault) <https://github.com/AlexDanault>`__
 - `Alex Iribarren (@alexiri) <https://github.com/alexiri>`__
+- `alexmaurer-madis (@alexmaurer-madis) <https://github.com/alexmaurer-madis>`__
 - `Alex Mekkering (@AlexMekkering) <https://github.com/AlexMekkering>`__
 - `Alex (@alexyao2015) <https://github.com/alexyao2015>`__
 - `Alfredo (@alfredopironti) <https://github.com/alfredopironti>`__
 - `Alibloke (@Alibloke) <https://github.com/Alibloke>`__
+- `aliktb (@aliktb) <https://github.com/aliktb>`__
 - `Alessandro Ranellucci (@alranel) <https://github.com/alranel>`__
 - `Maxime Gauduin (@alucryd) <https://github.com/alucryd>`__
+- `alva (@alva-seal) <https://github.com/alva-seal>`__
 - `Andreas Mandel (@amandel) <https://github.com/amandel>`__
 - `Andrew McFague (@amcfague) <https://github.com/amcfague>`__
 - `Amish Vishwakarma (@amishv) <https://github.com/amishv>`__
@@ -103,10 +112,13 @@ Contributors
 - `Andrzej (@andriej) <https://github.com/andriej>`__
 - `Andreas (@anduchs) <https://github.com/anduchs>`__
 - `Andy2No (@Andy2No) <https://github.com/Andy2No>`__
+- `andyboeh (@andyboeh) <https://github.com/andyboeh>`__
 - `Andy Barcinski (@andynumber2) <https://github.com/andynumber2>`__
 - `AndyRPH (@AndyRPH) <https://github.com/AndyRPH>`__
+- `anekinloewe (@anekinloewe) <https://github.com/anekinloewe>`__
 - `Vegetto (@angelnu) <https://github.com/angelnu>`__
 - `Sergey Anisimov (@anisimovsergey) <https://github.com/anisimovsergey>`__
+- `ankycooper (@ankycooper) <https://github.com/ankycooper>`__
 - `Nikolay Vasilchuk (@Anonym-tsk) <https://github.com/Anonym-tsk>`__
 - `Anthony Keane (@anthonykeane) <https://github.com/anthonykeane>`__
 - `Anthony (@AnthonyMaiorani) <https://github.com/AnthonyMaiorani>`__
@@ -133,6 +145,7 @@ Contributors
 - `ashp8i (@ashp8i) <https://github.com/ashp8i>`__
 - `Ashton Kemerling (@AshtonKem) <https://github.com/AshtonKem>`__
 - `杨成锴 (@asjdf) <https://github.com/asjdf>`__
+- `Pavel Pletenev (@ASMfreaK) <https://github.com/ASMfreaK>`__
 - `Andreas Soehlke (@asoehlke) <https://github.com/asoehlke>`__
 - `Mike Dunston (@atanisoft) <https://github.com/atanisoft>`__
 - `Glenn Morrison (@atomicpapa) <https://github.com/atomicpapa>`__
@@ -155,12 +168,14 @@ Contributors
 - `balk77 (@balk77) <https://github.com/balk77>`__
 - `Paulus Schoutsen (@balloob) <https://github.com/balloob>`__
 - `Andrew Zaborowski (@balrog-kun) <https://github.com/balrog-kun>`__
+- `Rutger Nijhuis (@BananaPukeh) <https://github.com/BananaPukeh>`__
 - `Josh Barnard (@barndawgie) <https://github.com/barndawgie>`__
 - `BarryMar (@BarryMar) <https://github.com/BarryMar>`__
 - `Bart Gysens (@BartGysens) <https://github.com/BartGysens>`__
 - `bartoszpierzchlewicz (@bartoszpierzchlewicz) <https://github.com/bartoszpierzchlewicz>`__
 - `BartoszPierzchlewiczMacrix (@BartoszPierzchlewiczMacrix) <https://github.com/BartoszPierzchlewiczMacrix>`__
 - `Bascht74 (@Bascht74) <https://github.com/Bascht74>`__
+- `bazuchan (@bazuchan) <https://github.com/bazuchan>`__
 - `Viktr (@BbIKTOP) <https://github.com/BbIKTOP>`__
 - `J. Nick Koston (@bdraco) <https://github.com/bdraco>`__
 - `Maxim Ocheretianko (@bearpawmaxim) <https://github.com/bearpawmaxim>`__
@@ -175,6 +190,7 @@ Contributors
 - `Ben Kristinsson (@benediktkr) <https://github.com/benediktkr>`__
 - `Ben Hoff (@benhoff) <https://github.com/benhoff>`__
 - `Benoît Leforestier (@Benichou34) <https://github.com/Benichou34>`__
+- `Benjamin Aigner (@benjaminaigner) <https://github.com/benjaminaigner>`__
 - `benniju (@benniju) <https://github.com/benniju>`__
 - `Benno Pütz (@bennop) <https://github.com/bennop>`__
 - `Benny H (@benny-aus) <https://github.com/benny-aus>`__
@@ -186,6 +202,8 @@ Contributors
 - `Bryan Berg (@berg) <https://github.com/berg>`__
 - `BerlinJoker (@BerlinJoker) <https://github.com/BerlinJoker>`__
 - `Bert Hertogen (@berthertogen) <https://github.com/berthertogen>`__
+- `Ivan Bessarabov (@bessarabov) <https://github.com/bessarabov>`__
+- `besteru (@besteru) <https://github.com/besteru>`__
 - `Brandon (@bgulla) <https://github.com/bgulla>`__
 - `Benedikt Hübschen (@bhuebschen) <https://github.com/bhuebschen>`__
 - `Bierchermuesli (@Bierchermuesli) <https://github.com/Bierchermuesli>`__
@@ -196,6 +214,7 @@ Contributors
 - `Brian Kaufman (@bkaufx) <https://github.com/bkaufx>`__
 - `JDavid (@blackhack) <https://github.com/blackhack>`__
 - `blackshoals (@blackshoals) <https://github.com/blackshoals>`__
+- `blacktirion (@blacktirion) <https://github.com/blacktirion>`__
 - `blakadder (@blakadder) <https://github.com/blakadder>`__
 - `Branimir Lambov (@blambov) <https://github.com/blambov>`__
 - `bleeisme (@bleeisme) <https://github.com/bleeisme>`__
@@ -209,10 +228,13 @@ Contributors
 - `Bodmer (@Bodmer) <https://github.com/Bodmer>`__
 - `Anthony Todd (@bohregard) <https://github.com/bohregard>`__
 - `Bomaker (@Bomaker) <https://github.com/Bomaker>`__
+- `Mauricio Bonani (@bonanitech) <https://github.com/bonanitech>`__
 - `Casey Olson (@bookcasey) <https://github.com/bookcasey>`__
+- `boradwell (@boradwell) <https://github.com/boradwell>`__
 - `Borja Burgos (@borjaburgos) <https://github.com/borjaburgos>`__
 - `Brian Orpin (@borpin) <https://github.com/borpin>`__
 - `BoukeHaarsma23 (@BoukeHaarsma23) <https://github.com/BoukeHaarsma23>`__
+- `Patrik Hermansson (@bphermansson) <https://github.com/bphermansson>`__
 - `brabl2 (@brabl2) <https://github.com/brabl2>`__
 - `brainiac27 (@brainiac27) <https://github.com/brainiac27>`__
 - `brambo123 (@brambo123) <https://github.com/brambo123>`__
@@ -221,6 +243,7 @@ Contributors
 - `Brad Davidson (@brandond) <https://github.com/brandond>`__
 - `Daniel H Brown (@brauhausdc) <https://github.com/brauhausdc>`__
 - `Brent Rubell (@brentru) <https://github.com/brentru>`__
+- `Jens Bretschneider (@breti) <https://github.com/breti>`__
 - `Brett Profitt (@brettp) <https://github.com/brettp>`__
 - `briangunderson (@briangunderson) <https://github.com/briangunderson>`__
 - `Brian Hanifin (@brianhanifin) <https://github.com/brianhanifin>`__
@@ -228,13 +251,17 @@ Contributors
 - `Ben Brooks (@brooksben11) <https://github.com/brooksben11>`__
 - `brtchip-tuannguyen (@brtchip-tuannguyen) <https://github.com/brtchip-tuannguyen>`__
 - `buddydvd (@buddydvd) <https://github.com/buddydvd>`__
+- `bulburDE (@bulburDE) <https://github.com/bulburDE>`__
 - `Matt Burke (@burkemw3) <https://github.com/burkemw3>`__
+- `Jon Little (@burundiocibu) <https://github.com/burundiocibu>`__
 - `buxtronix (@buxtronix) <https://github.com/buxtronix>`__
 - `bvansambeek (@bvansambeek) <https://github.com/bvansambeek>`__
 - `bvarick (@bvarick) <https://github.com/bvarick>`__
+- `bwente (@bwente) <https://github.com/bwente>`__
 - `bwynants (@bwynants) <https://github.com/bwynants>`__
 - `c0ffeeca7 (@c0ffeeca7) <https://github.com/c0ffeeca7>`__
 - `Captain Haddock (@ca-haddock) <https://github.com/ca-haddock>`__
+- `calco88 (@calco88) <https://github.com/calco88>`__
 - `Caleb Gabbie (@calebgab) <https://github.com/calebgab>`__
 - `Cal Howard (@calhoward) <https://github.com/calhoward>`__
 - `callacomp (@callacomp) <https://github.com/callacomp>`__
@@ -249,6 +276,7 @@ Contributors
 - `carstenschroeder (@carstenschroeder) <https://github.com/carstenschroeder>`__
 - `Christian Anders Schwarzgruber (@casch-at) <https://github.com/casch-at>`__
 - `Valentin Ochs (@Cat-Ion) <https://github.com/Cat-Ion>`__
+- `Stroe Andrei Catalin (@catalin2402) <https://github.com/catalin2402>`__
 - `Carter Nelson (@caternuson) <https://github.com/caternuson>`__
 - `cathelest (@cathelest) <https://github.com/cathelest>`__
 - `Chris AtLee (@catlee) <https://github.com/catlee>`__
@@ -258,6 +286,7 @@ Contributors
 - `Carlos Cordero (@ccorderor) <https://github.com/ccorderor>`__
 - `Cody Cutrer (@ccutrer) <https://github.com/ccutrer>`__
 - `cdmonk (@cdmonk) <https://github.com/cdmonk>`__
+- `Marco (@cdrfun) <https://github.com/cdrfun>`__
 - `ceaswaran (@ceaswaran) <https://github.com/ceaswaran>`__
 - `Xavi (@Cebeerre) <https://github.com/Cebeerre>`__
 - `Cellie (@CelliesProjects) <https://github.com/CelliesProjects>`__
@@ -265,6 +294,7 @@ Contributors
 - `Chris Feenstra (@cfeenstra1024) <https://github.com/cfeenstra1024>`__
 - `Filipe Mendonça (@cfilipem) <https://github.com/cfilipem>`__
 - `cg089 (@cg089) <https://github.com/cg089>`__
+- `Kostas Chatzikokolakis (@chatziko) <https://github.com/chatziko>`__
 - `chbmuc (@chbmuc) <https://github.com/chbmuc>`__
 - `Audric Schiltknecht (@chemicalstorm) <https://github.com/chemicalstorm>`__
 - `Charles Johnson (@ChemicalXandco) <https://github.com/ChemicalXandco>`__
@@ -277,6 +307,7 @@ Contributors
 - `ChuckMash (@ChuckMash) <https://github.com/ChuckMash>`__
 - `Pavel Skuratovich (@Chupaka) <https://github.com/Chupaka>`__
 - `Chris Johnson (@ciband) <https://github.com/ciband>`__
+- `Zimmermann Zsolt (@cinadr) <https://github.com/cinadr>`__
 - `CircuitGuy (@CircuitGuy) <https://github.com/CircuitGuy>`__
 - `John (@CircuitSetup) <https://github.com/CircuitSetup>`__
 - `Colby Rome (@cisasteelersfan) <https://github.com/cisasteelersfan>`__
@@ -287,9 +318,11 @@ Contributors
 - `Clyde Stubbs (@clydebarrow) <https://github.com/clydebarrow>`__
 - `Colin McCambridge (@cmccambridge) <https://github.com/cmccambridge>`__
 - `Clifford Roche (@cmroche) <https://github.com/cmroche>`__
+- `code-review-doctor (@code-review-doctor) <https://github.com/code-review-doctor>`__
 - `Casey Burnett (@codeangler) <https://github.com/codeangler>`__
 - `Marcin Krasowski (@CodeInPolish) <https://github.com/CodeInPolish>`__
 - `CODeRUS (@CODeRUS) <https://github.com/CODeRUS>`__
+- `Nick (@codewise-nicolas) <https://github.com/codewise-nicolas>`__
 - `Alex Miller (@Codex-) <https://github.com/Codex->`__
 - `Ricardo Salinas (@codingric) <https://github.com/codingric>`__
 - `Cody James (@codyjamestechnical) <https://github.com/codyjamestechnical>`__
@@ -300,6 +333,8 @@ Contributors
 - `Max (@coltoncat) <https://github.com/coltoncat>`__
 - `Conclusio (@Conclusio) <https://github.com/Conclusio>`__
 - `Conor Burns (@Conor-Burns) <https://github.com/Conor-Burns>`__
+- `John Coggeshall (@coogle) <https://github.com/coogle>`__
+- `James Crook (@cooljimy84) <https://github.com/cooljimy84>`__
 - `Cooper Dale (@Cooper-Dale) <https://github.com/Cooper-Dale>`__
 - `copercini (@copercini) <https://github.com/copercini>`__
 - `Corban Mailloux (@corbanmailloux) <https://github.com/corbanmailloux>`__
@@ -311,20 +346,28 @@ Contributors
 - `cptquad (@cptquad) <https://github.com/cptquad>`__
 - `CptSkippy (@cptskippy) <https://github.com/cptskippy>`__
 - `Grant Le Roux (@cram42) <https://github.com/cram42>`__
+- `cretep (@cretep) <https://github.com/cretep>`__
 - `CrewMdk (@CrewMdk) <https://github.com/CrewMdk>`__
 - `Corey Rice (@crice009) <https://github.com/crice009>`__
 - `crp500 (@crp500) <https://github.com/crp500>`__
 - `cryptelli (@cryptelli) <https://github.com/cryptelli>`__
+- `Christian Schwarzgruber (@cslux) <https://github.com/cslux>`__
 - `cstaahl (@cstaahl) <https://github.com/cstaahl>`__
 - `Chris Talkington (@ctalkington) <https://github.com/ctalkington>`__
+- `Massimo Cetra (@ctrix) <https://github.com/ctrix>`__
 - `CVan (@cvandesande) <https://github.com/cvandesande>`__
 - `cvwillegen (@cvwillegen) <https://github.com/cvwillegen>`__
 - `Christoph Wempe (@CWempe) <https://github.com/CWempe>`__
+- `cwitting (@cwitting) <https://github.com/cwitting>`__
 - `Steven Webb (@cy1701) <https://github.com/cy1701>`__
 - `Alex Solomaha (@CyanoFresh) <https://github.com/CyanoFresh>`__
+- `Luar Roji (@cyberplant) <https://github.com/cyberplant>`__
 - `Petr Diviš (@czechdude) <https://github.com/czechdude>`__
 - `Aleš Komárek (@cznewt) <https://github.com/cznewt>`__
 - `d-rez (@d-rez) <https://github.com/d-rez>`__
+- `d-two (@d-two) <https://github.com/d-two>`__
+- `d3wy (@d3wy) <https://github.com/d3wy>`__
+- `dab0g (@dab0g) <https://github.com/dab0g>`__
 - `Dale Higgs (@dale3h) <https://github.com/dale3h>`__
 - `damanti-me (@damanti-me) <https://github.com/damanti-me>`__
 - `Justin Grover (@dancingcactus) <https://github.com/dancingcactus>`__
@@ -353,6 +396,7 @@ Contributors
 - `DaveCorder (@DaveCorder) <https://github.com/DaveCorder>`__
 - `David Marín (@davefx) <https://github.com/davefx>`__
 - `Dave Richer (@davericher) <https://github.com/davericher>`__
+- `davestubbs (@davestubbs) <https://github.com/davestubbs>`__
 - `Dave T (@davet2001) <https://github.com/davet2001>`__
 - `David Watson (@davewatson91) <https://github.com/davewatson91>`__
 - `Dave Wongillies (@davewongillies) <https://github.com/davewongillies>`__
@@ -366,6 +410,7 @@ Contributors
 - `Davy Landman (@DavyLandman) <https://github.com/DavyLandman>`__
 - `Dawid Cieszyński (@dawidcieszynski) <https://github.com/dawidcieszynski>`__
 - `Darren Tucker (@daztucker) <https://github.com/daztucker>`__
+- `Donovan Baarda (@dbaarda) <https://github.com/dbaarda>`__
 - `David Buezas (@dbuezas) <https://github.com/dbuezas>`__
 - `dckiller51 (@dckiller51) <https://github.com/dckiller51>`__
 - `Daniel Correa Lobato (@dclobato) <https://github.com/dclobato>`__
@@ -373,24 +418,32 @@ Contributors
 - `ddt154 (@ddt154) <https://github.com/ddt154>`__
 - `DeadEnd (@DeadEnded) <https://github.com/DeadEnded>`__
 - `Debashish Sahu (@debsahu) <https://github.com/debsahu>`__
+- `declanshanaghy (@declanshanaghy) <https://github.com/declanshanaghy>`__
+- `Maximilian (@DeerMaximum) <https://github.com/DeerMaximum>`__
 - `definitio (@definitio) <https://github.com/definitio>`__
+- `deftdawg (@deftdawg) <https://github.com/deftdawg>`__
 - `Christiaan Blom (@Deinara) <https://github.com/Deinara>`__
 - `Daniel Eisterhold (@deisterhold) <https://github.com/deisterhold>`__
+- `Rsan (@deltazerorsan) <https://github.com/deltazerorsan>`__
 - `Mickaël Le Baillif (@demikl) <https://github.com/demikl>`__
 - `denes44 (@denes44) <https://github.com/denes44>`__
+- `Dennis (@dennisvbussel) <https://github.com/dennisvbussel>`__
 - `dentra (@dentra) <https://github.com/dentra>`__
 - `depasseg (@depasseg) <https://github.com/depasseg>`__
+- `Davide Depau (@Depau) <https://github.com/Depau>`__
 - `Davide Depau (@depau) <https://github.com/depau>`__
 - `dependabot[bot] (@dependabot[bot]) <https://github.com/dependabot[bot]>`__
 - `Joeri Colman (@depuits) <https://github.com/depuits>`__
 - `Mike La Spina (@descipher) <https://github.com/descipher>`__
 - `Stephan Martin (@designer2k2) <https://github.com/designer2k2>`__
 - `Destix (@Destix) <https://github.com/Destix>`__
+- `Deun Lee (@deunlee) <https://github.com/deunlee>`__
 - `Develo (@devyte) <https://github.com/devyte>`__
 - `Dewet Diener (@dewet22) <https://github.com/dewet22>`__
 - `dexn (@dexn) <https://github.com/dexn>`__
 - `Dezorian (@Dezorian) <https://github.com/Dezorian>`__
 - `Damian Gołda (@dgolda) <https://github.com/dgolda>`__
+- `dgtal1 (@dgtal1) <https://github.com/dgtal1>`__
 - `Dan Halbert (@dhalbert) <https://github.com/dhalbert>`__
 - `Dustin L. Howett (@DHowett) <https://github.com/DHowett>`__
 - `diesel437 (@diesel437) <https://github.com/diesel437>`__
@@ -400,17 +453,25 @@ Contributors
 - `Dirk Jahnke (@dirkj) <https://github.com/dirkj>`__
 - `Dennis (@dirrgang) <https://github.com/dirrgang>`__
 - `Johann V. (@divinitas) <https://github.com/divinitas>`__
+- `dj-bauer (@dj-bauer) <https://github.com/dj-bauer>`__
 - `Dominic Pearman (@djpearman) <https://github.com/djpearman>`__
+- `djtef (@djtef) <https://github.com/djtef>`__
+- `djwlindenaar (@djwlindenaar) <https://github.com/djwlindenaar>`__
 - `Marcos Pérez Ferro (@djwmarcx) <https://github.com/djwmarcx>`__
 - `Dan Mannock (@dmannock) <https://github.com/dmannock>`__
 - `Dmitriy Lopatko (@dmitriy5181) <https://github.com/dmitriy5181>`__
+- `dmkif (@dmkif) <https://github.com/dmkif>`__
+- `Farzad E. (@dnetguru) <https://github.com/dnetguru>`__
 - `Tristan Rowley (@doctea) <https://github.com/doctea>`__
+- `DrZoid (@docteurzoidberg) <https://github.com/docteurzoidberg>`__
 - `DominikBitzer (@DominikBitzer) <https://github.com/DominikBitzer>`__
 - `Dominik (@DomiStyle) <https://github.com/DomiStyle>`__
 - `Don Burch (@donburch888) <https://github.com/donburch888>`__
 - `Derek M. (@doolbneerg) <https://github.com/doolbneerg>`__
 - `Dorian Zedler (@dorianim) <https://github.com/dorianim>`__
+- `Mark Dietzer (@Doridian) <https://github.com/Doridian>`__
 - `Sebastian Krzyszkowiak (@dos1) <https://github.com/dos1>`__
+- `Jiang Sheng (@doskoi) <https://github.com/doskoi>`__
 - `Artem Sheremet (@dotdoom) <https://github.com/dotdoom>`__
 - `Robert Schütz (@dotlambda) <https://github.com/dotlambda>`__
 - `Daniel Hyles (@DotNetDann) <https://github.com/DotNetDann>`__
@@ -425,6 +486,7 @@ Contributors
 - `drogfild (@drogfild) <https://github.com/drogfild>`__
 - `Simone Rossetto (@droscy) <https://github.com/droscy>`__
 - `DrRob (@DrRob) <https://github.com/DrRob>`__
+- `drug123 (@drug123) <https://github.com/drug123>`__
 - `Drzony (@drzony) <https://github.com/drzony>`__
 - `Dmitrii Shcherbakov (@dshcherb) <https://github.com/dshcherb>`__
 - `Daniel Müller (@dtmuller) <https://github.com/dtmuller>`__
@@ -434,13 +496,16 @@ Contributors
 - `Sergey V. DUDANOV (@dudanov) <https://github.com/dudanov>`__
 - `David Girón (@duhow) <https://github.com/duhow>`__
 - `Duncan Findlay (@duncf) <https://github.com/duncf>`__
+- `Jannick (@DutchDeffy) <https://github.com/DutchDeffy>`__
 - `David van der Leij (@dvanderleij) <https://github.com/dvanderleij>`__
 - `dwildstr (@dwildstr) <https://github.com/dwildstr>`__
 - `dxta1986 (@dxta1986) <https://github.com/dxta1986>`__
 - `dyarkovoy (@dyarkovoy) <https://github.com/dyarkovoy>`__
 - `Janez Troha (@dz0ny) <https://github.com/dz0ny>`__
 - `Dimitris Zervas (@dzervas) <https://github.com/dzervas>`__
+- `dziobson (@dziobson) <https://github.com/dziobson>`__
 - `Dan Jackson (@e28eta) <https://github.com/e28eta>`__
+- `Ettore Beltrame (@E440QF) <https://github.com/E440QF>`__
 - `Earle F. Philhower, III (@earlephilhower) <https://github.com/earlephilhower>`__
 - `Ermanno Baschiera (@ebaschiera) <https://github.com/ebaschiera>`__
 - `ebw44 (@ebw44) <https://github.com/ebw44>`__
@@ -452,10 +517,12 @@ Contributors
 - `Eenoo (@Eenoo) <https://github.com/Eenoo>`__
 - `Eli Fidler (@efidler) <https://github.com/efidler>`__
 - `egandro (@egandro) <https://github.com/egandro>`__
+- `Erwin Kooi (@egeltje) <https://github.com/egeltje>`__
 - `Maxime Michel (@Egglestron) <https://github.com/Egglestron>`__
 - `Eike (@ei-ke) <https://github.com/ei-ke>`__
 - `Elazar Leibovich (@elazarl) <https://github.com/elazarl>`__
 - `Michael Jahn (@electr1cBugaloo) <https://github.com/electr1cBugaloo>`__
+- `electrofun-smart (@electrofun-smart) <https://github.com/electrofun-smart>`__
 - `Eli (@eli-xciv) <https://github.com/eli-xciv>`__
 - `Eli Lipsitz (@elipsitz) <https://github.com/elipsitz>`__
 - `Eli Yu (@elizhyu) <https://github.com/elizhyu>`__
@@ -464,32 +531,50 @@ Contributors
 - `Eduard Llull (@ellull) <https://github.com/ellull>`__
 - `Joakim Plate (@elupus) <https://github.com/elupus>`__
 - `Andrew Elwell (@Elwell) <https://github.com/Elwell>`__
+- `elyorkhakimov (@elyorkhakimov) <https://github.com/elyorkhakimov>`__
+- `EmbeddedDevver (@EmbeddedDevver) <https://github.com/EmbeddedDevver>`__
 - `EmmanuelLM (@EmmanuelLM) <https://github.com/EmmanuelLM>`__
 - `Emory Dunn (@emorydunn) <https://github.com/emorydunn>`__
 - `Eric van Blokland (@Emrvb) <https://github.com/Emrvb>`__
+- `Eric Muehlstein (@emuehlstein) <https://github.com/emuehlstein>`__
 - `Anders Persson (@emwap) <https://github.com/emwap>`__
 - `Bert (@Engelbert) <https://github.com/Engelbert>`__
 - `Engineer_Will (@EngineerWill) <https://github.com/EngineerWill>`__
+- `Nico Weichbrodt (@envy) <https://github.com/envy>`__
+- `Evan Petousis (@epetousis) <https://github.com/epetousis>`__
 - `erapade (@erapade) <https://github.com/erapade>`__
+- `Wilhelm Erasmus (@erasmuswill) <https://github.com/erasmuswill>`__
+- `erazor666 (@erazor666) <https://github.com/erazor666>`__
 - `Josh Gwosdz (@erdii) <https://github.com/erdii>`__
+- `Eric Coffman (@ericbrian) <https://github.com/ericbrian>`__
+- `Eric Hiller (@erichiller) <https://github.com/erichiller>`__
+- `Matt Hamilton (@Eriner) <https://github.com/Eriner>`__
+- `Ernst Klamer (@Ernst79) <https://github.com/Ernst79>`__
 - `Eduardo Roldan (@eroldan) <https://github.com/eroldan>`__
 - `ervede (@ervede) <https://github.com/ervede>`__
 - `escoand (@escoand) <https://github.com/escoand>`__
+- `Eric Severance (@esev) <https://github.com/esev>`__
 - `esphomebot (@esphomebot) <https://github.com/esphomebot>`__
 - `espressif2022 (@espressif2022) <https://github.com/espressif2022>`__
 - `Daniel Dunn (@EternityForest) <https://github.com/EternityForest>`__
+- `EtienneMD (@EtienneMD) <https://github.com/EtienneMD>`__
 - `etzisim (@etzisim) <https://github.com/etzisim>`__
 - `Evan Coleman (@evandcoleman) <https://github.com/evandcoleman>`__
 - `Clemens Kirchgatterer (@everslick) <https://github.com/everslick>`__
 - `Everything Smart Home (@EverythingSmartHome) <https://github.com/EverythingSmartHome>`__
 - `Evgeni Golov (@evgeni) <https://github.com/evgeni>`__
 - `evlo (@evlo) <https://github.com/evlo>`__
+- `Expaso (@Expaso) <https://github.com/Expaso>`__
 - `Malte Franken (@exxamalte) <https://github.com/exxamalte>`__
 - `f0rdprefect (@f0rdprefect) <https://github.com/f0rdprefect>`__
 - `Fabian Affolter (@fabaff) <https://github.com/fabaff>`__
 - `Fabian (@Fabian-Schmidt) <https://github.com/Fabian-Schmidt>`__
+- `Fabian Muehlberger (@fabianmuehlberger) <https://github.com/fabianmuehlberger>`__
+- `Federico Ariel Castagnini (@facastagnini) <https://github.com/facastagnini>`__
 - `C W (@fake-name) <https://github.com/fake-name>`__
+- `Florian idB (@fbeek) <https://github.com/fbeek>`__
 - `Fabian Bläse (@fblaese) <https://github.com/fblaese>`__
+- `Fabian Berthold (@fbrthld) <https://github.com/fbrthld>`__
 - `F.D.Castel (@fdcastel) <https://github.com/fdcastel>`__
 - `Sun Xiangyu (@feizi) <https://github.com/feizi>`__
 - `felixlungu (@felixlungu) <https://github.com/felixlungu>`__
@@ -501,10 +586,12 @@ Contributors
 - `Florian Golemo (@fgolemo) <https://github.com/fgolemo>`__
 - `Federico G. Schwindt (@fgsch) <https://github.com/fgsch>`__
 - `Frank Riley (@fhriley) <https://github.com/fhriley>`__
+- `Frederik (@fightforlife) <https://github.com/fightforlife>`__
 - `finity69x2 (@finity69x2) <https://github.com/finity69x2>`__
 - `Clemens (@firegore) <https://github.com/firegore>`__
 - `Fredrik Jansson (@fjansson) <https://github.com/fjansson>`__
 - `Frédéric Jouault (@fjouault) <https://github.com/fjouault>`__
+- `fkirill (@fkirill) <https://github.com/fkirill>`__
 - `FL42 (@fl42) <https://github.com/fl42>`__
 - `Sean Vig (@flacjacket) <https://github.com/flacjacket>`__
 - `Diego Elio Pettenò (@Flameeyes) <https://github.com/Flameeyes>`__
@@ -517,42 +604,64 @@ Contributors
 - `foltymat (@foltymat) <https://github.com/foltymat>`__
 - `Fabio Pugliese Ornellas (@fornellas) <https://github.com/fornellas>`__
 - `SmartShackMaster (@fototakas) <https://github.com/fototakas>`__
+- `foxsam21 (@foxsam21) <https://github.com/foxsam21>`__
+- `Fractal147 (@Fractal147) <https://github.com/Fractal147>`__
+- `Francis-labo (@Francis-labo) <https://github.com/Francis-labo>`__
+- `Francisk0 (@Francisk0) <https://github.com/Francisk0>`__
 - `Frank Bakker (@FrankBakkerNl) <https://github.com/FrankBakkerNl>`__
 - `Frank (@FrankBoesing) <https://github.com/FrankBoesing>`__
+- `Frank Langtind (@frankiboy1) <https://github.com/frankiboy1>`__
+- `Frankster-NL (@Frankster-NL) <https://github.com/Frankster-NL>`__
 - `frauhottelmann (@frauhottelmann) <https://github.com/frauhottelmann>`__
 - `Fredrik Erlandsson (@fredrike) <https://github.com/fredrike>`__
 - `freeasabeer (@freeasabeer) <https://github.com/freeasabeer>`__
+- `FreeBear-nc (@FreeBear-nc) <https://github.com/FreeBear-nc>`__
 - `Evgeny (@freekode) <https://github.com/freekode>`__
 - `Brett McKenzie (@freerangeeggs) <https://github.com/freerangeeggs>`__
 - `Franck Nijhof (@frenck) <https://github.com/frenck>`__
 - `Kenneth Fribert (@fribse) <https://github.com/fribse>`__
 - `frippe75 (@frippe75) <https://github.com/frippe75>`__
+- `Fritz Mueller (@fritzm) <https://github.com/fritzm>`__
+- `Marc Egli (@frog32) <https://github.com/frog32>`__
+- `frspp (@frspp) <https://github.com/frspp>`__
+- `Florian Trück (@ftrueck) <https://github.com/ftrueck>`__
 - `functionpointer (@functionpointer) <https://github.com/functionpointer>`__
 - `mr G1K (@G1K) <https://github.com/G1K>`__
 - `Aljaž Srebrnič (@g5pw) <https://github.com/g5pw>`__
 - `Alex Hermann (@gaaf) <https://github.com/gaaf>`__
 - `Gabe Cook (@gabe565) <https://github.com/gabe565>`__
 - `Gábor Poczkodi (@gabest11) <https://github.com/gabest11>`__
+- `Gareth Cooper (@gaco79) <https://github.com/gaco79>`__
 - `Matthew (@Gaff) <https://github.com/Gaff>`__
+- `galagaking (@galagaking) <https://github.com/galagaking>`__
 - `gazoodle (@gazoodle) <https://github.com/gazoodle>`__
 - `gcopeland (@gcopeland) <https://github.com/gcopeland>`__
 - `Greg Cormier (@gcormier) <https://github.com/gcormier>`__
+- `GeekVisit (@GeekVisit) <https://github.com/GeekVisit>`__
+- `Ian Reinhart Geiser (@geiseri) <https://github.com/geiseri>`__
 - `R Huish (@genestealer) <https://github.com/genestealer>`__
 - `Geoff Davis (@geoffdavis) <https://github.com/geoffdavis>`__
+- `Geoffrey Van Landeghem (@geoffrey-vl) <https://github.com/geoffrey-vl>`__
 - `Gérald Guiony (@gerald-guiony) <https://github.com/gerald-guiony>`__
 - `Gerard (@gerard33) <https://github.com/gerard33>`__
 - `Giampiero Baggiani (@giampiero7) <https://github.com/giampiero7>`__
 - `Gideon Kanikevich (@gid204) <https://github.com/gid204>`__
 - `Giel Janssens (@gieljnssns) <https://github.com/gieljnssns>`__
+- `Giovanni (@Gio-dot) <https://github.com/Gio-dot>`__
 - `Giovanni (@gio-dot) <https://github.com/gio-dot>`__
 - `git2212 (@git2212) <https://github.com/git2212>`__
+- `GitforZhangXL (@GitforZhangXL) <https://github.com/GitforZhangXL>`__
 - `github-actions[bot] (@github-actions[bot]) <https://github.com/github-actions[bot]>`__
 - `gitolicious (@gitolicious) <https://github.com/gitolicious>`__
 - `The Gitter Badger (@gitter-badger) <https://github.com/gitter-badger>`__
 - `Frederik Gladhorn (@gladhorn) <https://github.com/gladhorn>`__
 - `Guillermo Ruffino (@glmnet) <https://github.com/glmnet>`__
+- `Giorgos Logiotatidis (@glogiotatidis) <https://github.com/glogiotatidis>`__
 - `Germán Martín (@gmag11) <https://github.com/gmag11>`__
+- `Germain Masse (@gmasse) <https://github.com/gmasse>`__
 - `Garret Buell (@gmbuell) <https://github.com/gmbuell>`__
+- `Jelle Raaijmakers (@GMTA) <https://github.com/GMTA>`__
+- `Jelle Raaijmakers (@gmta) <https://github.com/gmta>`__
 - `gnicolasb (@gnicolasb) <https://github.com/gnicolasb>`__
 - `Mischa Siekmann (@gnumpi) <https://github.com/gnumpi>`__
 - `Go0oSer (@Go0oSer) <https://github.com/Go0oSer>`__
@@ -565,17 +674,27 @@ Contributors
 - `Granville Barker (@granvillebarker) <https://github.com/granvillebarker>`__
 - `Antoine GRÉA (@grea09) <https://github.com/grea09>`__
 - `Greg Arnold (@GregJArnold) <https://github.com/GregJArnold>`__
+- `Greg MacLellan (@gregmac) <https://github.com/gregmac>`__
 - `Gil Peeters (@grillp) <https://github.com/grillp>`__
+- `Guillaume Rischard (@grischard) <https://github.com/grischard>`__
 - `George (@grob6000) <https://github.com/grob6000>`__
 - `groovejumper (@groovejumper) <https://github.com/groovejumper>`__
+- `Stefan Grufman (@GruffyPuffy) <https://github.com/GruffyPuffy>`__
 - `gsexton (@gsexton) <https://github.com/gsexton>`__
 - `Gabriel Sieben (@gsieben) <https://github.com/gsieben>`__
+- `Jadson Santos (@gtjadsonsantos) <https://github.com/gtjadsonsantos>`__
+- `guardmedia (@guardmedia) <https://github.com/guardmedia>`__
+- `Andrea (@Guglio95) <https://github.com/Guglio95>`__
+- `Guillaume DELVIT (@guiguid) <https://github.com/guiguid>`__
 - `guillempages (@guillempages) <https://github.com/guillempages>`__
 - `Fabian Pflug (@gumulka) <https://github.com/gumulka>`__
+- `guptamp (@guptamp) <https://github.com/guptamp>`__
 - `Guyohms (@Guyohms) <https://github.com/Guyohms>`__
 - `Gilles van den Hoven (@gvdhoven) <https://github.com/gvdhoven>`__
+- `h0-- (@h0--) <https://github.com/h0-->`__
 - `h0jeZvgoxFepBQ2C (@h0jeZvgoxFepBQ2C) <https://github.com/h0jeZvgoxFepBQ2C>`__
 - `h3ndrik (@h3ndrik) <https://github.com/h3ndrik>`__
+- `H3 (@H3wastooshort) <https://github.com/H3wastooshort>`__
 - `Andi (@h4de5) <https://github.com/h4de5>`__
 - `haade (@haade-administrator) <https://github.com/haade-administrator>`__
 - `Peter van Dijk (@Habbie) <https://github.com/Habbie>`__
@@ -583,30 +702,45 @@ Contributors
 - `Hagai Shatz (@hagai-shatz) <https://github.com/hagai-shatz>`__
 - `hajar97 (@hajar97) <https://github.com/hajar97>`__
 - `Boris Hajduk (@hajdbo) <https://github.com/hajdbo>`__
+- `Gavin Mogan (@halkeye) <https://github.com/halkeye>`__
 - `Charles (@hallard) <https://github.com/hallard>`__
+- `Alex Griffith (@halomademeapc) <https://github.com/halomademeapc>`__
 - `Aniket (@HandyHat) <https://github.com/HandyHat>`__
+- `Harrison Jones (@harrisonhjones) <https://github.com/harrisonhjones>`__
 - `Charles Thompson (@haryadoon) <https://github.com/haryadoon>`__
 - `Ha Thach (@hathach) <https://github.com/hathach>`__
 - `Cong Hoang Nguyen (@HcNguyen111) <https://github.com/HcNguyen111>`__
 - `hcoohb (@hcoohb) <https://github.com/hcoohb>`__
+- `Héctor Giménez (@hectorgimenez) <https://github.com/hectorgimenez>`__
 - `helgek (@helgek) <https://github.com/helgek>`__
 - `hellotomtom (@hellotomtom) <https://github.com/hellotomtom>`__
 - `Jimmy Hedman (@HeMan) <https://github.com/HeMan>`__
 - `Hemi03 (@Hemi03) <https://github.com/Hemi03>`__
 - `HengYongChao (@HengYongChao) <https://github.com/HengYongChao>`__
+- `HepoH3 (@HepoH3) <https://github.com/HepoH3>`__
 - `Hermann Kraus (@herm) <https://github.com/herm>`__
 - `Herr Frei (@herrfrei) <https://github.com/herrfrei>`__
+- `Tom Cassady (@heytcass) <https://github.com/heytcass>`__
 - `Nate Clark (@heythisisnate) <https://github.com/heythisisnate>`__
 - `highground88 (@highground88) <https://github.com/highground88>`__
 - `hindenbugbite (@hindenbugbite) <https://github.com/hindenbugbite>`__
+- `Henrik Fransson (@hmfhmf) <https://github.com/hmfhmf>`__
+- `Hamish Moffatt (@hmoffatt) <https://github.com/hmoffatt>`__
 - `Hobby Components (@HobbyComponents) <https://github.com/HobbyComponents>`__
+- `Marcel Hoppe (@hobbypunk90) <https://github.com/hobbypunk90>`__
+- `Sebastian Raff (@hobbyquaker) <https://github.com/hobbyquaker>`__
+- `MoA (@honomoa) <https://github.com/honomoa>`__
 - `Hopperpop (@Hopperpop) <https://github.com/Hopperpop>`__
 - `Ilia Sotnikov (@hostcc) <https://github.com/hostcc>`__
+- `Yang Hau (@HowJMay) <https://github.com/HowJMay>`__
 - `Yang Hau (@howjmay) <https://github.com/howjmay>`__
 - `hpineapples (@hpineapples) <https://github.com/hpineapples>`__
 - `Antonio Vanegas (@hpsaturn) <https://github.com/hpsaturn>`__
 - `hreintke (@hreintke) <https://github.com/hreintke>`__
+- `Jan Hubík (@hubikj) <https://github.com/hubikj>`__
+- `Huub Eikens (@huubeikens) <https://github.com/huubeikens>`__
 - `Steve Rodgers (@hwstar) <https://github.com/hwstar>`__
+- `Petr Urbánek (@HyperReap) <https://github.com/HyperReap>`__
 - `hificat (@hzkincony) <https://github.com/hzkincony>`__
 - `Arjan Filius (@iafilius) <https://github.com/iafilius>`__
 - `Iain Hay (@IainPHay) <https://github.com/IainPHay>`__
@@ -614,70 +748,112 @@ Contributors
 - `Adrián Panella (@ianchi) <https://github.com/ianchi>`__
 - `Ian Anderson (@ianderso) <https://github.com/ianderso>`__
 - `Ian Leeder (@ianleeder) <https://github.com/ianleeder>`__
+- `Jan Pobořil (@iBobik) <https://github.com/iBobik>`__
+- `icarome (@icarome) <https://github.com/icarome>`__
 - `icefest (@icefest) <https://github.com/icefest>`__
 - `igg (@igg) <https://github.com/igg>`__
 - `Ignacio Hernandez-Ros (@IgnacioHR) <https://github.com/IgnacioHR>`__
+- `Petko Bordjukov (@ignisf) <https://github.com/ignisf>`__
 - `Ivan Grokhotkov (@igrr) <https://github.com/igrr>`__
 - `ikatkov (@ikatkov) <https://github.com/ikatkov>`__
 - `Dion (@ikbendion) <https://github.com/ikbendion>`__
+- `Tim Smeets (@ikilledmypc) <https://github.com/ikilledmypc>`__
 - `iKK001 (@iKK001) <https://github.com/iKK001>`__
 - `ilium007 (@ilium007) <https://github.com/ilium007>`__
 - `Iman Ahmadvand (@IMAN4K) <https://github.com/IMAN4K>`__
+- `Michael (@imeekle) <https://github.com/imeekle>`__
 - `imgbot[bot] (@imgbot[bot]) <https://github.com/imgbot[bot]>`__
+- `ImSorryButWho (@ImSorryButWho) <https://github.com/ImSorryButWho>`__
 - `imwoo90 (@imwoo90) <https://github.com/imwoo90>`__
+- `Lorenzo Ortiz (@Infinitte) <https://github.com/Infinitte>`__
 - `Dom (@Ing-Dom) <https://github.com/Ing-Dom>`__
+- `Samir El Benna (@ingbenna) <https://github.com/ingbenna>`__
 - `Ingo Becker (@ingobecker) <https://github.com/ingobecker>`__
+- `Ingurum (@Ingurum) <https://github.com/Ingurum>`__
 - `Marc J (@InvncibiltyCloak) <https://github.com/InvncibiltyCloak>`__
 - `IoT-devices LLC (@iotdevicesdev) <https://github.com/iotdevicesdev>`__
+- `Ivo Roefs (@ironirc) <https://github.com/ironirc>`__
 - `irtimaled (@irtimaled) <https://github.com/irtimaled>`__
+- `Ingo Theiss (@itn3rd77) <https://github.com/itn3rd77>`__
 - `itpeters (@itpeters) <https://github.com/itpeters>`__
+- `Ivan Shvedunov (@ivan4th) <https://github.com/ivan4th>`__
 - `Ivan Kravets (@ivankravets) <https://github.com/ivankravets>`__
 - `Ivan Lisenkov (@ivlis) <https://github.com/ivlis>`__
+- `Ivo-tje (@Ivo-tje) <https://github.com/Ivo-tje>`__
 - `J0RD4N300 (@J0RD4N300) <https://github.com/J0RD4N300>`__
 - `jacobswe (@jacobswe) <https://github.com/jacobswe>`__
 - `Fredrik Gustafsson (@jagheterfredrik) <https://github.com/jagheterfredrik>`__
+- `Jan Harkes (@jaharkes) <https://github.com/jaharkes>`__
 - `jakehdk (@jakehdk) <https://github.com/jakehdk>`__
 - `Jake Shirley (@JakeShirley) <https://github.com/JakeShirley>`__
 - `Jonathan Kollasch (@jakllsch) <https://github.com/jakllsch>`__
+- `Jakob Reiter (@jakommo) <https://github.com/jakommo>`__
 - `jakub-medrzak (@jakub-medrzak) <https://github.com/jakub-medrzak>`__
+- `James Braid (@jamesbraid) <https://github.com/jamesbraid>`__
+- `James Duke (@jamesduke) <https://github.com/jamesduke>`__
+- `James Gao (@jamesgao) <https://github.com/jamesgao>`__
 - `James Hirka (@jameshirka) <https://github.com/jameshirka>`__
 - `James Myatt (@jamesmyatt) <https://github.com/jamesmyatt>`__
 - `James Lakin (@jamesorlakin) <https://github.com/jamesorlakin>`__
+- `James Swift (@JamesSwift) <https://github.com/JamesSwift>`__
 - `Jamie Cole (@jamiejcole) <https://github.com/jamiejcole>`__
 - `Jason (@jamman9000) <https://github.com/jamman9000>`__
 - `Juraj Andrássy (@JAndrassy) <https://github.com/JAndrassy>`__
 - `Delio Castillo (@jangeador) <https://github.com/jangeador>`__
 - `Jan Grewe (@jangrewe) <https://github.com/jangrewe>`__
 - `Jan (@janlindblom) <https://github.com/janlindblom>`__
+- `János Rusiczki (@janosrusiczki) <https://github.com/janosrusiczki>`__
 - `Jan Pieper (@janpieper) <https://github.com/janpieper>`__
 - `Jared Ring (@jaredring) <https://github.com/jaredring>`__
+- `Jarek.P (@JaroslawPrzybyl) <https://github.com/JaroslawPrzybyl>`__
 - `Jason-nz (@Jason-nz) <https://github.com/Jason-nz>`__
 - `Jason2866 (@Jason2866) <https://github.com/Jason2866>`__
+- `Jason Hines (@jasonehines) <https://github.com/jasonehines>`__
+- `JasperPlant (@JasperPlant) <https://github.com/JasperPlant>`__
 - `Jas Strong (@jasstrong) <https://github.com/jasstrong>`__
 - `Alex Boyd (@javawizard) <https://github.com/javawizard>`__
 - `Jay Greco (@jaygreco) <https://github.com/jaygreco>`__
 - `Jay Newstrom (@JayNewstrom) <https://github.com/JayNewstrom>`__
 - `Jeff (@jazzmonger) <https://github.com/jazzmonger>`__
+- `Jonas Bergler (@jbergler) <https://github.com/jbergler>`__
+- `JbLb (@jblb) <https://github.com/jblb>`__
+- `Jonathan Burns (@jburns20) <https://github.com/jburns20>`__
+- `James Callaghan (@jcallaghan) <https://github.com/jcallaghan>`__
 - `Jc Miñarro (@JcMinarro) <https://github.com/JcMinarro>`__
 - `Josh Willox (@jcwillox) <https://github.com/jcwillox>`__
+- `Joshua Dadswell (@jdads1) <https://github.com/jdads1>`__
+- `jddonovan (@jddonovan) <https://github.com/jddonovan>`__
 - `JeeCee1 (@JeeCee1) <https://github.com/JeeCee1>`__
+- `Jeef (@jeeftor) <https://github.com/jeeftor>`__
 - `jeff-h (@jeff-h) <https://github.com/jeff-h>`__
+- `Jeffrey Borg (@jeffborg) <https://github.com/jeffborg>`__
+- `Jeff Eberl (@jeffeb3) <https://github.com/jeffeb3>`__
 - `Jeff Rescignano (@JeffResc) <https://github.com/JeffResc>`__
 - `Jej (@jej) <https://github.com/jej>`__
 - `Jens-Christian Skibakk (@jenscski) <https://github.com/jenscski>`__
 - `Jeremy Willans (@jeremywillans) <https://github.com/jeremywillans>`__
+- `Jeroen (@jeroen85) <https://github.com/jeroen85>`__
 - `Jeroen van Oort (@JeroenVanOort) <https://github.com/JeroenVanOort>`__
 - `jerome992 (@jerome992) <https://github.com/jerome992>`__
+- `Jérôme Laban (@jeromelaban) <https://github.com/jeromelaban>`__
 - `Jesse Hills (@jesserockz) <https://github.com/jesserockz>`__
 - `Jessica Hamilton (@jessicah) <https://github.com/jessicah>`__
 - `J.G.Aguado (@JGAguado) <https://github.com/JGAguado>`__
+- `James Szalay (@jgissend10) <https://github.com/jgissend10>`__
+- `Joel Goguen (@jgoguen) <https://github.com/jgoguen>`__
 - `Yuval Brik (@jhamhader) <https://github.com/jhamhader>`__
 - `Joe (@jhansche) <https://github.com/jhansche>`__
+- `Jan Pieter Waagmeester (@jieter) <https://github.com/jieter>`__
+- `Jim Bauwens (@jimbauwens) <https://github.com/jimbauwens>`__
 - `jimtng (@jimtng) <https://github.com/jimtng>`__
 - `jivesinger (@jivesinger) <https://github.com/jivesinger>`__
 - `jj-uk (@jj-uk) <https://github.com/jj-uk>`__
+- `Jeroen (@jjansen85) <https://github.com/jjansen85>`__
 - `Jean J. de Jong (@jjdejong) <https://github.com/jjdejong>`__
+- `Jérémy JOURDIN (@JJK801) <https://github.com/JJK801>`__
+- `Jonathan Jefferies (@jjok) <https://github.com/jjok>`__
 - `John K. Luebs (@jkl1337) <https://github.com/jkl1337>`__
+- `Justin Maxwell (@jkmaxwell) <https://github.com/jkmaxwell>`__
 - `Jeppe Ladefoged (@jladefoged) <https://github.com/jladefoged>`__
 - `Jean-Luc Béchennec (@jlbirccyn) <https://github.com/jlbirccyn>`__
 - `JLo (@jlpouffier) <https://github.com/jlpouffier>`__
@@ -689,7 +865,11 @@ Contributors
 - `Jonathas Barbosa (@jnthas) <https://github.com/jnthas>`__
 - `jochenvg (@jochenvg) <https://github.com/jochenvg>`__
 - `joederpoliveira (@joederpoliveira) <https://github.com/joederpoliveira>`__
+- `Joe Gross (@joegross) <https://github.com/joegross>`__
+- `Johan van der Kuijl (@johanvanderkuijl) <https://github.com/johanvanderkuijl>`__
 - `Johboh (@Johboh) <https://github.com/Johboh>`__
+- `John Britton (@johndbritton) <https://github.com/johndbritton>`__
+- `John Erik Halse (@johnerikhalse) <https://github.com/johnerikhalse>`__
 - `John Moxley (@johnmoxley) <https://github.com/johnmoxley>`__
 - `John White (@johnpwhite) <https://github.com/johnpwhite>`__
 - `Dave Johnston (@johnsto) <https://github.com/johnsto>`__
@@ -697,11 +877,16 @@ Contributors
 - `JonasEr (@JonasEr) <https://github.com/JonasEr>`__
 - `Jonas Niesner (@jonasniesner) <https://github.com/jonasniesner>`__
 - `Jonathan Adams (@jonathanadams) <https://github.com/jonathanadams>`__
+- `Jonathan Treffler (@JonathanTreffler) <https://github.com/JonathanTreffler>`__
 - `Jonathan Laliberte (@JonLaliberte) <https://github.com/JonLaliberte>`__
 - `JonnyaiR (@jonnyair) <https://github.com/jonnyair>`__
+- `Jonny Bergdahl (@jonnybergdahl) <https://github.com/jonnybergdahl>`__
+- `Jonathan V (@jonofmac) <https://github.com/jonofmac>`__
 - `jonOfrie (@jonOfrie) <https://github.com/jonOfrie>`__
+- `Joppy (@JoppyFurr) <https://github.com/JoppyFurr>`__
 - `Joris S (@Jorre05) <https://github.com/Jorre05>`__
 - `Jared Sanson (@jorticus) <https://github.com/jorticus>`__
+- `joseph douce (@josephdouce) <https://github.com/josephdouce>`__
 - `JosephTang (@JosephTang) <https://github.com/JosephTang>`__
 - `Joshua Baran  (@joshbaran) <https://github.com/joshbaran>`__
 - `Joshua Spence (@joshuaspence) <https://github.com/joshuaspence>`__
@@ -713,22 +898,40 @@ Contributors
 - `Jules-R (@Jules-R) <https://github.com/Jules-R>`__
 - `Julie Koubová (@juliekoubova) <https://github.com/juliekoubova>`__
 - `junkie1969 (@junkie1969) <https://github.com/junkie1969>`__
+- `junnikokuki (@junnikokuki) <https://github.com/junnikokuki>`__
+- `Justahobby01 (@Justahobby01) <https://github.com/Justahobby01>`__
 - `Mike Ryan (@justfalter) <https://github.com/justfalter>`__
+- `Justin Gerhardt (@justin-gerhardt) <https://github.com/justin-gerhardt>`__
+- `Justyn Shull (@justyns) <https://github.com/justyns>`__
+- `Jasper van der Neut - Stulen (@jvanderneutstulen) <https://github.com/jvanderneutstulen>`__
+- `João Vitor M. Roma (@jvmr1) <https://github.com/jvmr1>`__
+- `Jack Wozny (@jwozny) <https://github.com/jwozny>`__
+- `Jozef Zuzelka (@jzlka) <https://github.com/jzlka>`__
 - `Kris (@K-r-i-s-t-i-a-n) <https://github.com/K-r-i-s-t-i-a-n>`__
 - `k0rtina (@k0rtina) <https://github.com/k0rtina>`__
+- `Harald Nagel (@k7hpn) <https://github.com/k7hpn>`__
 - `kaegi (@kaegi) <https://github.com/kaegi>`__
 - `kahrendt (@kahrendt) <https://github.com/kahrendt>`__
 - `Kaldek (@Kaldek) <https://github.com/Kaldek>`__
+- `kalebzettl (@kalebzettl) <https://github.com/kalebzettl>`__
 - `Kamahat (@kamahat) <https://github.com/kamahat>`__
+- `Kapil Yedidi (@kapily) <https://github.com/kapily>`__
 - `Karl0ss (@karl0ss) <https://github.com/karl0ss>`__
+- `Karol Zlot (@karolzlot) <https://github.com/karolzlot>`__
 - `kartman85 (@kartman85) <https://github.com/kartman85>`__
 - `Kattni (@kattni) <https://github.com/kattni>`__
+- `Krasimir Nedelchev (@kaykayehnn) <https://github.com/kaykayehnn>`__
 - `Krzysztof Białek (@kbialek) <https://github.com/kbialek>`__
 - `Keilin Bickar (@kbickar) <https://github.com/kbickar>`__
+- `kbouchard111 (@kbouchard111) <https://github.com/kbouchard111>`__
 - `Keith Burzinski (@kbx81) <https://github.com/kbx81>`__
 - `Ken Piper (@Kealper) <https://github.com/Kealper>`__
+- `Tom Keller (@kellertk) <https://github.com/kellertk>`__
 - `Kelvie Wong (@kelvie) <https://github.com/kelvie>`__
+- `Kenny Stier (@KennyStier) <https://github.com/KennyStier>`__
+- `Robert Kiss (@kepten) <https://github.com/kepten>`__
 - `kernelpanic85 (@kernelpanic85) <https://github.com/kernelpanic85>`__
+- `Kevin O'Rourke (@kevinior) <https://github.com/kevinior>`__
 - `Kevin Reilly (@kevireilly) <https://github.com/kevireilly>`__
 - `kevlar10 (@kevlar10) <https://github.com/kevlar10>`__
 - `kfulko (@kfulko) <https://github.com/kfulko>`__
@@ -737,37 +940,73 @@ Contributors
 - `Khoi Hoang (@khoih-prog) <https://github.com/khoih-prog>`__
 - `AngeloGioacchino Del Regno (@kholk) <https://github.com/kholk>`__
 - `Kilowatt (@Kilowatt-W) <https://github.com/Kilowatt-W>`__
+- `kimonm (@kimonm) <https://github.com/kimonm>`__
 - `Kip (@kipwittchen) <https://github.com/kipwittchen>`__
+- `Ed (@kixtarter) <https://github.com/kixtarter>`__
+- `Kurt Kellner (@kkellner) <https://github.com/kkellner>`__
 - `Klaas Schoute (@klaasnicolaas) <https://github.com/klaasnicolaas>`__
 - `Klarstein (@Klarstein) <https://github.com/Klarstein>`__
 - `Marcus Klein (@kleini) <https://github.com/kleini>`__
+- `klenaers (@klenaers) <https://github.com/klenaers>`__
+- `Kevin Lewis (@kll) <https://github.com/kll>`__
 - `KNXBroker (@KNXBroker) <https://github.com/KNXBroker>`__
+- `KoenBreeman (@KoenBreeman) <https://github.com/KoenBreeman>`__
+- `Koen Vervloesem (@koenvervloesem) <https://github.com/koenvervloesem>`__
 - `kokangit (@kokangit) <https://github.com/kokangit>`__
+- `Petr Vraník (@konikvranik) <https://github.com/konikvranik>`__
 - `konsulten (@konsulten) <https://github.com/konsulten>`__
+- `korellas (@korellas) <https://github.com/korellas>`__
+- `Kevin Pelzel (@kpelzel) <https://github.com/kpelzel>`__
 - `Kevin P. Fleming (@kpfleming) <https://github.com/kpfleming>`__
 - `Karl Q. (@kquinsland) <https://github.com/kquinsland>`__
+- `krahabb (@krahabb) <https://github.com/krahabb>`__
 - `Anandha Saravanan (@KratosMr) <https://github.com/KratosMr>`__
+- `Kodey Converse (@krconv) <https://github.com/krconv>`__
+- `krikk (@krikk) <https://github.com/krikk>`__
+- `KristopherMackowiak (@KristopherMackowiak) <https://github.com/KristopherMackowiak>`__
 - `kroimon (@kroimon) <https://github.com/kroimon>`__
 - `krunkel (@krunkel) <https://github.com/krunkel>`__
 - `kryptonitecb3 (@kryptonitecb3) <https://github.com/kryptonitecb3>`__
 - `kstrouse (@kstrouse) <https://github.com/kstrouse>`__
 - `Kendell R (@KTibow) <https://github.com/KTibow>`__
 - `Kuba Szczodrzyński (@kuba2k2) <https://github.com/kuba2k2>`__
+- `Jakub Šimo (@kubik369) <https://github.com/kubik369>`__
 - `Mark Kuchel (@kuchel77) <https://github.com/kuchel77>`__
+- `kvvoff (@kvvoff) <https://github.com/kvvoff>`__
+- `Ken Davidson (@kwdavidson) <https://github.com/kwdavidson>`__
+- `Kyle Hendricks (@kylehendricks) <https://github.com/kylehendricks>`__
+- `Kyle Manna (@kylemanna) <https://github.com/kylemanna>`__
 - `Kyle Hill (@kylhill) <https://github.com/kylhill>`__
+- `Kalashnikov Ilya (@l1bbcsg) <https://github.com/l1bbcsg>`__
+- `la7dja (@la7dja) <https://github.com/la7dja>`__
 - `Limor "Ladyada" Fried (@ladyada) <https://github.com/ladyada>`__
+- `Stefan Lässer (@Laess3r) <https://github.com/Laess3r>`__
+- `Steffen Weinreich (@lairsdragon) <https://github.com/lairsdragon>`__
+- `Lakshantha Dissanayake (@lakshanthad) <https://github.com/lakshanthad>`__
+- `Luca Adrian L (@lal12) <https://github.com/lal12>`__
 - `Landon Rohatensky (@landonr) <https://github.com/landonr>`__
+- `Fredrik Lindqvist (@Landrash) <https://github.com/Landrash>`__
 - `lanik (@lanik) <https://github.com/lanik>`__
+- `larsonmpdx (@larsonmpdx) <https://github.com/larsonmpdx>`__
 - `Anton Viktorov (@latonita) <https://github.com/latonita>`__
 - `Lawrie George (@lawriege) <https://github.com/lawriege>`__
+- `Laszlo Gazdag (@lazlyhu) <https://github.com/lazlyhu>`__
 - `Ludovic BOUÉ (@lboue) <https://github.com/lboue>`__
 - `lcavalli (@lcavalli) <https://github.com/lcavalli>`__
 - `Craig Fletcher (@leakypixel) <https://github.com/leakypixel>`__
+- `Dominik Wagenknecht (@LeDominik) <https://github.com/LeDominik>`__
 - `Benny de Leeuw (@leeuwte) <https://github.com/leeuwte>`__
 - `Thayne (@Legot) <https://github.com/Legot>`__
+- `lein1013 (@lein1013) <https://github.com/lein1013>`__
 - `Leonardo La Rocca (@leoli51) <https://github.com/leoli51>`__
 - `leoshusar (@leoshusar) <https://github.com/leoshusar>`__
+- `Leo Winter (@LeoWinterDE) <https://github.com/LeoWinterDE>`__
 - `Leo Winter (@leowinterde) <https://github.com/leowinterde>`__
+- `Riku Lindblad (@lepinkainen) <https://github.com/lepinkainen>`__
+- `Lerosen (@Lerosen) <https://github.com/Lerosen>`__
+- `Lewis Baker (@lewissbaker) <https://github.com/lewissbaker>`__
+- `Leon Loopik (@Lewn) <https://github.com/Lewn>`__
+- `Luca Gugelmann (@lgugelmann) <https://github.com/lgugelmann>`__
 - `Lubos Horacek (@lhoracek) <https://github.com/lhoracek>`__
 - `Liionboy (@Liionboy) <https://github.com/Liionboy>`__
 - `Juraj Liso (@LiJu09) <https://github.com/LiJu09>`__
@@ -779,25 +1018,36 @@ Contributors
 - `Markus (@Links2004) <https://github.com/Links2004>`__
 - `LinusHeu (@LinusHeu) <https://github.com/LinusHeu>`__
 - `lkomurcu (@lkomurcu) <https://github.com/lkomurcu>`__
+- `Luis Andrade (@llluis) <https://github.com/llluis>`__
 - `loadrunner42 (@loadrunner42) <https://github.com/loadrunner42>`__
 - `Lazar Obradovic (@lobradov) <https://github.com/lobradov>`__
+- `Lode Vermeiren (@lodev) <https://github.com/lodev>`__
 - `Barry Loong (@loongyh) <https://github.com/loongyh>`__
+- `Michael Bisbjerg (@LordMike) <https://github.com/LordMike>`__
 - `LuBeDa (@lubeda) <https://github.com/lubeda>`__
+- `Lukáš Maňas (@LucasCZE) <https://github.com/LucasCZE>`__
 - `Lucas Prim (@lucasprim) <https://github.com/lucasprim>`__
+- `Lucas Reiners (@lucasreiners) <https://github.com/lucasreiners>`__
 - `Joakim Sørensen (@ludeeus) <https://github.com/ludeeus>`__
 - `ludrao (@ludrao) <https://github.com/ludrao>`__
 - `Luiz Correia (@luizcorreia) <https://github.com/luizcorreia>`__
 - `luka6000 (@luka6000) <https://github.com/luka6000>`__
+- `Lukas Klass (@LukasK13) <https://github.com/LukasK13>`__
+- `Lukas Lindner (@lukasl96) <https://github.com/lukasl96>`__
+- `lukaszrud (@lukaszrud) <https://github.com/lukaszrud>`__
 - `Łukasz Świtaj (@lukaszswitaj) <https://github.com/lukaszswitaj>`__
 - `Luke (@Lukeskaiwalker) <https://github.com/Lukeskaiwalker>`__
 - `Jayden (@lukyjay) <https://github.com/lukyjay>`__
 - `Lumpusz (@Lumpusz) <https://github.com/Lumpusz>`__
 - `Ohad Lutzky (@lutzky) <https://github.com/lutzky>`__
 - `Luke Fitzgerald (@lwfitzgerald) <https://github.com/lwfitzgerald>`__
+- `Lewis Juggins (@lwis) <https://github.com/lwis>`__
 - `Alex Peters (@Lx) <https://github.com/Lx>`__
 - `Linar Yusupov (@lyusupov) <https://github.com/lyusupov>`__
+- `Michael Klamminger (@m1ch) <https://github.com/m1ch>`__
 - `M3C-Owx (@M3C-Owx) <https://github.com/M3C-Owx>`__
 - `85368.MB (@M4dMikel) <https://github.com/M4dMikel>`__
+- `M95D (@M95D) <https://github.com/M95D>`__
 - `maaadc (@maaadc) <https://github.com/maaadc>`__
 - `Marc-Antoine Courteau (@macourteau) <https://github.com/macourteau>`__
 - `Madelena Mak (@Madelena) <https://github.com/Madelena>`__
@@ -805,9 +1055,12 @@ Contributors
 - `Massimiliano Ravelli (@madron) <https://github.com/madron>`__
 - `Alexandre-Jacques St-Jacques (@Maelstrom96) <https://github.com/Maelstrom96>`__
 - `Scott Cappellani (@maeneak) <https://github.com/maeneak>`__
+- `magnus (@magnusja) <https://github.com/magnusja>`__
 - `Magnus Nordlander (@magnusnordlander) <https://github.com/magnusnordlander>`__
+- `Magnus Øverli (@magnusoverli) <https://github.com/magnusoverli>`__
 - `majbthrd (@majbthrd) <https://github.com/majbthrd>`__
 - `Piotr Majkrzak (@majkrzak) <https://github.com/majkrzak>`__
+- `Major Péter (@majorpeter) <https://github.com/majorpeter>`__
 - `Dmitry (@mak-42) <https://github.com/mak-42>`__
 - `Kasper Malfroid (@malfroid) <https://github.com/malfroid>`__
 - `Malle355 (@Malle355) <https://github.com/Malle355>`__
@@ -819,13 +1072,19 @@ Contributors
 - `Marcel van der Veldt (@marcelveldt) <https://github.com/marcelveldt>`__
 - `Marc (@MarcHagen) <https://github.com/MarcHagen>`__
 - `marcinkowalczyk (@marcinkowalczyk) <https://github.com/marcinkowalczyk>`__
+- `Marcio Granzotto Rodrigues (@marciogranzotto) <https://github.com/marciogranzotto>`__
+- `Marc Teale (@marcteale) <https://github.com/marcteale>`__
 - `marecabo (@marecabo) <https://github.com/marecabo>`__
 - `Ben Marengo (@marengaz) <https://github.com/marengaz>`__
 - `Marvin Gaube (@margau) <https://github.com/margau>`__
+- `Martynas Griškonis (@Margriko) <https://github.com/Margriko>`__
 - `maringeph (@maringeph) <https://github.com/maringeph>`__
+- `Mario (@mario-tux) <https://github.com/mario-tux>`__
 - `Mario Di Vece (@mariodivece) <https://github.com/mariodivece>`__
 - `Mark Hildreth (@markhildreth) <https://github.com/markhildreth>`__
 - `Mark Schabacker (@markschabacker) <https://github.com/markschabacker>`__
+- `Marek Marczykowski-Górecki (@marmarek) <https://github.com/marmarek>`__
+- `Matthew Harrold (@marrold) <https://github.com/marrold>`__
 - `marshn (@marshn) <https://github.com/marshn>`__
 - `marsjan155 (@marsjan155) <https://github.com/marsjan155>`__
 - `Martin (@martgras) <https://github.com/martgras>`__
@@ -833,58 +1092,87 @@ Contributors
 - `Martin Hjelmare (@MartinHjelmare) <https://github.com/MartinHjelmare>`__
 - `MartinWelsch (@MartinWelsch) <https://github.com/MartinWelsch>`__
 - `M-A (@maruel) <https://github.com/maruel>`__
+- `MasterTim17 (@MasterTim17) <https://github.com/MasterTim17>`__
 - `Masterz69 (@Masterz69) <https://github.com/Masterz69>`__
 - `Christopher Masto (@masto) <https://github.com/masto>`__
 - `Mat931 (@Mat931) <https://github.com/Mat931>`__
+- `Maciej Sokołowski (@matemaciek) <https://github.com/matemaciek>`__
+- `Mateus Demboski (@mateusdemboski) <https://github.com/mateusdemboski>`__
 - `mathieu-mp (@mathieu-mp) <https://github.com/mathieu-mp>`__
 - `matikij (@matikij) <https://github.com/matikij>`__
 - `Matjah Sonneveld (@matjahs) <https://github.com/matjahs>`__
 - `Michel Marti (@matoxp) <https://github.com/matoxp>`__
 - `matt123p (@matt123p) <https://github.com/matt123p>`__
 - `Matteo Franceschini (@matteofranceschini) <https://github.com/matteofranceschini>`__
+- `Matthew Mazzanti (@matthewmazzanti) <https://github.com/matthewmazzanti>`__
 - `matthias882 (@matthias882) <https://github.com/matthias882>`__
 - `Mattia Baldani (@mattibal) <https://github.com/mattibal>`__
 - `mattsgreen (@mattsgreen) <https://github.com/mattsgreen>`__
 - `Matus Ivanecky (@maty535) <https://github.com/maty535>`__
 - `matzman666 (@matzman666) <https://github.com/matzman666>`__
+- `Maurice Schleußinger (@maurice-schleussinger) <https://github.com/maurice-schleussinger>`__
 - `Christian (@max246) <https://github.com/max246>`__
 - `Max Bachmann (@maxbachmann) <https://github.com/maxbachmann>`__
 - `Maximilian Gerhardt (@maxgerhardt) <https://github.com/maxgerhardt>`__
 - `mbo18 (@mbo18) <https://github.com/mbo18>`__
+- `mckaymatthew (@mckaymatthew) <https://github.com/mckaymatthew>`__
 - `mcmuller (@mcmuller) <https://github.com/mcmuller>`__
 - `Miguel Diaz Gonçalves (@mdiazgoncalves) <https://github.com/mdiazgoncalves>`__
+- `Matthew Donoughe (@mdonoughe) <https://github.com/mdonoughe>`__
 - `Me No Dev (@me-no-dev) <https://github.com/me-no-dev>`__
 - `Alexandr Zarubkin (@me21) <https://github.com/me21>`__
+- `Joseph Mearman (@Mearman) <https://github.com/Mearman>`__
 - `mechanarchy (@mechanarchy) <https://github.com/mechanarchy>`__
 - `Bas (@Mechazawa) <https://github.com/Mechazawa>`__
+- `Mechotronic (@Mechotronic) <https://github.com/Mechotronic>`__
 - `mecparts (@mecparts) <https://github.com/mecparts>`__
 - `Mohammed Chamma (@mef51) <https://github.com/mef51>`__
 - `megabitdragon (@megabitdragon) <https://github.com/megabitdragon>`__
+- `MeIchthys (@meichthys) <https://github.com/meichthys>`__
 - `meijerwynand (@meijerwynand) <https://github.com/meijerwynand>`__
+- `Marco  (@Melkor82) <https://github.com/Melkor82>`__
 - `Melopero (@melopero) <https://github.com/melopero>`__
 - `melyux (@melyux) <https://github.com/melyux>`__
 - `Merlin Schumacher (@merlinschumacher) <https://github.com/merlinschumacher>`__
+- `Marco Lusini (@met67) <https://github.com/met67>`__
 - `Martin Flasskamp (@MFlasskamp) <https://github.com/MFlasskamp>`__
 - `Michael Hoffmann (@mghoffmann) <https://github.com/mghoffmann>`__
+- `Michael Gorven (@mgorven) <https://github.com/mgorven>`__
 - `Michaël Guay-Lambert (@mguaylam) <https://github.com/mguaylam>`__
+- `Michael Haas (@mhaas) <https://github.com/mhaas>`__
+- `mhentschke (@mhentschke) <https://github.com/mhentschke>`__
 - `Marcel Hetzendorfer (@mhetzi) <https://github.com/mhetzi>`__
 - `M Hightower (@mhightower83) <https://github.com/mhightower83>`__
+- `Jörg Thalheim (@Mic92) <https://github.com/Mic92>`__
+- `Michaël Arnauts (@michaelarnauts) <https://github.com/michaelarnauts>`__
+- `michaelmeller (@michaelmeller) <https://github.com/michaelmeller>`__
 - `Michael Muré (@MichaelMure) <https://github.com/MichaelMure>`__
 - `Michal Fapso (@michalfapso) <https://github.com/michalfapso>`__
+- `Micha Nordmann (@Michanord) <https://github.com/Michanord>`__
 - `Michał (@michau-krakow) <https://github.com/michau-krakow>`__
 - `Michel Munzert (@michelde) <https://github.com/michelde>`__
 - `michlann (@michlann) <https://github.com/michlann>`__
+- `micronen (@micronen) <https://github.com/micronen>`__
 - `micw (@micw) <https://github.com/micw>`__
+- `Midbin (@Midbin) <https://github.com/Midbin>`__
 - `Pauline Middelink (@middelink) <https://github.com/middelink>`__
 - `Joel Midstjärna (@midstar) <https://github.com/midstar>`__
 - `Mike_Went (@MikeWent) <https://github.com/MikeWent>`__
+- `Mikko Tervala (@MikkoTervala) <https://github.com/MikkoTervala>`__
+- `mikosoft83 (@mikosoft83) <https://github.com/mikosoft83>`__
+- `MiKuBB (@MiKuBB) <https://github.com/MiKuBB>`__
 - `Milan Dzuriš (@milandzuris) <https://github.com/milandzuris>`__
 - `Tucker Kern (@mill1000) <https://github.com/mill1000>`__
 - `mingan666 (@mingan666) <https://github.com/mingan666>`__
+- `Minideezel (@minideezel) <https://github.com/minideezel>`__
+- `mipa87 (@mipa87) <https://github.com/mipa87>`__
 - `André Klitzing (@misery) <https://github.com/misery>`__
 - `Tomasz (@Misiu) <https://github.com/Misiu>`__
 - `MisterSilvereagle (@MisterSilvereagle) <https://github.com/MisterSilvereagle>`__
 - `mjbogusz (@mjbogusz) <https://github.com/mjbogusz>`__
+- `Matthew Edwards (@mje-nz) <https://github.com/mje-nz>`__
+- `Matthew Garrett (@mjg59) <https://github.com/mjg59>`__
+- `Maarten (@mjkl-gh) <https://github.com/mjkl-gh>`__
 - `Morton Jonuschat (@mjonuschat) <https://github.com/mjonuschat>`__
 - `mjoshd (@mjoshd) <https://github.com/mjoshd>`__
 - `Matt Kaatman (@mkaatman) <https://github.com/mkaatman>`__
@@ -893,25 +1181,39 @@ Contributors
 - `Matthew Kosmoski (@mkosmo) <https://github.com/mkosmo>`__
 - `Maurice Makaay (@mmakaay) <https://github.com/mmakaay>`__
 - `mmanza (@mmanza) <https://github.com/mmanza>`__
+- `mnaz (@mnaz) <https://github.com/mnaz>`__
+- `Michael Nieß (@mniess) <https://github.com/mniess>`__
 - `mnltake (@mnltake) <https://github.com/mnltake>`__
 - `Matt N. (@mnoorenberghe) <https://github.com/mnoorenberghe>`__
+- `Michał Obrembski (@mobrembski) <https://github.com/mobrembski>`__
+- `monkeyclass (@monkeyclass) <https://github.com/monkeyclass>`__
+- `Moriah Morgan (@moriahjmorgan) <https://github.com/moriahjmorgan>`__
 - `Moriah Morgan (@moriahmorgan) <https://github.com/moriahmorgan>`__
+- `Moritz Glöckl (@moritzgloeckl) <https://github.com/moritzgloeckl>`__
 - `moritzj29 (@moritzj29) <https://github.com/moritzj29>`__
+- `morph027 (@morph027) <https://github.com/morph027>`__
 - `Chris Laplante (@mostthingsweb) <https://github.com/mostthingsweb>`__
+- `Matthew Pettitt (@mpettitt) <https://github.com/mpettitt>`__
 - `Michael P. Flaga (@mpflaga) <https://github.com/mpflaga>`__
+- `Sam Hughes (@MrEditor97) <https://github.com/MrEditor97>`__
 - `MrEditor97 (@mreditor97) <https://github.com/mreditor97>`__
 - `MRemy2 (@MRemy2) <https://github.com/MRemy2>`__
+- `Morgan Robertson (@mrgnr) <https://github.com/mrgnr>`__
+- `Simon Sasburg (@MrHacky) <https://github.com/MrHacky>`__
 - `Mariusz Kryński (@mrk-its) <https://github.com/mrk-its>`__
 - `Michael Davidson (@MrMDavidson) <https://github.com/MrMDavidson>`__
 - `mrred2k (@mrred2k) <https://github.com/mrred2k>`__
+- `Ryan Matthews (@mrrsm) <https://github.com/mrrsm>`__
 - `André Cirne (@MrSuicideParrot) <https://github.com/MrSuicideParrot>`__
 - `mrtoy-me (@mrtoy-me) <https://github.com/mrtoy-me>`__
+- `MrZetor (@MrZetor) <https://github.com/MrZetor>`__
 - `Murray Scott (@mscottco) <https://github.com/mscottco>`__
 - `MSe-5-14 (@MSe-5-14) <https://github.com/MSe-5-14>`__
 - `mtl010957 (@mtl010957) <https://github.com/mtl010957>`__
 - `Giel van Schijndel (@muggenhor) <https://github.com/muggenhor>`__
 - `mulcmu (@mulcmu) <https://github.com/mulcmu>`__
 - `mulder-fbi (@mulder-fbi) <https://github.com/mulder-fbi>`__
+- `Murilo (@murilobaliego) <https://github.com/murilobaliego>`__
 - `Martin Murray (@murrayma) <https://github.com/murrayma>`__
 - `Michel van de Wetering (@mvdwetering) <https://github.com/mvdwetering>`__
 - `Marcus Voß (@mvoss96) <https://github.com/mvoss96>`__
@@ -921,11 +1223,17 @@ Contributors
 - `mwolter805 (@mwolter805) <https://github.com/mwolter805>`__
 - `Morgan Hunter (@mxc42) <https://github.com/mxc42>`__
 - `myhomeiot (@myhomeiot) <https://github.com/myhomeiot>`__
+- `Igor Scheller (@MyIgel) <https://github.com/MyIgel>`__
 - `Mykle (@myklemykle) <https://github.com/myklemykle>`__
+- `myml (@myml) <https://github.com/myml>`__
 - `Mynasru (@Mynasru) <https://github.com/Mynasru>`__
+- `Niels Ulrik Andersen (@myplacedk) <https://github.com/myplacedk>`__
+- `Mikhail Zakharov (@mzakharo) <https://github.com/mzakharo>`__
 - `Kevin Uhlir (@n0bel) <https://github.com/n0bel>`__
 - `n6ham (@n6ham) <https://github.com/n6ham>`__
 - `N6RDV (@N6RDV) <https://github.com/N6RDV>`__
+- `n8detar (@n8detar) <https://github.com/n8detar>`__
+- `Erik Näsström (@Naesstrom) <https://github.com/Naesstrom>`__
 - `H. Árkosi Róbert (@nagyrobi) <https://github.com/nagyrobi>`__
 - `Viktor Nagy (@nagyv) <https://github.com/nagyv>`__
 - `nanoparticle (@nanoparticle) <https://github.com/nanoparticle>`__
@@ -938,30 +1246,50 @@ Contributors
 - `ueno (@nayuta-ueno) <https://github.com/nayuta-ueno>`__
 - `Nazar Mokrynskyi (@nazar-pc) <https://github.com/nazar-pc>`__
 - `Bergont Nicolas (@nbergont) <https://github.com/nbergont>`__
+- `NMC (@ncareau) <https://github.com/ncareau>`__
+- `Nebula (@nebula-it) <https://github.com/nebula-it>`__
+- `needspeed (@needspeed) <https://github.com/needspeed>`__
 - `neilger (@neilger) <https://github.com/neilger>`__
 - `Neil Martin (@neilmartin83) <https://github.com/neilmartin83>`__
 - `Nejc Koncan (@nejc-cc) <https://github.com/nejc-cc>`__
+- `NeoAcheron (@NeoAcheron) <https://github.com/NeoAcheron>`__
+- `neographikal (@neographikal) <https://github.com/neographikal>`__
+- `nepozs (@nepozs) <https://github.com/nepozs>`__
 - `Nerijus Baliūnas (@nerijus) <https://github.com/nerijus>`__
+- `Mike Meessen (@netmikey) <https://github.com/netmikey>`__
 - `NewoPL (@NewoPL) <https://github.com/NewoPL>`__
 - `Nicolas Graziano (@ngraziano) <https://github.com/ngraziano>`__
+- `Nick B. (@NickB1) <https://github.com/NickB1>`__
 - `nickrout (@nickrout) <https://github.com/nickrout>`__
 - `Nick Whyte (@nickw444) <https://github.com/nickw444>`__
 - `Nicky Ivy (@nickyivyca) <https://github.com/nickyivyca>`__
+- `nicuh (@nicuh) <https://github.com/nicuh>`__
 - `NP v/d Spek (@nielsnl68) <https://github.com/nielsnl68>`__
 - `Niels Zeilemaker (@NielsZeilemaker) <https://github.com/NielsZeilemaker>`__
+- `Nigel VH (@nigelvh) <https://github.com/nigelvh>`__
+- `Joakim Vindgard (@nigobo) <https://github.com/nigobo>`__
 - `nikito7 (@nikito7) <https://github.com/nikito7>`__
 - `niklasweber (@niklasweber) <https://github.com/niklasweber>`__
+- `Niorix (@Niorix) <https://github.com/Niorix>`__
 - `Nippey (@Nippey) <https://github.com/Nippey>`__
 - `Zvonimir Haramustek (@nitko12) <https://github.com/nitko12>`__
 - `Nixspers (@Nixspers) <https://github.com/Nixspers>`__
+- `Dennis (@Nizzle) <https://github.com/Nizzle>`__
+- `Nikolay Kitanov (@nkitanov) <https://github.com/nkitanov>`__
 - `nldroid (@nldroid) <https://github.com/nldroid>`__
+- `Nicolas Liaudat (@nliaudat) <https://github.com/nliaudat>`__
 - `Niccolò Maggioni (@nmaggioni) <https://github.com/nmaggioni>`__
 - `nmeachen (@nmeachen) <https://github.com/nmeachen>`__
+- `Alex (@nnmalex) <https://github.com/nnmalex>`__
+- `Jan Sandbrink (@NobodysNightmare) <https://github.com/NobodysNightmare>`__
 - `David Friedland (@nohat) <https://github.com/nohat>`__
 - `Álvaro Fernández Rojas (@Noltari) <https://github.com/Noltari>`__
 - `Łukasz Śliwiński (@nonameplum) <https://github.com/nonameplum>`__
+- `ffabi (@norges) <https://github.com/norges>`__
+- `Greg Johnson (@notgwj) <https://github.com/notgwj>`__
 - `JJ (@notjj) <https://github.com/notjj>`__
 - `Geoffrey Mayo (@notmayo) <https://github.com/notmayo>`__
+- `notsonominal (@notsonominal) <https://github.com/notsonominal>`__
 - `nouser2013 (@nouser2013) <https://github.com/nouser2013>`__
 - `Paul Read (@nsolvepaul) <https://github.com/nsolvepaul>`__
 - `Nick (@ntompson) <https://github.com/ntompson>`__
@@ -978,6 +1306,7 @@ Contributors
 - `Dave Walker (@oddsockmachine) <https://github.com/oddsockmachine>`__
 - `Odd Stråbø (@oddstr13) <https://github.com/oddstr13>`__
 - `Andrey Ganzevich (@odya) <https://github.com/odya>`__
+- `Olivér Falvai (@ofalvai) <https://github.com/ofalvai>`__
 - `ogatatsu (@ogatatsu) <https://github.com/ogatatsu>`__
 - `Oğuzhan Başer (@oguzhanbaser) <https://github.com/oguzhanbaser>`__
 - `Larry (@ojaksch) <https://github.com/ojaksch>`__
@@ -986,15 +1315,19 @@ Contributors
 - `Oliver Hihn (@oliverhihn) <https://github.com/oliverhihn>`__
 - `Omar Ghader (@omarghader) <https://github.com/omarghader>`__
 - `Ömer Şiar Baysal (@omersiar) <https://github.com/omersiar>`__
+- `Oncleben31 (@oncleben31) <https://github.com/oncleben31>`__
+- `onde2rock (@onde2rock) <https://github.com/onde2rock>`__
 - `Onne (@onnlucky) <https://github.com/onnlucky>`__
 - `optimusprimespace (@optimusprimespace) <https://github.com/optimusprimespace>`__
 - `Oscar Bolmsten (@oscar-b) <https://github.com/oscar-b>`__
+- `Trammell Hudson (@osresearch) <https://github.com/osresearch>`__
 - `Otamay (@Otamay) <https://github.com/Otamay>`__
 - `Otto Winter (@OttoWinter) <https://github.com/OttoWinter>`__
 - `Maxime Dufour (@outscale-mdr) <https://github.com/outscale-mdr>`__
 - `Ben Owen (@owenb321) <https://github.com/owenb321>`__
 - `Oxan van Leeuwen (@oxan) <https://github.com/oxan>`__
 - `oxynatOr (@oxynatOr) <https://github.com/oxynatOr>`__
+- `Pack3tL0ss (@Pack3tL0ss) <https://github.com/Pack3tL0ss>`__
 - `Pablo Clemente Maseda (@paclema) <https://github.com/paclema>`__
 - `Paint Your Dragon (@PaintYourDragon) <https://github.com/PaintYourDragon>`__
 - `Victor Tseng (@Palatis) <https://github.com/Palatis>`__
@@ -1002,9 +1335,13 @@ Contributors
 - `Panuruj Khambanonda (PK) (@panuruj) <https://github.com/panuruj>`__
 - `Daniel Mahaney (@Papa-DMan) <https://github.com/Papa-DMan>`__
 - `Christian Schmitt (@papillon81) <https://github.com/papillon81>`__
+- `parats15 (@parats15) <https://github.com/parats15>`__
 - `Faidon Liambotis (@paravoid) <https://github.com/paravoid>`__
 - `Pascal Roeleven (@pascallj) <https://github.com/pascallj>`__
+- `Pasi Suominen (@pasiz) <https://github.com/pasiz>`__
+- `Patrick Felstead (@patfelst) <https://github.com/patfelst>`__
 - `Patrick Collins (@patrickcollins12) <https://github.com/patrickcollins12>`__
+- `Patrick van der Leer (@patvdleer) <https://github.com/patvdleer>`__
 - `Paul Deen (@PaulAntonDeen) <https://github.com/PaulAntonDeen>`__
 - `Paul Monigatti (@paulmonigatti) <https://github.com/paulmonigatti>`__
 - `Paul Nicholls (@pauln) <https://github.com/pauln>`__
@@ -1012,14 +1349,21 @@ Contributors
 - `Bartłomiej Biernacki (@pax0r) <https://github.com/pax0r>`__
 - `Pierre-Alexis Ciavaldini (@pciavald) <https://github.com/pciavald>`__
 - `pcr20 (@pcr20) <https://github.com/pcr20>`__
+- `Paul Doidge (@pdoidge) <https://github.com/pdoidge>`__
 - `peddamat (@peddamat) <https://github.com/peddamat>`__
 - `pedjas (@pedjas) <https://github.com/pedjas>`__
 - `pedrobsm (@pedrobsm) <https://github.com/pedrobsm>`__
+- `peq123 (@peq123) <https://github.com/peq123>`__
 - `Axotron (@per-magnusson) <https://github.com/per-magnusson>`__
 - `per1234 (@per1234) <https://github.com/per1234>`__
+- `perjury (@perjury) <https://github.com/perjury>`__
 - `David (@perldj) <https://github.com/perldj>`__
+- `Peter Valkov (@peter-valkov) <https://github.com/peter-valkov>`__
+- `Peter Foreman (@peterforeman) <https://github.com/peterforeman>`__
 - `Peter Galantha (@peterg79) <https://github.com/peterg79>`__
+- `Peter Halicky (@peterhalicky) <https://github.com/peterhalicky>`__
 - `Peter Polacek (@PeterPolacek) <https://github.com/PeterPolacek>`__
+- `Peter Remøy Paulsen (@petrepa) <https://github.com/petrepa>`__
 - `Peter Kieser (@pfak) <https://github.com/pfak>`__
 - `Lee (@phatone007) <https://github.com/phatone007>`__
 - `Philippe Delodder (@phdelodder) <https://github.com/phdelodder>`__
@@ -1028,23 +1372,32 @@ Contributors
 - `Philippe FOUQUET (@Philippe12) <https://github.com/Philippe12>`__
 - `Philipp Molitor (@PhilippMolitor) <https://github.com/PhilippMolitor>`__
 - `Philip Rosenberg-Watt (@PhilRW) <https://github.com/PhilRW>`__
+- `phjr (@phjr) <https://github.com/phjr>`__
+- `NuclearPhoenix (@Phoenix1747) <https://github.com/Phoenix1747>`__
 - `phoenixswiss (@phoenixswiss) <https://github.com/phoenixswiss>`__
 - `Philip Persson (@PhPersson) <https://github.com/PhPersson>`__
 - `Pierre Gordon (@pierlon) <https://github.com/pierlon>`__
 - `pieterbrink123 (@pieterbrink123) <https://github.com/pieterbrink123>`__
+- `pille (@pille) <https://github.com/pille>`__
 - `Jakub Augustynowicz (@pingwiniasty) <https://github.com/pingwiniasty>`__
 - `Piotr Kubiak (@piotr-kubiak) <https://github.com/piotr-kubiak>`__
+- `Tommy van der Vorst (@pixelspark) <https://github.com/pixelspark>`__
+- `pixiandreas (@pixiandreas) <https://github.com/pixiandreas>`__
 - `Peter Kuehne (@pkuehne) <https://github.com/pkuehne>`__
 - `Plácido Revilla (@placidorevilla) <https://github.com/placidorevilla>`__
 - `PlainTechEnthusiast (@PlainTechEnthusiast) <https://github.com/PlainTechEnthusiast>`__
+- `Marcus Kempe (@plopp) <https://github.com/plopp>`__
 - `Jan Pluskal (@pluskal) <https://github.com/pluskal>`__
 - `Peter (@pmannk) <https://github.com/pmannk>`__
 - `DK (@poldim) <https://github.com/poldim>`__
 - `poloswiss (@poloswiss) <https://github.com/poloswiss>`__
+- `polyfaces (@polyfaces) <https://github.com/polyfaces>`__
 - `polyfloyd (@polyfloyd) <https://github.com/polyfloyd>`__
 - `Pontus Oldberg (@PontusO) <https://github.com/PontusO>`__
 - `poptix (@poptix) <https://github.com/poptix>`__
+- `Iván Povedano (@pove) <https://github.com/pove>`__
 - `Dave (@pow4all) <https://github.com/pow4all>`__
+- `pplucky (@pplucky) <https://github.com/pplucky>`__
 - `Peter Provost (@PProvost) <https://github.com/PProvost>`__
 - `Q. Marchi (@preeefix) <https://github.com/preeefix>`__
 - `Francesco Ciocchetti (@primeroz) <https://github.com/primeroz>`__
@@ -1052,7 +1405,9 @@ Contributors
 - `Gary Morris (@progrmr) <https://github.com/progrmr>`__
 - `Mike Lynch (@Prow7) <https://github.com/Prow7>`__
 - `Peter Sarossy (@psarossy) <https://github.com/psarossy>`__
+- `Peter Stuifzand (@pstuifzand) <https://github.com/pstuifzand>`__
 - `Peter Tatrai (@ptatrai) <https://github.com/ptatrai>`__
+- `Patrick Toal (@ptoal) <https://github.com/ptoal>`__
 - `Pieter Viljoen (@ptr727) <https://github.com/ptr727>`__
 - `Leandro Puerari (@puerari) <https://github.com/puerari>`__
 - `puuu (@puuu) <https://github.com/puuu>`__
@@ -1060,60 +1415,92 @@ Contributors
 - `Alex (@pxe-la) <https://github.com/pxe-la>`__
 - `[pʲɵs] (@pyos) <https://github.com/pyos>`__
 - `Peter Zich (@pzich) <https://github.com/pzich>`__
+- `QbaF (@QbaF) <https://github.com/QbaF>`__
 - `Qc (@qc24) <https://github.com/qc24>`__
 - `Quinn Casey (@qcasey) <https://github.com/qcasey>`__
 - `qianh-wan (@qianh-wan) <https://github.com/qianh-wan>`__
+- `Karol Zlot (@qqgg231) <https://github.com/qqgg231>`__
 - `Tommy Jonsson (@quazzie) <https://github.com/quazzie>`__
+- `quentin9696 (@quentin9696) <https://github.com/quentin9696>`__
 - `Quentin Smith (@quentinmit) <https://github.com/quentinmit>`__
+- `Quentin Stafford-Fraser (@quentinsf) <https://github.com/quentinsf>`__
+- `Quinn Hosler (@quinnhosler) <https://github.com/quinnhosler>`__
+- `r-jordan (@r-jordan) <https://github.com/r-jordan>`__
+- `Johannes Rebling (@r0oland) <https://github.com/r0oland>`__
 - `Richard Kuhnt (@r15ch13) <https://github.com/r15ch13>`__
 - `Richard Miles (@r89m) <https://github.com/r89m>`__
+- `Pär Stålberg (@rabbadab) <https://github.com/rabbadab>`__
 - `Aaron Zhang (@rabbit-aaron) <https://github.com/rabbit-aaron>`__
 - `RadekHvizdos (@RadekHvizdos) <https://github.com/RadekHvizdos>`__
+- `Radim Karniš (@radimkarnis) <https://github.com/radimkarnis>`__
+- `Raph (@rafal83) <https://github.com/rafal83>`__
 - `rafalstarczak (@rafalstarczak) <https://github.com/rafalstarczak>`__
+- `Florian Ragwitz (@rafl) <https://github.com/rafl>`__
+- `Rai-Rai (@Rai-Rai) <https://github.com/Rai-Rai>`__
+- `rainero84 (@rainero84) <https://github.com/rainero84>`__
 - `raineth (@raineth) <https://github.com/raineth>`__
 - `Ben V. Brown (@Ralim) <https://github.com/Ralim>`__
 - `Benjamin G. (@Randomblock1) <https://github.com/Randomblock1>`__
 - `randomllama (@randomllama) <https://github.com/randomllama>`__
 - `Rodrigo Martín (@Rapsssito) <https://github.com/Rapsssito>`__
+- `razorback16 (@razorback16) <https://github.com/razorback16>`__
 - `Marc Seeger (@rb2k) <https://github.com/rb2k>`__
 - `rbaron (@rbaron) <https://github.com/rbaron>`__
 - `Robert Cambridge (@rcambrj) <https://github.com/rcambrj>`__
 - `Russell Cloran (@rcloran) <https://github.com/rcloran>`__
+- `Ronald Dehuysser (@rdehuyss) <https://github.com/rdehuyss>`__
 - `Rebbe Pod (@RebbePod) <https://github.com/RebbePod>`__
 - `reddn (@reddn) <https://github.com/reddn>`__
 - `redlukas (@redlukas) <https://github.com/redlukas>`__
 - `Alex (@redwngsrul) <https://github.com/redwngsrul>`__
+- `Refferic (@Refferic) <https://github.com/Refferic>`__
 - `Regev Brody (@regevbr) <https://github.com/regevbr>`__
 - `Rei Vilo (@rei-vilo) <https://github.com/rei-vilo>`__
 - `Alex Reid (@reidprojects) <https://github.com/reidprojects>`__
 - `RenierM26 (@RenierM26) <https://github.com/RenierM26>`__
+- `Reuben (@reubn) <https://github.com/reubn>`__
 - `RFDarter (@RFDarter) <https://github.com/RFDarter>`__
 - `Robin Pronk (@rfpronk) <https://github.com/rfpronk>`__
+- `Pavels Veretennikovs (@rfvermut) <https://github.com/rfvermut>`__
 - `Robert Gabrielson (@rgabrielson11) <https://github.com/rgabrielson11>`__
 - `Rafael Goes (@rgriffogoes) <https://github.com/rgriffogoes>`__
 - `rheinz (@rheinz) <https://github.com/rheinz>`__
 - `Rhys79 (@Rhys79) <https://github.com/Rhys79>`__
 - `richardhopton (@richardhopton) <https://github.com/richardhopton>`__
 - `Richard Klingler (@richardklingler) <https://github.com/richardklingler>`__
+- `richardweinberger (@richardweinberger) <https://github.com/richardweinberger>`__
+- `Rich Foley (@RichFoley) <https://github.com/RichFoley>`__
 - `Richard Lewis (@richrd) <https://github.com/richrd>`__
+- `Rico van Genugten (@ricovangenugten) <https://github.com/ricovangenugten>`__
 - `RIPPLE-CURRENT (@RIPPLE-CURRENT) <https://github.com/RIPPLE-CURRENT>`__
 - `Rishab Mehta (@rishabmehta7) <https://github.com/rishabmehta7>`__
 - `Andre Borie (@Rjevski) <https://github.com/Rjevski>`__
 - `rjlexx (@rjlexx) <https://github.com/rjlexx>`__
+- `rjmurph2241 (@rjmurph2241) <https://github.com/rjmurph2241>`__
+- `René Klomp (@rklomp) <https://github.com/rklomp>`__
 - `rlowens (@rlowens) <https://github.com/rlowens>`__
+- `Roy Meissner (@rmeissn) <https://github.com/rmeissn>`__
 - `rmmacias (@rmmacias) <https://github.com/rmmacias>`__
+- `LMR (@rmooreID) <https://github.com/rmooreID>`__
 - `Ryan Mounce (@rmounce) <https://github.com/rmounce>`__
 - `rnauber (@rnauber) <https://github.com/rnauber>`__
 - `Rob Deutsch (@rob-deutsch) <https://github.com/rob-deutsch>`__
+- `Rob de Jonge (@robdejonge) <https://github.com/robdejonge>`__
 - `Robert Alfaro (@robert-alfaro) <https://github.com/robert-alfaro>`__
 - `Robert91911 (@Robert91911) <https://github.com/Robert91911>`__
+- `Rob Gridley (@robgridley) <https://github.com/robgridley>`__
+- `Robin Smidsrød (@robinsmidsrod) <https://github.com/robinsmidsrod>`__
 - `Robinson1999 (@Robinson1999) <https://github.com/Robinson1999>`__
 - `RoboMagus (@RoboMagus) <https://github.com/RoboMagus>`__
+- `RockBomber (@RockBomber) <https://github.com/RockBomber>`__
 - `Roeland Lutters (@Roeland54) <https://github.com/Roeland54>`__
 - `RoganDawes (@RoganDawes) <https://github.com/RoganDawes>`__
 - `Roger Busser (@rogerbusser) <https://github.com/rogerbusser>`__
+- `Roi Tagar (@roitagar) <https://github.com/roitagar>`__
 - `Roman Ondráček (@Roman3349) <https://github.com/Roman3349>`__
+- `romerod (@romerod) <https://github.com/romerod>`__
 - `Jérôme W. (@RomRider) <https://github.com/RomRider>`__
+- `Robbie Page (@rorpage) <https://github.com/rorpage>`__
 - `roscoegray (@roscoegray) <https://github.com/roscoegray>`__
 - `rotarykite (@rotarykite) <https://github.com/rotarykite>`__
 - `Roving Ronin (@Roving-Ronin) <https://github.com/Roving-Ronin>`__
@@ -1121,23 +1508,31 @@ Contributors
 - `Rajan Patel (@rpatel3001) <https://github.com/rpatel3001>`__
 - `Bob Perciaccante (@rperciaccante) <https://github.com/rperciaccante>`__
 - `rradar (@rradar) <https://github.com/rradar>`__
+- `rrooggiieerr (@rrooggiieerr) <https://github.com/rrooggiieerr>`__
 - `rspaargaren (@rspaargaren) <https://github.com/rspaargaren>`__
 - `rsumner (@rsumner) <https://github.com/rsumner>`__
 - `Romain TORRENTE (@rtorrente) <https://github.com/rtorrente>`__
+- `Ruben De Smet (@rubdos) <https://github.com/rubdos>`__
+- `Rubén G. (@rubengargar) <https://github.com/rubengargar>`__
 - `@RubenKelevra (@RubenKelevra) <https://github.com/RubenKelevra>`__
 - `Ruben van Dijk (@RubenNL) <https://github.com/RubenNL>`__
 - `RubyBailey (@RubyBailey) <https://github.com/RubyBailey>`__
+- `rudgr (@rudgr) <https://github.com/rudgr>`__
 - `Rus Ti (@Rusti-gotrage) <https://github.com/Rusti-gotrage>`__
+- `Roberto Wagner (@rwagnervm) <https://github.com/rwagnervm>`__
 - `rweather (@rweather) <https://github.com/rweather>`__
 - `Rob Weir (@rweir) <https://github.com/rweir>`__
 - `rwilson131 (@rwilson131) <https://github.com/rwilson131>`__
 - `Ryan Lang (@ryan-lang) <https://github.com/ryan-lang>`__
 - `ryanalden (@ryanalden) <https://github.com/ryanalden>`__
+- `Ryan Nazaretian (@ryannazaretian) <https://github.com/ryannazaretian>`__
 - `ryansmigley (@ryansmigley) <https://github.com/ryansmigley>`__
 - `Lukas Bachschwell (@s00500) <https://github.com/s00500>`__
+- `Silvio (@s1lvi0) <https://github.com/s1lvi0>`__
 - `Sabas (@sabas1080) <https://github.com/sabas1080>`__
 - `Sabesto (@Sabesto) <https://github.com/Sabesto>`__
 - `Jan Čermák (@sairon) <https://github.com/sairon>`__
+- `samnewman86 (@samnewman86) <https://github.com/samnewman86>`__
 - `Sam Turner (@samturner3) <https://github.com/samturner3>`__
 - `Sender (@sanderlv) <https://github.com/sanderlv>`__
 - `Sanjay Govind (@sanjay900) <https://github.com/sanjay900>`__
@@ -1147,45 +1542,64 @@ Contributors
 - `sbur83 (@sbur83) <https://github.com/sbur83>`__
 - `Søren Christian Aarup (@scaarup) <https://github.com/scaarup>`__
 - `scamiv (@scamiv) <https://github.com/scamiv>`__
+- `Sascha (@Scarbous) <https://github.com/Scarbous>`__
+- `Matthew Schinckel (@schinckel) <https://github.com/schinckel>`__
+- `Lukas Schulte (@Schluggi) <https://github.com/Schluggi>`__
 - `Nils Schulte (@Schnilz) <https://github.com/Schnilz>`__
 - `Wolle (@schreibfaul1) <https://github.com/schreibfaul1>`__
 - `MSchwarzbach (@schwarzbach) <https://github.com/schwarzbach>`__
 - `Scobber (@Scobber) <https://github.com/Scobber>`__
 - `Ville Skyttä (@scop) <https://github.com/scop>`__
 - `Dan (@ScrewLooseDan) <https://github.com/ScrewLooseDan>`__
+- `Jeremy Pack (@scriptengine) <https://github.com/scriptengine>`__
 - `Sean True (@seantrue) <https://github.com/seantrue>`__
 - `Sebastian Rasor (@sebastianrasor) <https://github.com/sebastianrasor>`__
 - `sebcaps (@sebcaps) <https://github.com/sebcaps>`__
+- `Seganku (@seganku) <https://github.com/seganku>`__
 - `Stefan Seyfried (@seife) <https://github.com/seife>`__
+- `sekkr1 (@sekkr1) <https://github.com/sekkr1>`__
 - `SenexCrenshaw (@SenexCrenshaw) <https://github.com/SenexCrenshaw>`__
 - `Jason Sepinsky (@Sepinsky) <https://github.com/Sepinsky>`__
 - `Sergey Popov (@Sergey-SRG) <https://github.com/Sergey-SRG>`__
+- `Sergio (@sergio303) <https://github.com/sergio303>`__
 - `Sergio Mayoral Martínez (@sermayoral) <https://github.com/sermayoral>`__
+- `sethcohn (@sethcohn) <https://github.com/sethcohn>`__
 - `Seth Girvan (@sethgirvan) <https://github.com/sethgirvan>`__
 - `Emanuele Tessore (@setola) <https://github.com/setola>`__
 - `Abdelkader Boudih (@seuros) <https://github.com/seuros>`__
+- `shaeed (@shaeed) <https://github.com/shaeed>`__
 - `SharkSharp (@SharkSharp) <https://github.com/SharkSharp>`__
 - `Sebastiaan (@SharkWipf) <https://github.com/SharkWipf>`__
 - `Alexander Dimitrov (@sharkydog) <https://github.com/sharkydog>`__
+- `Fabio Todaro (@SharpEdgeMarshall) <https://github.com/SharpEdgeMarshall>`__
+- `shbatm (@shbatm) <https://github.com/shbatm>`__
 - `ShellAddicted (@ShellAddicted) <https://github.com/ShellAddicted>`__
 - `shenxiaozheng (@shenxiaozheng) <https://github.com/shenxiaozheng>`__
 - `sherbang (@sherbang) <https://github.com/sherbang>`__
 - `Shish (@shish) <https://github.com/shish>`__
+- `Shreyas Karnik (@shreyaskarnik) <https://github.com/shreyaskarnik>`__
 - `sibowler (@sibowler) <https://github.com/sibowler>`__
 - `signix (@signix) <https://github.com/signix>`__
 - `SiliconAvatar (@SiliconAvatar) <https://github.com/SiliconAvatar>`__
+- `sillyfrog (@sillyfrog) <https://github.com/sillyfrog>`__
 - `Mark Lopez (@Silvenga) <https://github.com/Silvenga>`__
 - `James Chaloupka (@SirGoodenough) <https://github.com/SirGoodenough>`__
 - `Maximilian Ertl (@Sirs0ri) <https://github.com/Sirs0ri>`__
+- `SirSydom (@SirSydom) <https://github.com/SirSydom>`__
+- `Francisco J. Solis (@sisco0) <https://github.com/sisco0>`__
 - `Derek Hageman (@Sizurka) <https://github.com/Sizurka>`__
 - `Stephen Tierney (@sjtrny) <https://github.com/sjtrny>`__
+- `Dominik Skalník (@skaldo) <https://github.com/skaldo>`__
 - `Niklas Wagner (@Skaronator) <https://github.com/Skaronator>`__
+- `Rafael Treviño (@skasi7) <https://github.com/skasi7>`__
 - `Brian Slesinsky (@skybrian) <https://github.com/skybrian>`__
 - `Jordan W. Cobb (@skykingjwc) <https://github.com/skykingjwc>`__
 - `slimeinacloak (@slimeinacloak) <https://github.com/slimeinacloak>`__
 - `Sebastian Lövdahl (@slovdahl) <https://github.com/slovdahl>`__
 - `smischny (@smischny) <https://github.com/smischny>`__
+- `Jacob Masen-Smith (@smithjacobj) <https://github.com/smithjacobj>`__
 - `John Mueller (@softplus) <https://github.com/softplus>`__
+- `Luca Zimmermann (@soundstorm) <https://github.com/soundstorm>`__
 - `Sourabh Jaiswal (@sourabhjaiswal) <https://github.com/sourabhjaiswal>`__
 - `Philip Allgaier (@spacegaier) <https://github.com/spacegaier>`__
 - `spacemanspiff2007 (@spacemanspiff2007) <https://github.com/spacemanspiff2007>`__
@@ -1194,11 +1608,21 @@ Contributors
 - `Sean Brogan (@spbrogan) <https://github.com/spbrogan>`__
 - `Justin Gerace (@spectrumjade) <https://github.com/spectrumjade>`__
 - `Spegs21 (@Spegs21) <https://github.com/Spegs21>`__
+- `Stephan Peijnik-Steinwender (@speijnik) <https://github.com/speijnik>`__
 - `Eric Lind (@sperly) <https://github.com/sperly>`__
+- `spilin (@spilin) <https://github.com/spilin>`__
 - `Spencer Owen (@spuder) <https://github.com/spuder>`__
+- `square99 (@square99) <https://github.com/square99>`__
+- `Paul Krischer (@SqyD) <https://github.com/SqyD>`__
+- `sredfern (@sredfern) <https://github.com/sredfern>`__
+- `srg74 (@srg74) <https://github.com/srg74>`__
 - `Samuel Sieb (@ssieb) <https://github.com/ssieb>`__
 - `Stefan Staub (@sstaub) <https://github.com/sstaub>`__
+- `St4n (@St4n) <https://github.com/St4n>`__
 - `Stanislav Habich (@standahabich) <https://github.com/standahabich>`__
+- `starwolf73 (@starwolf73) <https://github.com/starwolf73>`__
+- `Stas (@stas-sl) <https://github.com/stas-sl>`__
+- `Stefan (@stefanroelofs) <https://github.com/stefanroelofs>`__
 - `stegm (@stegm) <https://github.com/stegm>`__
 - `Stephen Papierski (@stephenpapierski) <https://github.com/stephenpapierski>`__
 - `Steve Baxter (@stevebaxter) <https://github.com/stevebaxter>`__
@@ -1206,13 +1630,16 @@ Contributors
 - `Stewart (@stewiem2000) <https://github.com/stewiem2000>`__
 - `sthorley (@sthorley) <https://github.com/sthorley>`__
 - `sticilface (@sticilface) <https://github.com/sticilface>`__
+- `StijnVdd (@StijnVdd) <https://github.com/StijnVdd>`__
 - `Stijn Tintel (@stintel) <https://github.com/stintel>`__
 - `Mathias Stock (@Stock-M) <https://github.com/Stock-M>`__
 - `Strixx76 (@Strixx76) <https://github.com/Strixx76>`__
 - `stubs12 (@stubs12) <https://github.com/stubs12>`__
+- `Jordan Vohwinkel (@sublime93) <https://github.com/sublime93>`__
 - `sud33p (@sud33p) <https://github.com/sud33p>`__
 - `sumirati (@sumirati) <https://github.com/sumirati>`__
 - `Sun Xiang yu (@sun-xiangyu) <https://github.com/sun-xiangyu>`__
+- `sveip (@sveip) <https://github.com/sveip>`__
 - `Penny Wood (@Swamp-Ig) <https://github.com/Swamp-Ig>`__
 - `SwedishChef (@SwedishChef) <https://github.com/SwedishChef>`__
 - `swhaat (@swhaat) <https://github.com/swhaat>`__
@@ -1220,40 +1647,57 @@ Contributors
 - `Jan Gutowski (@Switch123456789) <https://github.com/Switch123456789>`__
 - `swoboda1337 (@swoboda1337) <https://github.com/swoboda1337>`__
 - `Sybren A. Stüvel (@sybrenstuvel) <https://github.com/sybrenstuvel>`__
+- `Sympatron GmbH (@Sympatron) <https://github.com/Sympatron>`__
 - `synco (@synco) <https://github.com/synco>`__
+- `Marcel Feix (@Syndlex) <https://github.com/Syndlex>`__
 - `Suryandaru Triandana (@syndtr) <https://github.com/syndtr>`__
 - `Michael Hansen (@synesthesiam) <https://github.com/synesthesiam>`__
 - `SyXavier (@SyXavier) <https://github.com/SyXavier>`__
 - `Szewcson (@Szewcson) <https://github.com/Szewcson>`__
 - `Peter (@szpeter80) <https://github.com/szpeter80>`__
+- `Teemu Mikkonen (@T3m3z) <https://github.com/T3m3z>`__
 - `Taigar2015 (@Taigar2015) <https://github.com/Taigar2015>`__
 - `Stefan Dragnev (@tailsu) <https://github.com/tailsu>`__
+- `Levente Tamas (@tamisoft) <https://github.com/tamisoft>`__
 - `Aleksandr Oleinikov (@tannisroot) <https://github.com/tannisroot>`__
 - `tantive (@tantive) <https://github.com/tantive>`__
 - `Aiden (@tarontop) <https://github.com/tarontop>`__
 - `Hawawa McTaru (@TaruDesigns) <https://github.com/TaruDesigns>`__
+- `TBobsin (@TBobsin) <https://github.com/TBobsin>`__
+- `Team Super Panda (@teamsuperpanda) <https://github.com/teamsuperpanda>`__
 - `Jake Kromer (@techwithjake) <https://github.com/techwithjake>`__
+- `teffcz (@teffcz) <https://github.com/teffcz>`__
 - `tehniemer (@tehniemer) <https://github.com/tehniemer>`__
 - `Ryan Hoffman (@tekmaven) <https://github.com/tekmaven>`__
+- `Tempura San (@tempura-san) <https://github.com/tempura-san>`__
 - `testbughub (@testbughub) <https://github.com/testbughub>`__
 - `Tudor Sandu (@tetele) <https://github.com/tetele>`__
 - `Greg Lincoln (@tetious) <https://github.com/tetious>`__
+- `Thane Gill (@thanegill) <https://github.com/thanegill>`__
 - `Terry Hardie (@thardie) <https://github.com/thardie>`__
 - `Craig Dean (@thargy) <https://github.com/thargy>`__
+- `Michael Jahn (@thatSecOpsGuy) <https://github.com/thatSecOpsGuy>`__
 - `thatslolo (@thatslolo) <https://github.com/thatslolo>`__
+- `The Impaler (@the-impaler) <https://github.com/the-impaler>`__
 - `Avri Chen-Roth (@the-mentor) <https://github.com/the-mentor>`__
 - `The-Paran0id-Andr0id (@The-Paran0id-Andr0id) <https://github.com/The-Paran0id-Andr0id>`__
+- `Nejc (@thedexboy) <https://github.com/thedexboy>`__
 - `Thomas Eckerstorfer (@TheEggi) <https://github.com/TheEggi>`__
 - `Theexternaldisk (@Theexternaldisk) <https://github.com/Theexternaldisk>`__
 - `Martijn van der Pol (@TheFes) <https://github.com/TheFes>`__
 - `TheGroundZero (@TheGroundZero) <https://github.com/TheGroundZero>`__
 - `Alexander Münch (@theHacker) <https://github.com/theHacker>`__
+- `Spencer Hachmeister (@TheHackmeister) <https://github.com/TheHackmeister>`__
 - `thejonesyboy (@thejonesyboy) <https://github.com/thejonesyboy>`__
 - `TheJulianJES (@TheJulianJES) <https://github.com/TheJulianJES>`__
+- `Jozef Zuzelka (@TheKuko) <https://github.com/TheKuko>`__
+- `Mateusz Soszyński (@TheLastGimbus) <https://github.com/TheLastGimbus>`__
 - `Bart (@TheNameIsBart) <https://github.com/TheNameIsBart>`__
+- `Andrew Quested (@thenameiwantedwastaken) <https://github.com/thenameiwantedwastaken>`__
 - `Zixuan Wang (@TheNetAdmin) <https://github.com/TheNetAdmin>`__
 - `Dominik Bruhn (@theomega) <https://github.com/theomega>`__
 - `Alan Lord (@theopensourcerer) <https://github.com/theopensourcerer>`__
+- `Simon (@theOzzieRat) <https://github.com/theOzzieRat>`__
 - `Brian Levinsen (@therealeldaria) <https://github.com/therealeldaria>`__
 - `Steve Scott (@thewishy) <https://github.com/thewishy>`__
 - `Zachery Notz (@TheZackCodec) <https://github.com/TheZackCodec>`__
@@ -1262,11 +1706,15 @@ Contributors
 - `Thies Gerken (@thiesgerken) <https://github.com/thiesgerken>`__
 - `Matt (@ThisIsTheOnlyUsernameAvailable) <https://github.com/ThisIsTheOnlyUsernameAvailable>`__
 - `Mücahid Kamber (@thlstfs) <https://github.com/thlstfs>`__
+- `Thomas Hollstegge (@Tho85) <https://github.com/Tho85>`__
 - `Thomas Heiser (@thomasheiser85) <https://github.com/thomasheiser85>`__
+- `Thomas Klingbeil (@thomasklingbeil) <https://github.com/thomasklingbeil>`__
+- `Thomas Dietrich (@ThomDietrich) <https://github.com/ThomDietrich>`__
 - `Andrew Thompson (@thompsa) <https://github.com/thompsa>`__
 - `John (@thorrak) <https://github.com/thorrak>`__
 - `Thomas Langewouters (@thouters) <https://github.com/thouters>`__
 - `Transylvania High Tech (@thtro) <https://github.com/thtro>`__
+- `thubot (@thubot) <https://github.com/thubot>`__
 - `Thunderbiscuits (@Thunderbiscuits) <https://github.com/Thunderbiscuits>`__
 - `tiagofreire-pt (@tiagofreire-pt) <https://github.com/tiagofreire-pt>`__
 - `Tijs-B (@Tijs-B) <https://github.com/Tijs-B>`__
@@ -1275,49 +1723,69 @@ Contributors
 - `Tim Laurence (@timdaman) <https://github.com/timdaman>`__
 - `Aidan Timson (@timmo001) <https://github.com/timmo001>`__
 - `Tim Niemueller (@timn) <https://github.com/timn>`__
+- `Tim P (@timpur) <https://github.com/timpur>`__
 - `Tim Savage (@timsavage) <https://github.com/timsavage>`__
 - `Tinkerfish (@tinkerfish) <https://github.com/tinkerfish>`__
 - `TJ Horner (@tjhorner) <https://github.com/tjhorner>`__
+- `Max Efremov (@Tmin10) <https://github.com/Tmin10>`__
 - `Christian (@Tntdruid) <https://github.com/Tntdruid>`__
 - `Lars R. (@TNTLarsn) <https://github.com/TNTLarsn>`__
+- `Snōwball (@tobias-) <https://github.com/tobias->`__
 - `Philipp Tölke (@toelke) <https://github.com/toelke>`__
 - `tomaszduda23 (@tomaszduda23) <https://github.com/tomaszduda23>`__
 - `Tom Brien (@TomBrien) <https://github.com/TomBrien>`__
 - `Thomas Combriat (@tomcombriat) <https://github.com/tomcombriat>`__
+- `TomFahey (@TomFahey) <https://github.com/TomFahey>`__
 - `Tom Hartogs (@TomHartogs) <https://github.com/TomHartogs>`__
 - `TomKong666 (@TomKong666) <https://github.com/TomKong666>`__
+- `Tommy Kihlstrøm (@tomludd) <https://github.com/tomludd>`__
 - `tomlut (@tomlut) <https://github.com/tomlut>`__
+- `Tom Matheussen (@Tommatheussen) <https://github.com/Tommatheussen>`__
 - `tomle (@tomole444) <https://github.com/tomole444>`__
 - `Tom Price (@tomtom5152) <https://github.com/tomtom5152>`__
 - `Anthony Bourguignon (@Toniob) <https://github.com/Toniob>`__
+- `tony (@tony-fav) <https://github.com/tony-fav>`__
 - `David Kiliani (@torfbolt) <https://github.com/torfbolt>`__
 - `Aleksandra M (@tort32) <https://github.com/tort32>`__
+- `Torwag (@torwag) <https://github.com/torwag>`__
+- `Teemu Simola (@tpssim) <https://github.com/tpssim>`__
 - `tracestep (@tracestep) <https://github.com/tracestep>`__
 - `Trent Houliston (@TrentHouliston) <https://github.com/TrentHouliston>`__
+- `Felix Eckhofer (@tribut) <https://github.com/tribut>`__
 - `Trick van Staveren (@trickv) <https://github.com/trickv>`__
 - `TripitakaBC (@TripitakaBC) <https://github.com/TripitakaBC>`__
 - `Tobias (@tripplet) <https://github.com/tripplet>`__
 - `tronikos (@tronikos) <https://github.com/tronikos>`__
+- `Troon (@Troon) <https://github.com/Troon>`__
 - `Tyler Bules (@Troublebrewing) <https://github.com/Troublebrewing>`__
 - `Troy K (@Troy-K) <https://github.com/Troy-K>`__
 - `Olli Salonen (@trsqr) <https://github.com/trsqr>`__
+- `truglodite (@truglodite) <https://github.com/truglodite>`__
 - `Trevor North (@trvrnrth) <https://github.com/trvrnrth>`__
 - `Trygve Laugstøl (@trygvis) <https://github.com/trygvis>`__
 - `Gediminas Šaltenis (@trylika) <https://github.com/trylika>`__
 - `Tuan (@tuanpmt) <https://github.com/tuanpmt>`__
 - `tubalainen (@tubalainen) <https://github.com/tubalainen>`__
 - `tube0013 (@tube0013) <https://github.com/tube0013>`__
+- `Tuckie (@Tuckie) <https://github.com/Tuckie>`__
 - `Alexey Vlasov (@turbulator) <https://github.com/turbulator>`__
+- `Seppel Hardt (@tuxBurner) <https://github.com/tuxBurner>`__
 - `tvan0076 (@tvan0076) <https://github.com/tvan0076>`__
+- `TVDLoewe (@TVDLoewe) <https://github.com/TVDLoewe>`__
 - `Thorsten von Eicken (@tve) <https://github.com/tve>`__
 - `Tomek Wasilczyk (@twasilczyk) <https://github.com/twasilczyk>`__
+- `Tyler Menezes (@tylermenezes) <https://github.com/tylermenezes>`__
+- `tyomikh (@tyomikh) <https://github.com/tyomikh>`__
 - `Simon Hulme (@uberjew666) <https://github.com/uberjew666>`__
 - `Ubi de Feo (@ubidefeo) <https://github.com/ubidefeo>`__
+- `ukewea (@ukewea) <https://github.com/ukewea>`__
 - `ulic75 (@ulic75) <https://github.com/ulic75>`__
 - `Sever Sudakov (@UltimosHomo) <https://github.com/UltimosHomo>`__
+- `Unai (@unaiur) <https://github.com/unaiur>`__
 - `unhold (@unhold) <https://github.com/unhold>`__
 - `Aaron Mildenstein (@untergeek) <https://github.com/untergeek>`__
 - `uPesy Electronics (@uPesy) <https://github.com/uPesy>`__
+- `user897943 (@user897943) <https://github.com/user897943>`__
 - `UT2UH (@UT2UH) <https://github.com/UT2UH>`__
 - `Vlad Yarotsky (@v-yarotsky) <https://github.com/v-yarotsky>`__
 - `Vc (@Valcob) <https://github.com/Valcob>`__
@@ -1325,12 +1793,14 @@ Contributors
 - `Vicent Climent (@vcliment89) <https://github.com/vcliment89>`__
 - `Veli Veromann (@velijv) <https://github.com/velijv>`__
 - `André Lademann (@vergissberlin) <https://github.com/vergissberlin>`__
+- `Víctor Ferrer García (@vicfergar) <https://github.com/vicfergar>`__
 - `Austin (@vidplace7) <https://github.com/vidplace7>`__
 - `Vincèn (@vincegre) <https://github.com/vincegre>`__
 - `Virage Laboratories (@viragelabs) <https://github.com/viragelabs>`__
 - `Vishnu Mohanan (@vishnumaiea) <https://github.com/vishnumaiea>`__
 - `VitaliyKurokhtin (@VitaliyKurokhtin) <https://github.com/VitaliyKurokhtin>`__
 - `voed (@voed) <https://github.com/voed>`__
+- `voibit (@voibit) <https://github.com/voibit>`__
 - `Xuming Feng (@voicevon) <https://github.com/voicevon>`__
 - `Manuel Bichler (@votacom) <https://github.com/votacom>`__
 - `vozvivan (@vozvivan) <https://github.com/vozvivan>`__
@@ -1341,49 +1811,80 @@ Contributors
 - `WallyCZ (@WallyCZ) <https://github.com/WallyCZ>`__
 - `walzing (@walzing) <https://github.com/walzing>`__
 - `warpzone (@warpzone) <https://github.com/warpzone>`__
+- `John "Warthog9" Hawley (@warthog9) <https://github.com/warthog9>`__
 - `Warwick Bruce Chapman (@warwickchapman) <https://github.com/warwickchapman>`__
 - `Wauter (@Wauter) <https://github.com/Wauter>`__
+- `webeling67 (@webeling67) <https://github.com/webeling67>`__
 - `WeekendWarrior1 (@WeekendWarrior1) <https://github.com/WeekendWarrior1>`__
 - `Thomas Aldrian (@Weissnix4711) <https://github.com/Weissnix4711>`__
+- `Spenser Bushey (@Weldawadyathink) <https://github.com/Weldawadyathink>`__
+- `Ian Wells (@wellsi) <https://github.com/wellsi>`__
 - `Andrew Garrett (@werdnum) <https://github.com/werdnum>`__
+- `Werner Beroux (@wernight) <https://github.com/wernight>`__
 - `Alexander Puzynia (@werwolfby) <https://github.com/werwolfby>`__
 - `whimsee (@whimsee) <https://github.com/whimsee>`__
 - `wifwucite (@wifwucite) <https://github.com/wifwucite>`__
 - `wilberforce (@wilberforce) <https://github.com/wilberforce>`__
 - `wildekek (@wildekek) <https://github.com/wildekek>`__
+- `William Charlton (@willwill2will54) <https://github.com/willwill2will54>`__
+- `Wilmar den Ouden (@wilmardo) <https://github.com/wilmardo>`__
 - `Wingman3434 (@Wingman3434) <https://github.com/Wingman3434>`__
 - `Emil Hesslow (@WizKid) <https://github.com/WizKid>`__
 - `WJCarpenter (@wjcarpenter) <https://github.com/wjcarpenter>`__
 - `Wouter van der Wal (@wjtje) <https://github.com/wjtje>`__
 - `Artur 'Wodor' Wielogorski (@wodor) <https://github.com/wodor>`__
+- `Rick van Hattem (@WoLpH) <https://github.com/WoLpH>`__
 - `Rick van Hattem (@wolph) <https://github.com/wolph>`__
 - `workingmanrob (@workingmanrob) <https://github.com/workingmanrob>`__
 - `Dawid Wróbel (@wrobelda) <https://github.com/wrobelda>`__
 - `Sven Serlier (@wrt54g) <https://github.com/wrt54g>`__
+- `Wojtek Strzalka (@wstrzalka) <https://github.com/wstrzalka>`__
 - `Wolfgang Tremmel (@wtremmel) <https://github.com/wtremmel>`__
 - `Jiangang Wu (@wujiangang) <https://github.com/wujiangang>`__
+- `Wumpf (@Wumpf) <https://github.com/Wumpf>`__
+- `wutr (@wutr) <https://github.com/wutr>`__
+- `Wvirgil123 (@Wvirgil123) <https://github.com/Wvirgil123>`__
 - `wysiwyng (@wysiwyng) <https://github.com/wysiwyng>`__
 - `X-Ryl669 (@X-Ryl669) <https://github.com/X-Ryl669>`__
 - `De Cock Xavier (@xdecock) <https://github.com/xdecock>`__
 - `Jakob (@XDjackieXD) <https://github.com/XDjackieXD>`__
 - `Mike Brown (@xenoxaos) <https://github.com/xenoxaos>`__
+- `xheronimo (@xheronimo) <https://github.com/xheronimo>`__
 - `Péter Sárközi (@Xmister) <https://github.com/Xmister>`__
 - `Xose Pérez (@xoseperez) <https://github.com/xoseperez>`__
+- `Mike (@xsnoopy) <https://github.com/xsnoopy>`__
 - `WitchKing (@xvil) <https://github.com/xvil>`__
 - `Andrew Kroll (@xxxajk) <https://github.com/xxxajk>`__
 - `Yaroslav (@Yarikx) <https://github.com/Yarikx>`__
 - `Marcin Jaworski (@yawor) <https://github.com/yawor>`__
+- `ychieux (@ychieux) <https://github.com/ychieux>`__
+- `Pavel (@yekm) <https://github.com/yekm>`__
 - `Ylian Saint-Hilaire (@Ylianst) <https://github.com/Ylianst>`__
+- `Atsuko Ito (@yottatsa) <https://github.com/yottatsa>`__
+- `Nico B (@youknow0) <https://github.com/youknow0>`__
 - `yousaf465 (@yousaf465) <https://github.com/yousaf465>`__
+- `Jevgeni Kiski (@yozik04) <https://github.com/yozik04>`__
+- `YuanL.Lee (@yuanl) <https://github.com/yuanl>`__
 - `Yuval Aboulafia (@yuvalabou) <https://github.com/yuvalabou>`__
+- `ZabojnikM (@ZabojnikM) <https://github.com/ZabojnikM>`__
 - `Björn Stenberg (@zagor) <https://github.com/zagor>`__
+- `zaluthar (@zaluthar) <https://github.com/zaluthar>`__
 - `david reid (@zathras777) <https://github.com/zathras777>`__
+- `Zebble (@Zebble) <https://github.com/Zebble>`__
 - `Brynley McDonald (@ZephireNZ) <https://github.com/ZephireNZ>`__
+- `ZJY (@zhangjingye03) <https://github.com/zhangjingye03>`__
+- `San (@zhujunsan) <https://github.com/zhujunsan>`__
+- `Geek_cat (@zhzhzhy) <https://github.com/zhzhzhy>`__
+- `I. Tomita (@ziceva) <https://github.com/ziceva>`__
+- `Michael Labuschke (@zigman79) <https://github.com/zigman79>`__
 - `Stefan Goethals (@zipkid) <https://github.com/zipkid>`__
 - `zivillian (@zivillian) <https://github.com/zivillian>`__
+- `Loïc (@zoic21) <https://github.com/zoic21>`__
+- `Zoltant7 (@Zoltant7) <https://github.com/Zoltant7>`__
 - `zry98 (@zry98) <https://github.com/zry98>`__
 - `Zack Barett (@zsarnett) <https://github.com/zsarnett>`__
 - `Zsolt Zsiros (@ZsZs73) <https://github.com/ZsZs73>`__
+- `ZTX18 (@ZTX18) <https://github.com/ZTX18>`__
 - `Christian Zufferey (@zuzu59) <https://github.com/zuzu59>`__
 - `Zynth-dev (@Zynth-dev) <https://github.com/Zynth-dev>`__
 


### PR DESCRIPTION
## Description:


This is a temporary patch that uses the locally stored `.users_cache.json` file to insert all known contributors from the past that the GH api is not returning.

A true solution needs to be made and will probably involve a more complex set of api calls in https://github.com/esphome/esphome-release

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
