### PR TITLE
Fix dashboard command in getting_started_command_line.rst

### DIFF
--- a/guides/getting_started_command_line.rst
+++ b/guides/getting_started_command_line.rst
@@ -224,8 +224,9 @@ To start the ESPHome dashboard, simply start ESPHome with the following command
 .. code-block:: bash
 
     # Install dashboard dependencies
-    pip install tornado esptool\
-     esphome dashboard config
+    pip install tornado esptool
+
+    esphome dashboard config/
 
     # On Docker, host networking mode is required for online status indicators
     docker run --rm --net=host -v "${PWD}":/config -it ghcr.io/esphome/esphome

--- a/guides/getting_started_command_line.rst
+++ b/guides/getting_started_command_line.rst
@@ -224,9 +224,8 @@ To start the ESPHome dashboard, simply start ESPHome with the following command
 .. code-block:: bash
 
     # Install dashboard dependencies
-    pip install tornado esptool
-
-    esphome dashboard config/
+    pip install tornado esptool \
+     esphome dashboard config
 
     # On Docker, host networking mode is required for online status indicators
     docker run --rm --net=host -v "${PWD}":/config -it ghcr.io/esphome/esphome


### PR DESCRIPTION
## Description:

The command had a backslash that would prevent the actual command to be run


## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
