### PR TITLE
Update http_request.rst removing the erroneous extra character

### DIFF
--- a/components/http_request.rst
+++ b/components/http_request.rst
@@ -300,7 +300,7 @@ whose ``id`` is  set to ``player_volume``:
                 else:
                     - logger.log:
                         format: "Error: Response status: %d, message %s"
-                        args: [response->status_code, body.c_str()];
+                        args: [response->status_code, body.c_str()]
 
 See Also
 --------


### PR DESCRIPTION
removing the erroneous extra character in the example

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
