### PR TITLE
Update audio_clips_for_i2s.rst

### DIFF
--- a/guides/audio_clips_for_i2s.rst
+++ b/guides/audio_clips_for_i2s.rst
@@ -22,7 +22,7 @@ It is possible to create sound clips to include in your build to use with I²S s
 
 .. code-block:: console
 
-    xxd -i startup_again.raw startup.c
+    xxd -i startup_again.raw startup.h
 
 - The resulting file needs a modification in the start line:
   Open in an editor and change


### PR DESCRIPTION
Use .h file only for xxd in audio clips for i2s guide. (otherwise there is no .h file generated)

## Description:
The guide didn't work for me: xxd command did not generate a header (.h) file with the original command. Update the guide to use only .h files (for both xxd and config examples).

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
