### PR TITLE
Update ltr501.rst

### DIFF
--- a/components/sensor/ltr501.rst
+++ b/components/sensor/ltr501.rst
@@ -110,7 +110,7 @@ Proximity sensing
 -----------------
 
 The proximity sensor has a built-in emitter and detector. The sensor detects reflected IR light from the emitter and
-gives a raw count value inversely exponential to the distance. A decrease in the count value means an object is getting
+gives a raw count value inversely proportional to the distance squared. A decrease in the count value means an object is getting
 further away from the sensor (and vice-versa). Neither of the datasheets provide any information on how to convert
 the raw count value to distance. The only way to do so is to test the sensor yourself and select the threshold
 according to your needs and environment. Exact values will depend on the type of the object, its color and 


### PR DESCRIPTION

## Description:


in "proximity":
changed expression describing relation of counts to distance - never heard of "inversely exponential".

Should now be correct based on a physics-based intuition: radiation intensity drops with 1 over r^2 - so should the counts.

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

