### PR TITLE
Add remote transmitter triggers to support auto tx on/off 

### DIFF
--- a/components/remote_transmitter.rst
+++ b/components/remote_transmitter.rst
@@ -48,6 +48,26 @@ Configuration variables:
 -  **id** (*Optional*, :ref:`config-id`): Manually specify
    the ID used for code generation. Use this if you have multiple remote transmitters.
 
+Automations:
+------------
+
+- **on_transmit** (*Optional*, :ref:`Automation <automation>`): An automation to perform before
+  data is sent. Useful if the radio / IR hardware needs to change state or power on.
+- **on_complete** (*Optional*, :ref:`Automation <automation>`): An automation to perform after
+  data has been sent. Useful if the radio / IR hardware needs to change state or power off.
+
+.. code-block:: yaml
+
+    # Example automation
+    remote_transmitter:
+      ...
+      on_transmit:
+        then:
+          - lambda: 'id(radio_id)->start_tx();'
+      on_complete:
+        then:
+          - lambda: 'id(radio_id)->stop_tx();'
+
 .. _remote_transmitter-transmit_action:
 
 Remote Transmitter Actions

--- a/components/remote_transmitter.rst
+++ b/components/remote_transmitter.rst
@@ -63,10 +63,10 @@ Automations:
       ...
       on_transmit:
         then:
-          - lambda: 'id(radio_id)->start_tx();'
+          - switch.turn_on: tx_enable
       on_complete:
         then:
-          - lambda: 'id(radio_id)->stop_tx();'
+          - switch.turn_off: tx_enable
 
 .. _remote_transmitter-transmit_action:
 


### PR DESCRIPTION
## Description:

Need a way to seamlessly turn radio hardware transmitters on / off or switch rx / tx modes. Add two triggers to accomplish this.

Why this is needed:
- The transceiver could be locked to tx mode permanently but its generally not a good idea. Even in OOK there will be some leakage. If ASK or FSK are used its a really bad idea as it will be transmitting real power all the time.
- Many transceivers support both rx and tx (but not simultaneously). Without a way to switch modes the transceiver would have to be locked into rx or tx all the time. With this change the transceiver can be in rx mode and automatically switch to tx for a short period of time via these triggers.

These triggers will make supporting various radios / configurations much cleaner. Any state change can be done in one spot now instead of everywhere around every transmit automation. In addition to being cleaner these radio state changes can happen right before / after the actual transmit.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#7483

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
