### PR TITLE
Add 'always' as a valid time refresh value

### DIFF
--- a/guides/configuration-types.rst
+++ b/guides/configuration-types.rst
@@ -162,6 +162,7 @@ There are several ways of doing this. See below examples to see how you can spec
       # for all 'update_interval' options, also
       update_interval: never  # never update
       update_interval: 0ms  # update in every loop() iteration
+      update_interval: always # same as 0ms
 
 See Also
 --------


### PR DESCRIPTION
## Description:

Add 'always' as a valid time value. It is more explicit to user than 0s ou 0ms and already supported is the core code, see: 
https://github.com/esphome/esphome/blob/21cb941bbe7afb7096ee342fae2c88bdaa27d28b/esphome/config_validation.py#L1981C26-L1981C32

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
