### PR TITLE
Fix Modbus Example Server doc

### DIFF
--- a/components/modbus_controller.rst
+++ b/components/modbus_controller.rst
@@ -175,9 +175,9 @@ The following code allows a ModBUS client to read a sensor value from your ESPHo
       - modbus_id: modbus_server
         address: 0x4
         server_registers:
-          - start_address: 0x0002
+          - address: 0x0002
             value_type: S_DWORD_R
-            lambda: |-
+            read_lambda: |-
               return id(evse_voltage_l1).state;
 
     sensor:

--- a/components/modbus_controller.rst
+++ b/components/modbus_controller.rst
@@ -68,7 +68,7 @@ Configuration variables:
   responds to a command, it'll be marked online again.
 
 - **server_registers** (*Optional*): A list of registers that are responded to when acting as a server.
-  - **start_address** (**Required**, integer): start address of the first register in a range
+  - **address** (**Required**, integer): start address of the first register in a range
   - **value_type** (*Optional*): datatype of the mod_bus register data. The default data type for ModBUS is a 16 bit integer in big endian format (MSB first)
 
       - ``U_WORD``: unsigned 16 bit integer from 1 register = 16bit
@@ -86,7 +86,7 @@ Configuration variables:
 
     Defaults to ``U_WORD``.
 
-  - **lambda** (**Required**, :ref:`lambda <config-lambda>`):
+  - **read_lambda** (**Required**, :ref:`lambda <config-lambda>`):
     Lambda that returns the value of this register.
 
 


### PR DESCRIPTION
## Description:
Fix Modbus Example Server doc.

**Related issue (if applicable):**

The configuration had been changed but the documentation had not been updated.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
