### PR TITLE
[cse7761] add POWCT and frequency support

### DIFF
--- a/content/components/sensor/cse7761.md
+++ b/content/components/sensor/cse7761.md
@@ -56,10 +56,10 @@ The configuration above should work for Sonoff Dual R3 v1.x.
 - **current_2** (*Optional*): Use the current value of the channel 2 in amperes.
   All options from [Sensor](#config-sensor).
 
-- **active_power_1** (*Optional*): Use the (active) power value of the channel 1 in watts. 
+- **active_power_1** (*Optional*): Use the (active) power value of the channel 1 in watts.
   All options from [Sensor](#config-sensor).
 
-- **active_power_2** (*Optional*): Use the (active) power value of the channel 2 in watts. 
+- **active_power_2** (*Optional*): Use the (active) power value of the channel 2 in watts.
   All options from [Sensor](#config-sensor).
 
 - **model** (*Optional*, enum): The model of the device you are using.

--- a/content/components/sensor/cse7761.md
+++ b/content/components/sensor/cse7761.md
@@ -8,7 +8,7 @@ params:
 ---
 
 The `cse7761` sensor platform allows you to use your CSE7761 voltage/current and power sensors
-with ESPHome. This sensor is commonly found in Sonoff Dual R3 v1.x.
+with ESPHome. This sensor is commonly found in Sonoff Dual R3 v1.x and in Sonoff POW Ring (POWCT).
 
 {{< note >}}
 SAFETY HAZARD: Some devices such as Sonoff POWs/Shelly/etc, have the digital GND connected directly to mains voltage so **the GPIOs become LIVE during normal operation**. Our advice is to mark these boards to prevent any use of the dangerous digital pins.
@@ -22,8 +22,11 @@ Additionally, you need to set the baud rate to 38400 and parity to `EVEN`.
 # Example configuration entry
 sensor:
   - platform: cse7761
+    model: Sonoff DUALR3
     voltage:
       name: 'CSE7761 Voltage'
+    frequency:
+      name: 'CSE7761 Frequency'
     current_1:
       name: 'CSE7761 Current 1'
     current_2:
@@ -44,17 +47,25 @@ The configuration above should work for Sonoff Dual R3 v1.x.
 - **voltage** (*Optional*): Use the voltage value of the sensor in V (RMS).
   All options from [Sensor](#config-sensor).
 
-- **current_1** (*Optional*): Use the current value of the channel 1 in amperes. All options from
-  [Sensor](#config-sensor).
+- **frequency** (*Optional*): Use the frequency value of the sensor in Hz.
+  All options from [Sensor](#config-sensor).
 
-- **current_2** (*Optional*): Use the current value of the channel 2 in amperes. All options from
-  [Sensor](#config-sensor).
+- **current_1** (*Optional*): Use the current value of the channel 1 in amperes.
+  All options from [Sensor](#config-sensor).
 
-- **active_power_1** (*Optional*): Use the (active) power value of the channel 1 in watts. All options from
-  [Sensor](#config-sensor).
+- **current_2** (*Optional*): Use the current value of the channel 2 in amperes.
+  All options from [Sensor](#config-sensor).
 
-- **active_power_2** (*Optional*): Use the (active) power value of the channel 2 in watts. All options from
-  [Sensor](#config-sensor).
+- **active_power_1** (*Optional*): Use the (active) power value of the channel 1 in watts. 
+  All options from [Sensor](#config-sensor).
+
+- **active_power_2** (*Optional*): Use the (active) power value of the channel 2 in watts. 
+  All options from [Sensor](#config-sensor).
+
+- **model** (*Optional*, enum): The model of the device you are using.
+  
+  - `Sonoff DualR3` (default): Sonoff Dual R3 v1.x
+  - `Sonoff POWCT`: Sonoff POW Ring (POWCT)
 
 - **update_interval** (*Optional*, [Time](#config-time)): The interval to check the
   sensor. Defaults to `60s`.


### PR DESCRIPTION
Update documentation to add POWCT and frequency sensor configuration parameters.

## Description:


**Related issue (if applicable):** fixes 
https://community.home-assistant.io/t/sonoff-powct-pow-ring-power-not-accurate/789686

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#7836

## Checklist:

  - [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
