### PR TITLE
Uppercase `H` in `Hz`

### DIFF
--- a/components/ethernet.rst
+++ b/components/ethernet.rst
@@ -93,9 +93,9 @@ SPI configuration variables:
   This variable is **required** for older frameworks. See below.
 - **reset_pin** (*Optional*, :ref:`config-pin`): The reset pin.
 - **clock_speed** (*Optional*, float): The SPI clock speed.
-  Any frequency between `8Mhz` and `80Mhz` is allowed, but the nearest integer division
-  of `80Mhz` is used, i.e. `16Mhz` (`80Mhz` / 5) is used when `15Mhz` is configured.
-  Default: `26.67Mhz`.
+  Any frequency between `8MHz` and `80MHz` is allowed, but the nearest integer division
+  of `80MHz` is used, i.e. `16MHz` (`80MHz` / 5) is used when `15MHz` is configured.
+  Default: `26.67MHz`.
 - **polling_interval** (*Optional*, :ref:`config-time`): If ``interrupt_pin`` is not set,
   set the time interval for periodic polling. Minimum is 1ms, Defaults to 10ms.
   Older frameworks may not support this variable. See below for details.

--- a/components/remote_receiver.rst
+++ b/components/remote_receiver.rst
@@ -104,7 +104,7 @@ ESP32 IDF configuration variables:
   limited to ``rmt_symbols``.
 - **filter_symbols** (*Optional*, int): Filter out any data received with a length in symbols less than
   ``filter_symbols``. Useful for filtering out short bursts of noise.
-- **clock_resolution** (*Optional*, int): The clock resolution used by the RMT peripheral in hz. Defaults to
+- **clock_resolution** (*Optional*, int): The clock resolution used by the RMT peripheral in Hz. Defaults to
   ``1000000``.
 - **use_dma** (*Optional*, boolean): Enable DMA on variants that support it.
 
@@ -500,7 +500,7 @@ Remote code selection (exactly one of these has to be included):
 
 .. note::
 
-    The **CanalSat** and **CanalSatLD** protocols use a higher carrier frequency (56khz) and are very similar.
+    The **CanalSat** and **CanalSatLD** protocols use a higher carrier frequency (56kHz) and are very similar.
     Depending on the hardware used they may interfere with each other when enabled simultaneously.
 
 

--- a/components/remote_transmitter.rst
+++ b/components/remote_transmitter.rst
@@ -56,7 +56,7 @@ ESP32 IDF configuration variables:
       "ESP32-C6", "192 symbols", "48 symbols"
       "ESP32-H2", "192 symbols", "48 symbols"
 
-- **clock_resolution** (*Optional*, int): The clock resolution used by the RMT peripheral in hz. Defaults to ``1000000``.
+- **clock_resolution** (*Optional*, int): The clock resolution used by the RMT peripheral in Hz. Defaults to ``1000000``.
 - **use_dma** (*Optional*, boolean): Enable DMA on variants that support it.
 - **eot_level** (*Optional*, boolean): Overrides the default end of transmit level. Defaults to ``false`` unless ``pin``
   is set to inverted or open-drain.
@@ -234,7 +234,7 @@ This :ref:`action <config-action>` sends a CanalSat infrared remote code to a re
 
 .. note::
 
-    The CanalSat and CanalSatLD protocols use a higher carrier frequency (56khz) and are very similar.
+    The CanalSat and CanalSatLD protocols use a higher carrier frequency (56kHz) and are very similar.
     Depending on the hardware used they may interfere with each other when enabled simultaneously.
 
 .. code-block:: yaml
@@ -262,7 +262,7 @@ This :ref:`action <config-action>` sends a CanalSatLD infrared remote code to a 
 
 .. note::
 
-    The CanalSat and CanalSatLD protocols use a higher carrier frequency (56khz) and are very similar.
+    The CanalSat and CanalSatLD protocols use a higher carrier frequency (56kHz) and are very similar.
     Depending on the hardware used they may interfere with each other when enabled simultaneously.
 
 .. code-block:: yaml

--- a/components/sensor/ld2420.rst
+++ b/components/sensor/ld2420.rst
@@ -1,4 +1,4 @@
-LD2420 24Ghz mmWave Radar Sensor
+LD2420 24GHz mmWave Radar Sensor
 ================================
 
 .. seo::

--- a/components/sensor/mcp9600.rst
+++ b/components/sensor/mcp9600.rst
@@ -13,7 +13,7 @@ required to be set up in your configuration for this sensor to work.
 
 .. note::
 
-    The :ref:`I²C <i2c>` bus must be set to a minimum of ``10khz`` due to the limitations of the MCP9600 and MCP9601.
+    The :ref:`I²C <i2c>` bus must be set to a minimum of ``10kHz`` due to the limitations of the MCP9600 and MCP9601.
 
 .. figure:: images/mcp9600.jpg
     :align: center

--- a/components/sensor/sht3xd.rst
+++ b/components/sensor/sht3xd.rst
@@ -65,7 +65,7 @@ A solution that has been tested on ESP32 at 800kHz, is to increase the I²C time
       sda: 21
       scl: 22
       scan: true
-      frequency: 800khz
+      frequency: 800kHz
       timeout: 10ms
 
 See Also


### PR DESCRIPTION
## Description:
Uppercase the `H` in `Hz`

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
