### PR TITLE
Removed duplicate pm10 from Panasonic SN-GCJA5 Particulate Matter Sensor

### DIFF
--- a/components/sensor/gcja5.rst
+++ b/components/sensor/gcja5.rst
@@ -39,8 +39,6 @@ Configuration variables:
   All options from :ref:`Sensor <config-sensor>`.
 - **pm_10_0** (*Optional*): Mass of particles with a diameter of 10 micrometres or less (μg/m^3).
   All options from :ref:`Sensor <config-sensor>`.
-- **pm_10_0** (*Optional*): Mass of particles with a diameter of 10 micrometres or less (μg/m^3).
-  All options from :ref:`Sensor <config-sensor>`.
 - **pmc_0_3** (*Optional*): Count of particles with diameter > 0.3 um in 0.1 L of air (#/0.1L).
   All options from :ref:`Sensor <config-sensor>`.
 - **pmc_0_5** (*Optional*): Count of particles with diameter > 0.5 um in 0.1 L of air (#/0.1L).


### PR DESCRIPTION
## Description:
Removed duplicate pm10 from Panasonic SN-GCJA5 Particulate Matter Sensor, because it was most likely a copy paste error.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
