### PR TITLE
[esp32_rmt_led_strip] Add use_psram to the docs

### DIFF
--- a/components/light/esp32_rmt_led_strip.rst
+++ b/components/light/esp32_rmt_led_strip.rst
@@ -46,7 +46,7 @@ Configuration variables
 - **max_refresh_rate** (*Optional*, :ref:`config-time`): A time interval used to limit the number of commands a light
   can handle per second. For example, ``16ms`` will limit the light to a refresh rate of about 60Hz. Defaults to
   sending commands as quickly as changes are made to the lights.
-- **use_psram** (*Optional*, boolean): Will allocate the memory from PSRAM instead of DRAM. Defaults to ``true``.
+- **use_psram** (*Optional*, boolean): Will allocate the memory from PSRAM instead of DRAM. Defaults to ``false``.
 
 IDF configuration variables:
 ****************************
@@ -83,8 +83,8 @@ Arduino configuration variables:
 .. note::
 
     When **use_psram** is configured using IDF all RMT interrupts will be deferred, including RMT interrupts for other
-    components. RMT transactions rely on ping-pong interrupts, delayed handling can lead to an unpredictable result.
-    It is recommended to configure allocate the maximum RMT memory possible.
+    components. RMT transactions rely on ping-pong interrupts, delayed handling could lead to an unpredictable result.
+    It is recommended to allocate the maximum RMT memory possible to help mitigate this.
 
 .. _esp32-rmt-led-strip-manual_timings:
 

--- a/components/light/esp32_rmt_led_strip.rst
+++ b/components/light/esp32_rmt_led_strip.rst
@@ -46,7 +46,7 @@ Configuration variables
 - **max_refresh_rate** (*Optional*, :ref:`config-time`): A time interval used to limit the number of commands a light
   can handle per second. For example, ``16ms`` will limit the light to a refresh rate of about 60Hz. Defaults to
   sending commands as quickly as changes are made to the lights.
-- **use_psram** (*Optional*, boolean): Will allocate the memory from PSRAM instead of DRAM. Defaults to ``false``.
+- **use_psram** (*Optional*, boolean): Will allocate memory from PSRAM instead of DRAM. Defaults to ``false``.
 
 IDF configuration variables:
 ****************************

--- a/components/light/esp32_rmt_led_strip.rst
+++ b/components/light/esp32_rmt_led_strip.rst
@@ -46,6 +46,7 @@ Configuration variables
 - **max_refresh_rate** (*Optional*, :ref:`config-time`): A time interval used to limit the number of commands a light
   can handle per second. For example, ``16ms`` will limit the light to a refresh rate of about 60Hz. Defaults to
   sending commands as quickly as changes are made to the lights.
+- **use_psram** (*Optional*, boolean): Will allocate the memory from PSRAM instead of DRAM. Defaults to ``true``.
 
 IDF configuration variables:
 ****************************
@@ -78,6 +79,12 @@ Arduino configuration variables:
       "ESP32-C3", "0, 1"
 
 - All other options from :ref:`Light <config-light>`.
+
+.. note::
+
+    When **use_psram** is configured using IDF all RMT interrupts will be deferred, including RMT interrupts for other
+    components. RMT transactions rely on ping-pong interrupts, delayed handling can lead to an unpredictable result.
+    It is recommended to configure allocate the maximum RMT memory possible.
 
 .. _esp32-rmt-led-strip-manual_timings:
 


### PR DESCRIPTION
## Description:

Add use_psram to the docs and add a warning.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#8073

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
