### PR TITLE
Fix strftime example

### DIFF
--- a/components/time/index.rst
+++ b/components/time/index.rst
@@ -281,7 +281,7 @@ allows for a lot of flexibility.
 
 .. code-block:: cpp
 
-    # For example, in a display object
+    // For example, in a display object
     it.strftime(0, 0, id(font), "%Y-%m-%d %H:%M", id(time).now());
 
 The strftime will parse the format string (here ``"%Y-%m-%d %H:%M"``) and match anything beginning with


### PR DESCRIPTION
Fix strftime example by changing # to //.

## Description:
Fix C++ code example.

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
