### PR TITLE
Rename 'no2' to 'nitrogen_dioxide' in Grove Gas MC V2 docs

### DIFF
--- a/components/sensor/grove_gas_mc_v2.rst
+++ b/components/sensor/grove_gas_mc_v2.rst
@@ -34,7 +34,7 @@ an ``i2c:`` section in your config for this integration to work.
 
     sensor:
       - platform: grove_gas_mc_v2
-        no2:
+        nitrogen_dioxide:
           name: "Nitrogen Dioxide"
         ethanol:
           name: "Ethanol"
@@ -46,7 +46,7 @@ an ``i2c:`` section in your config for this integration to work.
 Configuration variables:
 ------------------------
 
-- **no2** (**Required**): The Nitrogen Dioxide sensor data.
+- **nitrogen_dioxide** (**Required**): The Nitrogen Dioxide sensor data.
   All options from :ref:`Sensor <config-sensor>`.
 - **ethanol** (**Required**): The Ethanol (C2H5OH) sensor data.
   All options from :ref:`Sensor <config-sensor>`.


### PR DESCRIPTION
Fixes https://github.com/esphome/issues/issues/6393

## Description:


**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/6393

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
