### PR TITLE
[speaker] Document mute actions and audio dac support

### DIFF
--- a/components/speaker/i2s_audio.rst
+++ b/components/speaker/i2s_audio.rst
@@ -55,6 +55,7 @@ Configuration variables:
   - ``pcm_short``
   - ``pcm_long``
 - **timeout** (*Optional*, :ref:`config-time`): How long to wait after finishing playback before releasing the bus. Defaults to ``100ms``.
+- All other options from :ref:`Speaker Component <config-speaker>`.
 
 External DAC
 ************

--- a/components/speaker/index.rst
+++ b/components/speaker/index.rst
@@ -13,12 +13,20 @@ speaker platforms.
 Base Speaker Configuration
 --------------------------
 
-No configuration variables
+.. code-block:: yaml
+
+    speaker:
+      - platform: ...
+
+
+Configuration variables:
+
+- **audio_dac** (*Optional*, :ref:`config-id`): The :doc:`audio DAC </components/audio_dac/index>` to use for volume control.
 
 .. _speaker-actions:
 
 Speaker Actions
-------------------
+---------------
 
 All ``speaker`` actions can be used without specifying an ``id`` if you have only one ``speaker`` in
 your configuration YAML.
@@ -26,7 +34,7 @@ your configuration YAML.
 .. _speaker-play:
 
 ``speaker.play`` Action
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^
 
 This action will start playing raw audio data from the speaker.
 
@@ -52,7 +60,7 @@ Configuration variables:
 .. _speaker-stop:
 
 ``speaker.stop`` Action
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^
 
 This action will stop playing audio data from the speaker and discard the unplayed data.
 
@@ -65,7 +73,29 @@ Configuration variables:
 ``speaker.finish`` Action
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-This action will stop playing audio data from the speaker after all data **is** played. 
+This action will stop playing audio data from the speaker after all data **is** played.
+
+Configuration variables:
+
+- **id** (*Optional*, :ref:`config-id`): The speaker to control. Defaults to the only one in YAML.
+
+.. _speaker-mute_on:
+
+``speaker.mute_on`` Action
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This action will mute the speaker.
+
+Configuration variables:
+
+- **id** (*Optional*, :ref:`config-id`): The speaker to control. Defaults to the only one in YAML.
+
+.. _speaker-mute_off:
+
+``speaker.mute_off`` Action
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This action will unmute the speaker.
 
 Configuration variables:
 
@@ -74,7 +104,7 @@ Configuration variables:
 .. _speaker-volume_set:
 
 ``speaker.volume_set`` Action
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 This action will set the volume of the speaker.
 
@@ -107,7 +137,7 @@ your configuration YAML.
 .. _speaker-is_playing:
 
 ``speaker.is_playing`` Condition
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 This condition will check if the speaker is currently playing audio data.
 


### PR DESCRIPTION
## Description:

Documents the new ``audio_dac`` configuration parameter for all speakers and the mute on and off actions. The ``i2s_speaker`` documentation now references the options in the base speaker configuration document.

**Related issue (if applicable):** not applicable

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
