### PR TITLE
Fix syntax for `datetime.date.set` lambda

### DIFF
--- a/components/datetime/index.rst
+++ b/components/datetime/index.rst
@@ -121,7 +121,7 @@ The ``date`` provided can be in one of 3 formats:
         id: my_datetime_date
         date: !lambda |-
           // Return an ESPTime struct
-          return {.day_of_month: 4, .month: 12, .year: 2023};
+          return {.day_of_month = 4, .month = 12, .year = 2023};
 
 Configuration variables:
 
@@ -192,7 +192,7 @@ The ``time`` provided can be in one of 3 formats:
         id: my_datetime_time
         time: !lambda |-
           // Return an ESPTime struct
-          return {.second: 56, .minute: 34, .hour: 12};
+          return {.second = 56, .minute = 34, .hour = 12};
 
 Configuration variables:
 
@@ -266,7 +266,7 @@ The ``datetime`` provided can be in one of 3 formats:
         id: my_datetime
         datetime: !lambda |-
           // Return an ESPTime struct
-          return {.second: 56, .minute: 34, .hour: 12, .day_of_month: 31, .month: 12, .year: 2024};
+          return {.second = 56, .minute = 34, .hour = 12, .day_of_month = 31, .month = 12, .year = 2024};
 
 Configuration variables:
 


### PR DESCRIPTION
## Description:

The syntax is wrong here
```
- datetime.date.set:
    id: my_datetime_date
    date: !lambda |-
      // Return an ESPTime struct
      return {.day_of_month: 4, .month: 12, .year: 2023};
```

It should be ` {.day_of_month = 4, .month = 12, .year = 2023}` (`=` not `:`).

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
