### PR TITLE
Add model option for 2.66in-b in waveshare e-paper documentation

### DIFF
--- a/components/display/waveshare_epaper.rst
+++ b/components/display/waveshare_epaper.rst
@@ -92,6 +92,7 @@ Configuration variables:
   - ``2.13in-ttgo-dke`` - T5_V2.3 with DKE group display (DEPG0213BN) tested
   - ``2.13inv2`` - 2.13in V2 display (Pico e-Paper 2.13v2 and Cloud Module)
   - ``2.13inv3`` - 2.13in V3 display (Pico e-Paper 2.13v3)
+  - ``2.66in-b`` - Black/White/Red
   - ``2.70in`` - currently not working with the HAT Rev 2.1 version
   - ``2.70inv2``
   - ``2.70in-b`` - Black/White/Red

--- a/components/display/waveshare_epaper.rst
+++ b/components/display/waveshare_epaper.rst
@@ -92,7 +92,7 @@ Configuration variables:
   - ``2.13in-ttgo-dke`` - T5_V2.3 with DKE group display (DEPG0213BN) tested
   - ``2.13inv2`` - 2.13in V2 display (Pico e-Paper 2.13v2 and Cloud Module)
   - ``2.13inv3`` - 2.13in V3 display (Pico e-Paper 2.13v3)
-  - ``2.66in-b`` - Black/White/Red
+  - ``2.66in-b`` - 2.66in Black/White/Red Pico e-Paper HAT
   - ``2.70in`` - currently not working with the HAT Rev 2.1 version
   - ``2.70inv2``
   - ``2.70in-b`` - Black/White/Red


### PR DESCRIPTION
## Description:

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#7763

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
