### PR TITLE
Tuya Select - Add int_datapoint option

### DIFF
--- a/components/select/tuya.rst
+++ b/components/select/tuya.rst
@@ -40,7 +40,6 @@ Based on this, you can create the select as follows:
       - platform: "tuya"
         name: "Sensor selection"
         enum_datapoint: 2
-        data_type: enum
         optimistic: true
         options:
           0: Internal
@@ -51,6 +50,9 @@ Configuration variables:
 ------------------------
 
 - **enum_datapoint** (**Required**, int): The enum datapoint id number for the select.
+  At least one of *enum_datapoint* or *int_datapoint* is required.
+- **int_datapoint** (**Required**, int): The int datapoint id number for the select.
+  At least one of *enum_datapoint* or *int_datapoint* is required.
 - **options** (**Required**, Map[int, str]): Provide a mapping from values (int) of
   this Select to options (str) of the *enum_datapoint* and vice versa. All options and
   all values have to be unique.

--- a/components/select/tuya.rst
+++ b/components/select/tuya.rst
@@ -58,7 +58,6 @@ Configuration variables:
   all values have to be unique.
 - **optimistic** (*Optional*, boolean): Whether to operate in optimistic mode - when in this mode,
   any command sent to the Select will immediately update the reported state.
-- **data_type** (*Optional*, enum): Set the backing data type, one of: ``enum`` or ``int``. Defaults to ``enum``.
 - All other options from :ref:`Select <config-select>`.
 
 

--- a/components/select/tuya.rst
+++ b/components/select/tuya.rst
@@ -40,6 +40,7 @@ Based on this, you can create the select as follows:
       - platform: "tuya"
         name: "Sensor selection"
         enum_datapoint: 2
+        data_type: enum
         optimistic: true
         options:
           0: Internal
@@ -55,7 +56,7 @@ Configuration variables:
   all values have to be unique.
 - **optimistic** (*Optional*, boolean): Whether to operate in optimistic mode - when in this mode,
   any command sent to the Select will immediately update the reported state.
-
+- **data_type** (*Optional*, enum): Set the backing data type, one of: ``enum`` or ``int``. Defaults to ``enum``.
 - All other options from :ref:`Select <config-select>`.
 
 


### PR DESCRIPTION
## Description:
Allow configuration of backing data type for Tuya Select, expanding from ``enum`` to also allowing ``int``

**Related issue (if applicable):** fixes N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#8393

## Checklist:

  - [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
