### PR TITLE
Fix typo for PCF8563 and PCF85063

### DIFF
--- a/components/time/pcf85063.rst
+++ b/components/time/pcf85063.rst
@@ -56,7 +56,7 @@ This :ref:`Action <config-action>` triggers a synchronization of the current sys
     on_...:
       - pcf85063.read_time
 
-      # in case you need to specify the DS1307 id
+      # in case you need to specify the PCF85063 id
       - pcf85063.read_time:
           id: pcf85063_time
 

--- a/components/time/pcf8563.rst
+++ b/components/time/pcf8563.rst
@@ -33,7 +33,7 @@ This :ref:`Action <config-action>` triggers a synchronization of the current sys
     on_...:
       - pcf8563.write_time
 
-      # in case you need to specify the DS1307 id
+      # in case you need to specify the PCF8563 id
       - pcf8563.write_time:
           id: pcf8563_time
 


### PR DESCRIPTION
## Description:

It seems that the original author forgot to edit the comments for the example configuration provided. This PR fixes the references to `DS1307 id` both of the files and replaces them to the corresponding IDs.

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
