### PR TITLE
[esp32] Set logger default interface for C6

### DIFF
--- a/components/logger.rst
+++ b/components/logger.rst
@@ -94,6 +94,13 @@ Default UART GPIO Pins
       - N/A
       - N/A
       - 18/19
+    * - ESP32-C6
+      - TX: 16, RX: 17
+      - N/A
+      - Undefined
+      - N/A
+      - N/A
+      - 12/13
     * - ESP32-S2
       - TX: 43, RX: 44
       - N/A
@@ -134,6 +141,9 @@ the original ESP32 or ESP8266) continue to use USB-to-serial bridge ICs for comm
       - ``UART0``
       - ``UART0``
     * - ESP32-C3
+      - ``USB_CDC``
+      - ``USB_SERIAL_JTAG``
+    * - ESP32-C6
       - ``USB_CDC``
       - ``USB_SERIAL_JTAG``
     * - ESP32-S2


### PR DESCRIPTION
## Description:

SSIA

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#8126

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
