### PR TITLE
Corrected an incidence of "servo" to "stepper motor"

### DIFF
--- a/components/stepper/index.rst
+++ b/components/stepper/index.rst
@@ -153,7 +153,7 @@ Configuration options:
 
 .. warning::
 
-    This turns the stepper to an absolute position! To have the servo move *relative* to the current
+    This turns the stepper to an absolute position! To have the stepper motor move *relative* to the current
     position, first reset the current position and then set the target to the relative value.
 
     .. code-block:: yaml


### PR DESCRIPTION
Corrected an incidence of "servo" to "stepper motor"

## Description:
Corrected an incidence of "servo" to "stepper motor"

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
