### PR TITLE
[web_server] event component grouping

### DIFF
--- a/components/event/index.rst
+++ b/components/event/index.rst
@@ -74,6 +74,7 @@ One of ``id`` or ``name`` is required.
 
   See https://www.home-assistant.io/integrations/event/#device-class
   for a list of available options.
+- If Webserver enabled and version 3 is selected, All other options from Webserver Component.. See :ref:`Webserver Version 3 <config-webserver-version-3-options>`.
 
 Automations:
 


### PR DESCRIPTION
## Description:

Adds `web_server` grouping docs to the `event` component 

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#7586

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
