### PR TITLE
[esp32_can] update docs for can tx enqueue timeout

### DIFF
--- a/components/canbus/esp32_can.rst
+++ b/components/canbus/esp32_can.rst
@@ -29,7 +29,7 @@ Configuration variables:
 - **rx_queue_len** (**Optional**, int): Length of RX queue.
 - **tx_queue_len** (**Optional**, int): Length of TX queue, 0 to disable.
 - **tx_enqueue_timeout** (**Optional**, :ref:`config-time`): Maximum time to wait when the TX queue is full before
-  dropping the message (by default, this is set to the time it takes to send 10 CAN messages at the given baud rate).
+  dropping the message (by default, this is set to the time it takes to send 10 CAN messages at the given bit rate).
 - All other options from :ref:`Canbus <config-canbus>`.
 
 .. _esp32-can-bit-rate:

--- a/components/canbus/esp32_can.rst
+++ b/components/canbus/esp32_can.rst
@@ -28,6 +28,8 @@ Configuration variables:
 - **tx_pin** (**Required**, :ref:`Pin <config-pin>`): Transmit pin.
 - **rx_queue_len** (**Optional**, int): Length of RX queue.
 - **tx_queue_len** (**Optional**, int): Length of TX queue, 0 to disable.
+- **tx_enqueue_timeout** (**Optional**, :ref:`config-time`): Maximum time to wait when the TX queue is full before
+  dropping the message (by default, this is set to the time it takes to send 10 CAN messages at the given baud rate).
 - All other options from :ref:`Canbus <config-canbus>`.
 
 .. _esp32-can-bit-rate:


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** -

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#8453

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
