### PR TITLE
Add pullup resistor documentation for DHT component 

### DIFF
--- a/components/sensor/dht.rst
+++ b/components/sensor/dht.rst
@@ -74,6 +74,9 @@ Configuration variables:
     DHT model with the ``model:`` configuration variable. Other problems could be wrong pull-up resistor values
     on the DATA pin or too long cables.
 
+    If you're using a DHT module with an external resistor and seeing invalid temperature/humidity warnings in the logs,
+    set ``pullup: false`` under your ``pin`` configuration.
+
 See Also
 --------
 

--- a/components/sensor/dht.rst
+++ b/components/sensor/dht.rst
@@ -74,7 +74,7 @@ Configuration variables:
     DHT model with the ``model:`` configuration variable. Other problems could be wrong pull-up resistor values
     on the DATA pin or too long cables.
 
-    If you're using a DHT module with an external resistor and seeing invalid temperature/humidity warnings in the logs,
+    If you're using a DHT module with an external pull-up resistor and seeing invalid temperature/humidity warnings in the logs,
     set ``pullup: false`` under your ``pin`` configuration.
 
 See Also


### PR DESCRIPTION
## Description:
Add a note to disable the internal pullup resistor when working with DHT modules which have an onboard resistor.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#8257

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
