### PR TITLE
Replace mac addresses in docs with XX:XX:XX:XX:XX:XX

### DIFF
--- a/components/binary_sensor/ble_presence.rst
+++ b/components/binary_sensor/ble_presence.rst
@@ -10,7 +10,7 @@ The ``ble_presence`` binary sensor platform lets you track the presence of a Blu
 .. warning::
 
     The BLE software stack on the ESP32 consumes a significant amount of RAM on the device.
-    
+
     **Crashes are likely to occur** if you include too many additional components in your device's
     configuration. Memory-intensive components such as :doc:`/components/voice_assistant` and other
     audio components are most likely to cause issues.
@@ -27,7 +27,7 @@ The ``ble_presence`` binary sensor platform lets you track the presence of a Blu
     binary_sensor:
       # Presence based on MAC address
       - platform: ble_presence
-        mac_address: AC:37:43:77:5F:4C
+        mac_address: XX:XX:XX:XX:XX:XX
         name: "ESP32 BLE Tracker Google Home Mini"
         min_rssi: -80dB
       # Presence based on Identity Resolving Key (IRK)
@@ -96,7 +96,7 @@ the logs to see discovered Bluetooth Low Energy devices.
 
 Using the configuration above, first you should see a ``Starting scan...`` debug message at
 boot-up. Then, when a BLE device is discovered, you should see messages like
-``Found device AC:37:43:77:5F:4C`` together with some information about their
+``Found device XX:XX:XX:XX:XX:XX`` together with some information about their
 address type and advertised name. If you don't see these messages, your device is unfortunately
 currently not supported.
 

--- a/components/ble_client.rst
+++ b/components/ble_client.rst
@@ -12,7 +12,7 @@ connections to them for use by other components.
 .. warning::
 
     The BLE software stack on the ESP32 consumes a significant amount of RAM on the device.
-    
+
     **Crashes are likely to occur** if you include too many additional components in your device's
     configuration. Memory-intensive components such as :doc:`/components/voice_assistant` and other
     audio components are most likely to cause issues.
@@ -36,7 +36,7 @@ to discover available client devices.
     esp32_ble_tracker:
 
     ble_client:
-      - mac_address: FF:FF:20:00:0F:15
+      - mac_address: XX:XX:XX:XX:XX:XX
         id: itag_black
         auto_connect: true
 
@@ -73,7 +73,7 @@ This automation is triggered when the client connects to the BLE device.
 .. code-block:: yaml
 
     ble_client:
-      - mac_address: 11:22:33:44:55:66
+      - mac_address: XX:XX:XX:XX:XX:XX
         id: ble_itag
         on_connect:
           then:
@@ -90,7 +90,7 @@ This automation is triggered when the client disconnects from a BLE device.
 .. code-block:: yaml
 
     ble_client:
-      - mac_address: 11:22:33:44:55:66
+      - mac_address: XX:XX:XX:XX:XX:XX
         id: ble_itag
         on_disconnect:
           then:
@@ -108,7 +108,7 @@ This automation is triggered when the BLE device requests a passkey for authenti
 .. code-block:: yaml
 
     ble_client:
-      - mac_address: 11:22:33:44:55:66
+      - mac_address: XX:XX:XX:XX:XX:XX
         id: ble_itag
         on_passkey_request:
           then:
@@ -126,7 +126,7 @@ This automation is triggered when a passkey is received from the BLE device.
 .. code-block:: yaml
 
     ble_client:
-      - mac_address: 11:22:33:44:55:66
+      - mac_address: XX:XX:XX:XX:XX:XX
         id: ble_itag
         on_passkey_notification:
           then:
@@ -144,7 +144,7 @@ This automation is triggered when a numeric comparison is requested by the BLE d
 .. code-block:: yaml
 
     ble_client:
-      - mac_address: 11:22:33:44:55:66
+      - mac_address: XX:XX:XX:XX:XX:XX
         id: ble_itag
         on_numeric_comparison_request:
           then:
@@ -174,10 +174,10 @@ on, hence the stop and start of the scan during connect.
 
     ble_client:
       - id: ble_clock
-        mac_address: 17:75:BC:F2:94:4D
+        mac_address: XX:XX:XX:XX:XX:XX
         auto_connect: false
       - id: other_device
-        mac_address: 0D:33:12:66:00:D4
+        mac_address: XX:XX:XX:XX:XX:XX
 
     interval:
       - interval: 60min
@@ -222,7 +222,7 @@ Example usage:
 .. code-block:: yaml
 
     ble_client:
-      - mac_address: 11:22:33:44:55:66
+      - mac_address: XX:XX:XX:XX:XX:XX
         id: my_ble_client
 
     switch:
@@ -308,7 +308,7 @@ Example usage:
 .. code-block:: yaml
 
     ble_client:
-      - mac_address: 11:22:33:44:55:66
+      - mac_address: XX:XX:XX:XX:XX:XX
         id: my_ble_client
         on_connect:
           then:
@@ -391,9 +391,9 @@ display them in the log:
 
 .. code-block:: text
 
-    [18:24:56][D][ble_client:043]: Found device at MAC address [FC:58:FA:B1:F8:93]
-    [18:24:56][I][ble_client:072]: Attempting BLE connection to fc:58:fa:b1:f8:93
-    [18:24:56][I][ble_client:097]: [fc:58:fa:b1:f8:93] ESP_GATTC_OPEN_EVT
+    [18:24:56][D][ble_client:043]: Found device at MAC address [XX:XX:XX:XX:XX:XX]
+    [18:24:56][I][ble_client:072]: Attempting BLE connection to XX:XX:XX:XX:XX:XX
+    [18:24:56][I][ble_client:097]: [XX:XX:XX:XX:XX:XX] ESP_GATTC_OPEN_EVT
     [18:24:57][I][ble_client:143]: Service UUID: 0x1800
     [18:24:57][I][ble_client:144]:   start_handle: 0x1  end_handle: 0x5
     [18:24:57][I][ble_client:305]:  characteristic 0x2A00, handle 0x3, properties 0x2
@@ -445,7 +445,7 @@ Secure connection with a fixed passkey:
     esp32_ble_tracker:
 
     ble_client:
-      - mac_address: A4:C1:38:B1:CD:7F
+      - mac_address: XX:XX:XX:XX:XX:XX
         id: pvvx_ble_display
         on_passkey_request:
           then:
@@ -483,7 +483,7 @@ Secure connection with a dynamically generated passkey:
     esp32_ble_tracker:
 
     ble_client:
-      - mac_address: AA:BB:CC:DD:EE:FF
+      - mac_address: XX:XX:XX:XX:XX:XX
         id: my_ble_client
         on_passkey_request:
           then:

--- a/components/button/wake_on_lan.rst
+++ b/components/button/wake_on_lan.rst
@@ -14,7 +14,7 @@ by specifying its MAC address.
     button:
       - platform: wake_on_lan
         name: "Start the Server"
-        target_mac_address: E9:48:B8:CA:58:A1
+        target_mac_address: XX:XX:XX:XX:XX:XX
 
 Configuration variables:
 ------------------------

--- a/components/climate/anova.rst
+++ b/components/climate/anova.rst
@@ -36,7 +36,7 @@ need to do conversion again within the frontend if you use Fahrenheit.
 .. code-block:: yaml
 
     ble_client:
-      - mac_address: 11:22:33:aa:bb:cc
+      - mac_address: XX:XX:XX:XX:XX:XX
         id: my_anova
 
     climate:

--- a/components/climate/bedjet.rst
+++ b/components/climate/bedjet.rst
@@ -31,7 +31,7 @@ and delegates status updates to individual platform components.
     esp32_ble_tracker:
 
     ble_client:
-      - mac_address: C4:4F:33:00:00:01
+      - mac_address: XX:XX:XX:XX:XX:XX
         id: bedjet_ble_id1
 
     bedjet:

--- a/components/cover/am43.rst
+++ b/components/cover/am43.rst
@@ -27,7 +27,7 @@ and state of the motor.
     esp32_ble_tracker:
 
     ble_client:
-      - mac_address: AA:BB:CC:DD:EE:FF
+      - mac_address: XX:XX:XX:XX:XX:XX
         id: am43_kitchen
 
     cover:

--- a/components/display/pvvx_mithermometer.rst
+++ b/components/display/pvvx_mithermometer.rst
@@ -29,7 +29,7 @@ The firmware configuration can be changed via browser using `TelinkMiFlasher.htm
     esp32_ble_tracker:
 
     ble_client:
-    - mac_address: "A4:C1:38:B1:CD:7F"
+    - mac_address: XX:XX:XX:XX:XX:XX
       id: pvvx_ble_display
 
     display:
@@ -139,12 +139,12 @@ The following example display the sensor states of a MiFlora sensor on a pvvx di
     esp32_ble_tracker:
 
     ble_client:
-    - mac_address: "A4:C1:38:B1:CD:7F"
+    - mac_address: XX:XX:XX:XX:XX:XX
       id: pvvx_ble_display
 
     sensor:
     - platform: pvvx_mithermometer
-      mac_address: "A4:C1:38:B1:CD:7F"
+      mac_address: XX:XX:XX:XX:XX:XX
       temperature:
         name: "PVVX Temperature"
       humidity:
@@ -154,7 +154,7 @@ The following example display the sensor states of a MiFlora sensor on a pvvx di
       battery_voltage:
         name: "PVVX Battery-Voltage"
     - platform: xiaomi_hhccjcy01
-      mac_address: '94:2B:FF:5C:91:61'
+      mac_address: XX:XX:XX:XX:XX:XX
       temperature:
         name: "Xiaomi HHCCJCY01 Temperature"
         id: miflora_temperature
@@ -199,12 +199,12 @@ The following example will synchronized the time of the pvvx device once a day.
     esp32_ble_tracker:
 
     ble_client:
-    - mac_address: "A4:C1:38:B1:CD:7F"
+    - mac_address: XX:XX:XX:XX:XX:XX
       id: pvvx_ble_display
 
     sensor:
     - platform: pvvx_mithermometer
-      mac_address: "A4:C1:38:B1:CD:7F"
+      mac_address: XX:XX:XX:XX:XX:XX
       temperature:
         name: "PVVX Temperature"
       humidity:

--- a/components/esp32_ble_tracker.rst
+++ b/components/esp32_ble_tracker.rst
@@ -14,7 +14,7 @@ the MAC address of a device and track it using ESPHome.
 .. warning::
 
     The BLE software stack on the ESP32 consumes a significant amount of RAM on the device.
-    
+
     **Crashes are likely to occur** if you include too many additional components in your device's
     configuration. Memory-intensive components such as :doc:`/components/voice_assistant` and other
     audio components are most likely to cause issues.
@@ -116,9 +116,9 @@ This automation will be triggered when a Bluetooth advertising is received. A va
 
     esp32_ble_tracker:
       on_ble_advertise:
-        - mac_address: 
-            - 11:11:11:11:11:11
-            - 22:22:22:22:22:22
+        - mac_address:
+            - "11:11:11:11:11:11"
+            - "22:22:22:22:22:22"
           then:
             - lambda: |-
                 ESP_LOGD("ble_adv", "New BLE device");
@@ -159,7 +159,7 @@ variable ``x`` of type ``std::vector<uint8_t>`` is passed to the automation for 
 
     esp32_ble_tracker:
       on_ble_manufacturer_data_advertise:
-        - mac_address: 11:22:33:44:55:66
+        - mac_address: "11:22:33:44:55:66"
           manufacturer_id: 0590
           then:
             - lambda: |-
@@ -190,7 +190,7 @@ variable ``x`` of type ``std::vector<uint8_t>`` is passed to the automation for 
 
     esp32_ble_tracker:
       on_ble_service_data_advertise:
-        - mac_address: 11:22:33:44:55:66
+        - mac_address: "11:22:33:44:55:66"
           service_uuid: 181A
           then:
             - lambda: 'id(ble_sensor).publish_state(x[0]);'

--- a/components/esp32_ble_tracker.rst
+++ b/components/esp32_ble_tracker.rst
@@ -26,15 +26,15 @@ the MAC address of a device and track it using ESPHome.
 
     binary_sensor:
       - platform: ble_presence
-        mac_address: AC:37:43:77:5F:4C
+        mac_address: XX:XX:XX:XX:XX:XX
         name: "ESP32 BLE Presence Google Home Mini"
 
     sensor:
       - platform: ble_rssi
-        mac_address: AC:37:43:77:5F:4C
+        mac_address: XX:XX:XX:XX:XX:XX
         name: "BLE Google Home Mini RSSI value"
       - platform: xiaomi_hhccjcy01
-        mac_address: 94:2B:FF:5C:91:61
+        mac_address: XX:XX:XX:XX:XX:XX
         temperature:
           name: "Xiaomi MiFlora Temperature"
         moisture:
@@ -46,7 +46,7 @@ the MAC address of a device and track it using ESPHome.
         battery_level:
           name: "Xiaomi MiFlora Battery Level"
       - platform: xiaomi_lywsdcgq
-        mac_address: 7A:80:8E:19:36:BA
+        mac_address: XX:XX:XX:XX:XX:XX
         temperature:
           name: "Xiaomi MiJia Temperature"
         humidity:
@@ -117,8 +117,8 @@ This automation will be triggered when a Bluetooth advertising is received. A va
     esp32_ble_tracker:
       on_ble_advertise:
         - mac_address:
-            - "11:11:11:11:11:11"
-            - "22:22:22:22:22:22"
+            - XX:XX:XX:XX:XX:XX
+            - XX:XX:XX:XX:XX:XX
           then:
             - lambda: |-
                 ESP_LOGD("ble_adv", "New BLE device");
@@ -159,7 +159,7 @@ variable ``x`` of type ``std::vector<uint8_t>`` is passed to the automation for 
 
     esp32_ble_tracker:
       on_ble_manufacturer_data_advertise:
-        - mac_address: "11:22:33:44:55:66"
+        - mac_address: XX:XX:XX:XX:XX:XX
           manufacturer_id: 0590
           then:
             - lambda: |-
@@ -190,7 +190,7 @@ variable ``x`` of type ``std::vector<uint8_t>`` is passed to the automation for 
 
     esp32_ble_tracker:
       on_ble_service_data_advertise:
-        - mac_address: "11:22:33:44:55:66"
+        - mac_address: XX:XX:XX:XX:XX:XX
           service_uuid: 181A
           then:
             - lambda: 'id(ble_sensor).publish_state(x[0]);'

--- a/components/output/ble_client.rst
+++ b/components/output/ble_client.rst
@@ -12,7 +12,7 @@ For more information on BLE services and characteristics, see :doc:`/components/
 .. warning::
 
     The BLE software stack on the ESP32 consumes a significant amount of RAM on the device.
-    
+
     **Crashes are likely to occur** if you include too many additional components in your device's
     configuration. Memory-intensive components such as :doc:`/components/voice_assistant` and other
     audio components are most likely to cause issues.
@@ -22,7 +22,7 @@ For more information on BLE services and characteristics, see :doc:`/components/
     esp32_ble_tracker:
 
     ble_client:
-      - mac_address: FF:FF:20:00:0F:15
+      - mac_address: XX:XX:XX:XX:XX:XX
         id: itag_black
 
     output:
@@ -39,7 +39,7 @@ Configuration variables:
 - **service_uuid** (**Required**, UUID): UUID of the service on the device.
 - **characteristic_uuid** (**Required**, UUID): UUID of the service's characteristic to write to.
 - **id** (*Optional*, :ref:`config-id`): The ID to use for code generation, and for reference by dependent components.
-- **require_response** (*Optional*, boolean): Control whether to require a remote response from the device when writing. 
+- **require_response** (*Optional*, boolean): Control whether to require a remote response from the device when writing.
   Whether or not this is required will vary by device. Defaults to ``false``
 - All other options from :ref:`Output <config-output>`.
 

--- a/components/sensor/airthings_ble.rst
+++ b/components/sensor/airthings_ble.rst
@@ -29,7 +29,7 @@ The device will then listen for nearby devices, and display a message like this 
 .. code-block:: text
 
     [D][airthings_ble:019]:
-    Found AirThings device Serial: 123456789 (MAC: 01:02:03:04:05:06)
+    Found AirThings device Serial: 123456789 (MAC: XX:XX:XX:XX:XX:XX)
 
 Once the device is found, remove the ``airthings_ble`` device tracker from your configuration and take note of the device MAC address, and use it when configuring a sensor below.
 
@@ -75,7 +75,7 @@ Configuration example:
           name: "WavePlus Battery Voltage"
 
     ble_client:
-      - mac_address: 01:02:03:04:05:06
+      - mac_address: XX:XX:XX:XX:XX:XX
         id: airthings01
 
     esp32_ble_tracker:
@@ -110,7 +110,7 @@ Configuration example:
           name: "WaveMini Battery Voltage"
 
     ble_client:
-      - mac_address: 01:02:03:04:05:06
+      - mac_address: XX:XX:XX:XX:XX:XX
         id: airthingsmini
 
     esp32_ble_tracker:

--- a/components/sensor/am43.rst
+++ b/components/sensor/am43.rst
@@ -25,7 +25,7 @@ to the device over the ESP32's BLE peripheral.
     esp32_ble_tracker:
 
     ble_client:
-      - mac: AA:BB:CC:DD:EE:FF
+      - mac: XX:XX:XX:XX:XX:XX
         id: am43_device
 
     sensor:

--- a/components/sensor/b_parasite.rst
+++ b/components/sensor/b_parasite.rst
@@ -24,7 +24,7 @@ The ``b_parasite`` sensor platform tracks b-parasite's Bluetooth Low Energy (BLE
 
     sensor:
       - platform: b_parasite
-        mac_address: F0:CA:F0:CA:01:01
+        mac_address: XX:XX:XX:XX:XX:XX
         humidity:
           name: 'b-parasite Air Humidity'
         temperature:

--- a/components/sensor/ble_client.rst
+++ b/components/sensor/ble_client.rst
@@ -13,7 +13,7 @@ For more information on BLE services and characteristics, see :doc:`/components/
 .. warning::
 
     The BLE software stack on the ESP32 consumes a significant amount of RAM on the device.
-    
+
     **Crashes are likely to occur** if you include too many additional components in your device's
     configuration. Memory-intensive components such as :doc:`/components/voice_assistant` and other
     audio components are most likely to cause issues.
@@ -23,7 +23,7 @@ For more information on BLE services and characteristics, see :doc:`/components/
     esp32_ble_tracker:
 
     ble_client:
-      - mac_address: FF:FF:20:00:0F:15
+      - mac_address: XX:XX:XX:XX:XX:XX
         id: itag_black
 
     sensor:

--- a/components/sensor/ble_rssi.rst
+++ b/components/sensor/ble_rssi.rst
@@ -13,7 +13,7 @@ instructions for setting up this platform.
 .. warning::
 
     The BLE software stack on the ESP32 consumes a significant amount of RAM on the device.
-    
+
     **Crashes are likely to occur** if you include too many additional components in your device's
     configuration. Memory-intensive components such as :doc:`/components/voice_assistant` and other
     audio components are most likely to cause issues.
@@ -26,7 +26,7 @@ instructions for setting up this platform.
     sensor:
       # RSSI based on MAC address
       - platform: ble_rssi
-        mac_address: AC:37:43:77:5F:4C
+        mac_address: XX:XX:XX:XX:XX:XX
         name: "BLE Google Home Mini RSSI value"
       # RSSI based on Identity Resolving Key (IRK)
       - platform: ble_rssi

--- a/components/sensor/inkbird_ibsth1_mini.rst
+++ b/components/sensor/inkbird_ibsth1_mini.rst
@@ -38,7 +38,7 @@ many IBS-TH1/TH2 devices at once as you want.
 
     sensor:
       - platform: inkbird_ibsth1_mini
-        mac_address: 38:81:D7:0A:9C:11
+        mac_address: XX:XX:XX:XX:XX:XX
         temperature:
           name: "Inkbird IBS-TH1 Temperature"
         external_temperature:
@@ -88,21 +88,21 @@ like so:
 
     esp32_ble_tracker:
 
-After uploading the ESP32 will immediately try to scan for BLE devices such as the Inkbird IBS-TH1/TH2. 
+After uploading the ESP32 will immediately try to scan for BLE devices such as the Inkbird IBS-TH1/TH2.
 When it detects these sensors, it will automatically parse the BLE message print a
 message like this one:
 
 .. code::
 
-    [13:36:43][D][esp32_ble_tracker:544]: Found device 38:81:D7:0A:9C:11 RSSI=-53
+    [13:36:43][D][esp32_ble_tracker:544]: Found device XX:XX:XX:XX:XX:XX RSSI=-53
     [13:36:43][D][esp32_ble_tracker:565]:   Address Type: PUBLIC
     [13:36:43][D][esp32_ble_tracker:567]:   Name: 'sps'
 
 Note that it can sometimes take some time for the first BLE broadcast to be received. Please note that address type
-should say 'PUBLIC' and the device name should be 'sps', this is how you find the Inkbird IBS-TH1/TH2 among all the 
+should say 'PUBLIC' and the device name should be 'sps', this is how you find the Inkbird IBS-TH1/TH2 among all the
 other devices.
 
-Then just copy the address (``38:81:D7:0A:9C:11``) into a new ``sensor.inkbird_ibsth1_mini`` platform
+Then just copy the address (``XX:XX:XX:XX:XX:XX``) into a new ``sensor.inkbird_ibsth1_mini`` platform
 entry like in the configuration example at the top.
 
 .. note::

--- a/components/sensor/mopeka_pro_check.rst
+++ b/components/sensor/mopeka_pro_check.rst
@@ -9,7 +9,7 @@ Mopeka Pro Check BLE Sensor
 The ``mopeka_pro_check`` sensor platform lets you track the output of Mopeka Pro
 Check LP, Mopeka Pro Plus, Mopeka Pro Universal or Lippert Propane Tank Sensors,   Bluetooth Low
 Energy devices using the :doc:`/components/esp32_ble_tracker`. This component
-will track the tank level, distance, temperature, and battery percentage of a 
+will track the tank level, distance, temperature, and battery percentage of a
 device every time the sensor sends out a BLE broadcast.
 
 .. warning::
@@ -21,7 +21,7 @@ device every time the sensor sends out a BLE broadcast.
       + Lippert Propane Tank Sensor, part number 2021130655
 
     Sensors are calibrated for propane only.
-      
+
     See :doc:`/components/sensor/mopeka_std_check` for original Mopeka Check sensors support.
 
 .. figure:: images/mopeka_pro_check.jpg
@@ -32,7 +32,7 @@ device every time the sensor sends out a BLE broadcast.
 .. figure:: images/mopeka_pro_check_lippert.jpg
     :align: center
 
-    Lippert™ Propane Tank Sensor 
+    Lippert™ Propane Tank Sensor
 
 The original Mopeka Check sensors are not supported.
 
@@ -46,7 +46,7 @@ Mopeka Pro Check LP over BLE:
     sensor:
       # Example using 20lb vertical propane tank.
       - platform: mopeka_pro_check
-        mac_address: D3:75:F2:DC:16:91
+        mac_address: XX:XX:XX:XX:XX:XX
         tank_type: 20LB_V
         temperature:
             name: "Propane test temp"
@@ -59,7 +59,7 @@ Mopeka Pro Check LP over BLE:
 
       # Custom example - user defined empty / full points
       - platform: mopeka_pro_check
-        mac_address: D3:75:F2:DC:16:91
+        mac_address: XX:XX:XX:XX:XX:XX
         tank_type: CUSTOM
         custom_distance_full: 40cm
         custom_distance_empty: 10mm
@@ -137,9 +137,9 @@ For all sensors found the ``mopeka_ble`` component will print a message like thi
 
 .. code::
 
-    [20:43:26][I][mopeka_ble:074]: MOPEKA PRO (NRF52) SENSOR FOUND: D3:75:F2:DC:16:91
+    [20:43:26][I][mopeka_ble:074]: MOPEKA PRO (NRF52) SENSOR FOUND: XX:XX:XX:XX:XX:XX
 
-Then just copy the address (``D3:75:F2:DC:16:91``) into a new
+Then just copy the address (``XX:XX:XX:XX:XX:XX``) into a new
 ``sensor.mopeka_pro_check`` platform entry like in the configuration example at the top.
 
 .. note::

--- a/components/sensor/mopeka_std_check.rst
+++ b/components/sensor/mopeka_std_check.rst
@@ -7,9 +7,9 @@ Mopeka Standard Check BLE Sensor
     :keywords: Mopeka, Mopeka Standard Check, Mopeka Std Check, BLE, Bluetooth
 
 The ``mopeka_std_check`` sensor platform lets you track the output of Mopeka
-Standard Check LP Bluetooth Low Energy devices using the 
-:doc:`/components/esp32_ble_tracker`. This component will track the tank level, 
-distance, temperature, and battery percentage of a Mopeka Standard Check LP BLE 
+Standard Check LP Bluetooth Low Energy devices using the
+:doc:`/components/esp32_ble_tracker`. This component will track the tank level,
+distance, temperature, and battery percentage of a Mopeka Standard Check LP BLE
 device every time the sensor sends out a BLE broadcast.
 
 .. warning::
@@ -29,7 +29,7 @@ device every time the sensor sends out a BLE broadcast.
     sensor:
       # Example using 11kg 100% propane tank.
       - platform: mopeka_std_check
-        mac_address: D3:75:F2:DC:16:91
+        mac_address: XX:XX:XX:XX:XX:XX
         tank_type: Europe_11kg
         temperature:
             name: "Propane test temp"
@@ -42,7 +42,7 @@ device every time the sensor sends out a BLE broadcast.
 
       # Custom example - user defined empty / full points and 80% butane and 20% propane.
       - platform: mopeka_std_check
-        mac_address: D3:75:F2:DC:16:91
+        mac_address: XX:XX:XX:XX:XX:XX
         tank_type: CUSTOM
         custom_distance_full: 40cm
         custom_distance_empty: 32mm
@@ -125,15 +125,15 @@ and the ``mopeka_ble`` component like so:
 
     mopeka_ble:
 
-After uploading, the ESP32 will immediately try to scan for BLE devices. For Mopeka Standard devices you must press and hold the green sync button for it to be identified. 
+After uploading, the ESP32 will immediately try to scan for BLE devices. For Mopeka Standard devices you must press and hold the green sync button for it to be identified.
 Or alternativly set the configuration flag ``show_sensors_without_sync: true`` to see all devices.
 For all sensors found the ``mopeka_ble`` component will print a message like this one:
 
 .. code::
 
-    [20:43:26][I][mopeka_ble:056]: MOPEKA STD (CC2540) SENSOR FOUND: D3:75:F2:DC:16:91
+    [20:43:26][I][mopeka_ble:056]: MOPEKA STD (CC2540) SENSOR FOUND: XX:XX:XX:XX:XX:XX
 
-Then just copy the address (``D3:75:F2:DC:16:91``) into a new
+Then just copy the address (``XX:XX:XX:XX:XX:XX``) into a new
 ``sensor.mopeka_std_check`` platform entry like in the configuration example at the top.
 
 .. note::

--- a/components/sensor/radon_eye_ble.rst
+++ b/components/sensor/radon_eye_ble.rst
@@ -29,7 +29,7 @@ The device will then listen for nearby devices, and display a message like this 
 .. code-block:: text
 
     [D][radon_eye_ble:017]:
-    Found Radon Eye RD200 device Name: FR:R20:SN1234      (MAC: 01:02:03:04:05:06)
+    Found Radon Eye RD200 device Name: FR:R20:SN1234      (MAC: XX:XX:XX:XX:XX:XX)
 
 Once the device is found, remove the ``radon_eye_ble`` device tracker from your configuration and
 take note of the device MAC address, and use it when configuring a sensor below.
@@ -61,7 +61,7 @@ Configuration example:
     esp32_ble_tracker:
 
     ble_client:
-      - mac_address: 01:02:03:04:05:06
+      - mac_address: XX:XX:XX:XX:XX:XX
         id: radon_eye_ble_id
 
     sensor:
@@ -80,7 +80,7 @@ Here is an example to use pCi/L (to match the value on the device display):
     esp32_ble_tracker:
 
     ble_client:
-      - mac_address: 01:02:03:04:05:06
+      - mac_address: XX:XX:XX:XX:XX:XX
         id: radon_eye_ble_id
 
     sensor:
@@ -99,4 +99,3 @@ Here is an example to use pCi/L (to match the value on the device display):
           accuracy_decimals: 2
           filters:
             - lambda: return x / 37;
-

--- a/components/sensor/ruuvitag.rst
+++ b/components/sensor/ruuvitag.rst
@@ -30,7 +30,7 @@ movement count and measurement sequence number are also tracked.
 
     sensor:
     - platform: ruuvitag
-      mac_address: FF:56:D3:2F:7D:E8
+      mac_address: XX:XX:XX:XX:XX:XX
       humidity:
         name: "RuuviTag Humidity"
       temperature:
@@ -167,11 +167,11 @@ print a message like this one:
 
 .. code::
 
-    Got ruuvi RuuviTag (FF:56:D3:2F:7D:E8): Humidity: 67.5%, Temperature: 22.97°C,
+    Got ruuvi RuuviTag (XX:XX:XX:XX:XX:XX): Humidity: 67.5%, Temperature: 22.97°C,
     Pressure: 977.09hPa, Acceleration X: 0.005G, Acceleration Y: 0.017G, Acceleration Z: 1.066G,
     Battery Voltage: 3.223V
 
-Then just copy the address (``FF:56:D3:2F:7D:E8``) into a new
+Then just copy the address (``XX:XX:XX:XX:XX:XX``) into a new
 ``sensor.ruuvitag`` platform entry like in the configuration example at the top.
 
 .. note::

--- a/components/sensor/xiaomi_ble.rst
+++ b/components/sensor/xiaomi_ble.rst
@@ -32,7 +32,7 @@ Configuration example:
 
     sensor:
       - platform: xiaomi_hhccjcy01
-        mac_address: '94:2B:FF:5C:91:61'
+        mac_address: XX:XX:XX:XX:XX:XX
         temperature:
           name: "Xiaomi HHCCJCY01 Temperature"
         moisture:
@@ -64,7 +64,7 @@ Configuration example:
 
     sensor:
       - platform: xiaomi_gcls002
-        mac_address: "94:2B:FF:5C:91:61"
+        mac_address: XX:XX:XX:XX:XX:XX
         temperature:
           name: "GCLS02 Temperature"
         moisture:
@@ -89,7 +89,7 @@ Configuration example:
 
     sensor:
       - platform: xiaomi_hhccpot002
-        mac_address: "94:2B:FF:5C:91:61"
+        mac_address: XX:XX:XX:XX:XX:XX
         moisture:
           name: "HHCCPOT002 Moisture"
         conductivity:
@@ -110,7 +110,7 @@ Configuration example:
 
     sensor:
       - platform: xiaomi_lywsdcgq
-        mac_address: "7A:80:8E:19:36:BA"
+        mac_address: XX:XX:XX:XX:XX:XX
         temperature:
           name: "LYWSDCGQ Temperature"
         humidity:
@@ -135,7 +135,7 @@ Configuration example:
 
     sensor:
       - platform: xiaomi_lywsd02
-        mac_address: "3F:5B:7D:82:58:4E"
+        mac_address: XX:XX:XX:XX:XX:XX
         temperature:
           name: "LYWSD02 Temperature"
         humidity:
@@ -160,7 +160,7 @@ Configuration example:
 
     sensor:
       - platform: xiaomi_cgg1
-        mac_address: "7A:80:8E:19:36:BA"
+        mac_address: XX:XX:XX:XX:XX:XX
         temperature:
           name: "CGG1 Temperature"
         humidity:
@@ -168,7 +168,7 @@ Configuration example:
         battery_level:
           name: "CGG1 Battery Level"
       - platform: xiaomi_cgg1
-        mac_address: "7A:80:8E:28:39:CD"
+        mac_address: XX:XX:XX:XX:XX:XX
         bindkey: "00112233445566778899aabbccddeeff"
         temperature:
           name: "CGG1 (New) Temperature"
@@ -200,7 +200,7 @@ Configuration example for Xiaomi stock firmware or ATC MiThermometer firmware se
 
     sensor:
       - platform: xiaomi_lywsd03mmc
-        mac_address: "A4:C1:38:B1:CD:7F"
+        mac_address: XX:XX:XX:XX:XX:XX
         bindkey: "eef418daf699a0c188f3bfd17e4565d9"
         temperature:
           name: "LYWSD03MMC Temperature"
@@ -215,7 +215,7 @@ Configuration example for PVVX MiThermometer firmware set to "Custom" advertisem
 
     sensor:
       - platform: pvvx_mithermometer
-        mac_address: "A4:C1:38:B1:CD:7F"
+        mac_address: XX:XX:XX:XX:XX:XX
         temperature:
           name: "PVVX Temperature"
         humidity:
@@ -233,7 +233,7 @@ Configuration example for ATC MiThermometer firmware set to "Custom" advertiseme
 
     sensor:
       - platform: atc_mithermometer
-        mac_address: "A4:C1:38:B1:CD:7F"
+        mac_address: XX:XX:XX:XX:XX:XX
         temperature:
           name: "ATC Temperature"
         humidity:
@@ -263,7 +263,7 @@ Configuration example:
 
     sensor:
       - platform: xiaomi_mhoc303
-        mac_address: "E7:50:59:32:A0:1C"
+        mac_address: XX:XX:XX:XX:XX:XX
         temperature:
           name: "MHO-C303 Climate Temperature"
         humidity:
@@ -296,7 +296,7 @@ Configuration example for Xiaomi stock firmware:
 
     sensor:
       - platform: xiaomi_mhoc401
-        mac_address: "A4:C1:38:B1:CD:7F"
+        mac_address: XX:XX:XX:XX:XX:XX
         bindkey: "eef418daf699a0c188f3bfd17e4565d9"
         temperature:
           name: "MHOC401 Temperature"
@@ -311,7 +311,7 @@ Configuration example for PVVX MiThermometer firmware set to "Custom" advertisem
 
     sensor:
       - platform: pvvx_mithermometer
-        mac_address: "A4:C1:38:B1:CD:7F"
+        mac_address: XX:XX:XX:XX:XX:XX
         temperature:
           name: "PVVX Temperature"
         humidity:
@@ -337,7 +337,7 @@ Configuration example:
 
     sensor:
       - platform: xiaomi_cgd1
-        mac_address: "A4:C1:38:8C:34:B7"
+        mac_address: XX:XX:XX:XX:XX:XX
         bindkey: "fe39106baeedb7c801e3d63c4396f97e"
         temperature:
           name: "CGD1 Temperature"
@@ -362,7 +362,7 @@ Configuration example:
 
     sensor:
       - platform: xiaomi_cgdk2
-        mac_address: "58:2D:34:11:34:B7"
+        mac_address: XX:XX:XX:XX:XX:XX
         bindkey: "fe39106baeedb7c801e3d63c4396f97e"
         temperature:
           name: "CGDK2 Temperature"
@@ -386,7 +386,7 @@ Configuration example:
 
     sensor:
       - platform: xiaomi_jqjcy01ym
-        mac_address: "7A:80:8E:19:36:BA"
+        mac_address: XX:XX:XX:XX:XX:XX
         temperature:
           name: "JQJCY01YM Temperature"
         humidity:
@@ -413,7 +413,7 @@ Configuration example:
 
     binary_sensor:
       - platform: xiaomi_wx08zm
-        mac_address: "74:a3:4a:b5:07:34"
+        mac_address: XX:XX:XX:XX:XX:XX
         tablet:
           name: "WX08ZM Mosquito Tablet"
         battery_level:
@@ -437,7 +437,7 @@ Configuration example:
     binary_sensor:
       - platform: xiaomi_mue4094rt
         name: "MUE4094RT Night Light"
-        mac_address: "7A:80:8E:19:36:BA"
+        mac_address: XX:XX:XX:XX:XX:XX
         timeout: "5s"
 
 MJYD02YL-A
@@ -458,7 +458,7 @@ Configuration example:
     binary_sensor:
       - platform: xiaomi_mjyd02yla
         name: "MJYD02YL-A Night Light"
-        mac_address: "50:EC:50:CD:32:02"
+        mac_address: XX:XX:XX:XX:XX:XX
         bindkey: "48403ebe2d385db8d0c187f81e62cb64"
         idle_time:
           name: "MJYD02YL-A Idle Time"
@@ -485,7 +485,7 @@ Configuration example:
     binary_sensor:
       - platform: xiaomi_cgpr1
         name: "CGPR1 Motion detector"
-        mac_address: 58:2D:34:60:32:A2
+        mac_address: XX:XX:XX:XX:XX:XX
         bindkey: "ff1ae526b23b4aebeadcaaad86f59055"
         idle_time:
           name: "CGPR1 Idle Time"
@@ -510,7 +510,7 @@ Configuration example:
 
     xiaomi_rtcgq02lm:
       - id: motion_one
-        mac_address: 01:23:45:67:89:AB
+        mac_address: XX:XX:XX:XX:XX:XX
         bindkey: fe39106baeedb7c801e3d63c4396f97e
 
     binary_sensor:
@@ -567,11 +567,11 @@ After uploading, the ESP32 will immediately try to scan for BLE devices. When it
 
 .. code::
 
-    Found device A4:C1:38:4E:16:78 RSSI=-78
+    Found device XX:XX:XX:XX:XX:XX RSSI=-78
       Address Type: PUBLIC
       Name: 'LYWSD03MMC'
 
-It can sometimes take some time for the first BLE broadcast to be received. Once the device has been found, copy the address ``A4:C1:38:4E:16:78`` into a new platform entry like shown in the example configurations.
+It can sometimes take some time for the first BLE broadcast to be received. Once the device has been found, copy the address ``XX:XX:XX:XX:XX:XX`` into a new platform entry like shown in the example configurations.
 
 .. _obtaining_the_bindkey:
 
@@ -621,7 +621,7 @@ Another option is to use a SSL packet sniffer. It can be setup on either an Andr
 
     packet: POST /app/device/bltbind
 
-    "data" = "{"did":"blt.3.129q4nasgeg00","token":"20c665a7ff82a5bfb5eefc36","props":[{"type":"prop","key":"bind_key","value":"cfc7cc892f4e32f7a733086cf3443cb0"},   {"type":"prop","key":"smac","value":"A4:C1:38:8C:34:B7"}]}"
+    "data" = "{"did":"blt.3.129q4nasgeg00","token":"20c665a7ff82a5bfb5eefc36","props":[{"type":"prop","key":"bind_key","value":"cfc7cc892f4e32f7a733086cf3443cb0"},   {"type":"prop","key":"smac","value":XX:XX:XX:XX:XX:XX}]}"
 
 The ``bind_key`` is the 32 digits "value" item in the above output which needs to be inserted into the config file.
 

--- a/components/sensor/xiaomi_hhccjcy10.rst
+++ b/components/sensor/xiaomi_hhccjcy10.rst
@@ -16,7 +16,7 @@ MiFlora, tuya (pink) version, measures temperature, moisture, ambient light and 
 
     sensor:
       - platform: xiaomi_hhccjcy10
-        mac_address: '94:2B:FF:5C:91:61'
+        mac_address: XX:XX:XX:XX:XX:XX
         temperature:
           name: "Xiaomi HHCCJCY10 Temperature"
         moisture:

--- a/components/sensor/xiaomi_miscale.rst
+++ b/components/sensor/xiaomi_miscale.rst
@@ -26,7 +26,7 @@ Miscale (left) measures weight only. Miscale2 (right) measures weight and impeda
 
     sensor:
       - platform: xiaomi_miscale
-        mac_address: '5C:CA:D3:70:D4:A2'
+        mac_address: XX:XX:XX:XX:XX:XX
         weight:
           name: "Xiaomi Mi Scale Weight"
         impedance:
@@ -59,7 +59,7 @@ You have to replace the numbers in the lambdas to determine your weight which is
 
     sensor:
       - platform: xiaomi_miscale
-        mac_address: '5C:CA:D3:70:D4:A2'
+        mac_address: XX:XX:XX:XX:XX:XX
         weight:
           name: "Xiaomi Mi Scale Weight"
           id: weight_miscale

--- a/components/switch/ble_client.rst
+++ b/components/switch/ble_client.rst
@@ -13,7 +13,7 @@ For more information on BLE services and characteristics, see :doc:`/components/
 .. warning::
 
     The BLE software stack on the ESP32 consumes a significant amount of RAM on the device.
-    
+
     **Crashes are likely to occur** if you include too many additional components in your device's
     configuration. Memory-intensive components such as :doc:`/components/voice_assistant` and other
     audio components are most likely to cause issues.
@@ -23,7 +23,7 @@ For more information on BLE services and characteristics, see :doc:`/components/
     esp32_ble_tracker:
 
     ble_client:
-      - mac_address: FF:FF:20:00:0F:15
+      - mac_address: XX:XX:XX:XX:XX:XX
         id: itag_black
 
     switch:

--- a/components/text_sensor/ble_client.rst
+++ b/components/text_sensor/ble_client.rst
@@ -16,7 +16,7 @@ For more information on BLE services and characteristics, see
     esp32_ble_tracker:
 
     ble_client:
-      - mac_address: FF:FF:20:00:0F:15
+      - mac_address: XX:XX:XX:XX:XX:XX
         id: itag_black
 
     text_sensor:

--- a/components/text_sensor/ble_scanner.rst
+++ b/components/text_sensor/ble_scanner.rst
@@ -39,7 +39,7 @@ Example json log:
 
     {
         "timestamp":1578254525,
-        "address":XX:XX:XX:XX:XX:XX,
+        "address": "XX:XX:XX:XX:XX:XX",
         "rssi":"-80",
         "name":"MI Band 2"
     }

--- a/components/text_sensor/ble_scanner.rst
+++ b/components/text_sensor/ble_scanner.rst
@@ -19,7 +19,7 @@ the data in JSON format.
 .. warning::
 
     The BLE software stack on the ESP32 consumes a significant amount of RAM on the device.
-    
+
     **Crashes are likely to occur** if you include too many additional components in your device's
     configuration. Memory-intensive components such as :doc:`/components/voice_assistant` and other
     audio components are most likely to cause issues.
@@ -39,7 +39,7 @@ Example json log:
 
     {
         "timestamp":1578254525,
-        "address":"D7:E7:E7:66:DD:33",
+        "address":XX:XX:XX:XX:XX:XX,
         "rssi":"-80",
         "name":"MI Band 2"
     }


### PR DESCRIPTION
## Description:

Examples are not to be copied verbatim.

**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/6032

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
