### PR TITLE
Update user manual links for HLK-LD2410 variants

### DIFF
--- a/components/sensor/ld2410.rst
+++ b/components/sensor/ld2410.rst
@@ -9,8 +9,12 @@ Component/Hub
 -------------
 .. _ld2410-component:
 
-The ``ld2410`` sensor platform allows you to use HI-LINK LD2410 motion and presence sensor
-(`datasheet and user manual <https://drive.google.com/drive/folders/1p4dhbEJA3YubyIjIIC7wwVsSo8x29Fq-?spm=a2g0o.detail.1000023.17.93465697yFwVxH>`__) with ESPHome.
+The ``ld2410`` sensor platform allows you to use HI-LINK LD2410 motion and presence sensors with ESPHome.
+There are three variants with similar communication protocols:
+
+- LD2410 (`datasheet and user manual <https://drive.google.com/drive/folders/1lCQv3mfHJ3XKXzweeHPFnJ_8_D_EWEKk>`__)
+- LD2410B (`datasheet and user manual <https://drive.google.com/drive/folders/16zI-fium_BZeP08EyQke0rWp0BJTMvw3>`__)
+- LD2410C (`datasheet and user manual <https://drive.google.com/drive/folders/1ypOlacBmmFXY6lDQ0f1hEJFmczNe-0WG>`__)
 
 The :ref:`UART <uart>` is required to be set up in your configuration for this sensor to work, ``parity`` and ``stop_bits`` **must be** respectively ``NONE`` and ``1``.
 Use of hardware UART pins is highly recommended, in order to support the out-of-the-box 256000 baud rate of the LD2410 sensor.


### PR DESCRIPTION
## Description:
There are three variants of this module, and it would be useful to have direct links to their manuals.
I was searching for this when I wanted to confirm that the C variant uses similar UART configurations as the others. Which it does.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** N/A

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
