### PR TITLE
Renames from ade7953 to ade7953_i2c

### DIFF
--- a/components/cover/current_based.rst
+++ b/components/cover/current_based.rst
@@ -132,7 +132,7 @@ Configuration example:
       scl: GPIO14
 
     sensor:
-      - platform: ade7953
+      - platform: ade7953_i2c
         irq_pin: GPIO16
         voltage:
           name: Shelly 2.5 Mains Voltage


### PR DESCRIPTION
## Description:

Fix "The ade7953 sensor component has been renamed to ade7953_i2c."

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:
  - [x ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

