### PR TITLE
add `test.esp32-s3-{ard,idf}.yaml` files to required tests

### DIFF
--- a/guides/contributing.rst
+++ b/guides/contributing.rst
@@ -1101,6 +1101,8 @@ components/platforms include the following test files:
 - ``test.esp32-idf.yaml`` - ESP32 (Xtensa)/IDF
 - ``test.esp32-c3-ard.yaml`` - ESP32-C3 (RISC-V)/Arduino
 - ``test.esp32-c3-idf.yaml`` - ESP32-C3 (RISC-V)/IDF
+- ``test.esp32-s3-ard.yaml`` - ESP32-S3 (Xtensa)/Arduino
+- ``test.esp32-s3-idf.yaml`` - ESP32-S3 (Xtensa)/IDF
 - ``test.esp8266-ard.yaml`` - ESP8266 (Xtensa)/Arduino
 - ``test.rp2040-ard.yaml`` - RP2040 (ARM)/Arduino
 


### PR DESCRIPTION
## Description:
add `test.esp32-s3-{ard,idf}.yaml` files to required tests because the ESP32-S3 is one of the recommended ESP32 variants to buy/use

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
