### PR TITLE
add link to integration from total_daily_energy

### DIFF
--- a/components/sensor/total_daily_energy.rst
+++ b/components/sensor/total_daily_energy.rst
@@ -71,12 +71,30 @@ Some sensors such as the :doc:`HLW8012 <hlw8012>` expose their power sensor with
             - multiply: 0.001
           unit_of_measurement: kW
 
+Lifetime instead of Daily
+-------------------------
+
+For a more-generic version of this component which does not reset every midnight, see :doc:`integration`, which can provide device-lifetime values instead of daily values with the following example settings:
+
+.. code-block:: yaml
+
+    # Example configuration entry
+    sensor:
+      - platform: integration
+        name: 'Total Energy'
+        sensor: my_power
+        time_unit: h
+        restore: true
+        state_class: total_increasing
+        device_class: energy
+
 See Also
 --------
 
 - :ref:`sensor-filters`
 - :doc:`hlw8012`
 - :doc:`cse7766`
+- :doc:`integration`
 - :doc:`/components/sensor/pulse_counter`
 - :doc:`/components/sensor/pulse_meter`
 - :doc:`/components/time/homeassistant`


### PR DESCRIPTION
## Description:

There is a lot of confusion around the internet how to get "total energy" instead of "total daily energy" with many people creating their own global variables and keeping track of the total with lambdas and templates on top of total_daily_energy. This change simply points out that there is a good, fully supported option available, and links to it.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
