### PR TITLE
Improves Mac install instructions

### DIFF
--- a/guides/installing_esphome.rst
+++ b/guides/installing_esphome.rst
@@ -49,14 +49,26 @@ with the following:
 Mac
 ---
 
-There are no tested installation instructions for Mac. ESPHome does support
-Mac & will run with no problem.
+The simplest way to install ESPHome on a Mac is with `Homebrew<https://brew.sh/>`:
 
-Contributions are welcome!
+.. code-block:: console
 
-The process will likely be similar to Windows. You can install Python from the
-official site, and then install ESPHome with ``pip3 install esphome``.  You can
-then test that things are properly installed with the following:
+    $ brew install esphome
+
+Or, if you have a working Python installation you can install it directly without Homebrew.
+There are several ways to install Python on a Mac, including with Homebrew, Apple's X-Code command 
+line tools, or from `official packages<https://www.python.org/downloads/>`.
+
+Make sure you're running python 3.9 or above, then install using ``pip3``:
+
+.. code-block:: console
+
+    $ python3 --version
+    Python 3.9.15
+
+    $ pip3 install esphome
+
+You can then test that things are properly installed with the following:
 
 .. code-block:: console
 

--- a/guides/installing_esphome.rst
+++ b/guides/installing_esphome.rst
@@ -49,15 +49,15 @@ with the following:
 Mac
 ---
 
-The simplest way to install ESPHome on a Mac is with `Homebrew<https://brew.sh/>`:
+The simplest way to install ESPHome on a Mac is with `Homebrew<https://brew.sh/>`_:
 
 .. code-block:: console
 
     $ brew install esphome
 
 Or, if you have a working Python installation you can install it directly without Homebrew.
-There are several ways to install Python on a Mac, including with Homebrew, Apple's X-Code command 
-line tools, or from `official packages<https://www.python.org/downloads/>`.
+There are several ways to install Python on a Mac, including with Homebrew, Apple's Xcode command 
+line tools, or from `official packages<https://www.python.org/downloads/>`_.
 
 Make sure you're running python 3.9 or above, then install using ``pip3``:
 

--- a/guides/installing_esphome.rst
+++ b/guides/installing_esphome.rst
@@ -49,15 +49,15 @@ with the following:
 Mac
 ---
 
-The simplest way to install ESPHome on a Mac is with `Homebrew<https://brew.sh/>`_:
+The simplest way to install ESPHome on a Mac is with `Homebrew <https://brew.sh/>`_:
 
 .. code-block:: console
 
     $ brew install esphome
 
 Or, if you have a working Python installation you can install it directly without Homebrew.
-There are several ways to install Python on a Mac, including with Homebrew, Apple's Xcode command 
-line tools, or from `official packages<https://www.python.org/downloads/>`_.
+There are several ways to install Python on a Mac, including with Apple's Xcode command 
+line tools or from `Python downloads <https://www.python.org/downloads/>`_.
 
 Make sure you're running python 3.9 or above, then install using ``pip3``:
 


### PR DESCRIPTION
## Description:
Better guidance on how to install ESPHome on a Mac

**Related issue (if applicable):** NA

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** NA

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
