### PR TITLE
fix typo 'post' to 'port'

### DIFF
--- a/components/statsd.rst
+++ b/components/statsd.rst
@@ -32,7 +32,7 @@ Configuration variables:
 ------------------------
 
 - **host** (**Required**, ip): The Host IP of your StatsD Server.
-- **post** (*Optional*, uint16): The Port of your StatsD Server. Defaults to ``8125``.
+- **port** (*Optional*, uint16): The Port of your StatsD Server. Defaults to ``8125``.
 - **prefix** (*Optional*, string): The prefix to automatically prepend every metric with.  Defaults to ``""``.
 - **update_interval** (*Optional*, uint16): How often to send the metrics. Defaults to ``10s``.
 - **sensor** (*Optional*, :ref:`sensors`): A list of sensors to generate metrics for.


### PR DESCRIPTION
## Description:
Small typo fix

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
