### PR TITLE
even parity is required for CSE7766

### DIFF
--- a/components/sensor/cse7766.rst
+++ b/components/sensor/cse7766.rst
@@ -17,7 +17,7 @@ and works with this component.
 
 As the communication with the CSE7766 done using UART, you need
 to have an :ref:`UART bus <uart>` in your configuration with the ``rx_pin`` connected to the CSE7766.
-Additionally, you need to set the baud rate to 4800.  The device sends multiple updates per second, so you
+Additionally, you need to set the baud rate to 4800 and parity to EVEN.  The device sends multiple updates per second, so you
 will probably want some sort of averaging or throttle filter on the sensors.
 
 .. code-block:: yaml
@@ -33,6 +33,7 @@ will probably want some sort of averaging or throttle filter on the sensors.
     uart:
       rx_pin: RX
       baud_rate: 4800
+      parity: EVEN
 
     sensor:
       - platform: cse7766


### PR DESCRIPTION
## Description:
Fix example to show required even parity.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** https://github.com/esphome/esphome/pull/7549

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
