### PR TITLE
[psram] Document use of experimental 120MHz octal mode

### DIFF
--- a/components/esp32.rst
+++ b/components/esp32.rst
@@ -112,6 +112,9 @@ Advanced Configuration
 - **ignore_efuse_mac_crc** (*Optional*, boolean): Can be set to ``true`` for devices on which the burned-in MAC
   address is not consistent with the burned-in CRC for that MAC address, resulting in an error like
   ``Base MAC address from BLK0 of EFUSE CRC error``. **Valid only on original ESP32 with** ``esp-idf`` **framework.**
+- **enable_idf_experimental_features** (*Optional*, boolean): Can be set to ``true`` to enable
+  experimental features in the ESP-IDF framework. Not valid for the Arduino framework. Use of experimental features
+  may cause instability or other issues.
 
 GPIO Pin Numbering
 ------------------

--- a/components/psram.rst
+++ b/components/psram.rst
@@ -27,7 +27,8 @@ Restrictions
 ------------
 * Not all ESP32 modules have PSRAM available. If you are unsure, consult the datasheet of your module.
 * Not all modules support all modes and speeds.
-* 120MHz is not available with octal mode.
+* 120MHz is not available with octal mode, unless using ESP-IDF and the ``enable_idf_experimental_features`` is enabled
+  in the ESP-IDF platform :ref:`esp32-advanced_configuration`.
 * If you choose the wrong mode for your board, the PSRAM will not work.
 * Configuring an unsupported speed will usually result in the PSRAM running at the default speed.
 * Typically on ESP32-S3 modules, a 2MB PSRAM will use quad mode, while 8 or 16MB will use octal mode.

--- a/components/psram.rst
+++ b/components/psram.rst
@@ -22,6 +22,9 @@ Configuration variables:
 
 - **mode** (*Optional*): Defines the operating mode the PSRAM should utilize. One of ``quad`` (default) or ``octal``.
 - **speed** (*Optional*, int): The speed at which the PSRAM should operate. One of ``40MHz`` (default), ``80MHz`` or ``120MHz``.
+- **enable_ecc** (*Optional*, bool): For octal mode, enable ECC (Error Correction Code) for the PSRAM (default is off.)
+  ECC is a method of detecting and correcting single-bit errors in memory. It will reduce the available PSRAM size and speed by
+  1/16th, but also increases the rated temperature range of some ESP32 modules.
 
 Restrictions
 ------------


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#8519

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
