### PR TITLE
Fix typo in esp32.rst

### DIFF
--- a/components/esp32.rst
+++ b/components/esp32.rst
@@ -121,7 +121,7 @@ worry about pin alias names or numbering...yay!
 
 Some notes about the pins on the original ESP32:
 
-- ``GPIO0`` is used to determine the boot mode on startup; note that **ESP32 variants use differnt pins to determine
+- ``GPIO0`` is used to determine the boot mode on startup; note that **ESP32 variants use different pins to determine
   the boot mode.** Bootstrapping pin(s) should **not** be pulled LOW on startup to avoid booting into flash mode when
   it's not desired. You can, however, still use the strapping pins as output pins.
 - ``GPIO34`` to ``GPIO39``: These pins **cannot** be used as outputs (yes, even though GPIO stands for "general purpose


### PR DESCRIPTION
## Description:

SSIA

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
