### PR TITLE
Add available range to measurement interval of SCD30

### DIFF
--- a/components/sensor/scd30.rst
+++ b/components/sensor/scd30.rst
@@ -66,7 +66,7 @@ Configuration variables:
   Defaults to ``0x61``.
 
 - **update_interval** (*Optional*, :ref:`config-time`): The interval to check the
-  sensor. Defaults to ``60s``.
+  sensor. Available range: [2 … 1800]. Defaults to ``60s``.
 
 
 Manual calibration:


### PR DESCRIPTION
added a note about the availiable range found in datasheet

## Description:

After I had entered a measuring time of 1s and received measurements that were far too high, I looked in the data sheet and found a minimum measuring time of 2s. 

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
