### PR TITLE
Update color_temperature.rst

### DIFF
--- a/components/light/color_temperature.rst
+++ b/components/light/color_temperature.rst
@@ -23,8 +23,8 @@ and the other channel controls the brightness.
 Configuration variables:
 ------------------------
 
-- **color_temperature** (**Required**, :ref:`config-id`): The id of the float :ref:`output` to use for the color temperature.
-- **brightness** (**Required**, :ref:`config-id`): The id of the float :ref:`output` to use for the brightness.
+- **color_temperature** (**Required**, :ref:`config-id`): The id of the float :ref:`output` to use for the color temperature. It returns a float from 0 to 1 in the mired scale. Hereby 0 corresponds to the cold white temperature and 1 to the warm white temperature.
+- **brightness** (**Required**, :ref:`config-id`): The id of the float :ref:`output` to use for the brightness. It returns a float from 0 to 1.
 - **cold_white_color_temperature** (**Required**, float): The coldest color temperature supported by this light. This
   is the lowest value when expressed in `mireds <https://en.wikipedia.org/wiki/Mired>`__, or the highest value when
   expressed in Kelvin.


### PR DESCRIPTION
Added important info about the output data units and range of color_temperature and brightness.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
