### PR TITLE
[i2s_audio] Document I2S speaker disable timeout option

### DIFF
--- a/components/speaker/i2s_audio.rst
+++ b/components/speaker/i2s_audio.rst
@@ -54,6 +54,7 @@ Configuration variables:
   - ``pcm``
   - ``pcm_short``
   - ``pcm_long``
+- **buffer_duration** (*Optional*, :ref:`config-time`): The duration of the internal ring buffer. Larger values can reduce stuttering but uses more memory. Defaults to ``500ms``.
 - **timeout** (*Optional*, :ref:`config-time`): How long to wait after finishing playback before releasing the bus. Set to ``disable`` to never stop the speaker due to a timeout. Defaults to ``500ms``.
 - All other options from :ref:`Speaker Component <config-speaker>`.
 

--- a/components/speaker/i2s_audio.rst
+++ b/components/speaker/i2s_audio.rst
@@ -54,7 +54,7 @@ Configuration variables:
   - ``pcm``
   - ``pcm_short``
   - ``pcm_long``
-- **timeout** (*Optional*, :ref:`config-time`): How long to wait after finishing playback before releasing the bus. Defaults to ``100ms``.
+- **timeout** (*Optional*, :ref:`config-time`): How long to wait after finishing playback before releasing the bus. Set to ``disable`` to never stop the speaker due to a timeout. Defaults to ``500ms``.
 - All other options from :ref:`Speaker Component <config-speaker>`.
 
 External DAC

--- a/components/speaker/i2s_audio.rst
+++ b/components/speaker/i2s_audio.rst
@@ -55,7 +55,7 @@ Configuration variables:
   - ``pcm_short``
   - ``pcm_long``
 - **buffer_duration** (*Optional*, :ref:`config-time`): The duration of the internal ring buffer. Larger values can reduce stuttering but uses more memory. Defaults to ``500ms``.
-- **timeout** (*Optional*, :ref:`config-time`): How long to wait after finishing playback before releasing the bus. Set to ``disable`` to never stop the speaker due to a timeout. Defaults to ``500ms``.
+- **timeout** (*Optional*, :ref:`config-time`): How long to wait after finishing playback before releasing the bus. Set to ``never`` to never stop the speaker due to a timeout. Defaults to ``500ms``.
 - All other options from :ref:`Speaker Component <config-speaker>`.
 
 External DAC


### PR DESCRIPTION
## Description:

Adds documentation for the new disable timeout option. Fixes the default timeout value to the current implementation.

**Related issue (if applicable):** not applicable

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#7749

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
