### PR TITLE
Note regarding platform support

### DIFF
--- a/components/mqtt.rst
+++ b/components/mqtt.rst
@@ -24,11 +24,13 @@ in which case this is not needed.
       username: livingroom
       password: !secret mqtt_password
 
-
 .. note::
 
     Support for esp-idf is still experminental. Please report issues you have with mqtt using the esp-idf framework.
 
+.. note::
+
+    As of ESPHome 2025.2.2, support for MQTT is "only available on ['esp32', 'esp8266', 'bk72xx']".
 
 Configuration variables:
 ------------------------


### PR DESCRIPTION
## Description:
  `esphome run` reports:
  INFO ESPHome 2025.2.2
  INFO Reading configuration xxx.yaml...
  Failed config
  
  mqtt: [source xxx.yaml:28]
    This feature is only available on ['esp32', 'esp8266', 'bk72xx'].

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
