### PR TITLE
[online_image] BMP 24-bit support

### DIFF
--- a/components/online_image.rst
+++ b/components/online_image.rst
@@ -13,7 +13,10 @@ With this component you can define images that will be downloaded, decoded and d
 
     Current supported formats:
 
-    - BMP images, currently only binary uncompressed images are supported
+    - BMP images
+
+      - 1-bit / binary / black and white
+      - 24-bit / RGB
 
     - JPEG images, currently only baseline images (no progressive support)
 


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#8612

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
