### PR TITLE
allow touchscreen binary_sensor to use raw touch values

### DIFF
--- a/components/touchscreen/index.rst
+++ b/components/touchscreen/index.rst
@@ -281,9 +281,7 @@ Configuration variables:
   Cannot be used with ``pages``.
 - **pages** (*Optional*, list of :ref:`config-id`): Only trigger this binary sensor if the display is showing one of these pages.
   Cannot be used with ``page_id``.
-- **use_raw** (*Optional*, boolean): Some touch screens are larger than the underlying screen, and this extra area is
-  used for touch buttons. Set this to `true` to and use the lambda from the Calibration section above to find the
-  correct min/max for your screen: touch the corners of each button area and look for the `x_raw` and `y_raw` values.
+- **use_raw** (*Optional*, boolean): Some touch screens are larger than the underlying screen, and use this extra area for touch buttons. To allow the sensor to register touches outside the display area set this to `true`. The calibration values as above should be set to the display bounds.
 
 - All other options from :ref:`Binary Sensor <config-binary_sensor>`.
 

--- a/components/touchscreen/index.rst
+++ b/components/touchscreen/index.rst
@@ -267,6 +267,7 @@ buttons.
         y_min: 0
         y_max: 100
         page_id: home_page_id
+        use_raw: true
 
 Configuration variables:
 ************************
@@ -280,6 +281,9 @@ Configuration variables:
   Cannot be used with ``pages``.
 - **pages** (*Optional*, list of :ref:`config-id`): Only trigger this binary sensor if the display is showing one of these pages.
   Cannot be used with ``page_id``.
+- **use_raw** (*Optional*, boolean): Some touch screens are larger than the underlying screen, and this extra area is
+  used for touch buttons. Set this to `true` to and use the lambda from the Calibration section above to find the
+  correct min/max for your screen: touch the corners of each button area and look for the `x_raw` and `y_raw` values.
 
 - All other options from :ref:`Binary Sensor <config-binary_sensor>`.
 


### PR DESCRIPTION
## Description:

Some touch screens cover more area than just the display, to (fi) provide touch buttons under the screen. The [M5Stack Core2](https://docs.m5stack.com/en/core/core2) is such a unit: it has a 320x240 display, but a 320x280 touch screen and it uses the bottom 40px of the touch screen for three "buttons". Currently the touchscreen implementation scales all touch coordinates to the underlying display dimensions. This PR allows someone to optionally specify the touchscreen binary_sensor to use raw x/y touch values, so touches outside of the display area can be used.

**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/5314

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#8296

## Checklist:

  - [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
