### PR TITLE
Add documentation for logger.rx_buffer_size

### DIFF
--- a/components/logger.rst
+++ b/components/logger.rst
@@ -35,6 +35,9 @@ Advanced settings:
 -  **tx_buffer_size** (*Optional*, int): The size of the buffer used
    for log messages. Decrease this if you’re having memory problems.
    Defaults to ``512``.
+-  **rx_buffer_size** (*Optional*, int): The size of the read buffer,
+   used for reading from console. Currently it affects only USB_SERIAL_JTAG
+   hardware uart (see below). Defaults to ``512``.
 -  **hardware_uart** (*Optional*, string): The Hardware UART to use for logging. The default varies depending on
    the specific processor/chip and framework you are using. See the :ref:`table below <logger-default_hardware_interfaces>`.
 -  **esp8266_store_log_strings_in_flash** (*Optional*, boolean): If set to false, disables storing


### PR DESCRIPTION
## Description:

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#7364

## Checklist:

  - [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
