### PR TITLE
Update to correct math for watt/kilowatt conversion

### DIFF
--- a/cookbook/power_meter.rst
+++ b/cookbook/power_meter.rst
@@ -96,7 +96,7 @@ When the total sensor is configured, ``pulse_meter`` also reports the total numb
           state_class: total_increasing
           accuracy_decimals: 3
           filters:
-            - multiply: 0.0001  # (1/10000 pulses per kWh)
+            - multiply: 0.001  # (1/10000 pulses per kWh)
             # - throttle_average: 10s
             # - filter_out: NaN
 

--- a/cookbook/power_meter.rst
+++ b/cookbook/power_meter.rst
@@ -96,7 +96,7 @@ When the total sensor is configured, ``pulse_meter`` also reports the total numb
           state_class: total_increasing
           accuracy_decimals: 3
           filters:
-            - multiply: 0.001  # (1/10000 pulses per kWh)
+            - multiply: 0.001  # (1/1000 pulses per kWh)
             # - throttle_average: 10s
             # - filter_out: NaN
 


### PR DESCRIPTION
1kW = 1000 watts
1 ÷ 1000 = 0.001

See [Home Assistant Glow config](https://github.com/klaasnicolaas/home-assistant-glow/blob/develop/components/pulse_meter.yaml#L79) for reference

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
