### PR TITLE
Add info on mac installation

### DIFF
--- a/guides/installing_esphome.rst
+++ b/guides/installing_esphome.rst
@@ -50,20 +50,22 @@ Mac
 ---
 
 ESPHome does support Mac & will run with no problem.
-It can be installed easily with [brew package manager](https://formulae.brew.sh/formula/esphome).
+It can be installed easily with `brew package manager <https://formulae.brew.sh/formula/esphome>`_.
 
 .. code-block:: console
 
     $ brew install esphome
 
 Alternatively, you can follow process similar to installing in Linux. You can install Python from the
-official site or brew, have in mind that you may have an outdated Python version installed already, and then install ESPHome with ``pip3 install esphome``.  You can
+official site or brew, have in mind that you may have an outdated Python version installed already. Once python 3 is installed, you can install ESPHome with ``pip3 install esphome``.  You can
 then test that things are properly installed with the following:
 
 .. code-block:: console
 
     $ esphome version
     Version: 2021.12.3
+
+Latest version can be found on the `releases page <https://github.com/esphome/esphome/releases>`_.
 
 Linux
 -----

--- a/guides/installing_esphome.rst
+++ b/guides/installing_esphome.rst
@@ -49,13 +49,15 @@ with the following:
 Mac
 ---
 
-There are no tested installation instructions for Mac. ESPHome does support
-Mac & will run with no problem.
+ESPHome does support Mac & will run with no problem.
+It can be installed easily with [brew package manager](https://formulae.brew.sh/formula/esphome).
 
-Contributions are welcome!
+.. code-block:: console
 
-The process will likely be similar to Windows. You can install Python from the
-official site, and then install ESPHome with ``pip3 install esphome``.  You can
+    $ brew install esphome
+
+Alternatively, you can follow process similar to installing in Linux. You can install Python from the
+official site or brew, have in mind that you may have an outdated Python version installed already, and then install ESPHome with ``pip3 install esphome``.  You can
 then test that things are properly installed with the following:
 
 .. code-block:: console


### PR DESCRIPTION
Brew just happily installed Version: 2024.12.4 for me

## Description:
Just an update on installation, no other changes needed 

## Checklist:
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook - just updated existing rst
