### PR TITLE
Update send_wait_time text to reflect modbus timing changes

### DIFF
--- a/components/modbus.rst
+++ b/components/modbus.rst
@@ -55,10 +55,9 @@ Configuration variables:
   This is useful for RS485 transceivers that do not have automatic flow control switching,
   like the common MAX485.
 
-- **send_wait_time** (*Optional*, :ref:`config-time`): Time in milliseconds before the next ModBUS command is sent if an answer from a previous command is pending. Defaults to 250 ms.
-  If multiple ModBUS devices are attached to the same bus increasing this value can help avoiding to to overlapping reads.
-  When two devices are sending a command at the same time the response read from UART can't be assigned to the proper design.
-  This value defines the maximum queuing time for a command before it is send anyways.
+- **send_wait_time** (*Optional*, :ref:`config-time`): Time in milliseconds before the next ModBUS command is sent when an answer from a previous command has not yet started (i.e. when to timeout and assume no response is coming). Defaults to 250 ms.
+  Set this value to the maximum time required for the slowest device on the bus to begin responding (time to first byte).
+  If a device starts responding within this time, the next command will be queued and sent after the response is finished, no matter how long the response.  
   
 - **disable_crc** (*Optional*, boolean): Ignores a bad CRC if set to ``true``. Defaults to ``false``
 


### PR DESCRIPTION
Documentation update to reflect change in how send_wait_time is handled in modbus.

Previously send_wait_time had to be set to the longest possible message on the bus, which is difficult to calculate, and error prone. It would clobber incoming messages by sending outgoing commands in the middle of receipt.

New functionality changes this to wait for the response to be complete, and then sending the next command.

Now send_wait_time only needs to be large enough to allow time for devices to send their first byte of response.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#7674

## Checklist:

  - [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
