### PR TITLE
Update deep_sleep.rst

### DIFF
--- a/components/deep_sleep.rst
+++ b/components/deep_sleep.rst
@@ -48,6 +48,11 @@ Configuration variables:
   - **touch_wakeup_reason** (*Optional*, :ref:`config-time`): run duration if woken up by touch.
 
 - **sleep_duration** (*Optional*, :ref:`config-time`): The time duration to stay in deep sleep mode.
+
+.. note::
+
+    ESP8266s have a max limit for sleep_duration based on the variable type used to store this in the hardware itself.  Using a larger number that causes overflow will give unexpected results (node may stop reporting, but still be connected to wifi, for example).  A safe value is approximately 3.5 hours, but can depend on hardware, so if you are not seeing the battery performance results you are expecting from deep sleep, this may be the cause.
+
 - **touch_wakeup** (*Optional*, boolean): Only on ESP32. Use a touch event to wakeup from deep sleep. To be able
   to wakeup from a touch event, :ref:`esp32-touch-binary-sensor` must be configured properly.
 - **wakeup_pin** (*Optional*, :ref:`Pin Schema <config-pin_schema>`): Only on ESP32. A pin to wake up to once


### PR DESCRIPTION
Discovered gotcha when sleep_duration is too long causing issues on ESP8266.  Not sure it's worth fixing in code, so adding a note in the docs may help others with the situation I was having.

## Description:
Added note about limits to sleep_duration on ESP8266

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
