### PR TITLE
[rp2040_pio_led_strip] Support for WRGB Strip

### DIFF
--- a/components/light/rp2040_pio_led_strip.rst
+++ b/components/light/rp2040_pio_led_strip.rst
@@ -42,6 +42,8 @@ Configuration variables
 
 - **is_rgbw** (*Optional*, boolean): Set to ``true`` if the strip is RGBW. Defaults to ``false``.
 
+- **is_wrgb** (*Optional*, boolean): Set to ``true`` if the strip is WRGB. Defaults to ``false``.
+
 - All other options from :ref:`Light <config-light>`.
 
 


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes esphome/issues#6450

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#7791

## Checklist:

  - [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
