### PR TITLE
[media_player] add new conditions to all conditions list

### DIFF
--- a/automations/all_conditions.rst
+++ b/automations/all_conditions.rst
@@ -8,7 +8,7 @@
 - **fan:** ``is_off``, ``is_on``
 - **light:** ``is_off``, ``is_on``
 - **lock:** ``is_locked``, ``is_unlocked``
-- **media_player:** ``is_idle``, ``is_playing``
+- **media_player:** ``is_announcing``, ``is_idle``, ``is_paused``, ``is_playing``
 - **micro_wake_word:** ``is_running``
 - **microphone:** ``is_capturing``
 - **mqtt:** ``connected``


### PR DESCRIPTION
## Description:

I missed adding the two new conditions to the all conditions list in the already merged #4387 

**Related issue (if applicable):** not applicable

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#7667

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
