### PR TITLE
[esp32_rmt] IDF 5+ update fixes

### DIFF
--- a/components/remote_transmitter.rst
+++ b/components/remote_transmitter.rst
@@ -59,6 +59,8 @@ ESP32 IDF configuration variables:
 - **clock_resolution** (*Optional*, int): The clock resolution used by the RMT peripheral in hz. Defaults to ``1000000``.
 - **one_wire** (*Optional*, boolean): Allows the GPIO to be used as both a transmitter and receiver.
 - **use_dma** (*Optional*, boolean): Enable DMA on variants that support it.
+- **eot_level** (*Optional*, boolean): Overrides the default end of transmit level. Defaults to ``false`` unless ``one_wire``
+  mode is ``true`` or ``pin`` is inverted.
 
 ESP32 Arduino configuration variables:
 **************************************


### PR DESCRIPTION
## Description:

Add docs for new eot_level config.

**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/6589

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#8002

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
