### PR TITLE
Update partition.rst

### DIFF
--- a/components/light/partition.rst
+++ b/components/light/partition.rst
@@ -115,6 +115,10 @@ Configuration variables:
 
     See :ref:`light-addressable_set_action` for that.
 
+.. note::
+
+    Some of the underlying light's configuration details like `color_correct` are bypassed by the partition.
+
 See Also
 --------
 


### PR DESCRIPTION
## Description:

Point out that a partition light does not build upon the configuration of the referred lights but uses them directly.

## Checklist:

  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.
