### PR TITLE
Fix for Mitsubishi units that only support cooling

### DIFF
--- a/components/climate/climate_ir.rst
+++ b/components/climate/climate_ir.rst
@@ -200,6 +200,10 @@ These air conditioners support two protocols: Midea and Coolix. Therefore, when 
 
 ``mitsubishi`` **Climate**:
 
+.. note::
+
+    - When using this component with Mitsubishi units that only support cooling mode, the Off command may not work. Set **supports_heat** to ``false`` to resolve that issue.
+
 - **set_fan_mode** (*Optional*, string): Select the fan modes desired or that are supported on your remote. Defaults to ``3levels``
 
   - Options are: ``3levels`` , ``4levels``, ``quiet_4levels``. 


### PR DESCRIPTION
## Description:

When this component is used with Mitsubishi units that only support cooling mode, the OFF command may not work. This fixes that issue.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#7143

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
