### PR TITLE
[cookbook/lvgl] Fix lingering references to use_transparency for images

### DIFF
--- a/components/lvgl/widgets.rst
+++ b/components/lvgl/widgets.rst
@@ -804,7 +804,7 @@ Images are the basic widgets used to display images.
 
 .. note::
 
-    Currently ``RGB565`` type images are supported, with transparency using the optional parameter ``use_transparency`` set. See :ref:`display-image` for how to load an image for rendering in ESPHome.
+    Currently ``RGB565`` type images are supported, with transparency using the optional parameter ``transparency`` set. See :ref:`display-image` for how to load an image for rendering in ESPHome.
 
 .. tip::
 

--- a/cookbook/lvgl.rst
+++ b/cookbook/lvgl.rst
@@ -1190,7 +1190,7 @@ To display a boot image with a spinner animation which disappears automatically 
         id: boot_logo
         resize: 200x200
         type: RGB565
-        use_transparency: alpha_channel
+        transparency: alpha_channel
 
     lvgl:
       ...


### PR DESCRIPTION
## Description:
In #4595 the documentation was updated for the change to the image component renaming `use_transparency` to `transparency`.  There are a couple of old references to the old name in the cookbook examples for LVGL.  This corrects those to use the correct parameter name.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#8113
- esphome/esphome#8115
- #4595

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
