### PR TITLE
Added ext1 wakeup reason

### DIFF
--- a/components/deep_sleep.rst
+++ b/components/deep_sleep.rst
@@ -46,6 +46,8 @@ Configuration variables:
   - **default** (**Required**, :ref:`config-time`): default run duration for timer wakeup and any unspecified wakeup reason.
   - **gpio_wakeup_reason** (*Optional*, :ref:`config-time`): run duration if woken up by GPIO.
   - **touch_wakeup_reason** (*Optional*, :ref:`config-time`): run duration if woken up by touch.
+  - **ext1_wakeup_reason** (*Optional*, :ref:`config-time`): run duration if woken up by ext1.
+
 
 - **sleep_duration** (*Optional*, :ref:`config-time`): The time duration to stay in deep sleep mode.
 - **touch_wakeup** (*Optional*, boolean): Only on ESP32. Use a touch event to wakeup from deep sleep. To be able

--- a/components/esp32.rst
+++ b/components/esp32.rst
@@ -62,7 +62,7 @@ Configuration variables:
 - **source** (*Optional*, string): The PlatformIO package or repository to use for framework. This can be used to use a
   custom or patched version of the framework.
 - **platform_version** (*Optional*, string): The version of the
-  `platformio/espressif32 <https://github.com/platformio/platform-espressif32/releases/>`__ package to use.
+  `pioarduino/espressif32 <https://github.com/pioarduino/platform-espressif32/releases>`__ package to use.
 - **advanced** (*Optional*, mapping): See :ref:`esp32-advanced_configuration` below.
 
 .. _esp32-espidf_framework:
@@ -96,7 +96,7 @@ Configuration variables:
 - **source** (*Optional*, string): The PlatformIO package or repository to use for the framework. This can be used to
   use a custom or patched version of the framework.
 - **platform_version** (*Optional*, string): The version of the
-  `platformio/espressif32 <https://github.com/platformio/platform-espressif32/releases/>`__ package to use.
+  `pioarduino/espressif32 <https://github.com/pioarduino/platform-espressif32/releases/>`__ package to use.
 - **sdkconfig_options** (*Optional*, mapping): Custom sdkconfig
   `compiler options <https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/kconfig.html#compiler-options>`__
   to set in the ESP-IDF project.


### PR DESCRIPTION
## Description:

Added ext1 wakeup reason to match proposed PR #8282 in esphome.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#8282

## Checklist:

  - [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
