### PR TITLE
[remote_base] Add Nexus protocol

### DIFF
--- a/components/remote_receiver.rst
+++ b/components/remote_receiver.rst
@@ -62,6 +62,7 @@ Configuration variables:
   - **sony**: Decode and dump Sony infrared codes.
   - **toshiba_ac**: Decode and dump Toshiba AC infrared codes.
   - **mirage**: Decode and dump Mirage infrared codes.
+  - **nexus**: Decode and dump Nexus temperature & humidity sensor RF codes.
 
 - **tolerance** (*Optional*, int, :ref:`config-time` or mapping): The percentage or time that the remote signal lengths can
   deviate in the decoding process.  Defaults to ``25%``.
@@ -194,6 +195,9 @@ Automations:
   is passed to the automation for use in lambdas.
 - **on_mirage** (*Optional*, :ref:`Automation <automation>`): An automation to perform when a
   Mirage remote code has been decoded. A variable ``x`` of type :apistruct:`remote_base::MirageData`
+  is passed to the automation for use in lambdas.
+- **on_nexus** (*Optional*, :ref:`Automation <automation>`): An automation to perform when a
+  Nexus remote code has been decoded. A variable ``x`` of type :apistruct:`remote_base::NexusData`
   is passed to the automation for use in lambdas.
 
 .. code-block:: yaml
@@ -437,6 +441,11 @@ Remote code selection (exactly one of these has to be included):
 
   - **code** (**Required**, 14-bytes list): The code to listen for, see :ref:`transmitter description <remote_transmitter-transmit_mirage>`
     for more info. Usually you only need to copy this directly from the dumper output.
+
+- **nexus**: Trigger on a decoded Nexus remote code with the given data.
+
+  - **channel** (**Required**, int): The channel to trigger on, see dumper output for more info.
+  - **address** (**Required**, int): The address to trigger on, see dumper output for more info.
 
 .. note::
 

--- a/components/remote_transmitter.rst
+++ b/components/remote_transmitter.rst
@@ -879,6 +879,31 @@ Configuration variables:
 - **code** (**Required**, list): The 14 byte Mirage code to send.
 - All other options from :ref:`remote_transmitter-transmit_action`.
 
+``remote_transmitter.transmit_nexus`` **Action**
+
+This :ref:`action <config-action>` sends a 36-bit Nexus code to a remote transmitter.
+
+.. code-block:: yaml
+
+    on_...:
+      - remote_transmitter.transmit_nexus:
+          channel: 1
+          address: 42
+          temperature: 34.5
+          humidity: 51
+          battery_level: true
+          force_update: false
+
+Configuration variables:
+
+- **channel** (**Required**, int): The 2-bit channel to send, between 1 and 4 inclusive.
+- **address** (**Required**, int): The 8-bit address (sensor ID) to send, between 0 and 255 inclusive. Each sensor has a unique one.
+- **temperature** (**Optional**, float): The 12-bit temperature to send, between -204.8 and 204.7 inclusive. Defaults to ``25.5``.
+- **humidity** (**Optional**, int): The 8-bit humidity to send, between 0 and 255 inclusive. Defaults to ``42``.
+- **battery_level** (**Optional**, boolean): The battery level normal flag bit to send, ``false`` means the battery level is low, ``true`` means normal. Defaults to ``true``.
+- **force_update** (**Optional**, boolean): The force update flag bit to send, ``false`` means the transmission is normal, ``true`` means forced. Defaults to ``false``.
+- All other options from :ref:`remote_transmitter-transmit_action`.
+
 .. _remote_transmitter-rc_switch-protocol:
 
 RC Switch Protocol


### PR DESCRIPTION
## Description:

Add support for Nexus protocol in Remote Receiver, a popular protocol used by some 433MHz temperature & humidity sensors, e.g., Digoo DG-TH8380.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#7713

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
