### PR TITLE
Add arg to strftime in TM1637

### DIFF
--- a/components/display/tm1637.rst
+++ b/components/display/tm1637.rst
@@ -124,7 +124,7 @@ segment of the previous position will be enabled.
           // Result: "S 42"
 
           // Print the current time
-          it.strftime("%H.%M", id(sntp_time).now());
+          it.strftime("%H.%M", id(homeassistant_time).now());
           // Result for 10:06:42 -> "10:06" on a display with : and "10.06" on a display with .
 
 Please see :ref:`display-printf` for a quick introduction into the ``printf`` formatting rules and

--- a/components/display/tm1637.rst
+++ b/components/display/tm1637.rst
@@ -124,7 +124,7 @@ segment of the previous position will be enabled.
           // Result: "S 42"
 
           // Print the current time
-          it.strftime("%H.%M");
+          it.strftime("%H.%M", id(sntp_time).now());
           // Result for 10:06:42 -> "10:06" on a display with : and "10.06" on a display with .
 
 Please see :ref:`display-printf` for a quick introduction into the ``printf`` formatting rules and


### PR DESCRIPTION
Added correction to example for strftime example - it needs 2 arguments, not only format, but also the data source.

## Description:
The example for strftime is wrong - the function requires 2 arguments.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
