### PR TITLE
Ensure no other clients connected before stopping scan

### DIFF
--- a/components/esp32_ble_tracker.rst
+++ b/components/esp32_ble_tracker.rst
@@ -285,7 +285,12 @@ enable the tracker only while the native API is connected. The following config 
         - esp32_ble_tracker.start_scan:
            continuous: true
       on_client_disconnected:
-        - esp32_ble_tracker.stop_scan:
+        - if:
+            condition:
+              - not:
+                  api.connected:
+            then:
+              - esp32_ble_tracker.stop_scan:
 
 See Also
 --------


### PR DESCRIPTION
## Description:

Fix suggested code for single core systems.
This will prevent stopping scan when more than one client is connected (like when looking for logs) and only one disconnects.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** N/A

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
