### PR TITLE
Remove doxygen api docs from main website

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         curl \
         git \
         make \
-        doxygen \
         openssh-client \
         software-properties-common \
         && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/*

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ PAGEFIND_VERSION=1.1.1
 PAGEFIND=pagefind
 NET_PAGEFIND=../pagefindbin/pagefind
 
-.PHONY: pagefind build-html html html-strict cleanhtml deploy help live-html live-pagefind Makefile netlify netlify-api api netlify-dependencies svg2png copy-svg2png minify
+.PHONY: pagefind build-html html html-strict cleanhtml deploy help live-html live-pagefind Makefile netlify netlify-dependencies svg2png copy-svg2png minify
 
 html: pagefind
 	sphinx-build -M html . _build -j auto -n $(O) -Dhtml_extra_path=_redirects,_pagefind
@@ -33,32 +33,12 @@ svg2png:
 help:
 	sphinx-build -M help . _build $(O)
 
-api:
-	mkdir -p _build/html/api
-	@if [ ! -d "$(ESPHOME_PATH)" ]; then \
-	  git clone --branch $(ESPHOME_REF) https://github.com/esphome/esphome.git $(ESPHOME_PATH) || \
-	  git clone --branch beta https://github.com/esphome/esphome.git $(ESPHOME_PATH); \
-	fi
-	ESPHOME_PATH=$(ESPHOME_PATH) doxygen Doxygen
-
 net-html:
 	sphinx-build -M html . _build -j auto -n $(O)
 	mkdir -p _pagefind/pagefind
 	${NET_PAGEFIND}
 	sphinx-build -M html . _build -j auto -n $(O) -Dhtml_extra_path=_redirects,_pagefind
-
-netlify-api: netlify-dependencies
-	mkdir -p _build/html/api
-	@if [ ! -d "$(ESPHOME_PATH)" ]; then \
-	  git clone --branch $(ESPHOME_REF) https://github.com/esphome/esphome.git $(ESPHOME_PATH) || \
-	  git clone --branch beta https://github.com/esphome/esphome.git $(ESPHOME_PATH); \
-	fi
-	ESPHOME_PATH=$(ESPHOME_PATH) ../doxybin/doxygen Doxygen
-
-netlify-dependencies: pagefind-binary
-	mkdir -p ../doxybin
-	curl -L https://github.com/esphome/esphome-docs/releases/download/v1.10.1/doxygen-1.8.13.xz | xz -d >../doxybin/doxygen
-	chmod +x ../doxybin/doxygen
+	sed -i 's@{{API_DOCS_URL}}@'"$API_DOCS_URL"'@' _redirects
 
 pagefind-binary:
 	mkdir -p ../pagefindbin
@@ -71,7 +51,7 @@ pagefind-binary:
 copy-svg2png:
 	cp svg2png/*.png _build/html/_images/
 
-netlify: netlify-dependencies netlify-api net-html copy-svg2png
+netlify: pagefind-binary net-html copy-svg2png
 
 lint: html-strict
 	python3 lint.py

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ help:
 	sphinx-build -M help . _build $(O)
 
 net-html:
-	sed -i 's@{{API_DOCS_URL}}@'"$API_DOCS_URL"'@' _redirects
+	sed -i 's@{{API_DOCS_URL}}@'"${API_DOCS_URL}"'@' _redirects
 	sphinx-build -M html . _build -j auto -n $(O)
 	mkdir -p _pagefind/pagefind
 	${NET_PAGEFIND}

--- a/Makefile
+++ b/Makefile
@@ -34,11 +34,11 @@ help:
 	sphinx-build -M help . _build $(O)
 
 net-html:
+	sed -i 's@{{API_DOCS_URL}}@'"$API_DOCS_URL"'@' _redirects
 	sphinx-build -M html . _build -j auto -n $(O)
 	mkdir -p _pagefind/pagefind
 	${NET_PAGEFIND}
 	sphinx-build -M html . _build -j auto -n $(O) -Dhtml_extra_path=_redirects,_pagefind
-	sed -i 's@{{API_DOCS_URL}}@'"$API_DOCS_URL"'@' _redirects
 
 pagefind-binary:
 	mkdir -p ../pagefindbin

--- a/_extensions/apiref.py
+++ b/_extensions/apiref.py
@@ -1,7 +1,8 @@
+import os
 import re
 import string
-from docutils import nodes, utils
 
+from docutils import nodes, utils
 
 value_re = re.compile(r"^(.*)\s*<(.*)>$")
 DOXYGEN_LOOKUP = {}
@@ -12,6 +13,8 @@ for s in string.ascii_uppercase:
 DOXYGEN_LOOKUP[":"] = "_1"
 DOXYGEN_LOOKUP["_"] = "__"
 DOXYGEN_LOOKUP["."] = "_8"
+
+API_DOCS_URL = os.getenv("API_DOCS_URL", "https://api-docs.esphome.io")
 
 
 def split_text_value(value):
@@ -25,15 +28,17 @@ def encode_doxygen(value):
     value = value.split("/")[-1]
     try:
         return "".join(DOXYGEN_LOOKUP[s] for s in value)
-    except KeyError:
-        raise ValueError("Unknown character in doxygen string! '{}'".format(value))
+    except KeyError as exc:
+        raise ValueError(
+            "Unknown character in doxygen string! '{}'".format(value)
+        ) from exc
 
 
 def apiref_role(name, rawtext, text, lineno, inliner, options=None, content=None):
     text, value = split_text_value(text)
     if text is None:
         text = "API Reference"
-    ref = "/api/{}.html".format(encode_doxygen(value))
+    ref = f"{API_DOCS_URL}/{encode_doxygen(value)}.html"
     return [make_link_node(rawtext, text, ref, options)], []
 
 
@@ -41,7 +46,7 @@ def apiclass_role(name, rawtext, text, lineno, inliner, options=None, content=No
     text, value = split_text_value(text)
     if text is None:
         text = value
-    ref = "/api/classesphome_1_1{}.html".format(encode_doxygen(value))
+    ref = f"{API_DOCS_URL}/classesphome_1_1{encode_doxygen(value)}.html"
     return [make_link_node(rawtext, text, ref, options)], []
 
 
@@ -49,13 +54,15 @@ def apistruct_role(name, rawtext, text, lineno, inliner, options=None, content=N
     text, value = split_text_value(text)
     if text is None:
         text = value
-    ref = "/api/structesphome_1_1{}.html".format(encode_doxygen(value))
+    ref = f"{API_DOCS_URL}/structesphome_1_1{encode_doxygen(value)}.html"
     return [make_link_node(rawtext, text, ref, options)], []
+
 
 def make_link_node(rawtext, text, ref, options=None):
     options = options or {}
     node = nodes.reference(rawtext, utils.unescape(text), refuri=ref, **options)
     return node
+
 
 def setup(app):
     app.add_role("apiref", apiref_role)

--- a/_redirects
+++ b/_redirects
@@ -1,5 +1,9 @@
 /esphomeyaml/* /:splat 301
 
+# This redirect is for the api docs that have been moved.
+# It is replaced by sed in the makefile when netlify is building the site.
+/api/* {{API_DOCS_URL}}/:splat 301
+
 # Moved components
 # e.g: /components/sensors/abc.html /components/sensors/xyz.html 301
 /components/sensor/sgp40.html /components/sensor/sgp4x.html 301

--- a/components/binary_sensor/modbus_controller.rst
+++ b/components/binary_sensor/modbus_controller.rst
@@ -69,5 +69,5 @@ See Also
 - :doc:`/components/select/modbus_controller`
 - :doc:`/components/text_sensor/modbus_controller`
 - https://www.modbustools.com/modbus.html
-- :apiclass:`:modbus_controller::ModbusBinarySensor`
+- :apiclass:`modbus_controller::ModbusBinarySensor`
 - :ghedit:`Edit`

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,13 +1,13 @@
 [build]
   publish = "_build/html"
   command = "make netlify"
-  environment = { BASE_URL = "https://esphome.io", PYTHON_VERSION = "3.12" }
+  environment = { BASE_URL = "https://esphome.io", API_DOCS_URL = "https://api-docs.esphome.io", PYTHON_VERSION = "3.12" }
 
 [context.beta]
-  environment = { BASE_URL = "https://beta.esphome.io" }
+  environment = { BASE_URL = "https://beta.esphome.io", API_DOCS_URL = "https://api-docs-beta.esphome.io" }
 
 [context.next]
-  environment = { BASE_URL = "https://next.esphome.io" }
+  environment = { BASE_URL = "https://next.esphome.io", API_DOCS_URL = "https://api-docs-dev.esphome.io" }
 
 [context.production]
-  environment = { BASE_URL = "https://esphome.io", PRODUCTION = "YES" }
+  environment = { BASE_URL = "https://esphome.io", API_DOCS_URL = "https://api-docs.esphome.io", PRODUCTION = "YES" }

--- a/script/bump-version.py
+++ b/script/bump-version.py
@@ -2,8 +2,8 @@
 
 import argparse
 import re
-from dataclasses import dataclass
 import sys
+from dataclasses import dataclass
 
 
 @dataclass
@@ -54,10 +54,6 @@ def write_version(version: Version):
         "Makefile",
         r"ESPHOME_REF = .*",
         f"ESPHOME_REF = {version}" if not version.dev else "ESPHOME_REF = dev",
-    )
-    # PROJECT_NUMBER         = 1.14.4
-    sub(
-        "Doxygen", r"PROJECT_NUMBER         = .*", f"PROJECT_NUMBER         = {version}"
     )
     # version = '1.14'
     sub("conf.py", r'version = ".*"', f'version = "{version.major}.{version.minor}"')


### PR DESCRIPTION
## Description:

API docs have been moved to:
- https://api-docs.esphome.io
- https://api-docs-beta.esphome.io
- https://api-docs-dev.esphome.io

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
