### PR TITLE
Update i2c.rst

### DIFF
--- a/components/i2c.rst
+++ b/components/i2c.rst
@@ -44,7 +44,7 @@ Configuration variables:
 
 .. note::
 
-    If the device can support multiple I²C buses (ESP32 has 2, ESP8266 does not support more than one) these buses need to be defined as below and sensors need to be setup specifying the correct bus:
+    If the device can support multiple I²C buses these buses need to be defined as below and sensors need to be setup specifying the correct bus:
 
     .. code-block:: yaml
 


### PR DESCRIPTION
https://github.com/esphome/esphome/pull/6145

Allows esp8266 to handle multiple i2c busses, tested and working.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
