### PR TITLE
Update remote_receiver.rst, B&O Beo4 IR protocol added

### DIFF
--- a/all_automations.json
+++ b/all_automations.json
@@ -202,6 +202,7 @@
     "pzemdc.reset_energy",
     "remote_transmitter.transmit_abbwelcome",
     "remote_transmitter.transmit_aeha",
+    "remote_transmitter.transmit_beo4",
     "remote_transmitter.transmit_byronsx",
     "remote_transmitter.transmit_canalsat",
     "remote_transmitter.transmit_canalsatld",

--- a/components/remote_receiver.rst
+++ b/components/remote_receiver.rst
@@ -36,6 +36,7 @@ Configuration variables:
   - **abbwelcome**: Decode and dump ABB-Welcome codes. Messages are sent via copper wires. See
     :ref:`transmitter description <remote_transmitter-transmit_abbwelcome>` for more details.
   - **aeha**: Decode and dump AEHA infrared codes.
+  - **beo4**: Decode and dump B&O Beo4 infrared codes.
   - **byronsx**: Decode and dump Byron SX doorbell RF codes.
   - **canalsat**: Decode and dump CanalSat infrared codes.
   - **canalsatld**: Decode and dump CanalSatLD infrared codes.
@@ -143,6 +144,9 @@ Automations:
   is passed to the automation for use in lambdas.
 - **on_aeha** (*Optional*, :ref:`Automation <automation>`): An automation to perform when a
   AEHA remote code has been decoded. A variable ``x`` of type :apistruct:`remote_base::AEHAData`
+  is passed to the automation for use in lambdas.
+- **on_beo4** (*Optional*, :ref:`Automation <automation>`): An automation to perform when a
+  B&O Beo4 infrared remote code has been decoded. A variable ``x`` of type :apistruct:`remote_base::Beo4Data`
   is passed to the automation for use in lambdas.
 - **on_byronsx** (*Optional*, :ref:`Automation <automation>`): An automation to perform when a
   Byron SX doorbell RF code has been decoded. A variable ``x`` of type :apistruct:`remote_base::ByronSXData`
@@ -296,6 +300,11 @@ Remote code selection (exactly one of these has to be included):
   - **data** (**Required**, 3-35 bytes list): The code to listen for, see
     :ref:`transmitter description <remote_transmitter-transmit_aeha>` for more info. Usually you only need to copy this
     directly from the dumper output.
+
+- **beo4**: Trigger on a decoded B&O Beo4 infrared remote code with the given data.
+
+  - **source** (**Required**, int): The 8-bit source to trigger on, e.g. 0x00=video, 0x01=audio,..., see dumper output for more info.
+  - **command** (**Required**, int): The 8-bit command to listen for, e.g. 0x00=number0, 0x0C=standby,..., see dumper output for more info.
 
 - **byronsx**: Trigger on a decoded Byron SX Doorbell RF remote code with the given data.
 

--- a/components/remote_transmitter.rst
+++ b/components/remote_transmitter.rst
@@ -205,6 +205,25 @@ Configuration variables:
 AEHA refers to the Association for Electric Home Appliances in Japan, a format used by Panasonic and many other
 companies.
 
+.. _remote_transmitter-transmit_beo4:
+
+``remote_transmitter.transmit_beo4`` **Action**
+
+This :ref:`action <config-action>` sends a B&O Beo4 infrared protocol code to a remote transmitter.
+
+.. code-block:: yaml
+
+    on_...:
+      - remote_transmitter.transmit_beo4:
+          source: '0x01'
+          command: '0x0d'
+
+Configuration variables:
+
+- **source** (**Required**, int): The 8-bit source to send, e.g. 0x00=video,0x01=audio,..., see dumper output for more info.
+- **command** (**Required**, int): The command to send, e.g. 0x01=num1, 0x0d=mute,...,  see dumper output for more info.
+- All other options from :ref:`remote_transmitter-transmit_action`.
+
 .. _remote_transmitter-transmit_byronsx:
 
 ``remote_transmitter.transmit_byronsx`` **Action**


### PR DESCRIPTION
Add B&O Beo4 infrared remote codes

## Description:
update documentation for newly added IR protocol for B&O Beo4 infrared remote codes. 

**Related issue (if applicable):** fixes -

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
