### PR TITLE
add a note to max7219digit.rst

### DIFF
--- a/components/display/max7219digit.rst
+++ b/components/display/max7219digit.rst
@@ -105,12 +105,13 @@ commands have been added to the basic display set.
 This is roughly the code used to display the MAX7219 pictured in the image.
 
 
-    .. note:: 
+Font usage
+**********
+Because 8x8 matrix displays has a limited height of 8 pixels only, the use of TrueType fonts for displaying text 
+is not recommended. While rendering the single characters easily unattractive artifacts will occur. Bitmap-based 
+fonts in `bdf format <https://en.wikipedia.org/wiki/Glyph_Bitmap_Distribution_Format>`__  are more suitable. 
+For example 5x7.bdf or 5x8.bdf
 
-    Because 8x8 matrix displays has a limited height of 8 pixels only, the use of TrueType fonts for displaying text 
-    is not recommended. While rendering the single characters easily unattractive artifacts will occur. Bitmap-based 
-    fonts in `bdf format <https://en.wikipedia.org/wiki/Glyph_Bitmap_Distribution_Format>`__  are more suitable. 
-    For example 5x7.bdf or 5x8.bdf
 
 
 Scrolling

--- a/components/display/max7219digit.rst
+++ b/components/display/max7219digit.rst
@@ -107,10 +107,10 @@ This is roughly the code used to display the MAX7219 pictured in the image.
 
   .. note:: 
 
-       Because 8x8 matrix displays has a limited height of 8 pixels only, the use of TrueType fonts for displaying text 
-       is not recommended. While rendering the single characters easily unattractive artifacts will occur. Bitmap-based 
-       fonts in `bdf format <https://en.wikipedia.org/wiki/Glyph_Bitmap_Distribution_Format>`__  are more suitable. 
-       For example 5x7.bdf or 5x8.bdf
+    Because 8x8 matrix displays has a limited height of 8 pixels only, the use of TrueType fonts for displaying text 
+    is not recommended. While rendering the single characters easily unattractive artifacts will occur. Bitmap-based 
+    fonts in `bdf format <https://en.wikipedia.org/wiki/Glyph_Bitmap_Distribution_Format>`__  are more suitable. 
+    For example 5x7.bdf or 5x8.bdf
 
 
 Scrolling

--- a/components/display/max7219digit.rst
+++ b/components/display/max7219digit.rst
@@ -104,6 +104,15 @@ commands have been added to the basic display set.
 
 This is roughly the code used to display the MAX7219 pictured in the image.
 
+
+  .. note:: 
+
+       Because 8x8 matrix displays has a limited height of 8 pixels only, the use of TrueType fonts for displaying text 
+       is not recommended. While rendering the single characters easily unattractive artifacts will occur. Bitmap-based 
+       fonts in `bdf format <https://en.wikipedia.org/wiki/Glyph_Bitmap_Distribution_Format>`__  are more suitable. 
+       For example 5x7.bdf or 5x8.bdf
+
+
 Scrolling
 *********
 

--- a/components/display/max7219digit.rst
+++ b/components/display/max7219digit.rst
@@ -105,7 +105,7 @@ commands have been added to the basic display set.
 This is roughly the code used to display the MAX7219 pictured in the image.
 
 
-  .. note:: 
+    .. note:: 
 
     Because 8x8 matrix displays has a limited height of 8 pixels only, the use of TrueType fonts for displaying text 
     is not recommended. While rendering the single characters easily unattractive artifacts will occur. Bitmap-based 


### PR DESCRIPTION
The example yaml code for the uses a TrueType Font for printing text strings. TrueType fonts are not really usable for displays with just a few pixels in height, e.g. 8 pixels. If the character height is limited to 8 pixels only, the font render engine has a hard time generating nice characters. Bitmap based fonts are more suitable for this type of display. 

So I just added a note to state this.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
