### PR TITLE
add `rmt_channel` options for C6 and H2

### DIFF
--- a/components/light/esp32_rmt_led_strip.rst
+++ b/components/light/esp32_rmt_led_strip.rst
@@ -32,6 +32,8 @@ Configuration variables
       "ESP32-S2", "0, 1, 2, 3"
       "ESP32-S3", "0, 1, 2, 3"
       "ESP32-C3", "0, 1"
+      "ESP32-C6", "0, 1"
+      "ESP32-H2", "0, 1"
 
 - **chipset** (**Required**, enum): The chipset to apply known timings from. Not used if specifying the timings manually, see below.
     - ``WS2811``

--- a/components/remote_receiver.rst
+++ b/components/remote_receiver.rst
@@ -82,6 +82,8 @@ Configuration variables:
       "ESP32-S2", "0, 1, 2, 3"
       "ESP32-S3", "4, 5, 6, 7"
       "ESP32-C3", "2, 3"
+      "ESP32-C6", "2, 3"
+      "ESP32-H2", "2, 3"
 
 - **memory_blocks** (*Optional*, int): The number of RMT memory blocks used. Only used on ESP32 platform. The maximum
   number of blocks shared by all receivers and transmitters depends on the ESP32 variant. Defaults to ``3``.
@@ -498,7 +500,7 @@ Remote code selection (exactly one of these has to be included):
           tolerance: 60%
           filter: 4us
           idle: 4ms
-       
+
         remote_transmitter:
           pin: 1
           carrier_duty_percent: 100%

--- a/components/remote_transmitter.rst
+++ b/components/remote_transmitter.rst
@@ -44,6 +44,8 @@ Configuration variables:
       "ESP32-S2", "0, 1, 2, 3"
       "ESP32-S3", "0, 1, 2, 3"
       "ESP32-C3", "0, 1"
+      "ESP32-C6", "0, 1"
+      "ESP32-H2", "0, 1"
 
 -  **id** (*Optional*, :ref:`config-id`): Manually specify
    the ID used for code generation. Use this if you have multiple remote transmitters.


### PR DESCRIPTION
## Description:
add `remote-receiver`, `remote_transmitter` and `esp32_rmt_led_strip` `rmt_channel` options for `ESP32-C6` and `ESP32-H2`

Definitions taken from: https://github.com/esphome/esphome/blob/dev/esphome/components/esp32_rmt/__init__.py#L9-L25

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
