### PR TITLE
[ethernet] add documentation for the new type ENC28J60

### DIFF
--- a/components/ethernet.rst
+++ b/components/ethernet.rst
@@ -55,6 +55,7 @@ Configuration variables:
   - ``KSZ8081`` (RMII)
   - ``KSZ8081RNA`` (RMII)
   - ``W5500`` (SPI)
+  - ``ENC28J60`` (SPI)
 
 RMII configuration variables:
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -113,7 +114,8 @@ Advanced common configuration variables:
   For example, if it's set to ``.local``, all uploads will be sent to ``<HOSTNAME>.local``.
   Defaults to ``.local``.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
-
+- **full_duplex** (*Optional*, boolean): Only applicable to the `ENC28J60`. Set to `true`
+  to force the chip into full-duplex (see note below).
 
 .. note::
 
@@ -126,6 +128,12 @@ Advanced common configuration variables:
 .. note::
 
     SPI based chips do *not* use :doc:`spi`. This means that SPI pins can't be shared with other devices.
+
+.. note::
+
+    ENC28J60 is not recommended due to the high power usage, being 10mbit only, and the lack of
+    auto duplex negotiation. If `full_duplex` is set to `true`, then you need to manually set the
+    duplex mode of the other device where the `ENC28J60` is going to be plugged into.
 
 Configuration examples
 ----------------------


### PR DESCRIPTION
## Description:

Add documentation for the new type of `ethernet`, which is for the ENC28J60 chip.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#7330

## Checklist:

  - [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
