### PR TITLE
Update psram.rst

### DIFF
--- a/components/psram.rst
+++ b/components/psram.rst
@@ -6,7 +6,8 @@ PSRAM
     :image: psram.svg
 
 This component enables and configures PSRAM if/when available on ESP32 modules/boards.
-It is automatically loaded and enabled by components that require it.
+It is automatically loaded and enabled by some, but not all components that require it.
+For instance it is not enabled automatically in the ``ili9xxx`` display driver.
 
 PSRAM is only available on the ESP32.
 


### PR DESCRIPTION
psram is not automatically enabled in the ili9xxx driver

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
