### PR TITLE
DateTime fix typo in lambda example

### DIFF
--- a/components/datetime/index.rst
+++ b/components/datetime/index.rst
@@ -288,7 +288,7 @@ For more complex use cases, several methods are available for use on datetimes f
 
       // Within lambda, set the datetime to 2024-12-31 12:34:56
       auto call = id(my_datetime).make_call();
-      call.set_date("2024-12-31 12:34:56");
+      call.set_datetime("2024-12-31 12:34:56");
       call.perform();
 
   Check the API reference for information on the methods that are available for


### PR DESCRIPTION
fixed copy&paste

## Description:

Looks like a copy&paste error for one form of the code sampes.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
