### PR TITLE
[scheduler] document debug_scheduler flag

### DIFF
--- a/components/esphome.rst
+++ b/components/esphome.rst
@@ -66,6 +66,7 @@ Advanced options:
   See :ref:`esphome-min_version`.
 - **compile_process_limit** (*Optional*, int): The maximum number of simultaneous compile processes to run.
   Defaults to the number of cores of the CPU which is also the maximum you can set.
+- **debug_scheduler** (*Optional*, boolean): If set, the scheduler will print debug information about scheduled tasks at log level DEBUG.
 
 Old-style platform options, which have been moved to the platform-specific :doc:`esp32 </components/esp32>` and
 :doc:`esp8266 </components/esp8266>` sections but are still accepted here for compatibility reasons (usage not


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#8197
## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
