### PR TITLE
[esp32_rmt] Enable pullup and od mode based on pin scheme

### DIFF
--- a/components/remote_transmitter.rst
+++ b/components/remote_transmitter.rst
@@ -57,7 +57,8 @@ ESP32 IDF configuration variables:
       "ESP32-H2", "192 symbols", "48 symbols"
 
 - **clock_resolution** (*Optional*, int): The clock resolution used by the RMT peripheral in hz. Defaults to ``1000000``.
-- **one_wire** (*Optional*, boolean): Allows the GPIO to be used as both a transmitter and receiver.
+- **one_wire** (*Optional*, boolean): Allows the ``pin`` to be used by both the transmitter and a receiver. As the ``pin`` will
+  be in open drain mode a pull-up is required, set the ``pin`` mode to pullup or provide an external one.
 - **use_dma** (*Optional*, boolean): Enable DMA on variants that support it.
 - **eot_level** (*Optional*, boolean): Overrides the default end of transmit level. Defaults to ``false`` unless ``one_wire``
   mode is ``true`` or ``pin`` is inverted.

--- a/components/remote_transmitter.rst
+++ b/components/remote_transmitter.rst
@@ -57,11 +57,9 @@ ESP32 IDF configuration variables:
       "ESP32-H2", "192 symbols", "48 symbols"
 
 - **clock_resolution** (*Optional*, int): The clock resolution used by the RMT peripheral in hz. Defaults to ``1000000``.
-- **one_wire** (*Optional*, boolean): Allows the ``pin`` to be used by both the transmitter and a receiver. As the ``pin`` will
-  be in open drain mode a pullup is required, set the ``pin`` mode to pullup or provide an external one.
 - **use_dma** (*Optional*, boolean): Enable DMA on variants that support it.
-- **eot_level** (*Optional*, boolean): Overrides the default end of transmit level. Defaults to ``false`` unless ``one_wire``
-  mode is ``true`` or ``pin`` is inverted.
+- **eot_level** (*Optional*, boolean): Overrides the default end of transmit level. Defaults to ``false`` unless ``pin``
+  is set to inverted or open-drain.
 
 ESP32 Arduino configuration variables:
 **************************************

--- a/components/remote_transmitter.rst
+++ b/components/remote_transmitter.rst
@@ -58,7 +58,7 @@ ESP32 IDF configuration variables:
 
 - **clock_resolution** (*Optional*, int): The clock resolution used by the RMT peripheral in hz. Defaults to ``1000000``.
 - **one_wire** (*Optional*, boolean): Allows the ``pin`` to be used by both the transmitter and a receiver. As the ``pin`` will
-  be in open drain mode a pull-up is required, set the ``pin`` mode to pullup or provide an external one.
+  be in open drain mode a pullup is required, set the ``pin`` mode to pullup or provide an external one.
 - **use_dma** (*Optional*, boolean): Enable DMA on variants that support it.
 - **eot_level** (*Optional*, boolean): Overrides the default end of transmit level. Defaults to ``false`` unless ``one_wire``
   mode is ``true`` or ``pin`` is inverted.


### PR DESCRIPTION
## Description:

Update docs for esphome/esphome#8178

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#8178

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
