### PR TITLE
Add clean_session as configurable option to the MQTT component

### DIFF
--- a/components/mqtt.rst
+++ b/components/mqtt.rst
@@ -39,6 +39,8 @@ Configuration variables:
   authentication. Empty (the default) means no authentication.
 - **password** (*Optional*, string): The password to use for
   authentication. Empty (the default) means no authentication.
+- **clean_session** (*Optional*, boolean): Whether the broker will clean
+  the MQTT session after disconnect. Defaults to ``false``.
 - **client_id** (*Optional*, string): The client id to use for opening
   connections. See :ref:`mqtt-defaults` for more information.
 - **discover_ip** (*Optional*, boolean): If Home Assistant automatic device


### PR DESCRIPTION
## Description:

Replacement for the reverted #4280

**Related issue (if applicable):** 

- fixes https://github.com/esphome/issues/issues/1719

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#7501

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
