### PR TITLE
[interval]Add documentation for start/stop actions

### DIFF
--- a/components/interval.rst
+++ b/components/interval.rst
@@ -21,7 +21,59 @@ Configuration variables:
 
 - **interval** (**Required**, :ref:`config-time`): The interval to execute the action with.
 - **startup_delay** (*Optional*, :ref:`config-time`): An optional startup delay - defaults to zero.
+- **autostart** (*Optional*, boolean): Whether the interval should start on boot, or wait until ``interval.start`` is called.
+- defaults to ``true``
 - **then** (**Required**, :ref:`Action <config-action>`): The action to perform.
+
+
+.. note::
+
+    ``startup_delay`` and ``autostart`` cannot be used together.
+
+Actions:
+********
+
+``interval.start`` Action
+-------------------------
+
+This action can be called on some trigger when the interval needs to be (re-)started, either because ``autostart`` was set to false, or because ``interval.stop`` was called before.
+
+.. code-block:: yaml
+
+    # Example configuration entry
+    interval:
+      - interval: 5s
+        id: my_interval
+        then:
+          - logger.log: Tick
+
+    # in some trigger
+    on_...:
+      - interval.start: my_interval
+
+Configuration options:
+- **id** (**Required**, :ref:`config-id`): The ID of the interval to start.
+
+``interval.stop`` Action
+-------------------------
+
+This action can be called on some trigger when the interval needs to be stopped.
+
+.. code-block:: yaml
+
+    # Example configuration entry
+    interval:
+      - interval: 5s
+        id: my_interval
+        then:
+          - logger.log: Tick
+
+    # in some trigger
+    on_...:
+      - interval.stop: my_interval
+
+Configuration options:
+- **id** (**Required**, :ref:`config-id`): The ID of the interval to stop.
 
 See Also
 --------


### PR DESCRIPTION
## Description:
Document the new actions `interval.start` and `interval.stop`

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#7479

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
