### PR TITLE
Add documentation for Toto remote transmitter/receiver protocol

### DIFF
--- a/components/remote_receiver.rst
+++ b/components/remote_receiver.rst
@@ -64,6 +64,7 @@ Configuration variables:
   - **sony**: Decode and dump Sony infrared codes.
   - **toshiba_ac**: Decode and dump Toshiba AC infrared codes.
   - **mirage**: Decode and dump Mirage infrared codes.
+  - **toto**: Decode and dump Toto infrared codes.
 
 - **tolerance** (*Optional*, int, :ref:`config-time` or mapping): The percentage or time that the remote signal lengths
   can deviate in the decoding process.  Defaults to ``25%``.
@@ -225,6 +226,9 @@ Automations:
   is passed to the automation for use in lambdas.
 - **on_mirage** (*Optional*, :ref:`Automation <automation>`): An automation to perform when a
   Mirage remote code has been decoded. A variable ``x`` of type :apistruct:`remote_base::MirageData`
+  is passed to the automation for use in lambdas.
+- **on_toto** (*Optional*, :ref:`Automation <automation>`): An automation to perform when a
+  Toto remote code has been decoded. A variable ``x`` of type :apistruct:`remote_base::TotoData`
   is passed to the automation for use in lambdas.
 
 .. code-block:: yaml
@@ -485,6 +489,12 @@ Remote code selection (exactly one of these has to be included):
   - **code** (**Required**, 14-bytes list): The code to listen for, see
     :ref:`transmitter description <remote_transmitter-transmit_mirage>` for more info. Usually you only need to copy
     this directly from the dumper output.
+
+- **toto**: Trigger on a decoded Toto remote code with the given data.
+
+  - **command** (**Required**, int): The 1-byte Toto command code to trigger on. Range is 0 to 0xFF.
+  - **rc_code_1** (*Optional*, int): The first 4-bit Toto code (usually a command parameter) to trigger on. Range is 0 to 0xF.
+  - **rc_code_2** (*Optional*, int): The second 4-bit Toto code (usually a command parameter) to trigger on. Range is 0 to 0xF.
 
 .. note::
 

--- a/components/remote_transmitter.rst
+++ b/components/remote_transmitter.rst
@@ -929,6 +929,30 @@ Configuration variables:
 - **code** (**Required**, list): The 14 byte Mirage code to send.
 - All other options from :ref:`remote_transmitter-transmit_action`.
 
+.. _remote_transmitter-transmit_toto:
+
+``remote_transmitter.transmit_toto`` **Action**
+
+This :ref:`action <config-action>` sends a Toto infrared remote code to a remote transmitter.
+
+.. code-block:: yaml
+
+    on_...:
+      - remote_transmitter.transmit_toto:
+          command: 0xED  # Set water and seat temperature
+          rc_code_1: 0x0 # Water heater off
+          rc_code_2: 0x0 # Seat heater off
+          # Repeats 3 times at a 32ms interval by default
+
+Configuration variables:
+
+- **command** (**Required**, int): The 1-byte Toto command code to send. Range is 0 to 0xFF.
+- **rc_code_1** (*Optional*, int): The first 4-bit Toto code (usually a command parameter) to send. Range is 0 to 0xF.
+- **rc_code_2** (*Optional*, int): The second 4-bit Toto code (usually a command parameter) to send. Range is 0 to 0xF.
+- All other options from :ref:`remote_transmitter-transmit_action`.
+   - **Note**: Toto remotes repeat all codes three times at a 32ms interval. This behavior will occur by default, but may be overridden by specifying ``repeat`` and ``wait time`` configuration variables. 
+
+
 .. _remote_transmitter-rc_switch-protocol:
 
 RC Switch Protocol


### PR DESCRIPTION
## Description:

Adds documentation for the Toto infrared protocol in the remote transmitter and receiver pages.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 
  - esphome/esphome#8177

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
