### PR TITLE
Add a helpful nudge to set a `friendly_name`

### DIFF
--- a/components/esphome.rst
+++ b/components/esphome.rst
@@ -30,9 +30,13 @@ Configuration variables:
   characters, digits and hyphens, and can be at most 24 characters long by default, or 31
   characters long if ``name_add_mac_suffix`` is ``false``.
   See :ref:`esphome-changing_node_name`.
-- **friendly_name** (*Optional*, string): This is the name sent to the frontend. It is used
-  by Home Assistant as the integration name, device name, and is automatically prefixed to entities
-  where necessary.
+- **friendly_name** (*Optional*, string):  
+  This name is sent to the frontend and used by Home Assistant as  
+  the integration and device name. It also gets prefixed to entity  
+  names when needed. While optional, leaving it out can result in  
+  less intuitive names and a less polished experience in Home  
+  Assistant. Setting a `friendly_name` helps keep things clear,  
+  consistent, and easier to manage.
 - **area** (*Optional*, string): This is the area sent to the frontend. It is used
   by Home Assistant as the area / zone which the node belongs to.
 


### PR DESCRIPTION
## Description:

Add a helpful nudge to set a `friendly_name`

https://github.com/home-assistant/core/pull/143049#discussion_r2047364632

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
