### PR TITLE
Update default frame interval for Toto infrared protocol

### DIFF
--- a/components/remote_transmitter.rst
+++ b/components/remote_transmitter.rst
@@ -943,7 +943,7 @@ This :ref:`action <config-action>` sends a Toto infrared remote code to a remote
           command: 0xED  # Set water and seat temperature
           rc_code_1: 0x0 # Water heater off
           rc_code_2: 0x0 # Seat heater off
-          # Repeats 3 times at a 32ms interval by default
+          # Repeats 3 times at a 36ms interval by default
 
 Configuration variables:
 
@@ -951,7 +951,7 @@ Configuration variables:
 - **rc_code_1** (*Optional*, int): The first 4-bit Toto code (usually a command parameter) to send. Range is 0 to 0xF.
 - **rc_code_2** (*Optional*, int): The second 4-bit Toto code (usually a command parameter) to send. Range is 0 to 0xF.
 - All other options from :ref:`remote_transmitter-transmit_action`.
-   - **Note**: Toto remotes repeat all codes three times at a 32ms interval. This behavior will occur by default, but may be overridden by specifying ``repeat`` and ``wait time`` configuration variables. 
+   - **Note**: Toto remotes repeat all codes three times at a 36ms interval. This behavior will occur by default, but may be overridden by specifying ``repeat`` and ``wait time`` configuration variables. 
 
 
 .. _remote_transmitter-rc_switch-protocol:


### PR DESCRIPTION
## Description:

Updates documentation to align with updated default frame interval for the Toto remote transmitter protocol. The documentation for this new protocol has already been merged into the next branch, but has not been released yet.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 
- esphome/esphome#8265

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
