### PR TITLE
Change average_throttle to throttle_average in power_meter.rst

### DIFF
--- a/cookbook/power_meter.rst
+++ b/cookbook/power_meter.rst
@@ -46,7 +46,7 @@ Adjust ``GPIO12`` to match your set up of course. The output from the pulse coun
 
 .. note::
 
-    The ``pulse_meter`` sensor sends an update every time a pulse is detected. This can quickly lead to sub-second updates which can be a bit much for Home Assistant to handle. To avoid this, you can use the ``average_throttle`` filter to only send updates up to a desired interval:
+    The ``pulse_meter`` sensor sends an update every time a pulse is detected. This can quickly lead to sub-second updates which can be a bit much for Home Assistant to handle. To avoid this, you can use the ``throttle_average`` filter to only send updates up to a desired interval:
 
     .. code-block:: yaml
 
@@ -54,7 +54,7 @@ Adjust ``GPIO12`` to match your set up of course. The output from the pulse coun
           - platform: pulse_meter
             # ...
             filters:
-              - average_throttle: 10s
+              - throttle_average: 10s
               - filter_out: NaN
 
 .. note::
@@ -97,7 +97,7 @@ When the total sensor is configured, ``pulse_meter`` also reports the total numb
           accuracy_decimals: 3
           filters:
             - multiply: 0.0001  # (1/10000 pulses per kWh)
-            # - average_throttle: 10s
+            # - throttle_average: 10s
             # - filter_out: NaN
 
 (Re)Setting the total energy value


### PR DESCRIPTION
Change `average_throttle` to `throttle_average`

## Description:

Hello! I'm not sure which is correct, but more knowing people can close this if this is wrong. I am implementing pulse_meter sensor and the editor kept bugging me about the `average_throttle` filter. I found out that there actually is `throttle_average` and the editor was happy about it. :)

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
