### PR TITLE
MQTT enabled Alarm Control Panel

### DIFF
--- a/components/alarm_control_panel/index.rst
+++ b/components/alarm_control_panel/index.rst
@@ -49,6 +49,7 @@ Configuration variables:
 - **on_chime** (*Optional*, :ref:`Action <config-action>`): An automation to perform
   when a zone has been marked as chime in the configuration, and it changes from closed to open. 
   See :ref:`alarm_control_panel_on_chime_trigger`.
+- If MQTT enabled, all other options from :ref:`MQTT Component <config-mqtt-component>`.
 - If Webserver enabled, ``web_server_sorting_weight`` can be set. See :ref:`Webserver Entity Sorting <config-webserver-sorting>`.
 
 


### PR DESCRIPTION
## Description:

Updates documentation to indicate that the Alarm Control Panel component now also accepts configuration options from the MQTT component when MQTT is enabled.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#7188

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
