### PR TITLE
Added "and/or brightness (e.g. monochromatic)" to the Random Effect description

### DIFF
--- a/components/light/index.rst
+++ b/components/light/index.rst
@@ -514,7 +514,7 @@ Configuration variables:
 Random Effect
 *************
 
-This effect makes a transition (of length ``transition_length``) to a randomly-chosen color every ``update_interval``.
+This effect makes a transition (of length ``transition_length``) to a randomly-chosen color and/or brightness (e.g. monochromatic) every ``update_interval``.
 
 .. code-block:: yaml
 


### PR DESCRIPTION
The Random Effect can also affect the brightness instead of color (e.g. monochromatic light components). I'm not sure if the brightness is also affected for RGB light components, so I put it as an "and/or" instead of just an "or." Of course, adjust based on how it actually works with RGB lights.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
