### PR TITLE
vl53l0x timing budget support

### DIFF
--- a/components/sensor/vl53l0x.rst
+++ b/components/sensor/vl53l0x.rst
@@ -72,6 +72,9 @@ Configuration variables:
   on vl53l0x to enable/disable sensor. **Required** if not using address ``0x29`` which is the cause if you
   have multiple VL53L0X on the same i2c bus. In this case you have to assign a different pin to each VL53L0X.
 - **timeout** (*Optional*, :ref:`config-time`): Sensor setup timeout. Default to ``10ms``.
+- **timing_budget** (*Optional*, :ref:`config-time`): Set the timing budget the sensor will use for a single range measurement. 
+  Range is from 17000us - 4294967295us, inclusive. The timing budget allows the user to trade off speed for accuracy.
+  If not specified, the default timing budget is 33000us.
 - All other options from :ref:`Sensor <config-sensor>`.
 
 


### PR DESCRIPTION
## Description:

Add support for timing budget with vl53l0x sensor.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#7991

## Checklist:

  - [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
