### PR TITLE
Add workflow to check mismatching labels

### DIFF
--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -1,7 +1,7 @@
 name: Check labels
 
 on:
-  pull_request:
+  pull_request_target:
     types: [labeled, unlabeled]
 
 jobs:

--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -9,7 +9,7 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     steps:
-      - name: Check for needs-docs label
+      - name: Check labels
         uses: actions/github-script@v7.0.1
         with:
           script: |
@@ -18,23 +18,23 @@ jobs:
               repo: context.repo.repo,
               issue_number: context.issue.number
             });
-            const hasParent = labels.find(label => label.name === 'has-parent');
-            const current = labels.find(label => label.name === 'current');
+            const hasParent = labels.find(label => label.name === "has-parent");
+            const current = labels.find(label => label.name === "current");
             if (hasParent && current) {
               await github.rest.issues.addLabels({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: context.issue.number,
-                labels: ['wrong-base-branch']
+                labels: ["wrong-base-branch"]
               });
 
               await github.rest.pulls.createReview({
                 pull_number: context.issue.number,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                event: 'REQUEST_CHANGES',
-                body: "As this is a feature matched with a PR in https://github.com/esphome/esphome, please target your PR to the 'next' branch and rebase."
+                event: "REQUEST_CHANGES",
+                body: "As this is a feature matched with a PR in https://github.com/esphome/esphome, please target your PR to the `next` branch and rebase."
               });
 
-              core.setFailed('As this is a feature matched with a PR in https://github.com/esphome/esphome, please target your PR to the 'next' branch and rebase.');
+              core.setFailed("As this is a feature matched with a PR in https://github.com/esphome/esphome, please target your PR to the 'next' branch and rebase.");
             }

--- a/.github/workflows/needs-docs.yml
+++ b/.github/workflows/needs-docs.yml
@@ -1,0 +1,25 @@
+name: Check labels
+
+on:
+  pull_request:
+    types: [labeled, unlabeled]
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for needs-docs label
+        uses: actions/github-script@v7.0.1
+        with:
+          script: |
+            const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number
+            });
+            const hasParent = labels.find(label => label.name === 'has-parent');
+            const current = labels.find(label => label.name === 'current');
+            if (hasParent && current) {
+              core.setFailed('Pull request has parent code PR but is targetting current. Please change the target branch to next.');
+            }

--- a/.github/workflows/needs-docs.yml
+++ b/.github/workflows/needs-docs.yml
@@ -21,5 +21,14 @@ jobs:
             const hasParent = labels.find(label => label.name === 'has-parent');
             const current = labels.find(label => label.name === 'current');
             if (hasParent && current) {
-              core.setFailed('Pull request has parent code PR but is targetting current. Please change the target branch to next.');
+              core.setFailed('Pull request has a linked PR in https://github.com/esphome/esphome but is targeting current. Please change the target branch to next.');
             }
+
+            const reviewMessage = 'Pull request has a linked PR in https://github.com/esphome/esphome but is targeting current. Please change the target branch to next.';
+            await github.pulls.createReview({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+              event: 'REQUEST_CHANGES',
+              body: reviewMessage
+            });

--- a/.github/workflows/needs-docs.yml
+++ b/.github/workflows/needs-docs.yml
@@ -21,14 +21,20 @@ jobs:
             const hasParent = labels.find(label => label.name === 'has-parent');
             const current = labels.find(label => label.name === 'current');
             if (hasParent && current) {
-              core.setFailed('Pull request has a linked PR in https://github.com/esphome/esphome but is targeting current. Please change the target branch to next.');
-            }
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                labels: ['wrong-base-branch']
+              });
 
-            const reviewMessage = 'Pull request has a linked PR in https://github.com/esphome/esphome but is targeting current. Please change the target branch to next.';
-            await github.pulls.createReview({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.issue.number,
-              event: 'REQUEST_CHANGES',
-              body: reviewMessage
-            });
+              await github.rest.pulls.createReview({
+                pull_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                event: 'REQUEST_CHANGES',
+                body: "As this is a feature matched with a PR in https://github.com/esphome/esphome, please target your PR to the 'next' branch and rebase."
+              });
+
+              core.setFailed('As this is a feature matched with a PR in https://github.com/esphome/esphome, please target your PR to the 'next' branch and rebase.');
+            }


### PR DESCRIPTION
## Description:

Many times I have accidentally merged a PR but it was targetted to current instead of next. 
This workflow will fail if the description has a code pr linked and targets current.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
