### PR TITLE
Correction to `http_request` example

### DIFF
--- a/components/http_request.rst
+++ b/components/http_request.rst
@@ -291,16 +291,19 @@ whose ``id`` is  set to ``player_volume``:
                 then:
                     - lambda: |-
                         json::parse_json(body, [](JsonObject root) -> bool {
-                          if (root["vol"]) {
-                              id(player_volume).publish_state(root["vol"]);
-                          } else {
-                            ESP_LOGD(TAG,"No 'vol' key in this json!");
-                          }
+                            if (root["vol"]) {
+                                id(player_volume).publish_state(root["vol"]);
+                                return true;
+                            }
+                            else {
+                              ESP_LOGI(TAG,"No 'vol' key in this json!");
+                              return false;
+                            }
                         });
                 else:
                     - logger.log:
                         format: "Error: Response status: %d, message %s"
-                        args: [response->status_code, body.c_str()];
+                        args: [ 'response->status_code', 'body.c_str()' ]
 
 See Also
 --------


### PR DESCRIPTION
The affected example code caused two errors:
- a `no return statement in function returning non-void [-Werror=return-type]` caused by missing `return`s within the `if`s.
- `while parsing a block mapping ... expected <block end>, but found '<scalar>'` caused by the `;` at the end of `args`

Also matched the example with the one at https://esphome.io/components/json#parsing-json

## Description:

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
