### PR TITLE
Changed Default address to 0x76

### DIFF
--- a/components/sensor/bmp280.rst
+++ b/components/sensor/bmp280.rst
@@ -54,7 +54,7 @@ Configuration variables:
   - All other options from :ref:`Sensor <config-sensor>`.
 
 - **address** (*Optional*, int): Manually specify the I²C address of
-  the sensor. Defaults to ``0x77``. Another address can be ``0x76``.
+  the sensor. Defaults to ``0x76``. Another address can be ``0x77`` when SDO pin is pulled High.
 - **iir_filter** (*Optional*): Set up an Infinite Impulse Response filter to increase accuracy. One of
   ``OFF``, ``2x``, ``4x``, ``16x``. Defaults to ``OFF``.
 - **update_interval** (*Optional*, :ref:`config-time`): The interval to check the

--- a/components/sensor/bmp280.rst
+++ b/components/sensor/bmp280.rst
@@ -54,8 +54,7 @@ Configuration variables:
   - All other options from :ref:`Sensor <config-sensor>`.
 
 - **address** (*Optional*, int): Manually specify the I²C address of
-  the sensor. Defaults to ``0x76`` (corresponding to SDO pin pulled low). Another address
-  can be ``0x77`` (corresponding to SDO pin pulled high).
+  the sensor. Defaults to ``0x76``. Another address can be ``0x77`` when SDO pin pulled high.
 - **iir_filter** (*Optional*): Set up an Infinite Impulse Response filter to increase accuracy. One of
   ``OFF``, ``2x``, ``4x``, ``16x``. Defaults to ``OFF``.
 - **update_interval** (*Optional*, :ref:`config-time`): The interval to check the

--- a/components/sensor/bmp280.rst
+++ b/components/sensor/bmp280.rst
@@ -54,7 +54,8 @@ Configuration variables:
   - All other options from :ref:`Sensor <config-sensor>`.
 
 - **address** (*Optional*, int): Manually specify the I²C address of
-  the sensor. Defaults to ``0x76``. Another address can be ``0x77`` when SDO pin is pulled High.
+  the sensor. Defaults to ``0x76`` (corresponding to SDO pin pulled low). Another address
+  can be ``0x77`` (corresponding to SDO pin pulled high).
 - **iir_filter** (*Optional*): Set up an Infinite Impulse Response filter to increase accuracy. One of
   ``OFF``, ``2x``, ``4x``, ``16x``. Defaults to ``OFF``.
 - **update_interval** (*Optional*, :ref:`config-time`): The interval to check the


### PR DESCRIPTION
Changed Default address to 0x76. Plus added note to change address by pulling SDO Pin High.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
