### PR TITLE
Add Elecrow CrowPanel 7.0" to RPI_DPI_RGB Display Driver

### DIFF
--- a/components/display/rpi_dpi_rgb.rst
+++ b/components/display/rpi_dpi_rgb.rst
@@ -16,6 +16,7 @@ This driver has been tested with the following displays:
 
   - Waveshare ESP32-S3-Touch-LCD-4.3
   - Makerfabs 4.3" display (Sunton)
+  - Elecrow CrowPanel 7.0"
 
 Usage
 -----
@@ -203,6 +204,55 @@ Makerfabs 4.3" 800x480 display
             - 9         #b4
             - 1         #b5
 
+
+
+Elecrow CrowPanel 7.0" 800x480
+******************************
+
+.. code-block:: yaml
+
+    display:
+      - platform: rpi_dpi_rgb
+        update_interval: never
+        auto_clear_enabled: false
+        id: rpi_display
+        color_order: RGB
+        rotation: 0
+        dimensions:
+          width: 800
+          height: 480
+        de_pin: 41
+        hsync_pin: 39
+        vsync_pin: 40
+        pclk_pin: 0
+        hsync_front_porch: 40
+        hsync_pulse_width: 48
+        hsync_back_porch: 13
+        vsync_front_porch: 1
+        vsync_pulse_width: 31
+        vsync_back_porch: 13
+        pclk_inverted: true
+        pclk_frequency: 8500000
+        data_pins:
+          red:
+            - 14
+            - 21
+            - 47
+            - 48
+            - 45
+          green:
+            - 9
+            - 46
+            - 3
+            - 8
+            - 16 
+            - 1
+          blue:
+            - 15
+            - 7
+            - 6
+            - 5
+            - 4
 
 
 See Also


### PR DESCRIPTION
## Description:
Support for [Elecrow CrowPanel 7.0" -HMI ESP32 Display 800x480 RGB TFT LCD Touch Screen](https://www.elecrow.com/esp32-display-7-inch-hmi-display-rgb-tft-lcd-touch-screen-support-lvgl.html) - Ref DIS08070H



**Related issue (if applicable):** fixes [2745](https://github.com/esphome/feature-requests/issues/2745)

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
