### PR TITLE
Remove removed old-style options.

### DIFF
--- a/components/esphome.rst
+++ b/components/esphome.rst
@@ -67,17 +67,6 @@ Advanced options:
 - **compile_process_limit** (*Optional*, int): The maximum number of simultaneous compile processes to run.
   Defaults to the number of cores of the CPU which is also the maximum you can set.
 
-Old-style platform options, which have been moved to the platform-specific :doc:`esp32 </components/esp32>` and
-:doc:`esp8266 </components/esp8266>` sections but are still accepted here for compatibility reasons (usage not
-recommended for new projects):
-
-- **platform** (**Required**, string): The platform used, either ``esp8266`` or ``esp32``.
-- **board** (**Required**, string): The board used, see
-  :doc:`esp32 </components/esp32>` and :doc:`esp8266 </components/esp8266>` for more information.
-- **arduino_version** (*Optional*, string): The version of the Arduino framework to compile the project against.
-- **esp8266_restore_from_flash** (*Optional*, boolean): For ESP8266s, whether to store some persistent preferences in flash
-  memory.
-
 Automations:
 
 - **on_boot** (*Optional*, :ref:`Automation <automation>`): An automation to perform


### PR DESCRIPTION
## Description:

The platform options have been removed from the `esphome:` config, but didn't get removed from the docs.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
