### PR TITLE
Update devboard_as_flasher.rst to additionally include ESP32 S series

### DIFF
--- a/guides/devboard_as_flasher.rst
+++ b/guides/devboard_as_flasher.rst
@@ -3,7 +3,8 @@ Using an ESP devboard as a USB-UART bridge
 
 .. _devboard-as-flasher:
 
-ESP development boards usually have an onboard USB interface, either built into the chip (e.g. ESP32-S3) or via an onboard USB-UART bridge chip.
+ESP development boards usually have an onboard USB interface,
+either built into the chip (e.g. ESP32-S Series) or via an onboard USB-UART bridge chip.
 However some ESP based devices not designed for development work don't bother with this,
 and only expose the UART0 pins (TX and RX) for flashing purposes.
 
@@ -16,7 +17,8 @@ and will not change anything already flashed onto it - it's purely a way to use 
 
 We will refer to the devboard with functional USB_UART bridge chip as flasher board for this guide.
 
-Make sure you've read the :doc:`/guides/physical_device_connection` for properly understanding the functionality of your flasher devboard.
+Make sure you've read the :doc:`/guides/physical_device_connection`
+for properly understanding the functionality of your flasher devboard.
 
 .. figure:: /guides/images/devboard-as-flasher.png
     :align: center
@@ -58,7 +60,7 @@ Users with ESP32-S2/S3 devboards can instead have a look at https://github.com/e
 But be warned, it demands flashing your S2/S3 board using ESP-IDF to act like a USB_UART bridge first.
 In the SDKconfig, make sure to verify the GPIO pins for the TxD/RxD signals.
 
-The connections needed in order to flash a binary on target device using an ESP32-S devboard are:
+The connections needed to flash a target device using an ESP32-S devboard are:
 
 - ``VU/VUSB/5V`` or ``3V3`` on the flasher devboard to ``VIN`` or ``3V3`` respectively of the target device
 - ``GND``, or ground of flasher devboard to ``GND`` of the target device
@@ -71,5 +73,5 @@ This is opposite to aforementioned boards with external USB_UART bridge chip.
 See Also
 --------
 
-- :doc:`Guides </guides/>`
+- :doc:`Guides </guides/index>`
 - :ghedit:`Edit`

--- a/guides/devboard_as_flasher.rst
+++ b/guides/devboard_as_flasher.rst
@@ -30,7 +30,7 @@ You need to make the following electrical connections:
 
 .. note::
 
-    - Most ESP32 S and C series devboards do *not* have a separate USB-UART chip - they have it built into the ESP. See below for instructions.
+    - Most ESP32 S and C series devboards do *not* have a separate USB-UART chip - they have it built into the ESP. See below for instructions regarding ESP32-S series.
     - The 5V connection on either board may be labelled either ``5V`` or ``VIN``. Some boards may not have a 5V connection and will require 3.3V only.
     - Rather than powering the target board from the flasher board, it is also possible to use a separate power supply, just make sure all the ground pins are connected together.
 
@@ -56,7 +56,7 @@ Making an ESP32-S Series devboard act like a USB-UART bridge
 
 .. _esp32s-usb-uart-bridge:
 
-Users with ESP32-S2/S3 devboards can instead have a look at https://github.com/espressif/esp-usb-bridge instead.
+Users with ESP32-S2/S3 devboards can have a look at https://github.com/espressif/esp-usb-bridge instead.
 But be warned, it demands flashing your S2/S3 board using ESP-IDF to act like a USB_UART bridge first.
 In the SDKconfig, make sure to verify the GPIO pins for the TxD/RxD signals.
 

--- a/guides/devboard_as_flasher.rst
+++ b/guides/devboard_as_flasher.rst
@@ -52,7 +52,7 @@ the ESP chip on flasher module from booting and polluting the serial lines.
 Once the connections are made, plug the flasher board into your computer via USB and proceed with flashing the target board via whichever means you intend to use.
 
 Making an ESP32-S Series devboard act like a USB-UART bridge
-============================================================
+------------------------------------------------------------
 
 .. _esp32s-usb-uart-bridge:
 
@@ -68,7 +68,14 @@ The connections needed to flash a target device using an ESP32-S devboard are:
 - ``RxD`` of flasher devboard to ``TX`` of the target device
 
 Because we are using the internal UART of the ESP the TX and RX lines should be crossed.
-This is opposite to aforementioned boards with external USB_UART bridge chip.
+This is in contrast to the aforementioned devboards with external USB_UART bridge chip.
+
+.. note::
+
+    Because we have made our ESP32-S Series board act like a USB_UART bridge,
+    flashing another binary on it won't work because the exposed COM port corresponds to the USB_UART bridge.
+    For that, you need to first manually put it into DOWNLOAD mode.
+    (by holding RESET and tapping BOOT button)
 
 See Also
 --------

--- a/guides/devboard_as_flasher.rst
+++ b/guides/devboard_as_flasher.rst
@@ -28,7 +28,7 @@ You need to make the following electrical connections:
 
 .. note::
 
-    - Most ESP32 S and C series boards do *not* have a separate USB-UART chip - they have it built into the ESP - so are not suitable for this application.
+    - Most ESP32 S and C series devboards do *not* have a separate USB-UART chip - they have it built into the ESP. See below for instructions.
     - The 5V connection on either board may be labelled either ``5V`` or ``VIN``. Some boards may not have a 5V connection and will require 3.3V only.
     - Rather than powering the target board from the flasher board, it is also possible to use a separate power supply, just make sure all the ground pins are connected together.
 
@@ -48,3 +48,28 @@ the ESP chip on flasher module from booting and polluting the serial lines.
     - Do not connect 3V3 to VIN of the target devices with a 3V3 LDO as it may lead to brownouts.
 
 Once the connections are made, plug the flasher board into your computer via USB and proceed with flashing the target board via whichever means you intend to use.
+
+Making an ESP32-S Series devboard act like a USB-UART bridge
+============================================================
+
+.. _esp32s-usb-uart-bridge:
+
+Users with ESP32-S2/S3 devboards can instead have a look at https://github.com/espressif/esp-usb-bridge instead.
+But be warned, it demands flashing your S2/S3 board using ESP-IDF to act like a USB_UART bridge first.
+In the SDKconfig, make sure to verify the GPIO pins for the TxD/RxD signals.
+
+The connections needed in order to flash a binary on target device using an ESP32-S devboard are:
+
+- ``VU/VUSB/5V`` or ``3V3`` on the flasher devboard to ``VIN`` or ``3V3`` respectively of the target device
+- ``GND``, or ground of flasher devboard to ``GND`` of the target device
+- ``TxD`` of flasher devboard to ``RX`` of the target device
+- ``RxD`` of flasher devboard to ``TX`` of the target device
+
+Because we are using the internal UART of the ESP the TX and RX lines should be crossed.
+This is opposite to aforementioned boards with external USB_UART bridge chip.
+
+See Also
+--------
+
+- :doc:`Guides </guides/>`
+- :ghedit:`Edit`


### PR DESCRIPTION
## Description:
Updates devboard_as_flasher.rst to additionally include ESP32 S2 and S3 series devboards.

![IMG_20241220_231610783_HDR](https://github.com/user-attachments/assets/f4493792-807e-4b2e-b56b-e171ef3a140e)
A SEEED Studio XIAO-S3 acting as a USB-UART bridge, flashing an ESP32 WROOM32E target

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
