### PR TITLE
[media_player] Document paused and announcing conditions

### DIFF
--- a/components/media_player/index.rst
+++ b/components/media_player/index.rst
@@ -254,6 +254,36 @@ This condition checks if the media player is playing media.
         condition:
           media_player.is_playing:
 
+.. _media_player-is_paused_condition:
+
+``media_player.is_paused`` Condition
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This condition checks if the media player is paused.
+
+.. code-block:: yaml
+
+    # In some trigger:
+    on_...:
+      if:
+        condition:
+          media_player.is_paused:
+
+.. _media_player-is_announcing_condition:
+
+``media_player.is_announcing`` Condition
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This condition checks if the media player is playing an announcement.
+
+.. code-block:: yaml
+
+    # In some trigger:
+    on_...:
+      if:
+        condition:
+          media_player.is_announcing:
+
 Play media in order
 -------------------
 


### PR DESCRIPTION
## Description:

Documents the newly added ``is_paused`` and ``is_announcing`` conditions.

**Related issue (if applicable):** not applicable

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#7667

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
