### PR TITLE
Add ``ADC`` pins for ``ESP32-C2``, ``ESP32-C6``, ``ESP32-H2``

### DIFF
--- a/components/sensor/adc.rst
+++ b/components/sensor/adc.rst
@@ -35,7 +35,7 @@ Configuration variables:
   attenuation to use. See :ref:`adc-esp32_attenuation`. Defaults to ``0db``.
 - **raw** (*Optional*): Allows to read the raw ADC output without any conversion or calibration. See :ref:`adc-raw`. Defaults to ``false``.
 - **samples** (*Optional*): The amount of ADC readings to take per sensor update. On the ESP32 this value is ignored if ``attenuation`` is set to ``auto``. Defaults to ``1``.
-- **sampling_mode** (*Optional*): Sampling method to use when multiple samples are taken. 
+- **sampling_mode** (*Optional*): Sampling method to use when multiple samples are taken.
 
   - ``avg`` average of all samples (**Default**)
   - ``min`` minimal value from all samples
@@ -95,9 +95,18 @@ ESP32 pins
     * - ESP32
       - GPIO32 - GPIO39
       - GPIO0, GPIO2, GPIO4, GPIO12 - GPIO15, GPIO25 - GPIO27
+    * - ESP32-C2
+      - GPIO0 - GPIO4
+      - GPIO5
     * - ESP32-C3
       - GPIO0 - GPIO4
       - GPIO5
+    * - ESP32-C6
+      - GPIO0 - GPIO6
+      - no ``ADC2``
+    * - ESP32-H2
+      - GPIO1 - GPIO5
+      - no ``ADC2``
     * - ESP32-S2
       - GPIO1 - GPIO10
       - GPIO11 - GPIO20


### PR DESCRIPTION
## Description:
Add `ADC` pins for `ESP32-C2`, `ESP32-C6`, `ESP32-H2`

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#8327

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
