### PR TITLE
Make sidebar logo navigate to home or component index based on current page

### DIFF
--- a/_templates/logo-components.html
+++ b/_templates/logo-components.html
@@ -1,0 +1,5 @@
+<p class="logo">
+  <a href="{{ pathto('components/index', 0) }}" aria-label="Documentation" title="Documentation">
+    {% include "_logo_svg.html" %}
+  </a>
+</p>

--- a/_templates/logo.html
+++ b/_templates/logo.html
@@ -1,0 +1,5 @@
+<p class="logo">
+  <a href="{{ pathto(master_doc) }}" aria-label="ESPHome" title="ESPHome">
+    {% include "_logo_svg.html" %}
+  </a>
+</p>

--- a/_templates/searchbox.html
+++ b/_templates/searchbox.html
@@ -1,5 +1,5 @@
 <p class="logo">
-    <a href="/components/index.html">
+    <a href="{{ pathto('components/index', 0) }}" aria-label="Documentation" title="Documentation">
         {% include "_logo_svg.html" %}
     </a>
 </p>

--- a/_templates/searchbox.html
+++ b/_templates/searchbox.html
@@ -1,9 +1,3 @@
-<p class="logo">
-    <a href="{{ pathto('components/index', 0) }}" aria-label="Documentation" title="Documentation">
-        {% include "_logo_svg.html" %}
-    </a>
-</p>
-
 <script src="/pagefind/pagefind-modular-ui.js"></script>
 <div class="pagefind-ui__form" id="search"></div>
 <script>

--- a/conf.py
+++ b/conf.py
@@ -24,7 +24,6 @@ import hashlib
 import os
 import sys
 
-
 sys.path.append(os.path.abspath("_extensions"))
 
 # -- General configuration ------------------------------------------------
@@ -161,16 +160,37 @@ html_static_path = ["_static"]
 #
 # This is required for the alabaster theme
 # refs: http://alabaster.readthedocs.io/en/latest/installation.html#sidebars
-html_sidebars = {
-    "**": [
-        # 'about.html',
-        "searchbox.html",
-        "localtoc.html",
-        "contact.html",
-    ],
-    "index": []
-}
 
+index_link_pages = [
+    "automations",
+    "changelog",
+    "cookbook",
+    "guides",
+    "projects",
+    "web-api",
+]
+
+index_sidebar = [
+    "logo.html",
+    "searchbox.html",
+    "localtoc.html",
+    "contact.html",
+]
+
+html_sidebars = {f"{k}/**": index_sidebar for k in index_link_pages}
+
+html_sidebars.update(
+    {
+        "components/**": [
+            "logo-components.html",
+            "searchbox.html",
+            "localtoc.html",
+            "contact.html",
+        ],
+        "components/index": index_sidebar,
+        "index": [],
+    }
+)
 
 
 # -- Options for HTMLHelp output ------------------------------------------


### PR DESCRIPTION
## Description:

https://github.com/esphome/esphome-docs/pull/4736 moved to use custom logo html in the sidebar and did not add a link wrapper around it


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
