### PR TITLE
Add mac_address to bluetooth_proxy

### DIFF
--- a/components/bluetooth_proxy.rst
+++ b/components/bluetooth_proxy.rst
@@ -45,6 +45,7 @@ Configuration:
 
 - **active** (*Optional*, boolean): Enables proxying active connections. Defaults to ``false``.
 - **cache_services** (*Optional*, boolean): Enables caching GATT services in NVS flash storage which significantly speeds up active connections. Defaults to ``true`` when using the ESP-IDF framework.
+- **mac_address** (*Optional*, list of MAC Address): The MAC addresses to filter when proxying.
 
 The Bluetooth proxy depends on :doc:`esp32_ble_tracker` so make sure to add that to your configuration.
 


### PR DESCRIPTION
This adds documentation for the new mac_address option for bluetooth_proxy added in https://github.com/esphome/esphome/pull/7216

## Description:

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** https://github.com/esphome/esphome/pull/7216

## Checklist:

  - [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
