### PR TITLE
Update send_wait_time description for modbus timing fix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,7 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 10
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: daily

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,7 +30,7 @@ jobs:
           repo: cloudcannon/pagefind
       -
         name: Checkout source code
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4.2.2
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,7 @@ jobs:
       uses: jaxxstorm/action-install-gh-release@v1.12.0
       with:
           repo: cloudcannon/pagefind
-    - uses: actions/checkout@v4.2.1
+    - uses: actions/checkout@v4.2.2
     - name: Set up Python 3.12
       uses: actions/setup-python@v5
       with:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 ESPHOME_PATH = ../esphome
 ESPHOME_REF = 2024.10.2
-PAGEFIND_VERSION=1.1.0
+PAGEFIND_VERSION=1.1.1
 PAGEFIND=pagefind
 NET_PAGEFIND=../pagefindbin/pagefind
 

--- a/_templates/searchbox.html
+++ b/_templates/searchbox.html
@@ -60,7 +60,7 @@
         if (!inpel)
             return;
 
-        var mobileWidth = getComputedStyle(document.body).getPropertyValue("--mobile-width-stop");
+        const mobileWidth = getComputedStyle(document.body).getPropertyValue("--mobile-width-stop");
 
         function isMobile() {
             return window.innerWidth <= mobileWidth;
@@ -74,26 +74,42 @@
 
         const margin = 20;
 
-        const resultTemplate = (result) => {
-            let wrapper = new El("li").class("pagefind-modular-list-result");
+        function getLink(location, anchors, url) {
+            if (!anchors || !anchors.length)
+                return null;
+            // find the closest anchor at or before the current location
+            const anchor = anchors.sort((a, b) => b.location - a.location).find(a => a.location <= location);
+            if (anchor) {
+                return url + "#" + anchor.id;
+            }
+            return null;
+        }
 
-            let thumb = new El("div").class("pagefind-modular-list-thumb").addTo(wrapper);
-            if (result?.meta?.image) {
+        const resultTemplate = (result) => {
+            const wrapper = new El("li").class("pagefind-modular-list-result");
+
+            const thumb = new El("div").class("pagefind-modular-list-thumb").addTo(wrapper);
+            let image = result?.meta?.image;
+            if (image) {
+                if (image.includes("/_images/"))
+                    image = image.substring(image.indexOf("/_images/"));
                 new El("img").class("pagefind-modular-list-image").attrs({
-                    src: result.meta.image,
+                    src: image,
                     alt: result.meta.image_alt || result.meta.title
                 }).addTo(thumb);
             }
 
-            let inner = new El("div").class("pagefind-modular-list-inner").addTo(wrapper);
-            let title = new El("p").class("pagefind-modular-list-title").addTo(inner);
+            const inner = new El("div").class("pagefind-modular-list-inner").addTo(wrapper);
+            const title = new El("p").class("pagefind-modular-list-title").addTo(inner);
             new El("a").class("pagefind-modular-list-link").text(result.meta?.title).attrs({
                 href: result.meta?.url || result.url
             }).addTo(title);
 
-            let excerpt = new El("p").class("pagefind-modular-list-excerpt").addTo(inner);
+            const excerpt = new El("p").class("pagefind-modular-list-excerpt").addTo(inner);
+            const locations = result.weighted_locations.sort((a, b) => b.weight - a.weight);
+            const url = getLink(locations[0]?.location, result.anchors, result.url) || result.meta?.url || result.url;
             new El("a").class("pagefind-modular-list-link").html(result.excerpt).attrs({
-                href: result.meta?.url || result.url
+                href: url
             }).addTo(excerpt);
 
             return wrapper.element;
@@ -102,9 +118,9 @@
 
         function resizeTarget() {
             const searchPos = inpel.getBoundingClientRect();
-            var leftPos;
-            var topPos;
-            var maxWidth = 650;
+            let leftPos;
+            let topPos;
+            const maxWidth = 650;
             target.style.width = "auto;"
             target.style.height = "fit-content";
             target.style.maxWidth = maxWidth + "px";
@@ -171,7 +187,7 @@
 
         const clickCallback = (event) => {
             const path = event.composedPath();
-            if (path.includes(target) || path.includes(inpel))
+            if (path.includes(inpel))
                 return;
             hideTargets();
         };
@@ -183,6 +199,15 @@
                     hideTargets();
                 }
             });
+        }
+        const input_field = document.getElementById("pfmod-input-0");
+        if (input_field) {
+            input_field.focus({preventScroll: true});
+            input_field.addEventListener("blur", () => {
+                requestAnimationFrame(() => {
+                    input_field.focus({preventScroll: true});
+                });
+            })
         }
     });
 </script>

--- a/_templates/searchbox.html
+++ b/_templates/searchbox.html
@@ -157,10 +157,20 @@
             resizeTarget();
         }
 
+        function search_focus() {
+            const input_field = document.getElementById("pfmod-input-0");
+            if (input_field) {
+                requestAnimationFrame(() => input_field.focus());
+            }
+        }
+
+
         function hideTargets() {
             if (target.style.display !== "none") {
                 target.style.display = "none";
                 document.removeEventListener('click', clickCallback);
+                // keep focus on search box after clicking on search result
+                search_focus();
             }
         }
 
@@ -200,14 +210,12 @@
                 }
             });
         }
-        const input_field = document.getElementById("pfmod-input-0");
-        if (input_field) {
-            input_field.focus({preventScroll: true});
-            input_field.addEventListener("blur", () => {
-                requestAnimationFrame(() => {
-                    input_field.focus({preventScroll: true});
-                });
-            })
+        // focus the search field on page load.
+        search_focus();
+        // focus when clicking on clear button
+        const clears = document.getElementsByClassName("pagefind-modular-list-clear");
+        for (let i = 0; i !== clears.length; i++) {
+            clears[i].addEventListener("click", search_focus);
         }
     });
 </script>

--- a/components/modbus.rst
+++ b/components/modbus.rst
@@ -55,10 +55,9 @@ Configuration variables:
   This is useful for RS485 transceivers that do not have automatic flow control switching,
   like the common MAX485.
 
-- **send_wait_time** (*Optional*, :ref:`config-time`): Time in milliseconds before the next ModBUS command is sent if an answer from a previous command is pending. Defaults to 250 ms.
-  If multiple ModBUS devices are attached to the same bus increasing this value can help avoiding to to overlapping reads.
-  When two devices are sending a command at the same time the response read from UART can't be assigned to the proper design.
-  This value defines the maximum queuing time for a command before it is send anyways.
+- **send_wait_time** (*Optional*, :ref:`config-time`): Time in milliseconds before the next ModBUS command is sent when an answer from a previous command has not yet started (i.e. when to timeout and assume no response is coming). Defaults to 250 ms.
+  Set this value to the maximum time required for the slowest device on the bus to begin responding (time to first byte).
+  If a device starts responding within this time, the next command will be queued and sent after the response is finished, no matter how long the response.  
   
 - **disable_crc** (*Optional*, boolean): Ignores a bad CRC if set to ``true``. Defaults to ``false``
 

--- a/components/packages.rst
+++ b/components/packages.rst
@@ -142,6 +142,8 @@ As an example, if the configuration needed to support three garage doors using t
         platform: gpio
         # ...
 
+.. _config-packages_extend:
+
 Extend
 ------
 
@@ -168,6 +170,8 @@ For example, to set a specific update interval on a common uptime sensor that is
     sensor:
       - id: !extend uptime_sensor
         update_interval: 10s
+
+.. _config-packages_remove:
 
 Remove
 ------

--- a/guides/contributing.rst
+++ b/guides/contributing.rst
@@ -864,7 +864,7 @@ and the ESPHome core will copy them with no additional code required by the comp
 
     ESPHome also has a ``custom_components`` mechanism like `Home Assistant does
     <https://developers.home-assistant.io/docs/creating_component_index>`__. Note, however, that
-    **custom componenets are deprecated** in favor of :doc:`/components/external_components`.
+    **custom components are deprecated** in favor of :doc:`/components/external_components`.
 
 .. _config_validation:
 

--- a/guides/made_for_esphome.rst
+++ b/guides/made_for_esphome.rst
@@ -34,6 +34,9 @@ For all projects
 - Your project is powered by an ESP32 or *supported* ESP32 variant such as the S2, S3, C3, etc.
 - Your ESPHome configuration is open source, available for end users to modify/update
 - Users should be able to apply updates if your project sells ready-made devices
+- All components/platforms used must have an ``id`` specified so users can easily refer to,
+  :ref:`config-packages_extend` and/or :ref:`config-packages_remove` configuration variables should they choose to
+  "take control"
 - Your project supports adoption via the ``dashboard_import`` feature of ESPHome (see
   :doc:`Sharing </guides/creators>`). In particular:
 

--- a/pagefind.yml
+++ b/pagefind.yml
@@ -5,6 +5,6 @@ exclude_selectors:
   - ".toctree-wrapper"
   - ".sphinxsidebar"
   - ".breadcrumbs"
+  - "pre"
 glob: "{components,cookbook,guides,projects,web-api}/**/*.html"
 root_selector: div[role=main]
-


### PR DESCRIPTION
Documentation update to reflect change in how send_wait_time is handled in modbus.

Previously send_wait_time had to be set to the longest possible message on the bus, which is difficult to calculate, and error prone. It would clobber incoming messages by sending outgoing commands in the middle of receipt.

New functionality changes this to wait for the response to be complete, and then sending the next command.

Now send_wait_time only needs to be large enough to allow time for devices to send their first byte of response.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#7674

## Checklist:

  - [X ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
