### PR TITLE
Add redirect from /components/images to /components/image

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -41,3 +41,4 @@
 /cookbook/dual-r2-cover.html /cookbook/lambda_magic.html#one-button-cover-control 301
 
 /ready-made/projects /projects/ 301
+/components/images /components/image 301


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
