### PR TITLE
Explain about ESP32-S3-BOX-3 sensors

### DIFF
--- a/projects/installer.html
+++ b/projects/installer.html
@@ -230,7 +230,15 @@
       The open-source reference design for voice assistants by Espressif. The
       non-3 and lite variant are older versions that are no longer for sale.
     </p>
-    <p>Buy ESP32-S3-BOX-3</p>
+    <p>
+      Also, keep in mind that <u>the currently available firmware does not support
+      any of the sensors from the additional dock</u>. Thus, unless you want
+      to tinker yourself with the device, it's recommended to buy the 3B variant,
+      which does not come with the blue dock that has temperature/humidity/radar
+      sensors and the IR emitter/receiver. It also does not include the adapter
+      bracket and breadboard, which would be exclusive to custom-made projects.
+    </p>
+    <p>Buy</p>
     <ul>
       <li>
         <a href="https://amzn.to/3u9HIUW">Amazon</a>


### PR DESCRIPTION
And the fact they go unavailable with the currently available firmware, so people have more information to buy the device more consciously.

## Description:
Long story short, there are two versions of the device available, and the "default" one (both in stores and in promos images) is the blue one, which is a bit more expensive and comes with extra parts that become useless with the currently available firmware. The device has all sensors working with the factory software, but once you install the wakeword assistant, they do not show on HA, given they're probably not implemented.

Interested users must be aware of this, so there's no chance they'll buy the extra parts thinking they'll get an assistant with sensors included. Or that, at least, they buy knowing it could be added... someday.

**Related issue (if applicable):** This issue got mentioned here (https://github.com/home-assistant/home-assistant.io/pull/35299#issuecomment-2427924998) a month ago, but it's not directly related.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** __none__

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
