### PR TITLE
Feature improv serial project identity

### DIFF
--- a/components/improv_serial.rst
+++ b/components/improv_serial.rst
@@ -10,6 +10,8 @@ for configuring Wi-Fi on an ESPHome device by using a serial connection to the d
 
 The ``improv_serial`` component requires the serial ``logger`` to be configured.
 
+The ``improv_serial`` component will use the project name and version instead of ESPHomes version whenever it's available.
+
 
 .. code-block:: yaml
 


### PR DESCRIPTION
## Description:

With this change the improv_serial component will use the project name and version as identify whenever project data is available.

When using ESP Web Tools it's possible to show the project name and version instead of ESPHome. This allows the use of the same firmware check paired with the manifest.json.

Without this change it's not possible to determine if the same ESPHome project firmware is running on the ESP, thus not possible to see the update button. Also it's not possible to install a firmware without erasing first because it's always a new firmware for ESP Web Tools.

**Related issue (if applicable):** resolves https://github.com/esphome/feature-requests/issues/2591

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#7248

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
