### PR TITLE
[alarm_control_panel] Document new `auto_bypass` option for template alarm control panel binary sensors

### DIFF
--- a/components/alarm_control_panel/template.rst
+++ b/components/alarm_control_panel/template.rst
@@ -36,6 +36,7 @@ Configuration variables:
   - **input** (**Required**, string): The id of the binary sensor component
   - **bypass_armed_home** (*Optional*, boolean): This binary sensor will not trigger the alarm when in ``armed_home`` state.
   - **bypass_armed_night** (*Optional*, boolean): This binary sensor will not trigger the alarm when in ``armed_night`` state.
+  - **bypass_auto** (*Optional*, boolean): This binary sensor will be automatically bypassed if left on/open at the time of arming.
   - **trigger_mode** (*Optional*, string): Sets the trigger mode for this sensor. One of ``delayed``, ``instant``, or ``delayed_follower``. (``delayed`` is the default if not specified)
   - **chime** (*Optional*, boolean): When set ``true``, the chime callback will be called whenever the sensor goes from closed to open. (``false`` is the default if not specified)
 


### PR DESCRIPTION
## Description:

Documents a new `bypass_auto` option for the `binary_sensors` schema used on a Template Alarm Control Panel component.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#8795

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
