### PR TITLE
Remove `esp8266_restore_from_flash` reference

### DIFF
--- a/components/sensor/rotary_encoder.rst
+++ b/components/sensor/rotary_encoder.rst
@@ -76,8 +76,6 @@ Configuration variables:
   "unknown" value at first. If you set this option to true, the value is published once after
   boot and when it changes. Defaults to ``false``.
 - **restore_mode** (*Optional*): Control how the Rotary Encoder attempts to restore state on bootup.
-  For restoring on ESP8266s, also see ``esp8266_restore_from_flash`` in the
-  :doc:`esphome section </components/esphome>`.
 
     - ``RESTORE_DEFAULT_ZERO`` - (Default) Attempt to restore state and default to zero (0) if not possible to restore.
     - ``ALWAYS_ZERO`` - Always initialize the counter with value zero (0).


### PR DESCRIPTION
## Description:

`esp8266_restore_from_flash` is deprecated and will be removed in a future version. The generic mention remains, to be platform-agnostic.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
