### PR TITLE
Add yac1fb9 model for the gree climate_ir component

### DIFF
--- a/components/climate/climate_ir.rst
+++ b/components/climate/climate_ir.rst
@@ -405,6 +405,7 @@ Configuration variables:
   - ``yan``
   - ``yaa``
   - ``yac``
+  - ``yac1fb9``
 
 
 .. code-block:: yaml


### PR DESCRIPTION
## Description:

Adds "yac1fb9" as one of the models supported by the gree climate_ir component

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#6024

See also https://github.com/esphome/esphome/pull/7056

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
