### PR TITLE
Add note about retiring `armv7`

### DIFF
--- a/changelog/2024.11.0.rst
+++ b/changelog/2024.11.0.rst
@@ -34,8 +34,17 @@ actually compile anything.
 OpenTherm
 ---------
 
-This release brings :doc:`/components/opentherm` support to ESPHome. Please see the :doc:`documentation </components/opentherm>` for detailed information about
-it and how to use it.
+This release brings :doc:`/components/opentherm` support to ESPHome. Please see the
+:doc:`documentation </components/opentherm>` for detailed information about it and how to use it.
+
+ESPHome ``armv7`` Docker Support
+--------------------------------
+
+We will be retiring ESPHome's Docker support for ``armv7`` hardware in the February 2025 release.
+
+This is due to both waning support as it relates to tooling and performance reasons. We strongly recommend moving to a
+more modern architecture, especiallly if you're using the ESPHome Device Compiler to build/compile firmware for your
+devices.
 
 Release 2024.11.1 - November 22
 -------------------------------


### PR DESCRIPTION
## Description:

SSIA

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
