### PR TITLE
Easier to find Devices Database

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -76,6 +76,11 @@ ESPHome is a system to control your microcontrollers by simple yet powerful conf
                     </a>
                 </li>
                 <li>
+                    <a class="reference" href="https://devices.esphome.io/">
+                        Device configuration examples
+                    </a>
+                </li>
+                <li>
                     <a class="reference" href="/guides/creators.html">
                         Sharing ESPHome devices
                     </a>
@@ -1195,10 +1200,20 @@ Cookbook
     Arduino Port Extender, cookbook/arduino_port_extender, arduino_logo.svg
     EHMTX a matrix status/text display, cookbook/ehmtx, ehmtx.jpg
 
+.. _device_database:
+
+Device Database
+---------------
+
+You will find configurations for specific devices in our `ESPHome Devices <https://devices.esphome.io/>`__ database.
+
+.. _contributing:
+
+Contributing
+------------
+
 Do you have other awesome automations or cool setups? Please feel free to add them to the
 documentation for others to copy. See :doc:`Contributing </guides/contributing>`.
-
-If you'd like to share configurations for specific devices, please contribute to our `ESPHome Devices <https://devices.esphome.io/>`__ database.
 
 .. toctree::
     :hidden:


### PR DESCRIPTION
Added link to device database in "Next Step" box at the top

Created sections for the information at the bottom of the page that didn't really belong in the "Cookbook" section so their respective topics will be easier to find as they'll be in the table of content.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
