### PR TITLE
Fix typo in contributing.rst

### DIFF
--- a/guides/contributing.rst
+++ b/guides/contributing.rst
@@ -864,7 +864,7 @@ and the ESPHome core will copy them with no additional code required by the comp
 
     ESPHome also has a ``custom_components`` mechanism like `Home Assistant does
     <https://developers.home-assistant.io/docs/creating_component_index>`__. Note, however, that
-    **custom componenets are deprecated** in favor of :doc:`/components/external_components`.
+    **custom components are deprecated** in favor of :doc:`/components/external_components`.
 
 .. _config_validation:
 


### PR DESCRIPTION
## Description:
componenets -> components

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
