### PR TITLE
online_image: allow setting templatable headers on http request

### DIFF
--- a/components/online_image.rst
+++ b/components/online_image.rst
@@ -35,6 +35,7 @@ Configuration variables
 - **format** (**Required**): The format that the image is encoded with.
 
   - ``PNG``: The image on the server is encoded in PNG format.
+- **http_request_headers** (*Optional*, mapping): Map of HTTP headers. Values are :ref:`templatable <config-templatable>`. Return {} if the header should not be set.
 - **resize** (*Optional*, string): If set, this will resize the image to fit inside the given dimensions ``WIDTHxHEIGHT``
   and preserve the aspect ratio.
 - **placeholder** (**Optional**, :ref:`config-id`): ID of an :doc:`Image </components/image>` to display while the downloaded image is not yet ready.


### PR DESCRIPTION
## Description:


The HTTP requests by the `online_image` component did not give the user a config option to set the HTTP headers. PR below implements this.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#7767

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
