### PR TITLE
Fix rtttl component documentation typo

### DIFF
--- a/components/rtttl.rst
+++ b/components/rtttl.rst
@@ -175,7 +175,7 @@ Sample code
 
     api:
       actions:
-        - action: play_rtttl
+        - action: rtttl_play
           variables:
             song_str: string
           then:


### PR DESCRIPTION
## Description:

The text description says 
> E.g. for calling `rtttl.play` select the service `esphome.test_esp8266_rtttl_play` and in service data enter

But the sample code creates a service named `..._play_rtttl`, with the last two words swapped. Fixing the sample code to match the text, because it also matches the name of the underlying component action, but I think the other way around would be fine too!

**Related issue (if applicable):** n/a

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** n/a

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
