### PR TITLE
[http_request] fix response

### DIFF
--- a/components/http_request.rst
+++ b/components/http_request.rst
@@ -88,8 +88,8 @@ This :ref:`action <config-action>` sends a GET request.
               - logger.log:
                   format: 'Response status: %d, Duration: %u ms'
                   args:
-                    - status_code
-                    - duration_ms
+                    - response->status_code
+                    - response->duration_ms
       # Short form
       - http_request.get: https://esphome.io
 
@@ -159,7 +159,7 @@ This :ref:`action <config-action>` sends a request.
 This automation will be triggered when the HTTP request is complete.
 The following variables are available for use in :ref:`lambdas <config-lambda>`:
 
-- ``response`` as a ``HttpContainer`` object which contains ``content_length``, ``status_code`` and ``duration_ms``.
+- ``response`` as a pointer to ``HttpContainer`` object which contains ``content_length``, ``status_code`` and ``duration_ms``.
 - ``body`` as ``std::string`` which contains the response body when ``capture_response``
   (see :ref:`http_request-get_action`) is set to ``true``.
 
@@ -174,8 +174,8 @@ The following variables are available for use in :ref:`lambdas <config-lambda>`:
                 - logger.log:
                     format: "Response status: %d, Duration: %u ms"
                     args:
-                      - response.status_code
-                      - response.duration_ms
+                      - response->status_code
+                      - response->duration_ms
 
 
 .. _http_request-examples:


### PR DESCRIPTION
## Description:

The documentation about `response` object is incorrect. 
  - `response` is a pointer to `HttpContainer`.
  - `status_code` and `duration_ms` can't be used alone. (need `response->...`)

note that's not apply to `body` in:
```C++
json::parse_json(body, [](JsonObject root) -> bool {...}
```


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
