### PR TITLE
Correct the api update from "pulse_counter" to "pulse_meter".

### DIFF
--- a/cookbook/power_meter.rst
+++ b/cookbook/power_meter.rst
@@ -113,7 +113,7 @@ Using this action, you are able to reset/set the total pulse count. This can be 
           variables:
             new_total: int
           then:
-            - pulse_counter.set_total_pulses:
+            - pulse_meter.set_total_pulses:
                 id: sensor_pulse_meter
                 value: !lambda 'return new_total * 1000;'
 


### PR DESCRIPTION
## Description:

Fixes error message "Unable to find action with the name 'pulse_counter.set_total_pulses'"

## Checklist:

  - [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.
