### PR TITLE
Update ld2410.rst

### DIFF
--- a/components/sensor/ld2410.rst
+++ b/components/sensor/ld2410.rst
@@ -521,7 +521,7 @@ For easy calibration process, you can use the following custom manual card.
       - type: horizontal-stack
         cards:
           - type: entity
-            entity: 'binary_sensor.DEVICE_gpio_out_pin_presence'
+            entity: 'binary_sensor.DEVICE_gpio_out_pin_presence_status'
             name: gpio presence
             state_color: true
           - type: entity


### PR DESCRIPTION
Correcting the name of the binary sensor binary_sensor.DEVICE_gpio_out_pin_presence_status

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
