### PR TITLE
Tabs label CSS dark mode fix

### DIFF
--- a/_static/custom.css
+++ b/_static/custom.css
@@ -370,7 +370,6 @@ img.logo {
   
   .sphinx-tabs-tab {
     border-bottom: 1px solid #fff;
-    border: 1px solid #cfcfcf !important;
     color: #3fc3ff !important;
     background: #212121 !important;
     margin: 0 !important;

--- a/_static/custom.css
+++ b/_static/custom.css
@@ -282,6 +282,10 @@ div.body p, div.body dd, div.body li, div.body blockquote {
     display: none;
 }
 
+.sphinx-tabs-tab {
+  line-height: 20px;
+}
+
 /* New branding changes */
 
 div.body h1, div.body h2, div.body h3, div.body h4, div.body h5, div.body h6, div.sphinxsidebar h3, div.sphinxsidebar h4, div.admonition p.admonition-title {
@@ -365,6 +369,9 @@ img.logo {
   }
   
   .sphinx-tabs-tab {
+    border-bottom: 1px solid #fff;
+    border: #cfcfcf !important;
+    color: #3fc3ff !important;
     background: #212121 !important;
     margin: 0 !important;
   }

--- a/_static/custom.css
+++ b/_static/custom.css
@@ -370,7 +370,7 @@ img.logo {
   
   .sphinx-tabs-tab {
     border-bottom: 1px solid #fff;
-    border: #cfcfcf !important;
+    border: 1px solid #cfcfcf !important;
     color: #3fc3ff !important;
     background: #212121 !important;
     margin: 0 !important;

--- a/_static/custom.css
+++ b/_static/custom.css
@@ -369,7 +369,6 @@ img.logo {
   }
   
   .sphinx-tabs-tab {
-    border-bottom: 1px solid #fff;
     color: #3fc3ff !important;
     background: #212121 !important;
     margin: 0 !important;


### PR DESCRIPTION
## Description:
In file _static/custom.css
Improved the contrast of Tabs label when in dark mode.
Also slightly compacted the tab height from 24px to 20px

Image showing dark mode contrast improvements
![image](https://github.com/user-attachments/assets/491d901a-99d8-4071-b862-e0f839229185)

**Related issue (if applicable):** fixes <link to issue> NONE

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here> NONE

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.