### PR TITLE
[esp32_rmt_led_strip] Add use_dma option for S3

### DIFF
--- a/components/light/esp32_rmt_led_strip.rst
+++ b/components/light/esp32_rmt_led_strip.rst
@@ -64,6 +64,8 @@ IDF configuration variables:
       "ESP32-C3", "192 symbols", "48 symbols"
       "ESP32-C6", "192 symbols", "48 symbols"
       "ESP32-H2", "192 symbols", "48 symbols"
+- **use_dma** (*Optional*, boolean): Enable DMA on variants that support it. If enabled ``rmt_symbols`` controls
+  the DMA buffer size and can be set to a large value.
 
 Arduino configuration variables:
 ********************************

--- a/components/remote_receiver.rst
+++ b/components/remote_receiver.rst
@@ -106,7 +106,8 @@ ESP32 IDF configuration variables:
   ``filter_symbols``. Useful for filtering out short bursts of noise.
 - **clock_resolution** (*Optional*, int): The clock resolution used by the RMT peripheral in hz. Defaults to
   ``1000000``.
-- **use_dma** (*Optional*, boolean): Enable DMA on variants that support it.
+- **use_dma** (*Optional*, boolean): Enable DMA on variants that support it. If enabled ``rmt_symbols`` controls
+  the DMA buffer size and can be set to a large value.
 
 ESP32 Arduino configuration variables:
 **************************************

--- a/components/remote_transmitter.rst
+++ b/components/remote_transmitter.rst
@@ -57,7 +57,8 @@ ESP32 IDF configuration variables:
       "ESP32-H2", "192 symbols", "48 symbols"
 
 - **clock_resolution** (*Optional*, int): The clock resolution used by the RMT peripheral in hz. Defaults to ``1000000``.
-- **use_dma** (*Optional*, boolean): Enable DMA on variants that support it.
+- **use_dma** (*Optional*, boolean): Enable DMA on variants that support it. If enabled ``rmt_symbols`` controls
+  the DMA buffer size and can be set to a large value.
 - **eot_level** (*Optional*, boolean): Overrides the default end of transmit level. Defaults to ``false`` unless ``pin``
   is set to inverted or open-drain.
 


### PR DESCRIPTION
## Description:

Add use_dma option for S3 and update remote docs to be consistent. 

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#8270

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
