### PR TITLE
[light][lvgl]Rename "widget" to "led"

### DIFF
--- a/components/light/lvgl.rst
+++ b/components/light/lvgl.rst
@@ -13,7 +13,7 @@ Supported widget is :ref:`lvgl-widget-led`. A single light supports only a singl
 Configuration variables:
 ------------------------
 
-- **widget** (**Required**): The ID of a ``led`` widget configured in LVGL, which will reflect the state of the light.
+- **led** (**Required**): The ID of a ``led`` widget configured in LVGL, which will reflect the state of the light.
 - All other options from :ref:`light <config-light>`.
 
 
@@ -23,7 +23,7 @@ Example:
 
     light:
       - platform: lvgl
-        widget: led_id
+        led: led_id
         name: LVGL light
 
 .. note::


### PR DESCRIPTION
## Description:

On the LVGL light component documentation, the link to the lvgl led widget is currently called "widget", but the code uses "led" and thus the example does not compile.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** N/A

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
