### PR TITLE
Add max_characteristics documentation

### DIFF
--- a/components/bluetooth_proxy.rst
+++ b/components/bluetooth_proxy.rst
@@ -45,6 +45,7 @@ Configuration:
 
 - **active** (*Optional*, boolean): Enables proxying active connections. Defaults to ``false``.
 - **cache_services** (*Optional*, boolean): Enables caching GATT services in NVS flash storage which significantly speeds up active connections. Defaults to ``true`` when using the ESP-IDF framework.
+- **max_characteristics** (*Optional*, int): The maximum number of characteristics to read from each device. Defaults to ``40`` when using the ESP-IDF framework.
 
 The Bluetooth proxy depends on :doc:`esp32_ble_tracker` so make sure to add that to your configuration.
 


### PR DESCRIPTION
## Description:

Add max_characteristics documentation in bluetooth proxy

**Related issue (if applicable):** fixes nothing

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#8063

## Checklist:

  - [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
