### PR TITLE
Update http_request.rst

### DIFF
--- a/components/http_request.rst
+++ b/components/http_request.rst
@@ -305,6 +305,8 @@ whose ``id`` is  set to ``player_volume``:
                         format: "Error: Response status: %d, message %s"
                         args: [ 'response->status_code', 'body.c_str()' ]
 
+**Note:** to access data in the response ``capture_response: true`` must be set in the request.
+
 See Also
 --------
 


### PR DESCRIPTION
Add a clarification note re capture_response in last example

## Description:
Suggest adding note to last example to ensure user sets capture_response to true in the request, which is not shown in the example. Otherwise the body will be empty

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
