### PR TITLE
LTR390 separate ALS and UV gain and resolution

### DIFF
--- a/components/sensor/ltr390.rst
+++ b/components/sensor/ltr390.rst
@@ -44,11 +44,11 @@ Configuration variables:
 - **update_interval** (*Optional*, :ref:`config-time`): The interval to check the
   sensor. Defaults to ``60s``. It is recommended that the update interval is at least 1 second since updates can take up to 800ms when using a high resolution value.
 
-Granular control over gain
-..........................
-The ``gain`` parameter by default sets the sensor's sensitivity for both ALS and UV measurements. In real life scenarios there might be significant
-differences in the light intensity and UV index, so it is recommended to use different gain values for ALS and for UV sensor to avoid 
-saturation. See the example below:
+Granular control over gain and resolution
+.........................................
+By default, the ``gain`` and ``resolution`` parameters set same values for both ALS and UV measurements. In real life scenarios there might be significant
+differences in the light intensity and UV index, so it is recommended to use different gain and resolution values for ALS and for UV sensor to avoid saturation.
+See the example below, where the gain and resolution are set to different values for ALS and UV sensors.:
 
 .. code-block:: yaml
 
@@ -61,6 +61,9 @@ saturation. See the example below:
         gain:
           ambient_light: X9
           uv: X3
+        resolution:
+          ambient_light: 18
+          uv: 13
 
 
 Lux and UVI Formulas

--- a/components/sensor/ltr390.rst
+++ b/components/sensor/ltr390.rst
@@ -44,6 +44,25 @@ Configuration variables:
 - **update_interval** (*Optional*, :ref:`config-time`): The interval to check the
   sensor. Defaults to ``60s``. It is recommended that the update interval is at least 1 second since updates can take up to 800ms when using a high resolution value.
 
+Granular control over gain
+..........................
+The ``gain`` parameter by default sets the sensor's sensitivity for both ALS and UV measurements. In real life scenarios there might be significant
+differences in the light intensity and UV index, so it is recommended to use different gain values for ALS and for UV sensor to avoid 
+saturation. See the example below:
+
+.. code-block:: yaml
+
+    sensor:
+      - platform: ltr390
+        uv:
+          name: "UV Sensor Counts"
+        ambient_light:
+          name: "Light Sensor Counts"
+        gain:
+          ambient_light: X9
+          uv: X3
+
+
 Lux and UVI Formulas
 --------------------
 


### PR DESCRIPTION
## Description:
More granular control of gain parameter

**Related issue (if applicable):** fixes https://github.com/esphome/feature-requests/issues/2765

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#7026

## Checklist:

  - [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
