### PR TITLE
Update bme280.rst with CSB pin hint

### DIFF
--- a/components/sensor/bme280.rst
+++ b/components/sensor/bme280.rst
@@ -13,6 +13,8 @@ is used in *Forced Mode* where measurement is performed and then
 the sensor returns to sleep mode until next measurement. The :ref:`I²C <i2c>` or :ref:`SPI <spi>` is
 required to be set up in your configuration for this sensor to work.
 
+**Note:** In :ref:`I²C <i2c>` mode pulling CSB to 3V is recommended, in order to avoid ``[E][sensor.bme280:155]: Communication with BME280 failed!`` error. See the *Connection diagram* chapter in datasheet above.
+
 .. figure:: images/bme280-full.jpg
     :align: center
     :width: 50.0%


### PR DESCRIPTION
Add warning to check connection diagram, since leaving CSB non-pulled will result in dropping out of I2C mode after some time after start.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
