### PR TITLE
Document the min_rssi_number_id option

### DIFF
--- a/components/binary_sensor/ble_presence.rst
+++ b/components/binary_sensor/ble_presence.rst
@@ -72,6 +72,9 @@ Configuration variables:
 -  **ibeacon_minor** (*Optional*, int): The iBeacon minor identifier of the beacon that needs
    to be tracked. Usually used to identify beacons within an iBeacon group.
 -  **min_rssi** (*Optional*, int): at which minimum RSSI level would the component report the device be present.
+   Only one of `min_rssi` and `min_rssi_number_id` can be specified.
+-  **min_rssi_number_id** (*Optional*, :ref:`config-id`): An ID of a number entity, controlling the minimum RSSI level in which 
+   the component would report the device to be present. Only one of `min_rssi` and `min_rssi_number_id` can be specified.
 -  **timeout** (*Optional*, :ref:`config-time`): The delay after last detecting the device before publishing not present state.
    The default is 5 minutes.
 -  All other options from :ref:`Binary Sensor <config-binary_sensor>`.


### PR DESCRIPTION
## Description: Control the min_rssi parameter of ble_presence component with a number entity.


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#7314

## Checklist:

  - [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
