### PR TITLE
`esp32_improv` authorizer no longer accepts `false`

### DIFF
--- a/components/esp32_improv.rst
+++ b/components/esp32_improv.rst
@@ -32,7 +32,7 @@ Configuration variables:
 ------------------------
 
 - **authorizer** (**Required**, :ref:`config-id`): A :doc:`binary sensor <binary_sensor/index>` to authorize with.
-  Also accepts ``none``/``false`` to skip authorization.
+  Also accepts ``none`` to skip authorization.
 - **authorized_duration** (*Optional*, :ref:`config-time`): The amount of time until authorization times out and needs
   to be re-authorized. Defaults to ``1min``.
 - **status_indicator** (*Optional*, :ref:`config-id`): An :doc:`output <output/index>` to display feedback to the user.


### PR DESCRIPTION
## Description:

Starting in 2024.12.0b1 (https://github.com/esphome/esphome/pull/7821), `false` is no longer accepted as a substitute for `none` values, so this PR changes the docs on the `esp32_improv` component to reflect that.

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
