### PR TITLE
Fix components.json generation

### DIFF
--- a/changelog/v1.9.0.rst
+++ b/changelog/v1.9.0.rst
@@ -137,7 +137,7 @@ New Features
 
 - You can now upload OTA firmware files with the :doc:`web server component </components/web_server>`
 
-- Added the ability to define global variables in esphomeyaml: :ref:`config-globals`.
+- Added the ability to define global variables in esphomeyaml: :doc:`/components/globals`.
 
 - Added a ``frequency`` option to the :doc:`/components/output/esp8266_pwm`.
 

--- a/components/globals.rst
+++ b/components/globals.rst
@@ -1,5 +1,3 @@
-.. _config-globals:
-
 Global Variables
 ----------------
 
@@ -54,7 +52,7 @@ Configuration variables:
 ``globals.set`` Action
 ----------------------
 
-This :ref:`Action <config-action>` allows you to change the value of a :ref:`global <config-globals>`
+This :ref:`Action <config-action>` allows you to change the value of a ``global``
 variable without having to use the lambda syntax.
 
 .. code-block:: yaml

--- a/components/interval.rst
+++ b/components/interval.rst
@@ -1,7 +1,5 @@
-.. _interval:
-
-``interval`` Component
-----------------------
+Interval Component
+------------------
 
 This component allows you to run actions at fixed time intervals. For example, if you want to toggle a switch every
 minute, you can use this component. Please note that it's possible to achieve the same thing with the

--- a/components/script.rst
+++ b/components/script.rst
@@ -1,7 +1,5 @@
-.. _script:
-
-``script`` Component
---------------------
+Script Component
+----------------
 
 ESPHome's ``script`` component allows you to define a list of steps (actions) in a central place. You can then execute
 the script from nearly anywhere in your device's configuration with a single call.

--- a/cookbook/http_request_sensor.rst
+++ b/cookbook/http_request_sensor.rst
@@ -35,7 +35,7 @@ On the client nodes we need an :doc:`/components/http_request` with an ``id`` se
 Pulling the data
 ****************
 
-To automate the request for data, we use an :ref:`interval` requesting the URL pointing to the sensor id for which the state is needed. See :ref:`api-rest` on how to build up the URL for your sensors.
+To automate the request for data, we use an :doc:`/components/interval` requesting the URL pointing to the sensor id for which the state is needed. See :ref:`api-rest` on how to build up the URL for your sensors.
 
 In the example below we request the value of a sensor from the server node, and after parsing the resulted JSON string we publish it to the local template sensor:
 
@@ -118,6 +118,6 @@ See Also
 - :doc:`/components/web_server`
 - :doc:`/components/http_request`
 - :doc:`/components/sensor/template`
-- :ref:`interval`
+- :doc:`/components/interval`
 - :ref:`api-rest`
 - :ghedit:`Edit`


### PR DESCRIPTION
## Description:

- Fix headers to not have symbols etc.
- Remove extra `ref` above the header and just use `doc` references

Fixes:
```json
  "script": {
    "title": "<code class=\"docutils literal notranslate\"><span class=\"pre\">script</span></code> Component",
    "url": "https://esphome.io/components/script.html",
    "path": "components/script"
  },
```


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
