### PR TITLE
Update lvgl.rst - Prevent burn-in of LCD recipe fix

### DIFF
--- a/cookbook/lvgl.rst
+++ b/cookbook/lvgl.rst
@@ -2204,7 +2204,6 @@ In the example below, pixel training is done four times for a half an hour every
               then:
                 - lvgl.resume:
                 - lvgl.widget.redraw:
-                - delay: 1s
           - lvgl.pause:
               show_snow: true
         turn_off_action:
@@ -2214,8 +2213,6 @@ In the example below, pixel training is done four times for a half an hour every
               then:
                 - lvgl.resume:
                 - lvgl.widget.redraw:
-                - delay: 1s
-                - lvgl.pause:
 
     touchscreen:
       - platform: ...


### PR DESCRIPTION
## Description:


This PR removes an extraneous `lvgl.pause:` step under the `turn_off_action` for the "[Prevent burn-in of LCD recipe]" which would result in:

1. lvgl is resumed
2. the screen is redrawn
3. lvgl is paused again (without `show_snow: true`) which is unnecessary

Now the logic is fixed to where it is not paused again after redrawing.

1. lvgl is resumed
2. the screen is redrawn

I also took out the `delay: 1s` under both actions because they weren't explained as being necessary and elsewhere [where `lvgl.widget.redraw` is used], there is no subsequent delay added. Testing it myself, I didn't see a reason to keep the delay either.


[where `lvgl.widget.redraw` is used]: https://esphome.io/cookbook/lvgl.html#turn-off-screen-when-idle
[Prevent burn-in of LCD recipe]: https://esphome.io/cookbook/lvgl.html#prevent-burn-in-of-lcd

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
