### PR TITLE
[i2s_audio] Document mclk_multiple and bits_per_sample vs bits_per_channel on IDF5 driver

### DIFF
--- a/components/microphone/i2s_audio.rst
+++ b/components/microphone/i2s_audio.rst
@@ -43,10 +43,9 @@ Configuration variables:
 - **channel** (*Optional*, enum): The channel of the microphone. One of ``left``, ``right``, or ``stereo``. If ``stereo``, the output data will
   be twice as big, with each right sample followed by a left sample. Defaults to ``right``.
 - **sample_rate** (*Optional*, positive integer): I2S sample rate. Defaults to ``16000``.
-- **bits_per_sample** (*Optional*, enum): The bit depth of the audio samples. Note that with the legacy driver while set to ``24bit`` or ``32bit``, the samples
-  will be scaled down to 16bit before being forwarded. Setting is ignored if the legacy driver is not used. One of ``8bit``, ``16bit``, ``24bit``, or ``32bit``. Defaults to ``32bit``.
-- **bits_per_channel** (*Optional*, enum): The bit depth of the audio channels. This is what is actually received from the microphone. Note that while set to ``24bit`` or ``32bit``, the samples
-  will be scaled down to 16bit before being forwarded. See the datasheet of your I2S device for details. Defaults to ``bits_per_sample`` or ``16bit`` when not using the legacy driver.
+- **bits_per_sample** (*Optional*, enum): The bit depth of audio samples representing real data received from the microphone. One of ``8bit``, ``16bit``, ``24bit``, or ``32bit``. Defaults to ``32bit``.
+- **bits_per_channel** (*Optional*, enum): The bit depth of audio samples actually read from the microphone. One of ``8bit``, ``16bit``, ``24bit``, or ``32bit``. Defaults to ``32bit``. Setting is ignored if the legacy driver is not used.
+- **mclk_multiple** (*Optional*, enum): The multiple of the MCLK frequency to the sample rate. Must be divisible by 3 if using 24 bits per sample. One of ``128``, ``256``, ``384``, ``512``. Defaults to ``256``.
 - **use_apll** (*Optional*, boolean): I2S using APLL as main I2S clock, enable it to get accurate clock. Defaults to ``false``.
 - **i2s_mode** (*Optional*, enum): The I²S mode to use. One of ``primary`` (clock driven by the host) or ``secondary`` (clock driven by the attached device). Defaults to ``primary``.
 - **i2s_audio_id** (*Optional*, :ref:`config-id`): The ID of the :ref:`I²S Audio <i2s_audio>` you wish to use for this microphone.

--- a/components/speaker/i2s_audio.rst
+++ b/components/speaker/i2s_audio.rst
@@ -36,10 +36,10 @@ Configuration variables:
 - **channel** (*Optional*, enum): The channel of the speaker. One of ``left``, ``right``, ``mono``, or ``stereo``. If ``stereo``, the input data should be twice as big,
   with each right sample followed by a left sample. ``left`` and ``right`` mute the unused channel, while ``mono`` plays the same samples on both. Defaults to ``mono``.
 - **sample_rate** (*Optional*, positive integer): I2S sample rate. If in ``primary`` I²S mode the sample rate of the audio stream is used. Defaults to ``16000``.
-- **bits_per_sample** (*Optional*, enum): The bit depth of the audio samples. Note that with the I²S legacy driver while set to ``24bit`` or ``32bit``, the samples
-  will be scaled up from 16bit before being forwarded. Setting is ignored if the legacy driver is not used. One of ``8bit``, ``16bit``, ``24bit``, or ``32bit``. Defaults to ``16bit``.
+- **bits_per_sample** (*Optional*, enum): The bit depth of the audio samples sent to the DAC. One of ``8bit``, ``16bit``, ``24bit``, or ``32bit``. Defaults to ``16bit``.
 - **bits_per_channel** (*Optional*, enum): The bit depth of the audio channels. This is what is actually send to the DAC and needs to be equal or larger than ``bits_per_sample``.
-  See the datasheet of your I2S device for details. Defaults to ``bits_per_sample`` or the bit width of the audio stream when not using the legacy driver.
+  See the datasheet of your I2S device for details. Defaults to ``bits_per_sample``. Setting is ignored if the legacy driver is not used.
+- **mclk_multiple** (*Optional*, enum): The multiple of the MCLK frequency to the sample rate. Must be divisible by 3 if using 24 bits per sample. One of ``128``, ``256``, ``384``, ``512``. Defaults to ``256``.
 - **use_apll** (*Optional*, boolean): I2S using APLL as main I2S clock, enable it to get accurate clock. Defaults to ``false``.
 - **i2s_mode** (*Optional*, enum): The I²S mode to use. One of ``primary`` (clock driven by the host) or ``secondary`` (clock driven by the attached device). Defaults to ``primary``.
 - **i2s_audio_id** (*Optional*, :ref:`config-id`): The ID of the :ref:`I²S Audio <i2s_audio>` you wish to use for this speaker.


### PR DESCRIPTION
## Description:

- Adds documentation for the ``mclk_multiple`` configuration option.
- Documents the change to using the ``bits_per_sample`` setting instead of ``bits_per_channel`` setting with the new IDF5 driver, and notes that ``bits_per_channel`` is unused with the IDF5 driver. This will avoid a breaking change for a large number of users.

**Related issue (if applicable):** not applicable

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#8651

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
