### PR TITLE
[ac_dimmer] Add notice about pin schema for zero cross pin reuse

### DIFF
--- a/components/output/ac_dimmer.rst
+++ b/components/output/ac_dimmer.rst
@@ -52,7 +52,9 @@ Configuration variables:
   Mosfet.
 - **zero_cross_pin** (**Required**, :ref:`config-pin`): The pin used to sense the AC
   Zero cross event, you can have several dimmers controlled with the same zero cross
-  detector, in such case duplicate the ``zero_cross_pin`` config on each output.
+  detector, in such case duplicate the ``zero_cross_pin`` config on each output. When
+  doing so, ``allow_other_uses`` pin schema option **must** be set to ``true`` to
+  avoid configuration errors due to pin reuse.
 - **method** (*Optional*): Set the method for dimming, can be:
 
   - ``leading pulse``: (default) a short pulse to trigger a triac.


### PR DESCRIPTION
## Description:

This PR updates the documentation for the ``zero_cross_pin`` configuration option to clarify the behavior when using the same pin across multiple dimmer outputs. It explicitly mentions the need to set ``allow_other_uses: true`` when duplicating ``zero_cross_pin``, in accordance with the pin schema's handling of shared pins.

**Related issue (if applicable):** fixes https://github.com/esphome/esphome/discussions/8543

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
