### PR TITLE
add config for bus_voltage_over_limit to ina2xx.rst

### DIFF
--- a/components/sensor/ina2xx.rst
+++ b/components/sensor/ina2xx.rst
@@ -84,6 +84,7 @@ Configuration variables:
 - **temperature_coefficient** (*Optional*, integer from ``0`` to ``16383``): Temperature coefficient (ppm/°C) of the 
   shunt for temperature compensation correction. Only applicable to INA228 and INA229 devices. Zero value means 
   no compensation is done. Defaults to ``0``.
+- **bus_voltage_over_limit** (*Optional*, float): Set a the bus voltage over limit threshold to trigger an alert. Only applicable to INA228 and INA229 devices.
 - **update_interval** (*Optional*, :ref:`config-time`): The interval to check the sensor. Defaults to ``60s``.
 - All other options from :ref:`Sensor <config-sensor>` and :ref:`I²C device <i2c>`.
 
@@ -135,6 +136,7 @@ Configuration variables:
 - **temperature_coefficient** (*Optional*, integer from ``0`` to ``16383``): Temperature coefficient (ppm/°C) of the 
   shunt for temperature compensation correction. Only applicable to INA228 and INA229 devices. Zero value means 
   no compensation is done. Defaults to ``0``.
+- **bus_voltage_over_limit** (*Optional*, float): Set a the bus voltage over limit threshold to trigger an alert. Only applicable to INA228 and INA229 devices.
 - **update_interval** (*Optional*, :ref:`config-time`): The interval to check the sensor. Defaults to ``60s``.
 - All other options from :ref:`Sensor <config-sensor>` and :ref:`SPI device <spi>`.
 


### PR DESCRIPTION
## Description:
Add a new config option for ina2xx: bus_voltage_over_limit

INA228/229 have the ability to set a threshold that triggers the alert pin when the bus voltage exceeds the provided limit.
This change adds the ability to set the threshold.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#8020

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
