### PR TITLE
Update inkplate6.rst

### DIFF
--- a/components/display/inkplate6.rst
+++ b/components/display/inkplate6.rst
@@ -395,7 +395,7 @@ Below is a config example:
         address: 0x20
 
     display:
-    - platform: inkplate5
+    - platform: inkplate6
       id: inkplate_display
       greyscale: true
       partial_updating: false


### PR DESCRIPTION
Typo in the Inkplate 5 sample.

## Description:

Fixed a typo that would prevent sample to be runned.

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
