### PR TITLE
Updated platformio to pioarduino in esp32.rst

### DIFF
--- a/components/esp32.rst
+++ b/components/esp32.rst
@@ -62,7 +62,7 @@ Configuration variables:
 - **source** (*Optional*, string): The PlatformIO package or repository to use for framework. This can be used to use a
   custom or patched version of the framework.
 - **platform_version** (*Optional*, string): The version of the
-  `platformio/espressif32 <https://github.com/platformio/platform-espressif32/releases/>`__ package to use.
+  `pioarduino/espressif32 <https://github.com/pioarduino/platform-espressif32/releases>`__ package to use.
 - **advanced** (*Optional*, mapping): See :ref:`esp32-advanced_configuration` below.
 
 .. _esp32-espidf_framework:
@@ -96,7 +96,7 @@ Configuration variables:
 - **source** (*Optional*, string): The PlatformIO package or repository to use for the framework. This can be used to
   use a custom or patched version of the framework.
 - **platform_version** (*Optional*, string): The version of the
-  `platformio/espressif32 <https://github.com/platformio/platform-espressif32/releases/>`__ package to use.
+  `pioarduino/espressif32 <https://github.com/pioarduino/platform-espressif32/releases/>`__ package to use.
 - **sdkconfig_options** (*Optional*, mapping): Custom sdkconfig
   `compiler options <https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/kconfig.html#compiler-options>`__
   to set in the ESP-IDF project.

--- a/components/sensor/scd4x.rst
+++ b/components/sensor/scd4x.rst
@@ -6,7 +6,7 @@ SCD4X CO₂, Temperature and Relative Humidity Sensor
     :image: scd4x.jpg
 
 The ``scd4x`` sensor platform  allows you to use your Sensirion SCD4X CO₂
-(`datasheet <https://sensirion.com/media/documents/E0F04247/631EF271/CD_DS_SCD40_SCD41_Datasheet_D1.pdf>`__) sensors with ESPHome.
+(`datasheet <https://sensirion.com/media/documents/48C4B7FB/66E05452/CD_DS_SCD4x_Datasheet_D1.pdf>`__) sensors with ESPHome.
 The :ref:`I²C Bus <i2c>` is required to be set up in your configuration for this sensor to work.
 
 .. figure:: images/scd4x.jpg


### PR DESCRIPTION
## Description:

Updated platformio to pioarduino in both cases (links too). When changing out the platformio framework to pioarduino (see changelog: https://esphome.io/changelog/2024.12.0.html) the docs needs to be updated for the users to not get confused over which framework they use.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
