### PR TITLE
[http_request] Allow configure buffer size on ESP-IDF 

### DIFF
--- a/components/http_request.rst
+++ b/components/http_request.rst
@@ -36,7 +36,7 @@ Configuration variables:
   experiencing device reboots due to watchdog timeouts;** doing so may prevent the device from rebooting due to a
   legitimate problem. **Only available on ESP32 and RP2040**.
 
-**For the ESP-IDF:**
+**For the ESP32 when using ESP-IDF:**
 
 - **buffer_size_rx** (*Optional*, integer): Change HTTP receive buffer size. Defaults to ``512``.
 - **buffer_size_tx** (*Optional*, integer): Change HTTP transmit buffer size. Defaults to ``512``.

--- a/components/http_request.rst
+++ b/components/http_request.rst
@@ -36,6 +36,11 @@ Configuration variables:
   experiencing device reboots due to watchdog timeouts;** doing so may prevent the device from rebooting due to a
   legitimate problem. **Only available on ESP32 and RP2040**.
 
+**For the ESP-IDF:**
+
+- **buffer_size_rx** (*Optional*, integer): Change HTTP receive buffer size. Defaults to ``512``.
+- **buffer_size_tx** (*Optional*, integer): Change HTTP transmit buffer size. Defaults to ``512``.
+
 **For the ESP8266:**
 
 - **esp8266_disable_ssl_support** (*Optional*, boolean): Determines whether to include HTTPS/SSL support in the


### PR DESCRIPTION
## Description:

Documentation for http_request new esp-idf parameters: buffer_size_rx and buffer_size_tx.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#7125

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
