### PR TITLE
Described new esp32_camera frame buffer option.

### DIFF
--- a/components/esp32_camera.rst
+++ b/components/esp32_camera.rst
@@ -74,6 +74,8 @@ Frame Settings:
   Up to 60Hz is possible (with reduced frame sizes), but beware of overheating. Defaults to ``10 fps``.
 - **idle_framerate** (*Optional*, float): The framerate to capture images at when no client
   is requesting a full stream. Defaults to ``0.1 fps``.
+- **frame_buffer_count** (*Optional*, int): The number of frame buffers to use when reading from the camera sensor.
+  Must be between 1 and 2.  Defaults to ``1``.
 
 Image Settings:
 


### PR DESCRIPTION
## Description:
Described new esp32_camera frame buffer option.

Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable): https://github.com/esphome/esphome/pull/7360

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
