### PR TITLE
Update xgzp68xx.rst

### DIFF
--- a/components/sensor/xgzp68xx.rst
+++ b/components/sensor/xgzp68xx.rst
@@ -47,7 +47,7 @@ Configuration variables:
 
 .. code-block:: yaml
 
-     measuring range of the sensor
+    measuring range of the sensor
             kpa           k 
        131 < P ≤ 262     32
         65 < P ≤ 131     64

--- a/components/sensor/xgzp68xx.rst
+++ b/components/sensor/xgzp68xx.rst
@@ -1,5 +1,5 @@
 Sencoch Semiconductor GZP68xx / CFSensor XGZP68xx Series Differential Pressure Sensor
-=====================================================
+=====================================================================================
 
 .. seo::
     :description: Instructions for setting up the CFSensor XGZP68xx Series Differential Pressure sensor.

--- a/components/sensor/xgzp68xx.rst
+++ b/components/sensor/xgzp68xx.rst
@@ -43,21 +43,21 @@ Configuration variables:
 
 - **temperature** (*Optional*): All options from :ref:`Sensor <config-sensor>`.
 - **pressure** (*Optional*): All options from :ref:`Sensor <config-sensor>`.
-- **k_value** (*Optional*, int): The K value comes from the following table. Pressure is intrensically an analog value, and these I2C digital sensors have an internal ADC to convert the signal.  The k-value is used to configure the algorithm used by the ADC to the range of pressure.  It will default to 4096 if not specified, which is appropriate for a sensor measuring a maximum pressure in the window of +/- 1-2 kPa.
+- **k_value** (*Optional*, int): The K value comes from the following table. Pressure is intrinsically an analog value, and these I2C digital sensors have an internal ADC to convert the signal.  The k-value is used to configure the algorithm used by the ADC to the range of pressure.  It will default to 4096 if not specified, which is appropriate for a sensor measuring a maximum pressure in the window of +/- 1-2 kPa.
 
 .. code-block:: yaml
 
      measuring range of the sensor
             kpa           k 
-        131 < P ≤ 262     32
-         65 < P ≤ 131     64
-         32 < P ≤ 65     128
-         16 < P ≤ 32     256
-          8 < P ≤ 16     512
-          4 < P ≤ 8     1024
-          2 ≤ P ≤ 4     2048
-          1 ≤ P < 2     4096
-              P < 1     8192
+       131 < P ≤ 262     32
+        65 < P ≤ 131     64
+        32 < P ≤ 65     128
+        16 < P ≤ 32     256
+         8 < P ≤ 16     512
+         4 < P ≤ 8     1024
+         2 ≤ P ≤ 4     2048
+         1 ≤ P < 2     4096
+             P < 1     8192
 
     So for example, when measuring -30~80kpa, P=80kpa and the k value is 64.
     

--- a/components/sensor/xgzp68xx.rst
+++ b/components/sensor/xgzp68xx.rst
@@ -1,15 +1,14 @@
-CFSensor XGZP68xx Series Differential Pressure Sensor
+Sencoch Semiconductor GZP68xx / CFSensor XGZP68xx Series Differential Pressure Sensor
 =====================================================
 
 .. seo::
     :description: Instructions for setting up the CFSensor XGZP68xx Series Differential Pressure sensor.
     :image: 6897d.jpg
-    :keywords: XGZP68xx, XGZP6897, XGZP6899, XGZP6899D, XGZP6897D
+    :keywords: XGZP68xx, XGZP6897, XGZP6899, XGZP6899D, XGZP6897D, GZP6899, GZP68xx, GZP6897, GXP6899, GZP6897D, GXP6899D
 
-The XGZP68xx Differential Pressure sensor allows you to use digital differential pressure sensors such as the 6899D
-(`datasheet <https://cfsensor.com/wp-content/uploads/2022/11/XGZP6899D-Pressure-Sensor-V2.8.pdf>`__) or 
-6897D Series (`datasheet <https://cfsensor.com/wp-content/uploads/2022/11/XGZP6897D-Pressure-Sensor-V2.7.pdf>`__)
-sensors with ESPHome. The sensors pressure ranges are specified in the datasheets.
+The XGZP68xx Differential Pressure sensor allows you to use digital differential pressure sensors such as the 6899D or 
+6897D Series sensors with ESPHome. They are made by the Chinese OEM Sencoch under the GZP68xxD P/N.
+The sensors pressure ranges are specified in the datasheets.
 
 Calibrating the sensor can be done by checking the value that is returned when
 the ports are open to the air. This value should be 0. If it is not, you can use the offset option to correct the
@@ -44,7 +43,25 @@ Configuration variables:
 
 - **temperature** (*Optional*): All options from :ref:`Sensor <config-sensor>`.
 - **pressure** (*Optional*): All options from :ref:`Sensor <config-sensor>`.
-- **k_value** (*Optional*, int): The K value comes from the datasheet. It will default to 4096 if not specified, which is appropriate for a sensor with a range of +/- 0.5kPa.
+- **k_value** (*Optional*, int): The K value comes from the following table. Pressure is intrensically an analog value, and these I2C digital sensors have an internal ADC to convert the signal.  The k-value is used to configure the algorithm used by the ADC to the range of pressure.  It will default to 4096 if not specified, which is appropriate for a sensor measuring a maximum pressure in the window of +/- 1-2 kPa.
+
+.. code-block:: yaml
+
+     measuring range of the sensor
+            kpa           k 
+        131 < P ≤ 262     32
+         65 < P ≤ 131     64
+         32 < P ≤ 65     128
+         16 < P ≤ 32     256
+          8 < P ≤ 16     512
+          4 < P ≤ 8     1024
+          2 ≤ P ≤ 4     2048
+          1 ≤ P < 2     4096
+              P < 1     8192
+
+    So for example, when measuring -30~80kpa, P=80kpa and the k value is 64.
+    
+
 - **update_interval** (*Optional*, :ref:`config-time`): The interval to check the sensor. Defaults to ``60s``.
 
 


### PR DESCRIPTION
- Added mention of the OEM of the chips which matches the P/N which are available from many board fabs and part suppliers
- removed dead links to datasheets
- added the data from the datasheet for configuring the k-value from the datasheets

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
