### PR TITLE
fixed i2c multi-bus sample code

### DIFF
--- a/components/i2c.rst
+++ b/components/i2c.rst
@@ -48,17 +48,19 @@ Configuration variables:
 
     .. code-block:: yaml
 
-        # Example configuration entry
-        i2c:
-          - id: bus_a
-            sda: GPIOXX
-            scl: GPIOXX
-            scan: true
-          - id: bus_b
-            sda: GPIOXX
-            scl: GPIOXX
-            scan: true
+      # Example configuration entry
+      i2c:
+        - id: bus_a
+          sda: GPIOXX
+          scl: GPIOXX
+          scan: true
+        - id: bus_b
+          sda: GPIOXX
+          scl: GPIOXX
+          scan: true
+
        # Sensors should be specified as follows
+      sensor:
        - platform: bme680
          i2c_id: bus_b
          address: 0x76


### PR DESCRIPTION
## Description:
- corrected esphome-docs i2c component multi-bus code example


## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
