### PR TITLE
Add note about not using ``sstream``

### DIFF
--- a/guides/contributing.rst
+++ b/guides/contributing.rst
@@ -1168,9 +1168,11 @@ ESPHome's maintainers work hard to maintain a high standard for its code. We try
 
 - Components **must** use the provided abstractions like ``sensor``, ``switch``, etc. Components specifically should
   **not** directly access other components -- for example, to publish to MQTT topics.
-- Implementations for new devices should contain reference links for the datasheet and other sample implementations.
+- Implementations for new devices should contain reference links for the data sheet and other sample implementations.
 - If you have used ``delay()`` or constructed code which blocks for a duration longer than ten milliseconds, be sure to
   read :ref:`delays_in_code`.
+- Do **not** use ``sstream``/``stringstream`` to format variables into strings. This library bloats the compiled binary
+  by over 200 kilobytes (KBs) which causes problems for devices with small amounts (1-4 MB) of flash memory.
 - Comments in code should be used as appropriate, such as to help explain some complexity or to provide a brief summary
   of what a class, method, etc. is doing. PRs which include large blocks of commented-out code will not be accepted.
   Single lines of commented code may be useful from time to time (for example, to call out something which was


### PR DESCRIPTION
## Description:

Adds a note about not using `sstream`.

EDIT: This probably should've gone into `current`...sorry!

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
