### PR TITLE
Minor wording update for duty_time.rst

### DIFF
--- a/components/sensor/duty_time.rst
+++ b/components/sensor/duty_time.rst
@@ -2,13 +2,13 @@ Duty Time
 =========
 
 .. seo::
-    :description: Instructions for setting up a sensor that tracks the duty time of the some object.
+    :description: Instructions for setting up a sensor that tracks the duty time of some object.
     :image: timer-play-outline.svg
 
-The ``duty_time`` sensor allows you to track the total duty time of the some object, for example, a light bulb, in seconds.
+The ``duty_time`` sensor allows you to track the total duty time of some object, for example, a light bulb, in seconds.
 Able to calculate the last turn-on time when an optional sensor ``last_time`` is included in the configuration.
 
-Supports boolean signal sources: ``binary_sensor`` or ``lambda`` that returns a boolean state of tracked object.
+Supports boolean signal sources: ``binary_sensor`` or ``lambda`` that returns a boolean state of the tracked object.
 As an alternative to controlling a component in automations, may be used the ``sensor.duty_time.start`` and ``sensor.duty_time.stop`` actions.
 
 


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
