### PR TITLE
update documentation for esp32_can

### DIFF
--- a/components/canbus/esp32_can.rst
+++ b/components/canbus/esp32_can.rst
@@ -26,6 +26,8 @@ Configuration variables:
 
 - **rx_pin** (**Required**, :ref:`Pin <config-pin>`): Receive pin.
 - **tx_pin** (**Required**, :ref:`Pin <config-pin>`): Transmit pin.
+- **rx_queue_len** (**Optional**, int): Length of RX queue.
+- **tx_queue_len** (**Optional**, int): Length of TX queue, 0 to disable.
 - All other options from :ref:`Canbus <config-canbus>`.
 
 .. _esp32-can-bit-rate:


### PR DESCRIPTION
Add documentation for rx_queue_len and tx_queue_len params

## Description:

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#7361

## Checklist:

  - [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
