### PR TITLE
Document software_coexistence for esp32_ble_tracker

### DIFF
--- a/components/esp32_ble_tracker.rst
+++ b/components/esp32_ble_tracker.rst
@@ -87,7 +87,7 @@ Configuration variables:
     asked to start a scan (with start_scan action). Defaults to ``true``.
   - **software_coexistence** (*Optional*, boolean): When enabled, software coexistence will
     briefly prioritize Bluetooth over Wi-Fi during the initial establishment of BLE connections,
-    which can improve reliability. Has no effect if the ``wifi`` component is not configured. 
+    which can improve reliability. Only available if ``wifi`` component is configured.
     Defaults to ``true``.
 
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID for this ESP32 BLE Hub.

--- a/components/esp32_ble_tracker.rst
+++ b/components/esp32_ble_tracker.rst
@@ -85,6 +85,10 @@ Configuration variables:
     you can save power and RF pollution by setting it to ``false``. Defaults to ``true``.
   - **continuous** (*Optional*, boolean): Whether to scan continuously (forever) or to only scan when
     asked to start a scan (with start_scan action). Defaults to ``true``.
+  - **software_coexistence** (*Optional*, boolean): When enabled, software coexistence will
+    briefly prioritize Bluetooth over Wi-Fi during the initial establishment of BLE connections,
+    which can improve reliability. Has no effect if the ``wifi`` component is not configured. 
+    Defaults to ``true``.
 
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID for this ESP32 BLE Hub.
 - **max_connections** (*Optional*, int): The maximum number of BLE connection slots to use.


### PR DESCRIPTION
## Description:

Document software_coexistence for esp32_ble_tracker

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#8683

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
