### PR TITLE
[esp32_ble_server] Fix broken code examples

### DIFF
--- a/components/esp32_ble_server.rst
+++ b/components/esp32_ble_server.rst
@@ -224,7 +224,7 @@ This action sets the value of a characteristic. A characteristic may not have a 
 
     on_...:
       then:
-        - ble_server.characteristic_set_value:
+        - ble_server.characteristic.set_value:
             id: test_write_characteristic
             value: [0, 1, 2]
 
@@ -244,7 +244,7 @@ This action triggers a notification to the client. The value sent will be the cu
 
     on_...:
       then:
-        - ble_server.characteristic_notify:
+        - ble_server.characteristic.notify:
             id: test_notify_characteristic
 
 Configuration variables:
@@ -262,7 +262,7 @@ This action sets the value of a descriptor.
 
     on_...:
       then:
-        - ble_server.descriptor:
+        - ble_server.descriptor.set_value:
             id: test_write_descriptor
             value: [0, 1, 2]
 


### PR DESCRIPTION
Fix used actions.

Please check if `ble_server.descriptor.set_value` if also correct, as it didn't have ".set_value" at all.

## Description:
I took the code/yaml examples, but they returned an error, fixed my local code, updated the documentation accordingly.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
