### PR TITLE
Add wire color codes for RJ45 to pylontech.rst

### DIFF
--- a/components/pylontech.rst
+++ b/components/pylontech.rst
@@ -31,22 +31,26 @@ If you have multiple batteries you need to connect to the master battery's conso
 .. list-table:: Pylontech RJ45 Console Port (US2000C, US3000C, US5000C)
     :header-rows: 1
 
-    * - RJ45 Pin
-      - Function
-      - Connect to
-      - *Usual* wire
-    * - 3
-      - Pylontech TX
-      - ESPHome RX via transceiver
-      - White/green
-    * - 6
-      - Pylontech RX
-      - ESPHome TX via transceiver
-      - Green
-    * - 8
-      - GND
-      - GND
-      - Brown
+   * - RJ45 Pin
+     - TIA-568B Color
+     - TIA-568A Color
+     - Function
+     - Connect to
+   * - 3
+     - White/Green
+     - White/Orange
+     - Pylontech TX
+     - ESPHome RX via transceiver
+   * - 6
+     - Green
+     - Orange
+     - Pylontech RX
+     - ESPHome TX via transceiver
+   * - 8
+     - Brown
+     - Brown
+     - GND
+     - GND
 
 .. figure:: images/rj45_pinout.jpg
     :align: center

--- a/components/pylontech.rst
+++ b/components/pylontech.rst
@@ -28,21 +28,25 @@ MAX3232-based transceivers have been tested and work well.
 
 If you have multiple batteries you need to connect to the master battery's console port.
 
-.. list-table:: Pylontech RJ45 Console Port (US2000C, US3000C)
+.. list-table:: Pylontech RJ45 Console Port (US2000C, US3000C, US5000C)
     :header-rows: 1
 
     * - RJ45 Pin
       - Function
       - Connect to
+      - *Usual* wire
     * - 3
       - Pylontech TX
       - ESPHome RX via transceiver
+      - White/green
     * - 6
       - Pylontech RX
       - ESPHome TX via transceiver
+      - Green
     * - 8
       - GND
       - GND
+      - Brown
 
 .. figure:: images/rj45_pinout.jpg
     :align: center

--- a/components/pylontech.rst
+++ b/components/pylontech.rst
@@ -31,26 +31,26 @@ If you have multiple batteries you need to connect to the master battery's conso
 .. list-table:: Pylontech RJ45 Console Port (US2000C, US3000C, US5000C)
     :header-rows: 1
 
-   * - RJ45 Pin
-     - TIA-568B Color
-     - TIA-568A Color
-     - Function
-     - Connect to
-   * - 3
-     - White/Green
-     - White/Orange
-     - Pylontech TX
-     - ESPHome RX via transceiver
-   * - 6
-     - Green
-     - Orange
-     - Pylontech RX
-     - ESPHome TX via transceiver
-   * - 8
-     - Brown
-     - Brown
-     - GND
-     - GND
+    * - RJ45 Pin
+      - TIA-568B Color
+      - TIA-568A Color
+      - Function
+      - Connect to
+    * - 3
+      - White/Green
+      - White/Orange
+      - Pylontech TX
+      - ESPHome RX via transceiver
+    * - 6
+      - Green
+      - Orange
+      - Pylontech RX
+      - ESPHome TX via transceiver
+    * - 8
+      - Brown
+      - Brown
+      - GND
+      - GND
 
 .. figure:: images/rj45_pinout.jpg
     :align: center


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
