### PR TITLE
Add sphinx_copybutton to code-blocks

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -45,6 +45,7 @@ extensions = [
     "sphinx_tabs.tabs",
     "sphinx_toolbox.collapse",
     "tables",
+    "sphinx_copybutton",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ sphinx==7.1.2
 sphinx-autobuild==2021.3.14
 sphinx-tabs==3.4.7
 sphinx-toolbox==3.8.0
+sphinx-copybutton==0.5.2


### PR DESCRIPTION
## Description:
Add sphinx_copybutton to code-blocks

Source: https://sphinx-copybutton.readthedocs.io/en/latest/

**Related issue (if applicable):** fixes <link to issue> NONE

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here> NONE

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
