### PR TITLE
Add SPI bus to spi_led_strip example

### DIFF
--- a/components/light/spi_led_strip.rst
+++ b/components/light/spi_led_strip.rst
@@ -18,6 +18,10 @@ LEDs, or any others with a similar interface - SPI, 8 bits per colour and BGR or
 .. code-block:: yaml
 
     # Example configuration entry
+    spi:
+      mosi_pin: GPIO06
+      clk_pin: GPIO07
+
     light:
       - platform: spi_led_strip
         num_leds: 30


### PR DESCRIPTION
## Description:
spi_led_strip example was missing an spi bus entry. This PR adds an spi config entry to the example in the documentation.

**Related issue (if applicable):** fixes none

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
