### PR TITLE
feedback component: Support for overshoot_duration

### DIFF
--- a/content/components/cover/feedback.md
+++ b/content/components/cover/feedback.md
@@ -156,6 +156,11 @@ Additional options:
   issuing a command to reaching endstop.
   Defaults to `0s`.
 
+- **overshoot_duration** (*Optional*, [Time](#config-time)): After the cover reaches max opened or closed position (0% or 100%),
+  keep it moving for this duration before stopping. Intended to reset any accumulated error when doing multiple partial
+  open/close actions. Does nothing if endstops are used.
+  Defaults to `0s`.
+
 - **update_interval** (*Optional*, [Time](#config-time)): The interval
   to publish updated position information to the UI while the cover is moving.
   Defaults to `1s`.


### PR DESCRIPTION
## Description:

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#7530

## Checklist:

  - [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
