### PR TITLE
fixed i2c multiple bus sample code, adding missing "sensor:" sensor line. sample code will now validate.

### DIFF
--- a/components/i2c.rst
+++ b/components/i2c.rst
@@ -58,11 +58,12 @@ Configuration variables:
             sda: GPIOXX
             scl: GPIOXX
             scan: true
-       # Sensors should be specified as follows
-       - platform: bme680
-         i2c_id: bus_b
-         address: 0x76
-         # ...
+        # Sensors should be specified as follows
+        sensor:
+          - platform: bme680
+            i2c_id: bus_b
+            address: 0x76
+        # ...
 
 For I2C multiplexing see :doc:`/components/tca9548a`.
 


### PR DESCRIPTION
## Description:
fixed a missing line entry for "sensor:" in the i2c multiple bus sample code so that the sample code is now correct and will validate.

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
