### PR TITLE
Clarify the time unit that a template should return

### DIFF
--- a/components/deep_sleep.rst
+++ b/components/deep_sleep.rst
@@ -131,6 +131,12 @@ This action makes the given deep sleep component enter deep sleep immediately.
             id: deep_sleep_1
             sleep_duration: 20min
 
+    # Sleep duration is also templatable
+    on_...:
+      then:
+        - deep_sleep.enter:
+            id: deep_sleep_1
+            sleep_duration: !lambda "return 20 * 60 * 1000;"
 
     # ESP32 can sleep until a specific time of day.
     on_...:
@@ -142,7 +148,7 @@ This action makes the given deep sleep component enter deep sleep immediately.
 
 Configuration options:
 
-- **sleep_duration** (*Optional*, :ref:`templatable <config-templatable>`, :ref:`config-time`): The time duration to stay in deep sleep mode.
+- **sleep_duration** (*Optional*, :ref:`templatable <config-templatable>`, :ref:`config-time`): The time duration to stay in deep sleep mode. If a template is used, it should return a value in milliseconds.
 - **until** (*Optional*, string): The time of day to wake up. Only on ESP32.
 - **time_id** (*Optional*, :ref:`config-id`): The ID of the time component to use for the ``until`` option. Only on ESP32.
 


### PR DESCRIPTION
## Description:

In `deep_sleep.enter`, **sleep_durartion** is templatable but the unit is never provided. This commit clarifies that it should be in ms.

Reference: https://github.com/esphome/esphome/pull/1765/commits/da82562771dcafb172d6c14cfb6df19046be5400

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** N/A


## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
