### PR TITLE
Image path CANBUS update to absolute paths

### DIFF
--- a/components/canbus/esp32_can.rst
+++ b/components/canbus/esp32_can.rst
@@ -69,13 +69,13 @@ use a voltage divider here instead.
 
 .. figure:: images/canbus_esp32_5v.png
     :align: center
-    :target: ../_images/canbus_esp32_5v.png
+    :target: /_images/canbus_esp32_5v.png
 
 If you prefer to only have a 3.3V power supply, special 3.3V CAN transceivers are available.
 
 .. figure:: images/canbus_esp32_3v3.png
     :align: center
-    :target: ../_images/canbus_esp32_3v3.png
+    :target: /_images/canbus_esp32_3v3.png
 
 See Also
 --------

--- a/components/canbus/mcp2515.rst
+++ b/components/canbus/mcp2515.rst
@@ -63,13 +63,13 @@ and CS out of specification which is rarely a problem.
 
 .. figure:: images/canbus_mcp2515_resistor.png
     :align: center
-    :target: ../_images/canbus_mcp2515_resistor.png
+    :target: /_images/canbus_mcp2515_resistor.png
 
 A more complex option is to properly convert the 3.3V and 5V logic levels with a level shifter.
 
 .. figure:: images/canbus_mcp2515_txs0108e.png
     :align: center
-    :target: ../_images/canbus_mcp2515_txs0108e.png
+    :target: /_images/canbus_mcp2515_txs0108e.png
 
 See Also
 --------


### PR DESCRIPTION
https://esphome.io/components/canbus/mcp2515

URL directs towards:
https://esphome.io/components/_images/canbus_mcp2515_resistor.png 

But the image is located outside the 'compontens' 'folder' https://esphome.io/_images/canbus_mcp2515_resistor.png

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
