### PR TITLE
HA style version label

### DIFF
--- a/_static/index.css
+++ b/_static/index.css
@@ -293,6 +293,12 @@
     .feature-icon {
         color: #00bfff;
     }
+
+    .release-date a {
+        background: #393939;
+        color: #3fc3ff !important;
+    }
+
 }
 
 @media (max-width: 768px) {

--- a/_static/index.css
+++ b/_static/index.css
@@ -31,7 +31,7 @@
     align-items: center;
 }
 
-.release-date a {
+a.release-date {
     font-size: 10px;
     padding: 0 5px 0 5px;
     background: #ececec;

--- a/_static/index.css
+++ b/_static/index.css
@@ -32,9 +32,9 @@
 }
 
 a.release-date {
-    font-size: 10px;
+    font-size: 12px;
     padding: 0 5px 0 5px;
-    background: #ececec;
+    background: #1d5c87;
     color: #007fa8 !important;
     border-radius: 5px;
     height: fit-content;

--- a/_static/index.css
+++ b/_static/index.css
@@ -31,6 +31,16 @@
     align-items: center;
 }
 
+.release-date a {
+    font-size: 10px;
+    padding: 0 5px 0 5px;
+    background: #ececec;
+    color: #007fa8 !important;
+    border-radius: 5px;
+    height: fit-content;
+    letter-spacing: 0.025rem;
+}
+
 /* Hamburger Button Styles */
 .hamburger-button {
     display: none;

--- a/_static/index.css
+++ b/_static/index.css
@@ -34,8 +34,8 @@
 a.release-date {
     font-size: 12px;
     padding: 0 5px 0 5px;
-    background: #1d5c87;
-    color: #007fa8 !important;
+    background: #ececec;
+    color: #1d5c87 !important;
     border-radius: 5px;
     height: fit-content;
     letter-spacing: 0.025rem;

--- a/_static/index.css
+++ b/_static/index.css
@@ -294,7 +294,7 @@ a.release-date {
         color: #00bfff;
     }
 
-    .release-date a {
+    a.release-date {
         background: #393939;
         color: #3fc3ff !important;
     }

--- a/index.rst
+++ b/index.rst
@@ -16,6 +16,7 @@
         <nav class="sticky-nav">
             <div class="nav-logo">
                 <a href="/"><img src="_images/logo.svg" alt="ESPHome Logo" height="30"></a>
+                <a class="release-date" href="/changelog/" title="Latest version 2025.4.1 released April 29, 2025">2025.4.1</a>
             </div>
             <button type="button" class="hamburger-button" aria-label="Open menu" aria-expanded="false">
                 <span></span>


### PR DESCRIPTION
## Description:
HA style version label from home-assistant.io

**Related issue (if applicable):** fixes <link to issue>
NONE
**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 
NONE
- esphome/esphome#<esphome PR number goes here> NONE

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
