### PR TITLE
Update host-related docs

### DIFF
--- a/components/display/sdl.rst
+++ b/components/display/sdl.rst
@@ -17,14 +17,13 @@ than compiling for and flashing a microcontroller target system.
 .. code-block:: yaml
 
     # Example configuration entry
+    esphome:
+      name: sdl
+
     host:
-      mac_address: "62:23:45:AF:B3:DD"
 
     display:
       - platform: sdl
-        id: sdl_display
-        update_interval: 1s
-        auto_clear_enabled: false
         show_test_card: true
         dimensions:
           width: 450
@@ -95,13 +94,7 @@ Linux instructions above. See https://learn.microsoft.com/en-us/windows/wsl/inst
 Build and run
 -------------
 
-The ``esphome`` command will not automatically run the build file on the ``host`` platform. Instead use ``esphome compile yourfile.yaml``
-then locate the executable file called ``program`` within the ``.esphome`` build tree:
-
-.. code-block:: sh
-
-    `find .esphome -name program`
-
+The ``esphome run yourfile.yaml`` command will compile and automatically run the build file on the ``host`` platform.
 
 See Also
 --------

--- a/components/host.rst
+++ b/components/host.rst
@@ -23,17 +23,23 @@ configure wifi - network will automatically be available using the host computer
 
     # Example configuration entry
     host:
-      mac_address: "98:35:69:ab:f6:79"
+      mac_address: "06:35:69:ab:f6:79"
 
 Configuration variables:
 ------------------------
 
 - **mac_address** (**Optional**, MAC address): A dummy MAC address to use when communicating with HA.
 
+Build and run
+-------------
+
+The ``esphome run yourfile.yaml`` command will compile and automatically run the build file on the ``host`` platform.
+
 
 See Also
 --------
 
+- :ref:`SDL display <sdl>`
 - :doc:`esphome`
 - :doc:`/components/time/host`
 - :ghedit:`Edit`


### PR DESCRIPTION
## Description:
`esphome run` now works on host, so document it;
Make sdl docs less open to mis-interpretation.
Change example MAC address to locally administered



## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
