### PR TITLE
Support for new i2s audio driver

### DIFF
--- a/components/i2s_audio.rst
+++ b/components/i2s_audio.rst
@@ -24,6 +24,7 @@ Configuration variables:
 - **i2s_bclk_pin** (*Optional*, :ref:`config-pin`): The GPIO pin to use for the I²S ``BCLK`` *(Bit Clock)* signal, also referred to as ``SCK`` *(Serial Clock)*.
 - **i2s_mclk_pin** (*Optional*, :ref:`config-pin`): The GPIO pin to use for the I²S ``MCLK`` *(Master Clock)* signal.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID for this I²S bus if you need multiple.
+- **use_legacy** (*Optional, boolean*): Use the legacy i2s driver when using esp-idf framework version 5.x.x. Not valid for Arduino framework or esp-idf version < 5. All ``i2s_audio`` components need to use the same setting. Defaults to ``false``.
 
 See also
 --------

--- a/components/i2s_audio.rst
+++ b/components/i2s_audio.rst
@@ -24,7 +24,7 @@ Configuration variables:
 - **i2s_bclk_pin** (*Optional*, :ref:`config-pin`): The GPIO pin to use for the I²S ``BCLK`` *(Bit Clock)* signal, also referred to as ``SCK`` *(Serial Clock)*.
 - **i2s_mclk_pin** (*Optional*, :ref:`config-pin`): The GPIO pin to use for the I²S ``MCLK`` *(Master Clock)* signal.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID for this I²S bus if you need multiple.
-- **use_legacy** (*Optional, boolean*): Use the legacy i2s driver when using esp-idf framework version 5.x.x. Not valid for Arduino framework or esp-idf version < 5. All ``i2s_audio`` components need to use the same setting. Defaults to ``false``.
+- **use_legacy** (*Optional, boolean*): Use the legacy I²S driver when using esp-idf framework version 5.x.x. Not valid for Arduino framework or esp-idf version < 5. All ``i2s_audio`` components need to use the same setting. Defaults to ``false``.
 
 See also
 --------

--- a/components/microphone/i2s_audio.rst
+++ b/components/microphone/i2s_audio.rst
@@ -59,7 +59,7 @@ External ADC
 
   .. note::
 
-      PDM microphones are only supported on ESP32 and ESP32-S3 by the legacy I²S driver.
+      PDM microphones are only supported on ESP32 and ESP32-S3.
 
 Internal ADC
 ------------

--- a/components/microphone/i2s_audio.rst
+++ b/components/microphone/i2s_audio.rst
@@ -59,14 +59,14 @@ External ADC
 
   .. note::
 
-      PDM microphones are only supported on ESP32 and ESP32-S3.
+      PDM microphones are only supported on ESP32 and ESP32-S3 by the legacy I²S driver.
 
 Internal ADC
 ------------
 
   .. note::
 
-      Internal ADC microphones are only supported on a regular ESP32, not the variants.
+      Internal ADC microphones are only supported by the legacy I²S driver on a regular ESP32, not the variants.
 
 - **adc_pin** (**Required**, :ref:`Pin Schema <config-pin_schema>`): The GPIO pin to use for the ADC input.
 

--- a/components/microphone/i2s_audio.rst
+++ b/components/microphone/i2s_audio.rst
@@ -43,9 +43,10 @@ Configuration variables:
 - **channel** (*Optional*, enum): The channel of the microphone. One of ``left``, ``right``, or ``stereo``. If ``stereo``, the output data will
   be twice as big, with each right sample followed by a left sample. Defaults to ``right``.
 - **sample_rate** (*Optional*, positive integer): I2S sample rate. Defaults to ``16000``.
-- **bits_per_sample** (*Optional*, enum): The bit depth of the audio samples. Note that while set to ``24bit`` or ``32bit``, the samples
-  will be scaled down to 16bit before being forwarded. One of ``8bit``, ``16bit``, ``24bit``, or ``32bit``. Defaults to ``32bit``.
-- **bits_per_channel** (*Optional*, enum): The bit depth of the audio channels. See the datasheet of your I2S device for details. Defaults to ``bits_per_sample``.
+- **bits_per_sample** (*Optional*, enum): The bit depth of the audio samples. Note that with the legacy driver while set to ``24bit`` or ``32bit``, the samples
+  will be scaled down to 16bit before being forwarded. Setting is ignored if the legacy driver is not used. One of ``8bit``, ``16bit``, ``24bit``, or ``32bit``. Defaults to ``32bit``.
+- **bits_per_channel** (*Optional*, enum): The bit depth of the audio channels. This is what is actually received from the microphone. Note that while set to ``24bit`` or ``32bit``, the samples
+  will be scaled down to 16bit before being forwarded. See the datasheet of your I2S device for details. Defaults to ``bits_per_sample`` or ``16bit`` when not using the legacy driver.
 - **use_apll** (*Optional*, boolean): I2S using APLL as main I2S clock, enable it to get accurate clock. Defaults to ``false``.
 - **i2s_mode** (*Optional*, enum): The I²S mode to use. One of ``primary`` (clock driven by the host) or ``secondary`` (clock driven by the attached device). Defaults to ``primary``.
 - **i2s_audio_id** (*Optional*, :ref:`config-id`): The ID of the :ref:`I²S Audio <i2s_audio>` you wish to use for this microphone.

--- a/components/speaker/i2s_audio.rst
+++ b/components/speaker/i2s_audio.rst
@@ -68,6 +68,10 @@ For best results, keep the wires as short as possible.
 Internal DAC
 ************
 
+  .. note::
+
+      Internal DAC speakers are only supported by the legacy I²S driver on a regular ESP32, not the variants.
+
 - **mode** (**Required**, enum): The channel mode of the internal DAC.
 
   - ``left``

--- a/components/speaker/i2s_audio.rst
+++ b/components/speaker/i2s_audio.rst
@@ -35,10 +35,11 @@ Configuration variables:
 
 - **channel** (*Optional*, enum): The channel of the speaker. One of ``left``, ``right``, ``mono``, or ``stereo``. If ``stereo``, the input data should be twice as big,
   with each right sample followed by a left sample. ``left`` and ``right`` mute the unused channel, while ``mono`` plays the same samples on both. Defaults to ``mono``.
-- **sample_rate** (*Optional*, positive integer): I2S sample rate. Defaults to ``16000``.
-- **bits_per_sample** (*Optional*, enum): The bit depth of the audio samples. Note that while set to ``24bit`` or ``32bit``, the samples
-  will be scaled up from 16bit before being forwarded. One of ``8bit``, ``16bit``, ``24bit``, or ``32bit``. Defaults to ``16bit``.
-- **bits_per_channel** (*Optional*, enum): The bit depth of the audio channels. See the datasheet of your I2S device for details. Defaults to ``bits_per_sample``.
+- **sample_rate** (*Optional*, positive integer): I2S sample rate. If in ``primary`` I²S mode the sample rate of the audio stream is used. Defaults to ``16000``.
+- **bits_per_sample** (*Optional*, enum): The bit depth of the audio samples. Note that with the I²S legacy driver while set to ``24bit`` or ``32bit``, the samples
+  will be scaled up from 16bit before being forwarded. Setting is ignored if the legacy driver is not used. One of ``8bit``, ``16bit``, ``24bit``, or ``32bit``. Defaults to ``16bit``.
+- **bits_per_channel** (*Optional*, enum): The bit depth of the audio channels. This is what is actually send to the DAC and needs to be equal or larger than ``bits_per_sample``.
+  See the datasheet of your I2S device for details. Defaults to ``bits_per_sample`` or the bit width of the audio stream when not using the legacy driver.
 - **use_apll** (*Optional*, boolean): I2S using APLL as main I2S clock, enable it to get accurate clock. Defaults to ``false``.
 - **i2s_mode** (*Optional*, enum): The I²S mode to use. One of ``primary`` (clock driven by the host) or ``secondary`` (clock driven by the attached device). Defaults to ``primary``.
 - **i2s_audio_id** (*Optional*, :ref:`config-id`): The ID of the :ref:`I²S Audio <i2s_audio>` you wish to use for this speaker.
@@ -48,7 +49,7 @@ Configuration variables:
   - ``stand_msb``
   - ``stand_pcm_short``
   - ``stand_pcm_long``
-  - ``stand_max``
+  - ``stand_max`` (only with legacy driver)
   - ``i2s_msb``
   - ``i2s_lsb``
   - ``pcm``


### PR DESCRIPTION
## Description:
Added use_legacy parameter.


**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#8181
## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
