### PR TITLE
Make certain MDNS config options templatable

### DIFF
--- a/components/mdns.rst
+++ b/components/mdns.rst
@@ -50,5 +50,5 @@ Configuration variables:
 
   - **service** (**Required**, string): Name of extra service.
   - **protocol** (**Required**, string): Protocol of service (_udp or _tcp).
-  - **port** (*Optional*, int): Port number of extra service.
-  - **txt** (*Optional*, mapping): Additional text records to add to service.
+  - **port** (*Optional*, :ref:`templatable <config-templatable>`, int): Port number of extra service.
+  - **txt** (*Optional*, mapping): Additional text records to add to service. Values are :ref:`templatable <config-templatable>`.


### PR DESCRIPTION
## Description:

Adds support for MDNS service configurations with templatable configuration options for port and txt entry values. This allows for device makers to publish custom MDNS entries with values that are unique per device or build.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#8606

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
