### PR TITLE
"Temperature" to "Pressure" correction

### DIFF
--- a/components/sensor/bmp280.rst
+++ b/components/sensor/bmp280.rst
@@ -48,7 +48,7 @@ Configuration variables:
 - **pressure** (*Optional*): The information for the pressure sensor.
 
   - **name** (**Required**, string): The name for the pressure sensor.
-  - **oversampling** (*Optional*): The oversampling parameter for the temperature sensor.
+  - **oversampling** (*Optional*): The oversampling parameter for the pressure sensor.
     See :ref:`Oversampling Options <bmp280-oversampling>`.
   - **id** (*Optional*, :ref:`config-id`): Set the ID of this sensor for use in lambdas.
   - All other options from :ref:`Sensor <config-sensor>`.


### PR DESCRIPTION
## Description:
Just a little correction - "Temperature" used instead of "Pressure" in text

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
