### PR TITLE
add new finish action and is_stopped condition

### DIFF
--- a/components/speaker/index.rst
+++ b/components/speaker/index.rst
@@ -92,7 +92,7 @@ Configuration variables:
 
 - **id** (*Optional*, :ref:`config-id`): The speaker to check. Defaults to the only one in YAML.
 
-.. _speaker-is_playing:
+.. _speaker-is_stopped:
 
 ``speaker.is_stopped`` Condition
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/components/speaker/index.rst
+++ b/components/speaker/index.rst
@@ -62,6 +62,19 @@ Configuration variables:
 
 .. _speaker-conditions:
 
+.. _speaker-finish:
+
+``speaker.finish`` Action
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This action will stop playing audio data from the speaker until all data has been played.
+
+Configuration variables:
+
+- **id** (*Optional*, :ref:`config-id`): The speaker to control. Defaults to the only one in YAML.
+
+.. _speaker-conditions:
+
 Speaker Conditions
 ---------------------
 
@@ -74,6 +87,17 @@ your configuration YAML.
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 This condition will check if the speaker is currently playing audio data.
+
+Configuration variables:
+
+- **id** (*Optional*, :ref:`config-id`): The speaker to check. Defaults to the only one in YAML.
+
+.. _speaker-is_playing:
+
+``speaker.is_stopped`` Condition
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This condition will check if the speaker is really stopped.
 
 Configuration variables:
 


### PR DESCRIPTION
Based on the ideas of @gnumpi

## Description:
Added a new action named **speaker.finish** this will stop the speaker after playing all data in the buffer. And added a new condition **speaker.is_stopped** this will return true when the speaker is really stopped.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#4083

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
