### PR TITLE
Update OtaUrl for migration from tasmota

### DIFF
--- a/guides/migrate_sonoff_tasmota.rst
+++ b/guides/migrate_sonoff_tasmota.rst
@@ -104,7 +104,7 @@ You may also use Tasmota console to invoke the upgrade with just two commands:
 
 :: 
 
-  OtaUrl http://<MY-ESPHOME:6052>/download.bin?configuration=<MY_DEVICE>.yaml&type=firmware-factory.bin&compressed=1
+  OtaUrl http://<MY-ESPHOME:6052>/download.bin?configuration=<MY_DEVICE>.yaml&type=firmware.bin&compressed=1
   Upgrade 1
 
 replacing ``http://<MY-ESPHOME:6052>/`` with the host and port of your ESPHome installation and ``<MY_DEVICE>.yaml``

--- a/guides/migrate_sonoff_tasmota.rst
+++ b/guides/migrate_sonoff_tasmota.rst
@@ -104,7 +104,7 @@ You may also use Tasmota console to invoke the upgrade with just two commands:
 
 :: 
 
-  OtaUrl http://<MY-ESPHOME:6052>/download.bin?configuration=<MY_DEVICE>.yaml&type=firmware.bin&compressed=1
+  OtaUrl http://<MY-ESPHOME:6052>/download.bin?configuration=<MY_DEVICE>.yaml&file=firmware.bin&compressed=1
   Upgrade 1
 
 replacing ``http://<MY-ESPHOME:6052>/`` with the host and port of your ESPHome installation and ``<MY_DEVICE>.yaml``


### PR DESCRIPTION
## Description:

Fixes ota download url in tasmota migration guide.

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
