### PR TITLE
add collapse and tab examples to guides/contributing.rst

### DIFF
--- a/guides/contributing.rst
+++ b/guides/contributing.rst
@@ -267,10 +267,12 @@ adhere to the following order:
 
       .. collapse:: Open
           :open:
+
           This section is expected to be open by default.
 
   .. collapse:: Open
       :open:
+
       This section is expected to be open by default.
 
   .. code-block:: rst

--- a/guides/contributing.rst
+++ b/guides/contributing.rst
@@ -254,6 +254,7 @@ adhere to the following order:
 - **Collapsible section**: To add a collapsible section, use the ``collapse`` directive:
 
   .. code-block:: rst
+
       .. collapse:: Details
           Something small enough to escape casual notice.
       

--- a/guides/contributing.rst
+++ b/guides/contributing.rst
@@ -256,20 +256,20 @@ adhere to the following order:
   .. code-block:: rst
 
       .. collapse:: Details
-          
+
           Something small enough to escape casual notice.
       
       .. collapse:: Open
-          
+
           :open:
           This section is open by default.
       
       .. collapse:: A long code block
-          
+
           .. code-block:: python
-              
+
               print("Not really")
-  
+
   .. collapse:: Details
 
       Something small enough to escape casual notice.
@@ -285,7 +285,7 @@ adhere to the following order:
       .. code-block:: python
 
           print("Not really")
-  
+
   .. note::
 
       A blank line is *required* after every ``collapse`` directive.

--- a/guides/contributing.rst
+++ b/guides/contributing.rst
@@ -261,8 +261,7 @@ adhere to the following order:
       
       .. collapse:: Open
 
-          :open:
-          This section is open by default.
+          This section is expected to be open by default.
       
       .. collapse:: A long code block
 

--- a/guides/contributing.rst
+++ b/guides/contributing.rst
@@ -258,30 +258,42 @@ adhere to the following order:
       .. collapse:: Details
 
           Something small enough to escape casual notice.
-      
-      .. collapse:: Open
-
-          This section is expected to be open by default.
-      
-      .. collapse:: A long code block
-
-          .. code-block:: python
-
-              print("Not really")
 
   .. collapse:: Details
 
       Something small enough to escape casual notice.
 
-  .. collapse:: Open
+  .. code-block:: rst
 
+      .. collapse:: Open
+          :open:
+          This section is expected to be open by default.
+
+  .. collapse:: Open
+      :open:
       This section is expected to be open by default.
+
+  .. code-block:: rst
+
+      .. collapse:: A long code block
+
+          .. code-block:: yaml
+
+              # Sample configuration entry
+              switch:
+                - platform: gpio
+                  name: "Relay #42"
+                  pin: GPIOXX
 
   .. collapse:: A long code block
 
-      .. code-block:: python
+      .. code-block:: yaml
 
-          print("Not really")
+          # Sample configuration entry
+          switch:
+            - platform: gpio
+              name: "Relay #42"
+              pin: GPIOXX
 
   .. note::
 

--- a/guides/contributing.rst
+++ b/guides/contributing.rst
@@ -130,7 +130,7 @@ Then, use the provided Makefile to build the changes and start a live-updating w
     # Start web server on port 8000
     make live-html
 
-s
+Notes
 *****
 
 - Use the English language (duh...)
@@ -265,18 +265,6 @@ adhere to the following order:
 
   .. code-block:: rst
 
-      .. collapse:: Open
-          :open:
-
-          This section is open by default.
-
-  .. collapse:: Open
-      :open:
-
-      This section is open by default.
-
-  .. code-block:: rst
-
       .. collapse:: A long code block
 
           .. code-block:: yaml
@@ -297,12 +285,26 @@ adhere to the following order:
               name: "Relay #42"
               pin: GPIOXX
 
+  The ``:open:`` flag can be used to have the section open by default.
+
+  .. code-block:: rst
+
+      .. collapse:: Open
+          :open:
+
+          This section is open by default.
+
+  .. collapse:: Open
+      :open:
+
+      This section is open by default.
+
   .. note::
 
-      - The ``:open:`` flag has to be immediately after the ``collapse`` directive without a blank line.
+      - The ``:open:`` flag following the ``collapse`` directive has to be without a blank line.
       - A blank line is *required* after every ``collapse`` directive.
 
-- **Tabs**: To group content into tabs, use the ``tabs`` directive. The tabs directive to define a tab set.
+- **Tabs**: To group content into tabs, use the ``tabs`` directive. The tabs directive defines a tab set.
   Basic tabs are added using the ``tab`` directive (without s), which takes the tab’s label as an argument:
 
   .. code-block:: rst
@@ -336,9 +338,6 @@ adhere to the following order:
       .. tab:: Oranges
 
           Oranges are orange.
-
-  The contents of each tab can be displayed by clicking on the tab that you wish to show.
-  Clicking on the tab that is currently open will hide the tab’s content, leaving only the tab set labels visible.
 
   Tabs can also be nested inside one another:
 
@@ -408,8 +407,8 @@ adhere to the following order:
 
       - A blank line is *required* after every ``tabs`` directive.
       - The contents of each tab can be displayed by clicking on the tab that you wish to show.
-        Clicking on the tab that is currently open will hide the tab’s content, leaving only the tab set labels visible.
-      - For advanced features like tab-groupings refer to https://sphinx-tabs.readthedocs.io/en/latest/
+        Clicking again on the tab that is currently open will hide its content, leaving only the tab set labels visible.
+      - For advanced features like tab-groupings, refer to https://sphinx-tabs.readthedocs.io/en/latest/
 
 - **Images**: Use the ``figure`` directive to display an image:
 

--- a/guides/contributing.rst
+++ b/guides/contributing.rst
@@ -311,15 +311,15 @@ adhere to the following order:
 
           .. tab:: Apples
 
-            Apples are green, or sometimes red.
+              Apples are green, or sometimes red.
 
           .. tab:: Pears
 
-            Pears are green.
+              Pears are green.
 
           .. tab:: Oranges
 
-            Oranges are orange.
+              Oranges are orange.
 
   This will appear as
 
@@ -327,15 +327,15 @@ adhere to the following order:
 
       .. tab:: Apples
 
-        Apples are green, or sometimes red.
+          Apples are green, or sometimes red.
 
       .. tab:: Pears
 
-        Pears are green.
+          Pears are green.
 
       .. tab:: Oranges
 
-        Oranges are orange.
+          Oranges are orange.
 
   The contents of each tab can be displayed by clicking on the tab that you wish to show.
   Clicking on the tab that is currently open will hide the tab’s content, leaving only the tab set labels visible.
@@ -348,63 +348,63 @@ adhere to the following order:
 
           .. tab:: Stars
 
-            .. tabs::
+              .. tabs::
 
-                .. tab:: The Sun
+                  .. tab:: The Sun
 
-                  The closest star to us.
+                      The closest star to us.
 
-                .. tab:: Proxima Centauri
+                  .. tab:: Proxima Centauri
 
-                  The second closest star to us.
+                      The second closest star to us.
 
-                .. tab:: Polaris
+                  .. tab:: Polaris
 
-                  The North Star.
+                      The North Star.
 
           .. tab:: Moons
 
-            .. tabs::
+              .. tabs::
 
-                .. tab:: The Moon
+                  .. tab:: The Moon
 
-                  Orbits the Earth
+                      Orbits the Earth
 
-                .. tab:: Titan
+                  .. tab:: Titan
 
-                  Orbits Jupiter
+                      Orbits Jupiter
 
   .. tabs::
 
       .. tab:: Stars
 
-        .. tabs::
+          .. tabs::
 
-            .. tab:: The Sun
+              .. tab:: The Sun
 
-              The closest star to us.
+                  The closest star to us.
 
-            .. tab:: Proxima Centauri
+              .. tab:: Proxima Centauri
 
-              The second closest star to us.
+                  The second closest star to us.
 
-            .. tab:: Polaris
+              .. tab:: Polaris
 
-              The North Star.
+                  The North Star.
 
       .. tab:: Moons
 
-        .. tabs::
+          .. tabs::
 
-            .. tab:: The Moon
+              .. tab:: The Moon
 
-              Orbits the Earth
+                  Orbits the Earth
 
-            .. tab:: Titan
+              .. tab:: Titan
 
-              Orbits Jupiter
+                  Orbits Jupiter
 
-    .. note::
+  .. note::
 
       - A blank line is *required* after every ``tabs`` directive.
       - The contents of each tab can be displayed by clicking on the tab that you wish to show.

--- a/guides/contributing.rst
+++ b/guides/contributing.rst
@@ -301,7 +301,7 @@ adhere to the following order:
 
   .. note::
 
-      - The ``:open:`` flag following the ``collapse`` directive has to be without a blank line.
+      - The ``:open:`` flag must immediately follow the ``collapse`` directive without a blank line between them.
       - A blank line is *required* after every ``collapse`` directive.
 
 - **Tabs**: To group content into tabs, use the ``tabs`` directive. The tabs directive defines a tab set.

--- a/guides/contributing.rst
+++ b/guides/contributing.rst
@@ -251,6 +251,39 @@ adhere to the following order:
 
       Note that a blank line is *required* after every ``code-block`` directive.
 
+- **Collapsible section**: To add a collapsible section, use the ``collapse`` directive:
+
+  .. code-block:: rst
+      .. collapse:: Details
+          Something small enough to escape casual notice.
+      
+      .. collapse:: Open
+          :open:
+          This section is open by default.
+      
+      .. collapse:: A long code block
+          .. code-block:: python
+              print("Not really")
+  
+  .. collapse:: Details
+
+      Something small enough to escape casual notice.
+
+  .. collapse:: Open
+
+      :open:
+
+      This section is expected to be open by default.
+
+  .. collapse:: A long code block
+
+      .. code-block:: python
+          print("Not really")
+  
+  .. note::
+
+      A blank line is *required* after every ``collapse`` directive.
+
 - **Images**: Use the ``figure`` directive to display an image:
 
   .. code-block:: rst

--- a/guides/contributing.rst
+++ b/guides/contributing.rst
@@ -256,14 +256,18 @@ adhere to the following order:
   .. code-block:: rst
 
       .. collapse:: Details
+          
           Something small enough to escape casual notice.
       
       .. collapse:: Open
+          
           :open:
           This section is open by default.
       
       .. collapse:: A long code block
+          
           .. code-block:: python
+              
               print("Not really")
   
   .. collapse:: Details
@@ -279,6 +283,7 @@ adhere to the following order:
   .. collapse:: A long code block
 
       .. code-block:: python
+
           print("Not really")
   
   .. note::

--- a/guides/contributing.rst
+++ b/guides/contributing.rst
@@ -275,8 +275,6 @@ adhere to the following order:
 
   .. collapse:: Open
 
-      :open:
-
       This section is expected to be open by default.
 
   .. collapse:: A long code block

--- a/guides/contributing.rst
+++ b/guides/contributing.rst
@@ -130,7 +130,7 @@ Then, use the provided Makefile to build the changes and start a live-updating w
     # Start web server on port 8000
     make live-html
 
-Notes
+s
 *****
 
 - Use the English language (duh...)
@@ -268,12 +268,12 @@ adhere to the following order:
       .. collapse:: Open
           :open:
 
-          This section is expected to be open by default.
+          This section is open by default.
 
   .. collapse:: Open
       :open:
 
-      This section is expected to be open by default.
+      This section is open by default.
 
   .. code-block:: rst
 
@@ -299,7 +299,117 @@ adhere to the following order:
 
   .. note::
 
-      A blank line is *required* after every ``collapse`` directive.
+      - The ``:open:`` flag has to be immediately after the ``collapse`` directive without a blank line.
+      - A blank line is *required* after every ``collapse`` directive.
+
+- **Tabs**: To group content into tabs, use the ``tabs`` directive. The tabs directive to define a tab set.
+  Basic tabs are added using the ``tab`` directive (without s), which takes the tab’s label as an argument:
+
+  .. code-block:: rst
+
+      .. tabs::
+
+          .. tab:: Apples
+
+            Apples are green, or sometimes red.
+
+          .. tab:: Pears
+
+            Pears are green.
+
+          .. tab:: Oranges
+
+            Oranges are orange.
+
+  This will appear as
+
+  .. tabs::
+
+      .. tab:: Apples
+
+        Apples are green, or sometimes red.
+
+      .. tab:: Pears
+
+        Pears are green.
+
+      .. tab:: Oranges
+
+        Oranges are orange.
+
+  The contents of each tab can be displayed by clicking on the tab that you wish to show.
+  Clicking on the tab that is currently open will hide the tab’s content, leaving only the tab set labels visible.
+
+  Tabs can also be nested inside one another:
+
+  .. code-block:: rst
+
+      .. tabs::
+
+          .. tab:: Stars
+
+            .. tabs::
+
+                .. tab:: The Sun
+
+                  The closest star to us.
+
+                .. tab:: Proxima Centauri
+
+                  The second closest star to us.
+
+                .. tab:: Polaris
+
+                  The North Star.
+
+          .. tab:: Moons
+
+            .. tabs::
+
+                .. tab:: The Moon
+
+                  Orbits the Earth
+
+                .. tab:: Titan
+
+                  Orbits Jupiter
+
+  .. tabs::
+
+      .. tab:: Stars
+
+        .. tabs::
+
+            .. tab:: The Sun
+
+              The closest star to us.
+
+            .. tab:: Proxima Centauri
+
+              The second closest star to us.
+
+            .. tab:: Polaris
+
+              The North Star.
+
+      .. tab:: Moons
+
+        .. tabs::
+
+            .. tab:: The Moon
+
+              Orbits the Earth
+
+            .. tab:: Titan
+
+              Orbits Jupiter
+
+    .. note::
+
+      - A blank line is *required* after every ``tabs`` directive.
+      - The contents of each tab can be displayed by clicking on the tab that you wish to show.
+        Clicking on the tab that is currently open will hide the tab’s content, leaving only the tab set labels visible.
+      - For advanced features like tab-groupings refer to https://sphinx-tabs.readthedocs.io/en/latest/
 
 - **Images**: Use the ``figure`` directive to display an image:
 


### PR DESCRIPTION
## Description:
To file guides/contributing.rst ,
examples have been added regarding how to use collapsible sections and tabs.

Source:
https://sphinx-toolbox.readthedocs.io/en/latest/extensions/collapse.html
https://sphinx-tabs.readthedocs.io/en/latest/

**Related issue (if applicable):** fixes <link to issue>
None
**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>
None
## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
