### PR TITLE
Add a02yytw

### DIFF
--- a/components/esphome.rst
+++ b/components/esphome.rst
@@ -100,10 +100,9 @@ is already set up. You can however change this using the ``priority`` parameter.
     esphome:
       # ...
       on_boot:
-        priority: 600
-        # ...
-        then:
-          - switch.turn_off: switch_1
+        - priority: 600
+          then:
+            - switch.turn_off: switch_1
 
 Configuration variables:
 
@@ -138,9 +137,9 @@ too many WiFi/MQTT connection attempts, Over-The-Air updates being applied or th
     esphome:
       # ...
       on_shutdown:
-        priority: 700
-        then:
-          - switch.turn_off: switch_1
+        - priority: 700
+          then:
+            - switch.turn_off: switch_1
 
 Configuration variables:
 

--- a/components/font.rst
+++ b/components/font.rst
@@ -52,12 +52,13 @@ Next, create a ``font:`` section in your configuration:
         size: 28
         bpp: 4
         glyphs: [
-          a,A,á,Á,e,E,é,É,
+          0123456789aAáÁeEéÉ,
           (,),+,-,_,.,°,•,µ,
-          "\u0020", #space
-          "\u0021", #!
-          "\u0022", #"
-          "\u0027", #'
+          "\u0020", # space
+          "\u002C", # ,
+          "\u0021", # !
+          "\u0022", # "
+          "\u0027", # '
           ]
 
       - file: "fonts/RobotoCondensed-Regular.ttf"

--- a/components/http_request.rst
+++ b/components/http_request.rst
@@ -291,16 +291,19 @@ whose ``id`` is  set to ``player_volume``:
                 then:
                     - lambda: |-
                         json::parse_json(body, [](JsonObject root) -> bool {
-                          if (root["vol"]) {
-                              id(player_volume).publish_state(root["vol"]);
-                          } else {
-                            ESP_LOGD(TAG,"No 'vol' key in this json!");
-                          }
+                            if (root["vol"]) {
+                                id(player_volume).publish_state(root["vol"]);
+                                return true;
+                            }
+                            else {
+                              ESP_LOGI(TAG,"No 'vol' key in this json!");
+                              return false;
+                            }
                         });
                 else:
                     - logger.log:
                         format: "Error: Response status: %d, message %s"
-                        args: [response->status_code, body.c_str()];
+                        args: [ 'response->status_code', 'body.c_str()' ]
 
 See Also
 --------

--- a/components/light/esp32_rmt_led_strip.rst
+++ b/components/light/esp32_rmt_led_strip.rst
@@ -54,6 +54,7 @@ Configuration variables
   A time interval used to limit the number of commands a light can handle per second. For example
   16ms will limit the light to a refresh rate of about 60Hz. Defaults to sending commands as quickly as
   changes are made to the lights.
+- **use_psram** (*Optional*, boolean): Set to ``false`` to force internal RAM allocation even if you have the the PSRAM component enabled. This can be useful if you're experiencing issues like flickering with your leds strip. Defaults to ``true``.
 
 - All other options from :ref:`Light <config-light>`.
 

--- a/components/remote_receiver.rst
+++ b/components/remote_receiver.rst
@@ -469,7 +469,7 @@ Remote code selection (exactly one of these has to be included):
 
 .. note::
 
-    For the Sonoff RF Bridge, you can bypass the EFM8BB1 microcontroller handling RF signals with
+    For the black Sonoff RF Bridge, you can bypass the EFM8BB1 microcontroller handling RF signals with
     `this hack <https://github.com/xoseperez/espurna/wiki/Hardware-Itead-Sonoff-RF-Bridge---Direct-Hack>`__
     created by the GitHub user wildwiz. Then use this configuration for the remote receiver/transmitter hubs:
 
@@ -483,7 +483,25 @@ Remote code selection (exactly one of these has to be included):
           pin: 5
           carrier_duty_percent: 100%
 
+    There's also a software `"hack" <https://github.com/mightymos/RF-Bridge-OB38S003>`__ that allows the radio chip to mirror all the voltages to the ESP to do the decoding,
+    rendering the hardware hack uncessary. This software passthrough mode can be used for the OB38S003 (white) and EFM8BB1 (black) sonoff RF bridge. Then use this configuration for the remote receiver/transmitter hubs:
 
+    .. code-block:: yaml
+
+        remote_receiver:
+          pin:
+            # sonoff and wemos board
+            number: GPIO3
+            mode:
+              input: true
+              pullup: false
+          tolerance: 60%
+          filter: 4us
+          idle: 4ms
+       
+        remote_transmitter:
+          pin: 1
+          carrier_duty_percent: 100%
 
 See Also
 --------

--- a/components/sensor/a02yyuw.rst
+++ b/components/sensor/a02yyuw.rst
@@ -1,19 +1,23 @@
-A02YYUW Waterproof Ultrasonic Sensor
+A02YY Waterproof Ultrasonic Sensor
 ====================================
 
 .. seo::
-    :description: Instructions for setting up A02YYUW waterproof ultrasonic distance sensor in ESPHome.
+    :description: Instructions for setting up A02YYUW and A02YYTW waterproof ultrasonic distance sensor in ESPHome.
     :image: a02yyuw.jpg
-    :keywords: ultrasonic, DFRobot, A02YYUW
+    :keywords: ultrasonic, DFRobot, A02YYUW, A02YYTW, A02
 
-This sensor allows you to use A02YYUW waterproof ultrasonic sensor by DFRobot
-(`datasheet <https://wiki.dfrobot.com/_A02YYUW_Waterproof_Ultrasonic_Sensor_SKU_SEN0311>`__)
-with ESPHome to measure distances. This sensor can measure
-ranges between 3 centimeters and 450 centimeters with a resolution of 1 milimeter.
+This sensor allows you to use A02YYUW and A02YYTW waterproof ultrasonic sensors
+(`datasheet <https://www.dypcn.com/uploads/A02-Datasheet.pdf>`__)
+with ESPHome to measure distances. These sensors can measure
+ranges between 3 centimeters and 450 centimeters with a resolution of 1 millimeter.
 
-Since this sensor reads multiple times per second, :ref:`sensor-filters` are highly recommended.
+Since this sensors can reads multiple times per second, :ref:`sensor-filters` are highly recommended.
 
-To use the sensor, first set up an :ref:`uart` with a baud rate of 9600 and connect the sensor to the specified pin.
+**A02YYUW** is an automatic output version, while **A02YYTW** is a trigger output version. The trigger output version is more suitable for applications where power consumption is a concern.
+
+Select the model using the `model` parameter. For the A02YYTW model it's also possible to change the update interval using the `update_interval` parameter.
+
+To use the sensors, first set up an :ref:`uart` with a baud rate of 9600 and connect the sensor to the specified pin.
 
 .. figure:: images/a02yyuw-full.jpg
     :align: center
@@ -23,10 +27,19 @@ To use the sensor, first set up an :ref:`uart` with a baud rate of 9600 and conn
 
 .. code-block:: yaml
 
-    # Example configuration entry
+    # Example configuration entry for A02YYUW
     sensor:
-      - platform: "a02yyuw"
-        name: "Distance"
+      - platform: a02yyuw
+        name: "Distance A02YYUW"
+
+.. code-block:: yaml
+
+    # Example configuration entry for A02YYTW
+    sensor:
+      - platform: a02yyuw
+        model: a02yytw
+        update_interval: 100ms
+        name: "Distance A02YYTW"
 
 
 Configuration variables:
@@ -34,6 +47,8 @@ Configuration variables:
 
 - **uart_id** (*Optional*, :ref:`config-id`): The ID of the :ref:`UART bus <uart>` you wish to use for this sensor.
   Use this if you want to use multiple UART buses at once.
+- **model** (Optional): Sensor model. Available options: a02yyuw (default) and a02yytw.
+- **update_interval** (Optional, Time): The interval to check the sensor. Defaults to 100ms.
 - All other options from :ref:`Sensor <config-sensor>`.
 
 .. note::

--- a/components/sensor/as7341.rst
+++ b/components/sensor/as7341.rst
@@ -7,7 +7,7 @@ AS7341 Spectral Color Sensor
     :keywords: AS7341
 
 The ``as7341`` sensor platform allows you to use your AS7341 spectral color sensor
-(`datasheet <https://ams.com/documents/20143/36005/AS7341_DS000504_3-00.pdf/5eca1f59-46e2-6fc5-daf5-d71ad90c9b2b>`__,
+(`datasheet <https://look.ams-osram.com/m/24266a3e584de4db/original/AS7341-DS000504.pdf>`__,
 `Adafruit`_) with ESPHome. The :ref:`I²C Bus <i2c>` is required to be set up in
 your configuration for this sensor to work.
 

--- a/guides/getting_started_command_line.rst
+++ b/guides/getting_started_command_line.rst
@@ -224,8 +224,10 @@ To start the ESPHome dashboard, simply start ESPHome with the following command
 .. code-block:: bash
 
     # Install dashboard dependencies
-    pip install tornado esptool \
-     esphome dashboard config
+    pip install tornado esptool
+
+    # Start the dashboard
+    esphome dashboard config
 
     # On Docker, host networking mode is required for online status indicators
     docker run --rm --net=host -v "${PWD}":/config -it ghcr.io/esphome/esphome


### PR DESCRIPTION
…2yytw model in addition to the existent a02yyuw model

## Description:

Update documentation for the existent sensor A02YYUW to inform about support for the A02YYTW model, 
The current model is UART auto output model, in wich the sensor outputs distance readings every 100ms, the model being added A02YYTW is a controlled modek, in which ESP should request a reading in configurable intervals.

This also intends to fix an error inducing issue caused by the current documentation, in which it status the existing code supports the UART model, but as there are two UART models users may buy the UART controlled model and it would not work because the current support is only for the UART auto output model.
Now adding support for both UART models, chances are it will work no matter which model end users have in hands.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#8046

## Checklist:

  - [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
