### PR TITLE
[microphone] Document software mute automations

### DIFF
--- a/components/microphone/index.rst
+++ b/components/microphone/index.rst
@@ -65,6 +65,20 @@ and will be available in the ``on_data`` trigger.
 
 This action will stop capturing audio data from the microphone.
 
+.. _microphone-mute:
+
+``microphone.mute`` Action
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This action will apply a software mute to the audio data from the microphone before passing it to any listening components.
+
+.. _microphone-unmute:
+
+``microphone.unmute`` Action
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This action will disable applying a software mute initiated with ``microphone.mute``.
+
 
 .. _microphone-triggers:
 
@@ -112,6 +126,13 @@ Configuration variables:
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 This condition will check if the microphone is currently capturing audio data.
+
+.. _microphone-is_muted:
+
+``microphone.is_muted`` Condition
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This condition will check if the microphone is currently apply a software mute.
 
 
 Platforms

--- a/components/microphone/index.rst
+++ b/components/microphone/index.rst
@@ -77,7 +77,8 @@ Microphone Triggers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 This trigger will fire when new data is received from the microphone.
-The data is available as a ``std::vector<int16_t>`` in the variable ``x``.
+The data is available as a ``std::vector<uint8_t>`` in the variable ``x``.
+This data is the raw microphone audio and includes all the read bits per sample and channels.
 
 .. code-block:: yaml
 


### PR DESCRIPTION
## Description:

- Documents the ``microphone.mute`` and ``microphone.unmute`` actions
- Documents the ``microphone.is_muted`` condition
- Fixes the description of the ``on_data`` trigger to reflect the recent microphone code changes.

**Related issue (if applicable):** not applicable

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#8667

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
