### PR TITLE
Note how MQTT initialization will block other components from loading until WiFi becomes available. 

### DIFF
--- a/components/mqtt.rst
+++ b/components/mqtt.rst
@@ -35,7 +35,8 @@ Configuration variables:
 
 - **broker** (**Required**, string): The host of your MQTT broker.
 - **enable_on_boot** (*Optional*, boolean): If enabled, MQTT will be enabled on boot. Defaults to ``true``. 
-  MQTT initialization during boot will wait until wifi is available. See :ref:`mqtt-enable-action` for more information.
+  If enabled during boot, MQTT initialization will block other components from loading until WiFi becomes available. 
+  See :ref:`mqtt-enable-action` for more information.
 - **port** (*Optional*, int): The port to connect to. Defaults to 1883.
 - **username** (*Optional*, string): The username to use for
   authentication. Empty (the default) means no authentication.

--- a/components/mqtt.rst
+++ b/components/mqtt.rst
@@ -36,7 +36,7 @@ Configuration variables:
 - **broker** (**Required**, string): The host of your MQTT broker.
 - **enable_on_boot** (*Optional*, boolean): If enabled, MQTT will be enabled on boot. Defaults to ``true``. 
   If enabled during boot, MQTT initialization will block other components from loading until WiFi becomes available. 
-  See :ref:`mqtt-enable-action` for more information.
+  See :ref:`mqtt-enable_action` for more information.
 - **port** (*Optional*, int): The port to connect to. Defaults to 1883.
 - **username** (*Optional*, string): The username to use for
   authentication. Empty (the default) means no authentication.
@@ -752,6 +752,7 @@ This action turns off the MQTT component on demand.
 
     The configuration option ``enable_on_boot`` can be set to ``false`` if you do not want MQTT to be enabled on boot.
 
+.. _mqtt-enable_action:
 
 ``mqtt.enable`` Action
 ----------------------

--- a/components/mqtt.rst
+++ b/components/mqtt.rst
@@ -34,7 +34,8 @@ Configuration variables:
 ------------------------
 
 - **broker** (**Required**, string): The host of your MQTT broker.
-- **enable_on_boot** (*Optional*, boolean): If enabled, MQTT will be enabled on boot. Defaults to ``true``.
+- **enable_on_boot** (*Optional*, boolean): If enabled, MQTT will be enabled on boot. Defaults to ``true``. 
+  MQTT initialization during boot will wait until wifi is available. See :ref:`mqtt-enable-action` for more information.
 - **port** (*Optional*, int): The port to connect to. Defaults to 1883.
 - **username** (*Optional*, string): The username to use for
   authentication. Empty (the default) means no authentication.
@@ -785,6 +786,30 @@ This action turns on the MQTT component on demand.
       then:
         - lambda: !lambda id(mqtt_id).set_broker_address(id(broker_address));
         - mqtt.enable:
+
+.. note::
+
+    When MQTT is initialized during boot, initialization will block and wait until a connection is established. This 
+    will prevent other components like ``improv_serial`` from loading. To load all components during boot before WiFi 
+    is configured, set ``enable_on_boot`` to ``false`` and enable MQTT after the boot is complete.
+
+.. code-block:: yaml
+
+    esphome:
+      # ...
+      on_boot:
+        priority: 250
+        then:
+          - delay: 3s
+          - mqtt.enable:
+
+    mqtt:
+      # ...
+      enable_on_boot: False
+
+    wifi:
+
+    improv_serial:
 
 .. _mqtt-connected_condition:
 


### PR DESCRIPTION
## Description:

Improve documentation of MQTT when used in combination with improv_serial.
Initializing MQTT during boot up will block improv_serial from loading.
This documentation explains the behaviour and shows how MQTT can be used with improv_serial effectively.

**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/6957


## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
