### PR TITLE
Fix example: wrong pin for the S3 Box 3 and specify channel

### DIFF
--- a/components/audio_dac/es8311.rst
+++ b/components/audio_dac/es8311.rst
@@ -53,7 +53,7 @@ Configuration Examples
       - id: i2s_output
         i2s_lrclk_pin: GPIO45
         i2s_bclk_pin: GPIO17
-        i2s_mclk_pin: GPIO23
+        i2s_mclk_pin: GPIO2
 
     speaker:
       - platform: i2s_audio

--- a/components/audio_dac/es8311.rst
+++ b/components/audio_dac/es8311.rst
@@ -63,7 +63,7 @@ Configuration Examples
         dac_type: external
         sample_rate: 16000
         bits_per_sample: 16bit
-        channel: stereo
+        channel: left
         audio_dac: es8311_dac
 
     switch:


### PR DESCRIPTION
## Description:

The MCLK pin is on GPIO2 for the S3 box 3. See the [schematic](https://github.com/espressif/esp-box/blob/master/hardware/SCH_ESP32-S3-BOX-3_V1.0/SCH_ESP32-S3-BOX-3-MB_V1.1_20230808.pdf) for reference. Also specifies left channel, otherwise I couldn't hear TTS responses from the voice assistant.

**Related issue (if applicable):** not applicable

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** not applicable

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
