### PR TITLE
Update font renderer example to avoid number to string ambiguity

### DIFF
--- a/components/font.rst
+++ b/components/font.rst
@@ -52,12 +52,13 @@ Next, create a ``font:`` section in your configuration:
         size: 28
         bpp: 4
         glyphs: [
-          a,A,á,Á,e,E,é,É,
+          0123456789aAáÁeEéÉ,
           (,),+,-,_,.,°,•,µ,
-          "\u0020", #space
-          "\u0021", #!
-          "\u0022", #"
-          "\u0027", #'
+          "\u0020", # space
+          "\u002C", # ,
+          "\u0021", # !
+          "\u0022", # "
+          "\u0027", # '
           ]
 
       - file: "fonts/RobotoCondensed-Regular.ttf"


### PR DESCRIPTION
If someone would add numeric characters (say `0`) like in the affected example, this error would occur:
```
      Must be string, got <class 'esphome.helpers.EInt'>. did you forget putting quotes around the value?.
      - 0
```
Instead, the numeric characters should be listed in a string with the other plain ones. The specials can still be added on new rows, even with commas if desired.
Also added the comma character as unicode.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
