### PR TITLE
Clarified the correct model for Pimoroni Badger in waveshare_epaper.rst

### DIFF
--- a/components/display/waveshare_epaper.rst
+++ b/components/display/waveshare_epaper.rst
@@ -141,7 +141,7 @@ Configuration variables:
   - ``7.50inV2p`` - Support for partial refresh and fast refresh (Only suitable for ``7.50inV2`` models manufactured after September 2023)
   - ``7.50in-hd-b`` - Can't use with an ESP8266 as it runs out of RAM
   - ``gdey029t94`` - GooDisplay GDEY029t94, as used in the monochrome 2.9inch display from seeedstudio
-  - ``gdew029t5`` - GooDisplay GDEW029T5, as used on the AdaFruit MagTag
+  - ``gdew029t5`` - GooDisplay GDEW029T5, as used on the AdaFruit MagTag and Pimoroni Badger
   - ``1.54in-m5coreink-m09`` - GoodDisplay gdew0154m09, as used in the M5Stack Core Ink
   - ``13.3in-k`` - 13.3in, with the K model, 960x680, B/W rendering only
 


### PR DESCRIPTION
added note to make clear which model to use for Pimoroni Badger

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
