### PR TITLE
Corrected incorrect descriptions

### DIFF
--- a/components/number/modbus_controller.rst
+++ b/components/number/modbus_controller.rst
@@ -20,9 +20,9 @@ Configuration variables:
     - ``U_DWORD_R`` (unsigned 32 bit integer from 2 registers low word first)
     - ``S_DWORD_R`` (signed 32 bit integer from 2 registers low word first)
     - ``U_QWORD`` (unsigned 64 bit integer from 4 registers = 64bit)
-    - ``S_QWORD`` (unsigned 64 bit integer from 4 registers = 64bit)
+    - ``S_QWORD`` (signed 64 bit integer from 4 registers = 64bit)
     - ``U_QWORD_R`` (unsigned 64 bit integer from 4 registers low word first)
-    - ``U_QWORD_R`` signed 64 bit integer from 4 registers low word first)
+    - ``S_QWORD_R`` (signed 64 bit integer from 4 registers low word first)
     - ``FP32`` (32 bit IEEE 754 floating point from 2 registers)
     - ``FP32_R`` (32 bit IEEE 754 floating point - same as FP32 but low word first)
 


### PR DESCRIPTION
Fixed some small mistakes in the signed/unsigned descriptions

  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.
