### PR TITLE
Removed mode: mono

### DIFF
--- a/components/speaker/i2s_audio.rst
+++ b/components/speaker/i2s_audio.rst
@@ -24,7 +24,7 @@ This platform only works on ESP32 based chips.
       - platform: i2s_audio
         dac_type: external
         i2s_dout_pin: GPIOXX
-        mode: mono
+        mode: stereo
 
 Configuration variables:
 ------------------------


### PR DESCRIPTION
## Description:
Seems like there is error in docs - mono seems not to be valid option in mode:, only left/right/stereo are allowed.


## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
