### PR TITLE
``service`` -> ``action`` take 2

### DIFF
--- a/components/packages.rst
+++ b/components/packages.rst
@@ -28,7 +28,7 @@ Local Packages
 Consider the following example where the author put common pieces of configuration (like Wi-Fi and API) into base files
 and then extends it with some device-specific configuration in the main configuration.
 
-Note how the piece of configuration describing ``api`` component in ``device_base.yaml`` gets merged with the services
+Note how the piece of configuration describing ``api`` component in ``device_base.yaml`` gets merged with the actions
 definitions from main configuration file.
 
 .. code-block:: yaml
@@ -39,8 +39,8 @@ definitions from main configuration file.
       device_base: !include common/device_base.yaml
 
     api:
-      services:
-        - service: start_laundry
+      actions:
+        - action: start_laundry
           then:
             - switch.turn_on: relay
 


### PR DESCRIPTION
## Description:

Fixing up some references after https://github.com/esphome/esphome-docs/pull/4095 was merged into next too

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
