### PR TITLE
Correct lvgl.style.update example

### DIFF
--- a/components/lvgl/index.rst
+++ b/components/lvgl/index.rst
@@ -474,9 +474,8 @@ The action takes a style ID and a dictionary of properties to update. The proper
     on_...:
       - lvgl.style.update:
           id: my_style
-          properties:
-            bg_color: 0xFF0000
-            border_color: 0x00FF00
+          bg_color: 0xFF0000
+          border_color: 0x00FF00
 
 .. _lvgl-layouts:
 


### PR DESCRIPTION
## Description:
Correct lvgl.style.update example

The properties to be updated must be listed directly in a dictionary under lvgl.style.update, not nested within a `properties` key.


**Related issue (if applicable):**

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
