### PR TITLE
Update bp5758d.rst to fix config vars bullet list

### DIFF
--- a/components/output/bp5758d.rst
+++ b/components/output/bp5758d.rst
@@ -67,8 +67,8 @@ Configuration variables:
 
 - **id** (**Required**, :ref:`config-id`): The id to use for this output component.
 - **channel** (**Required**, int): Chose the channel of the BP5758D chain of
-  this output component. Valid values are 1-5
-  **current** (*Optional*, int): Current in mA, valid values are 0-90, default 10.
+  this output component. Valid values are 1-5.
+- **current** (*Optional*, int): Current in mA, valid values are 0-90, default 10.
 - **bp5758d_id** (*Optional*, :ref:`config-id`): Manually specify the ID of the
   :ref:`bp5758d-component`.
   Use this if you have multiple BP5758D chains you want to use at the same time.


### PR DESCRIPTION
## Description:
**current** should be a separate bullet point.  

## Checklist:

  - [X ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.