### PR TITLE
Correct ENS160 default address

### DIFF
--- a/components/sensor/ens160.rst
+++ b/components/sensor/ens160.rst
@@ -81,7 +81,7 @@ Configuration variables:
   frequency of the ENS160 which is up to 1 second.
 
 - **address** (*Optional*, int): *I²C only.* Manually specify the I²C address of
-  the sensor. Defaults to ``0x53``. Another address can be ``0x52``.
+  the sensor. Defaults to ``0x52``. Another address can be ``0x53``.
 
 - **cs_pin** (*Required*, :ref:`Pin Schema <config-pin_schema>`): *SPI only.* The Chip Select pin.
 


### PR DESCRIPTION
Default address was changed in [#6369](https://github.com/esphome/esphome/blob/f1aa254e4810999d7bb70619ba9c09bb9be5cf98/esphome/components/ens160_i2c/sensor.py#L16) and documentation was not updated.

## Description:

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
