### PR TITLE
Add docs for `round_to_multiple_of` filter

### DIFF
--- a/components/sensor/index.rst
+++ b/components/sensor/index.rst
@@ -296,6 +296,27 @@ Rounds the value to the given decimal places.
         - round: 1 # will round to 1 decimal place
 
 
+
+``round_to_multiple_of``
+************************
+
+Rounds the value to the nearest multiple. Takes a float greater than zero.
+
+.. code-block:: yaml
+
+    - platform: ...
+      filters:
+        - round_to_multiple_of: 10
+        # 123 -> 120
+        # 126 -> 130
+
+    - platform: ...
+      filters:
+        - round_to_multiple_of: 0.25
+        # 3.1415 -> 3.25
+        # 1.6180 -> 1.5
+
+
 ``quantile``
 ************
 


### PR DESCRIPTION
## Description:


~~**Related issue (if applicable):** fixes <link to issue>~~

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#7142

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] ~~I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.~~

  - [ ] ~~Link added in `/index.rst` when creating new documents for new components or cookbook.~~
