### PR TITLE
[microphone] Document Microphone Source

### DIFF
--- a/components/microphone/index.rst
+++ b/components/microphone/index.rst
@@ -29,12 +29,12 @@ A microphone source configuration is used by components to ensure that it receiv
 Configuration variables:
 
 - **microphone** (**Required**, :ref:`config-id`): The :doc:`microphone </components/microphone/index>` to use for input.
-- **bits_per_sample** (*Optional*, int): The bits per sample to use as input to the component. 
+- **bits_per_sample** (*Optional*, int): The bits per sample to use as input to the component.
   May be restricted by the component to a specific value.
 - **channels** (*Optional*, list): A list of 0-indexed channel numbers enabling them to use as
-  input to the component. The total amount may be restricted by the component. Defaults to 0, 
+  input to the component. The total amount may be restricted by the component. Defaults to 0,
   the first channel read by the microphone.
-- **gain_factor** (*Optional*, int): The gain factor to apply to audio read from the microphone. Ranges from 1 to 64. 
+- **gain_factor** (*Optional*, int): The gain factor to apply to audio read from the microphone. Ranges from 1 to 64.
   Defaults to 1, no gain.
 
 .. _microphone-actions:

--- a/components/microphone/index.rst
+++ b/components/microphone/index.rst
@@ -29,9 +29,13 @@ A microphone source configuration is used by components to ensure that it receiv
 Configuration variables:
 
 - **microphone** (**Required**, :ref:`config-id`): The :doc:`microphone </components/microphone/index>` to use for input.
-- **bits_per_sample** (*Optional*, int): The bits per sample to use as input to the component. May be restricted by the component to a specific value.
-- **channels** (*Optional*, list): A list of 0-indexed channel numbers enabling them to use as input to the component. The total amount may be restricted by the component. Defaults to 0, the first channel read by the microphone.
-- **gain_factor** (*Optional*, int): The gain factor to apply to audio read from the microphone. Ranges from 1 to 64. Defaults to 1, no gain.
+- **bits_per_sample** (*Optional*, int): The bits per sample to use as input to the component. 
+  May be restricted by the component to a specific value.
+- **channels** (*Optional*, list): A list of 0-indexed channel numbers enabling them to use as
+  input to the component. The total amount may be restricted by the component. Defaults to 0, 
+  the first channel read by the microphone.
+- **gain_factor** (*Optional*, int): The gain factor to apply to audio read from the microphone. Ranges from 1 to 64. 
+  Defaults to 1, no gain.
 
 .. _microphone-actions:
 

--- a/components/microphone/index.rst
+++ b/components/microphone/index.rst
@@ -18,6 +18,21 @@ Configuration variables:
 - **on_data** (*Optional*, :ref:`Automation <automation>`): An automation to
   perform when new data is received.
 
+
+.. _config-microphone-source:
+
+Microphone Source Configuration
+-------------------------------
+
+A microphone source configuration is used by components to ensure that it receives audio in the required format.
+
+Configuration variables:
+
+- **microphone** (**Required**, :ref:`config-id`): The :doc:`microphone </components/microphone/index>` to use for input.
+- **bits_per_sample** (**Optional**, int): The bits per sample to use as input to the component. May be restricted by the component to a specific value.
+- **channels** (**Optional**, list): A list of 0-indexed channel numbers enabling them to use as input to the component. The total amount may be restricted by the component. Defaults to 0, the first channel read by the microphone.
+- **gain_factor** (**Optional**, int): The gain factor to apply to audio read from the microphone. Ranges from 1 to 64. Defaults to 1, no gain.
+
 .. _microphone-actions:
 
 Microphone Actions

--- a/components/microphone/index.rst
+++ b/components/microphone/index.rst
@@ -29,9 +29,9 @@ A microphone source configuration is used by components to ensure that it receiv
 Configuration variables:
 
 - **microphone** (**Required**, :ref:`config-id`): The :doc:`microphone </components/microphone/index>` to use for input.
-- **bits_per_sample** (**Optional**, int): The bits per sample to use as input to the component. May be restricted by the component to a specific value.
-- **channels** (**Optional**, list): A list of 0-indexed channel numbers enabling them to use as input to the component. The total amount may be restricted by the component. Defaults to 0, the first channel read by the microphone.
-- **gain_factor** (**Optional**, int): The gain factor to apply to audio read from the microphone. Ranges from 1 to 64. Defaults to 1, no gain.
+- **bits_per_sample** (*Optional*, int): The bits per sample to use as input to the component. May be restricted by the component to a specific value.
+- **channels** (*Optional*, list): A list of 0-indexed channel numbers enabling them to use as input to the component. The total amount may be restricted by the component. Defaults to 0, the first channel read by the microphone.
+- **gain_factor** (*Optional*, int): The gain factor to apply to audio read from the microphone. Ranges from 1 to 64. Defaults to 1, no gain.
 
 .. _microphone-actions:
 


### PR DESCRIPTION
## Description:

Documents the new Microphone Source helper that individual components will use to configure reading from an actual microphone component. A future PR will use and link to this documentation in the ``micro_wake_word`` and ``voice_assistant`` components.

**Related issue (if applicable):** not applicable

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#8641

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
