### PR TITLE
Minor phrasing change

### DIFF
--- a/guides/contributing.rst
+++ b/guides/contributing.rst
@@ -540,7 +540,7 @@ Beyond basic functionality (*"does it work?"*), here are a few other items we ch
 
 .. _prs-are-being-drafted-when-changes-are-needed:
 
-Why Was My PR was Marked as a Draft?
+Why was my PR marked as a draft?
 ************************************
 
 If your PR was reviewed and changes were requested, our bot will automatically mark your PR as a draft. This means that


### PR DESCRIPTION
Minot phrasing change. 

## Description:

An extra “was” snuck into this FAQ line. Lower-cased the words to match the other questions in this section.

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
