### PR TITLE
[voice_assistant] document micro_wake_word configuration option

### DIFF
--- a/components/voice_assistant.rst
+++ b/components/voice_assistant.rst
@@ -32,6 +32,7 @@ Configuration variables:
       microphone: mic_id
 
 - **microphone** (**Required**, :ref:`config-microphone-source`): The :doc:`microphone </components/microphone/index>` settings to use for input.
+- **micro_wake_word** (*Optional*, :ref:`config-id`): The :doc:`micro_wake_word </components/micro_wake_word>` component used for wake word detection. Configuring this allows Home Assistant to change which wake word model is enabled.
 - **speaker** (*Optional*, :ref:`config-id`): The :doc:`speaker </components/speaker/index>` to use to output the response.
   Cannot be used with ``media_player`` below.
 - **media_player** (*Optional*, :ref:`config-id`): The :doc:`media_player </components/media_player/index>` to use


### PR DESCRIPTION
## Description:

Documents the new ``micro_wake_word`` configuration option.

**Related issue (if applicable):** not applicable

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#8657

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
