### PR TITLE
[micro_wake_word] Update documentation to discuss how voice activity is detected

### DIFF
--- a/components/micro_wake_word.rst
+++ b/components/micro_wake_word.rst
@@ -55,7 +55,7 @@ Configuration variables:
   - **probability_cutoff** (*Optional*, percentage): The probability cutoff for voice activity detection.
     If the probability is below this value, then no wake word will be accepted.
     A larger value reduces the number of false accepts but increases the number of false rejections.
-  - **sliding_window_size** (*Optional*, int): The size of the sliding window for voice activity detection. The maximum of the probabilities in the sliding window is compared to ``probability_cutoff`` to determine if voice activity is detected.
+  - **sliding_window_size** (*Optional*, int): The size of the sliding window average for voice activity detection. The average probability is compared to ``probability_cutoff`` to determine if voice activity is detected.
 
 
 The ``probability_cutoff`` and ``sliding_window_size`` are provided by the JSON file but can be overridden in YAML. A default VAD model is provided with the ``vad`` configuration variables, but a different model can be overridden in YAML.


### PR DESCRIPTION
## Description:

The linked PR modifies how voice activity is detected. This documentation update changes the wording to describe a sliding window average instead of the max of a sliding window to match the new code.

**Related issue (if applicable):** not applicable

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#7164
## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
