### PR TITLE
Update absolute_humidity.rst with detailed example

### DIFF
--- a/components/sensor/absolute_humidity.rst
+++ b/components/sensor/absolute_humidity.rst
@@ -26,6 +26,86 @@ See the links at the bottom of the page for details on absolute humidity and the
         humidity:
           name: Relative Humidity
           id: relative_humidity
+    
+    # Complete  yaml example with a HDC3020 temperature humidity sensor 
+    # Added and Id (abHumidity4) to display the absolute humidity on an OLED display 
+    esphome:
+  name: sensor1
+  friendly_name: Demo
+
+esp32:
+  board: esp32-c3-devkitm-1
+  framework:
+    type: arduino
+
+# Enable logging
+logger:
+
+# Enable Home Assistant API
+api:
+  encryption:
+    key: "da5j6DRLuSO3mjiS6ihVwxqu5kVsu0Q6QoNm0/ME1O4="
+
+ota:
+  - platform: esphome
+    password: "75b695ebdd1cb8b4aa4ff39654a4b0ed"
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+
+  # Enable fallback hotspot (captive portal) in case wifi connection fails
+  ap:
+    ssid: "Sensor1 Fallback Hotspot"
+    password: "VbWEDXbmtuRk"
+
+captive_portal:
+
+
+external_components:
+  - source: config/my_components
+    components: hdc3020
+
+i2c:
+  sda: GPIO5
+  scl: GPIO6
+  scan: false
+
+sensor:
+  - platform: hdc3020
+    address: 0x44
+    temperature:
+      name: "Outside Temperature"
+      id: temperature4
+    humidity:
+      name: "Outside Humidity"
+      id: humidity4
+    update_interval: 10s
+  - platform: absolute_humidity
+    name: Absolute Humidity
+    id:   abHumidity4
+    temperature: temperature4
+    humidity: humidity4
+
+
+font:
+  - file: "config/arial.ttf"
+    id: my_font
+    size: 26
+
+display:
+  - platform: ssd1306_i2c
+    model: "SSD1306 128x64"
+    address: 0x3c
+    lambda: |-
+      it.printf(12,8,id(my_font),TextAlign::LEFT,"%.1f°C", id(temperature4).state);
+      it.printf(12,36,id(my_font),TextAlign::LEFT,"%.1f g/m3", id(abHumidity4).state);
+
+deep_sleep:
+  id: deep_sleep_1
+  run_duration: 18s  # must be long enough to wirelessly update after a rest or power up
+  sleep_duration: 5min # must be long enough to cool down board for accurate temperature
+----------------------------------
 
 Configuration variables:
 ------------------------


### PR DESCRIPTION
Added an example with a complete sensor yaml file for aHDC3020

## Description:
Simple documentation improvement.


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
