### PR TITLE
fix link in adc.rst

### DIFF
--- a/components/sensor/adc.rst
+++ b/components/sensor/adc.rst
@@ -71,7 +71,7 @@ Measuring higher voltages requires setting ``attenuation`` to one of the followi
 There's more information `at the manufacturer's website <https://docs.espressif.com/projects/esp-idf/en/v4.4.7/esp32/api-reference/peripherals/adc.html#_CPPv425adc1_config_channel_atten14adc1_channel_t11adc_atten_t>`__.
 
 To simplify this, we provide the setting ``attenuation: auto`` for an automatic/seamless transition among scales. `Our implementation
-<https://github.com/esphome/esphome/blob/dev/esphome/components/adc/adc_sensor.cpp>`__ combines all available ranges to allow the best resolution without having to compromise on a specific attenuation.
+<https://github.com/esphome/esphome/blob/dev/esphome/components/adc/adc_sensor_esp32.cpp>`__ combines all available ranges to allow the best resolution without having to compromise on a specific attenuation.
 
 .. note::
 


### PR DESCRIPTION
Fixed 404 error for "our implementation" now pointing to the esp32 code file.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
