### PR TITLE
[http_request] Simplify component examples

### DIFF
--- a/components/http_request.rst
+++ b/components/http_request.rst
@@ -13,8 +13,6 @@ The ``http_request`` component lets you make HTTP/HTTPS requests. To do so, you 
 
     # Example configuration entry
     http_request:
-      useragent: esphome/device
-      timeout: 10s
 
 .. _http_request-configuration_variables:
 

--- a/cookbook/http_request_sensor.rst
+++ b/cookbook/http_request_sensor.rst
@@ -23,8 +23,6 @@ On the client nodes we need an :doc:`/components/http_request` with an ``id`` se
 .. code-block:: yaml
 
     http_request:
-      useragent: esphome/device
-      id: http_request_id
 
     sensor:
       - platform: template


### PR DESCRIPTION
## Description:

I keep seeing people having the `useragent: esphome/device` in their YAMLs instead of letting it use the default one with the version and url. This explains why :laughing: 

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
