### PR TITLE
Regenerate 2025.4.0 changelog with new dependency section

### DIFF
--- a/changelog/2025.4.0.rst
+++ b/changelog/2025.4.0.rst
@@ -75,78 +75,87 @@ Beta Changes
 All changes
 ^^^^^^^^^^^
 
-- Bump setuptools from 69.2.0 to 76.0.0 :esphomepr:`8405` by :ghuser:`dependabot[bot]`
-- Bump puremagic from 1.27 to 1.28 :esphomepr:`8406` by :ghuser:`dependabot[bot]`
-- Bump esphome-glyphsets from 0.1.0 to 0.2.0 :esphomepr:`8403` by :ghuser:`dependabot[bot]`
-- Bump actions/cache from 4.2.2 to 4.2.3 in /.github/actions/restore-python :esphomepr:`8437` by :ghuser:`dependabot[bot]`
-- Bump actions/cache from 4.2.2 to 4.2.3 :esphomepr:`8433` by :ghuser:`dependabot[bot]`
-- Bump ruff from 0.9.2 to 0.11.0 :esphomepr:`8409` by :ghuser:`dependabot[bot]`
-- Bump pylint from 3.2.7 to 3.3.6 :esphomepr:`8441` by :ghuser:`dependabot[bot]`
-- Update wheel requirement from ~=0.43.0 to >=0.43,<0.46 :esphomepr:`8421` by :ghuser:`dependabot[bot]`
-- Bump tzlocal from 5.2 to 5.3.1 :esphomepr:`8423` by :ghuser:`dependabot[bot]`
-- [esp32] Allow pioarduino versions 5.3.2 and 5.4.0 :esphomepr:`8440` by :ghuser:`swoboda1337`
-- [cli] Add `--reset` and `--upload_speed` options :esphomepr:`8380` by :ghuser:`clydebarrow`
-- Bump aioesphomeapi from 29.6.0 to 29.7.0 :esphomepr:`8448` by :ghuser:`dependabot[bot]`
-- Bump pytest-asyncio from 0.23.6 to 0.25.3 :esphomepr:`8447` by :ghuser:`dependabot[bot]`
-- [core] Fix 5.4.0 build issue :esphomepr:`8455` by :ghuser:`swoboda1337`
-- [core] Fix s2 build after crc header fix :esphomepr:`8459` by :ghuser:`swoboda1337`
-- [esp32_can] Configurable enqueue timeout :esphomepr:`8453` by :ghuser:`patagonaa`
-- [scheduler] Properly handle millis() overflow :esphomepr:`8197` by :ghuser:`clydebarrow`
-- [esp32] Allow pioarduino version 5.4.1 :esphomepr:`8480` by :ghuser:`swoboda1337`
-- Bump ruff from 0.11.0 to 0.11.2 :esphomepr:`8461` by :ghuser:`dependabot[bot]`
-- [psram] 120MHz does not work in octal mode :esphomepr:`8477` by :ghuser:`clydebarrow`
-- Bump actions/setup-python from 5.4.0 to 5.5.0 :esphomepr:`8468` by :ghuser:`dependabot[bot]`
-- Bump actions/setup-python from 5.4.0 to 5.5.0 in /.github/actions/restore-python :esphomepr:`8467` by :ghuser:`dependabot[bot]`
-- Bump pytest-cov from 5.0.0 to 6.0.0 :esphomepr:`8462` by :ghuser:`dependabot[bot]`
-- Bump pytest-asyncio from 0.25.3 to 0.26.0 :esphomepr:`8490` by :ghuser:`dependabot[bot]`
-- Bump async-timeout from 4.0.3 to 5.0.1 :esphomepr:`8491` by :ghuser:`dependabot[bot]`
-- Bump platformio from 6.1.16 to 6.1.18 :esphomepr:`8449` by :ghuser:`dependabot[bot]`
-- Move CONF_DEFAULT to const.py :esphomepr:`8497` by :ghuser:`nielsnl68`
-- [lvgl] Add some defines :esphomepr:`8501` by :ghuser:`clydebarrow`
-- Add support for MCP4461 quad i2c digipot/rheostat :esphomepr:`8180` by :ghuser:`p1ngb4ck` (new-integration)
-- Bump peter-evans/create-pull-request from 7.0.7 to 7.0.8 :esphomepr:`8362` by :ghuser:`dependabot[bot]`
-- Bump docker/login-action from 3.3.0 to 3.4.0 in the docker-actions group :esphomepr:`8408` by :ghuser:`dependabot[bot]`
-- Bump actions/download-artifact from 4.1.9 to 4.2.1 :esphomepr:`8434` by :ghuser:`dependabot[bot]`
-- Bump actions/upload-artifact from 4.6.1 to 4.6.2 :esphomepr:`8435` by :ghuser:`dependabot[bot]`
-- Bump ruamel-yaml from 0.18.6 to 0.18.10 :esphomepr:`8446` by :ghuser:`dependabot[bot]`
-- Bump yamllint from 1.35.1 to 1.37.0 :esphomepr:`8495` by :ghuser:`dependabot[bot]`
-- Bump pyupgrade from 3.15.2 to 3.19.1 :esphomepr:`8496` by :ghuser:`dependabot[bot]`
-- Bump voluptuous from 0.14.2 to 0.15.2 :esphomepr:`8506` by :ghuser:`dependabot[bot]`
-- Bump zeroconf from 0.146.1 to 0.146.3 :esphomepr:`8507` by :ghuser:`dependabot[bot]`
-- Bump platformio to 6.1.18 :esphomepr:`8430` by :ghuser:`shvmm`
-- Update emails from nabucasa to OHF :esphomepr:`8508` by :ghuser:`jesserockz`
-- [nau7802] fix bad blocking code (#6395) :esphomepr:`8070` by :ghuser:`cujomalainey`
-- [core, qspi_dbi] Clang tidy fixes for 5.3.2 :esphomepr:`8509` by :ghuser:`swoboda1337`
-- [CI] Clang tidy fixes for 5.3.2 :esphomepr:`8510` by :ghuser:`swoboda1337`
-- [ethernet_info] return actual ethernet MAC address :esphomepr:`8492` by :ghuser:`victorclaessen`
-- Bump setuptools from 76.0.0 to 78.1.0 :esphomepr:`8512` by :ghuser:`dependabot[bot]`
-- Bump flake8 from 7.0.0 to 7.2.0 :esphomepr:`8493` by :ghuser:`dependabot[bot]`
-- Rework max connections for BLE to avoid exceeding the hard limit :esphomepr:`8303` by :ghuser:`bdraco` (breaking-change)
-- [component] Show error message for failed component :esphomepr:`8478` by :ghuser:`clydebarrow`
-- [psram] Allow use of experimental 120MHz octal mode :esphomepr:`8519` by :ghuser:`clydebarrow`
-- Ensure plaintext responds with bad indicator byte before dropping the connection :esphomepr:`8521` by :ghuser:`bdraco`
-- Bump aioesphomeapi to 29.9.0 :esphomepr:`8522` by :ghuser:`bdraco`
-- [lvgl] add on_boot trigger :esphomepr:`8498` by :ghuser:`clydebarrow`
-- [lvgl] Make line points templatable :esphomepr:`8502` by :ghuser:`clydebarrow`
-- [spi] Implement octal mode :esphomepr:`8386` by :ghuser:`clydebarrow`
-- Bump pytest from 8.2.0 to 8.3.5 :esphomepr:`8528` by :ghuser:`dependabot[bot]`
-- real_time_clock: Apply timezone immediately in set_timezone() :esphomepr:`8531` by :ghuser:`dwmw2`
-- [lvgl] Implement canvas widget :esphomepr:`8504` by :ghuser:`clydebarrow`
-- [lvgl] Fix use of image without canvas (Bugfix) :esphomepr:`8540` by :ghuser:`clydebarrow`
-- Include MAC address in noise hello :esphomepr:`8551` by :ghuser:`bdraco`
-- [axs15231] Don't overwrite manual dimensions :esphomepr:`8553` by :ghuser:`clydebarrow`
-- [lvgl] Fix initial focus on roller :esphomepr:`8547` by :ghuser:`clydebarrow`
-- [lvgl] Add restore_value to select and number :esphomepr:`8494` by :ghuser:`clydebarrow`
-- Speaker-Media-Player: Fix potential deadlock in audio pipeline :esphomepr:`8548` by :ghuser:`gnumpi`
-- [lvgl] Ensure captured lambdas are in correct order :esphomepr:`8560` by :ghuser:`clydebarrow`
-- Bump aioesphomeapi from 29.9.0 to 29.10.0 :esphomepr:`8562` by :ghuser:`dependabot[bot]`
-- Bump zeroconf from 0.146.3 to 0.146.4 :esphomepr:`8563` by :ghuser:`dependabot[bot]`
-- Bump esphome-dashboard to 20250415.0 :esphomepr:`8565` by :ghuser:`swoboda1337`
-- Fix '--device MQTT' for devices with static IP :esphomepr:`8535` by :ghuser:`dwmw2`
-- [am2315c] Use warning not fail during update :esphomepr:`8499` by :ghuser:`swoboda1337`
-- Bump zeroconf from 0.146.4 to 0.146.5 :esphomepr:`8569` by :ghuser:`dependabot[bot]`
-- Fix vscode validation not showing error squiggles :esphomepr:`8500` by :ghuser:`glmnet`
-- SML runtime optimizations :esphomepr:`8571` by :ghuser:`mariusgreuel`
+.. collapse:: Show
+    :open:
+
+    - [esp32] Allow pioarduino versions 5.3.2 and 5.4.0 :esphomepr:`8440` by :ghuser:`swoboda1337`
+    - [cli] Add `--reset` and `--upload_speed` options :esphomepr:`8380` by :ghuser:`clydebarrow`
+    - [core] Fix 5.4.0 build issue :esphomepr:`8455` by :ghuser:`swoboda1337`
+    - [core] Fix s2 build after crc header fix :esphomepr:`8459` by :ghuser:`swoboda1337`
+    - [esp32_can] Configurable enqueue timeout :esphomepr:`8453` by :ghuser:`patagonaa`
+    - [scheduler] Properly handle millis() overflow :esphomepr:`8197` by :ghuser:`clydebarrow`
+    - [esp32] Allow pioarduino version 5.4.1 :esphomepr:`8480` by :ghuser:`swoboda1337`
+    - [psram] 120MHz does not work in octal mode :esphomepr:`8477` by :ghuser:`clydebarrow`
+    - Move CONF_DEFAULT to const.py :esphomepr:`8497` by :ghuser:`nielsnl68`
+    - [lvgl] Add some defines :esphomepr:`8501` by :ghuser:`clydebarrow`
+    - Add support for MCP4461 quad i2c digipot/rheostat :esphomepr:`8180` by :ghuser:`p1ngb4ck` (new-integration)
+    - Bump platformio to 6.1.18 :esphomepr:`8430` by :ghuser:`shvmm`
+    - Update emails from nabucasa to OHF :esphomepr:`8508` by :ghuser:`jesserockz`
+    - [nau7802] fix bad blocking code (#6395) :esphomepr:`8070` by :ghuser:`cujomalainey`
+    - [core, qspi_dbi] Clang tidy fixes for 5.3.2 :esphomepr:`8509` by :ghuser:`swoboda1337`
+    - [CI] Clang tidy fixes for 5.3.2 :esphomepr:`8510` by :ghuser:`swoboda1337`
+    - [ethernet_info] return actual ethernet MAC address :esphomepr:`8492` by :ghuser:`victorclaessen`
+    - Rework max connections for BLE to avoid exceeding the hard limit :esphomepr:`8303` by :ghuser:`bdraco` (breaking-change)
+    - [component] Show error message for failed component :esphomepr:`8478` by :ghuser:`clydebarrow`
+    - [psram] Allow use of experimental 120MHz octal mode :esphomepr:`8519` by :ghuser:`clydebarrow`
+    - Ensure plaintext responds with bad indicator byte before dropping the connection :esphomepr:`8521` by :ghuser:`bdraco`
+    - Bump aioesphomeapi to 29.9.0 :esphomepr:`8522` by :ghuser:`bdraco`
+    - [lvgl] add on_boot trigger :esphomepr:`8498` by :ghuser:`clydebarrow`
+    - [lvgl] Make line points templatable :esphomepr:`8502` by :ghuser:`clydebarrow`
+    - [spi] Implement octal mode :esphomepr:`8386` by :ghuser:`clydebarrow`
+    - real_time_clock: Apply timezone immediately in set_timezone() :esphomepr:`8531` by :ghuser:`dwmw2`
+    - [lvgl] Implement canvas widget :esphomepr:`8504` by :ghuser:`clydebarrow`
+    - [lvgl] Fix use of image without canvas (Bugfix) :esphomepr:`8540` by :ghuser:`clydebarrow`
+    - Include MAC address in noise hello :esphomepr:`8551` by :ghuser:`bdraco`
+    - [axs15231] Don't overwrite manual dimensions :esphomepr:`8553` by :ghuser:`clydebarrow`
+    - [lvgl] Fix initial focus on roller :esphomepr:`8547` by :ghuser:`clydebarrow`
+    - [lvgl] Add restore_value to select and number :esphomepr:`8494` by :ghuser:`clydebarrow`
+    - Speaker-Media-Player: Fix potential deadlock in audio pipeline :esphomepr:`8548` by :ghuser:`gnumpi`
+    - [lvgl] Ensure captured lambdas are in correct order :esphomepr:`8560` by :ghuser:`clydebarrow`
+    - Bump esphome-dashboard to 20250415.0 :esphomepr:`8565` by :ghuser:`swoboda1337`
+    - Fix '--device MQTT' for devices with static IP :esphomepr:`8535` by :ghuser:`dwmw2`
+    - [am2315c] Use warning not fail during update :esphomepr:`8499` by :ghuser:`swoboda1337`
+    - Fix vscode validation not showing error squiggles :esphomepr:`8500` by :ghuser:`glmnet`
+    - SML runtime optimizations :esphomepr:`8571` by :ghuser:`mariusgreuel`
+
+Dependency Changes
+^^^^^^^^^^^^^^^^^^
+
+.. collapse:: Show
+
+    - Bump setuptools from 69.2.0 to 76.0.0 :esphomepr:`8405` by :ghuser:`dependabot[bot]`
+    - Bump puremagic from 1.27 to 1.28 :esphomepr:`8406` by :ghuser:`dependabot[bot]`
+    - Bump esphome-glyphsets from 0.1.0 to 0.2.0 :esphomepr:`8403` by :ghuser:`dependabot[bot]`
+    - Bump actions/cache from 4.2.2 to 4.2.3 in /.github/actions/restore-python :esphomepr:`8437` by :ghuser:`dependabot[bot]`
+    - Bump actions/cache from 4.2.2 to 4.2.3 :esphomepr:`8433` by :ghuser:`dependabot[bot]`
+    - Bump ruff from 0.9.2 to 0.11.0 :esphomepr:`8409` by :ghuser:`dependabot[bot]`
+    - Bump pylint from 3.2.7 to 3.3.6 :esphomepr:`8441` by :ghuser:`dependabot[bot]`
+    - Update wheel requirement from ~=0.43.0 to >=0.43,<0.46 :esphomepr:`8421` by :ghuser:`dependabot[bot]`
+    - Bump tzlocal from 5.2 to 5.3.1 :esphomepr:`8423` by :ghuser:`dependabot[bot]`
+    - Bump aioesphomeapi from 29.6.0 to 29.7.0 :esphomepr:`8448` by :ghuser:`dependabot[bot]`
+    - Bump pytest-asyncio from 0.23.6 to 0.25.3 :esphomepr:`8447` by :ghuser:`dependabot[bot]`
+    - Bump ruff from 0.11.0 to 0.11.2 :esphomepr:`8461` by :ghuser:`dependabot[bot]`
+    - Bump actions/setup-python from 5.4.0 to 5.5.0 :esphomepr:`8468` by :ghuser:`dependabot[bot]`
+    - Bump actions/setup-python from 5.4.0 to 5.5.0 in /.github/actions/restore-python :esphomepr:`8467` by :ghuser:`dependabot[bot]`
+    - Bump pytest-cov from 5.0.0 to 6.0.0 :esphomepr:`8462` by :ghuser:`dependabot[bot]`
+    - Bump pytest-asyncio from 0.25.3 to 0.26.0 :esphomepr:`8490` by :ghuser:`dependabot[bot]`
+    - Bump async-timeout from 4.0.3 to 5.0.1 :esphomepr:`8491` by :ghuser:`dependabot[bot]`
+    - Bump platformio from 6.1.16 to 6.1.18 :esphomepr:`8449` by :ghuser:`dependabot[bot]`
+    - Bump peter-evans/create-pull-request from 7.0.7 to 7.0.8 :esphomepr:`8362` by :ghuser:`dependabot[bot]`
+    - Bump docker/login-action from 3.3.0 to 3.4.0 in the docker-actions group :esphomepr:`8408` by :ghuser:`dependabot[bot]`
+    - Bump actions/download-artifact from 4.1.9 to 4.2.1 :esphomepr:`8434` by :ghuser:`dependabot[bot]`
+    - Bump actions/upload-artifact from 4.6.1 to 4.6.2 :esphomepr:`8435` by :ghuser:`dependabot[bot]`
+    - Bump ruamel-yaml from 0.18.6 to 0.18.10 :esphomepr:`8446` by :ghuser:`dependabot[bot]`
+    - Bump yamllint from 1.35.1 to 1.37.0 :esphomepr:`8495` by :ghuser:`dependabot[bot]`
+    - Bump pyupgrade from 3.15.2 to 3.19.1 :esphomepr:`8496` by :ghuser:`dependabot[bot]`
+    - Bump voluptuous from 0.14.2 to 0.15.2 :esphomepr:`8506` by :ghuser:`dependabot[bot]`
+    - Bump zeroconf from 0.146.1 to 0.146.3 :esphomepr:`8507` by :ghuser:`dependabot[bot]`
+    - Bump setuptools from 76.0.0 to 78.1.0 :esphomepr:`8512` by :ghuser:`dependabot[bot]`
+    - Bump flake8 from 7.0.0 to 7.2.0 :esphomepr:`8493` by :ghuser:`dependabot[bot]`
+    - Bump pytest from 8.2.0 to 8.3.5 :esphomepr:`8528` by :ghuser:`dependabot[bot]`
+    - Bump aioesphomeapi from 29.9.0 to 29.10.0 :esphomepr:`8562` by :ghuser:`dependabot[bot]`
+    - Bump zeroconf from 0.146.3 to 0.146.4 :esphomepr:`8563` by :ghuser:`dependabot[bot]`
+    - Bump zeroconf from 0.146.4 to 0.146.5 :esphomepr:`8569` by :ghuser:`dependabot[bot]`
 
 Past Changelogs
 ---------------


### PR DESCRIPTION
## Description:

Hopefully this makes them slightly easier to read

https://github.com/esphome/esphome-release/commit/656097045670452b5e1639f8994f687df752da00

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
