### PR TITLE
[rp2040] Document watchdog_timeout setting

### DIFF
--- a/components/rp2040.rst
+++ b/components/rp2040.rst
@@ -41,6 +41,9 @@ Configuration variables:
 ------------------------
 
 - **board** (*Optional*, string): The board type. Valid option is ``rpipicow``.
+- **watchdog_timeout** (*Optional*, string): The timeout to apply to the RP2040 watchdog (in seconds or milliseconds).
+  When the device hangs for that period of time, it will reboot. Defaults to ``8388ms`` (maximum). Set to ``0s`` to
+  disable the watchdog entirely.
 
 See Also
 --------


### PR DESCRIPTION
## Description:

Documentation supporting the `watchdog_timeout` feature.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#8868

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
