### PR TITLE
[modbus_controller] fix register address range overlap #6998 

### DIFF
--- a/components/modbus_controller.rst
+++ b/components/modbus_controller.rst
@@ -74,7 +74,7 @@ Configuration variables:
 - **max_cmd_retries** (*Optional*, integer): How many times a command will be retried if no response is received. It doesn't include the initial transmition. Defaults to 4.
 
 - **server_registers** (*Optional*): A list of registers that are responded to when acting as a server.
-  - **address** (**Required**, integer): start address of the first register in a range
+  - **address** (**Required**, integer): start address of the first register in a range. Address ranges must not overlap.
   - **value_type** (*Optional*): datatype of the mod_bus register data. The default data type for ModBUS is a 16 bit integer in big endian format (MSB first)
 
       - ``U_WORD``: unsigned 16 bit integer from 1 register = 16bit


### PR DESCRIPTION
`server_register` address ranges may not overlap

## Description:

Update `server_register` documentation to note that address ranges may not overlap


**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/6998

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#8697

## Checklist:

  - [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
