### PR TITLE
Fix typo in endstop.rst

### DIFF
--- a/components/cover/endstop.rst
+++ b/components/cover/endstop.rst
@@ -62,7 +62,7 @@ Configuration variables:
   :ref:`Binary Sensor <config-binary_sensor>` that turns on when the closed position is reached.
 
 - **stop_action** (**Required**, :ref:`Action <config-action>`): The action that should
-  be performed when the remote requests the cover to be closed or an endstop is reached.
+  be performed when the remote requests the cover to stop or an endstop is reached.
 - **max_duration** (*Optional*, :ref:`config-time`): The maximum duration the cover should be opening
   or closing. Useful for protecting from dysfunctional endstops.
 - All other options from :ref:`Cover <config-cover>`.


### PR DESCRIPTION
copy&paste typo in description of stop.

## Description:

Quick fix in the documentation for the stop action

## Checklist:

  - [X ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.