### PR TITLE
Update bme68x_bsec2.rst

### DIFF
--- a/components/sensor/bme68x_bsec2.rst
+++ b/components/sensor/bme68x_bsec2.rst
@@ -52,7 +52,7 @@ The :ref:`I²C <i2c>` is required to be set up in your configuration for this se
       model: bme680
       operating_age: 28d
       sample_rate: LP
-      voltage: 3.3V
+      supply_voltage: 3.3V
 
 
 


### PR DESCRIPTION
Example using voltage is inconsistant with configuration variable of supply_voltage. Updated example

## Description:
Example using voltage is inconsistant with configuration variable of supply_voltage. Updated example


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
