### PR TITLE
Update manual for uponor_smatrix component (esphome#7745)

### DIFF
--- a/components/uponor_smatrix.rst
+++ b/components/uponor_smatrix.rst
@@ -115,6 +115,8 @@ Sensor component
           name: Temperature Living Room
         external_temperature:
           name: Floor Temperature Living Room
+        target_temperature:
+          name: Thermostat Target Temperature Living Room
 
 Configuration variables:
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -127,6 +129,8 @@ Configuration variables:
   All options from :ref:`Sensor <config-sensor>`.
 - **external_temperature** (*Optional*): A sensor reading the current external temperature the thermostat reports.
   This comes from an optionally attached external temperature sensor that can measure the floor or outdoor temperature.
+  All options from :ref:`Sensor <config-sensor>`.
+- **target_temperature** (*Optional*): A sensor reading the currently set target temperature the thermostat reports.
   All options from :ref:`Sensor <config-sensor>`.
 
 


### PR DESCRIPTION
## Description:
Add documentation for uponor_smatrix component target_temperature sensor.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#7745

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
