### PR TITLE
Fix script link

### DIFF
--- a/components/script.rst
+++ b/components/script.rst
@@ -1,4 +1,4 @@
-.. _scripts:
+.. _script:
 
 ``script`` Component
 --------------------

--- a/index.rst
+++ b/index.rst
@@ -172,7 +172,7 @@ ESPHome-specific components or components supporting ESPHome device provisioning
     Improv via BLE, components/esp32_improv, improv.svg, dark-invert
     Improv via Serial, components/improv_serial, improv.svg, dark-invert
     Interval, components/interval, description.svg, dark-invert
-    Scripts, components/scripts, description.svg, dark-invert
+    Script, components/script, description.svg, dark-invert
 
 Network Hardware
 ----------------


### PR DESCRIPTION
## Description:

Fixes broken link to `script` page

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
