### PR TITLE
Document Speaker volume set action

### DIFF
--- a/automations/all_actions.rst
+++ b/automations/all_actions.rst
@@ -57,7 +57,7 @@
 - **senseair:** ``abc_disable``, ``abc_enable``, ``abc_get_period``, ``background_calibration``, ``background_calibration_result``
 - **servo:** ``detach``, ``write``
 - **sim800l:** ``connect``, ``dial``, ``disconnect``, ``send_sms``, ``send_ussd``
-- **speaker:** ``play``, ``stop``
+- **speaker:** ``play``, ``stop``, ``finish``, ``volume_set``
 - **sprinkler:** ``clear_queued_valves``, ``next_valve``, ``pause``, ``previous_valve``, ``queue_valve``, ``resume``, ``resume_or_start_full_cycle``, ``set_divider``, ``set_multiplier``, ``set_repeat``, ``set_valve_run_duration``, ``shutdown``, ``start_from_queue``, ``start_full_cycle``, ``start_single_valve``
 - **sps30:** ``start_fan_autoclean``
 - **stepper:** ``report_position``, ``set_acceleration``, ``set_deceleration``, ``set_speed``, ``set_target``

--- a/components/speaker/index.rst
+++ b/components/speaker/index.rst
@@ -71,6 +71,31 @@ Configuration variables:
 
 - **id** (*Optional*, :ref:`config-id`): The speaker to control. Defaults to the only one in YAML.
 
+.. _speaker-volume_set:
+
+``speaker.volume_set`` Action
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This action will set the volume of the speaker.
+
+.. code-block::
+
+    on_...:
+      # Simple
+      - speaker.volume_set: 50%
+
+      # Full
+      - speaker.volume_set:
+          id: speaker_id
+          volume: 50%
+
+      # Simple with lambda
+      -  speaker.volume_set: !lambda "return 0.5;"
+
+Configuration variables:
+
+**volume** (**Required**, percentage): The volume to set the speaker to.
+
 .. _speaker-conditions:
 
 Speaker Conditions


### PR DESCRIPTION
## Description:

Adds documentation for the speaker volume set action.

**Related issue (if applicable):** not applicable

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#7605

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
