### PR TITLE
Update bme280 description humidity

### DIFF
--- a/components/sensor/bme280.rst
+++ b/components/sensor/bme280.rst
@@ -60,7 +60,7 @@ Configuration variables:
     See :ref:`Oversampling Options <bme280-oversampling>`.
   - All other options from :ref:`Sensor <config-sensor>`.
 
-- **humidity** (*Optional*): The information for the pressure sensor.
+- **humidity** (*Optional*): The information for the humidity sensor.
 
   - **oversampling** (*Optional*): The oversampling parameter for the temperature sensor.
     See :ref:`Oversampling Options <bme280-oversampling>`.


### PR DESCRIPTION
copy paste failure.

## Description:


**Related issue (if applicable):** fixes the description of BME280 humidity

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
