### PR TITLE
Move pad_column to layout

### DIFF
--- a/cookbook/lvgl.rst
+++ b/cookbook/lvgl.rst
@@ -1875,8 +1875,8 @@ The weather condition icons we use are from MDI. We import just the ones corresp
                 width: 228
                 height: 250
                 pad_all: 10
-                pad_column: 0
                 layout:
+                  pad_column: 0
                   type: GRID
                   grid_rows: [FR(48), FR(13), FR(13), FR(13), FR(13)]
                   grid_columns: [FR(10), FR(40), FR(40), FR(10)]


### PR DESCRIPTION
## Description:
The Weather forecast panel didn't work due to pad_column being in the wrong place

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
