### PR TITLE
[online_image] Add placeholder documentation

### DIFF
--- a/components/online_image.rst
+++ b/components/online_image.rst
@@ -37,6 +37,8 @@ Configuration variables
   - ``PNG``: The image on the server is encoded in PNG format.
 - **resize** (*Optional*, string): If set, this will resize the image to fit inside the given dimensions ``WIDTHxHEIGHT``
   and preserve the aspect ratio.
+- **placeholder** (**Optional**, :ref:`config-id`): ID of an :doc:`Image </components/image>` to display while the downloaded image is not yet ready.
+  This placeholder image will **not** be resized; regardless of the ``resize`` option value for the ``online_image``.
 - **type** (*Optional*): Specifies how to encode image internally. Defaults to ``BINARY``.
 
   - ``BINARY``: Two colors, suitable for 1 color displays or 2 color image in color displays. Uses 1 bit


### PR DESCRIPTION
## Description:
Add documentation for the extra option "placeholder" for the online image component

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#7083

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
