### PR TITLE
Remove atom lite from recommended bluetooth proxy

### DIFF
--- a/projects/installer.html
+++ b/projects/installer.html
@@ -311,18 +311,6 @@
         type="radio"
         name="bluetooth-device"
         class="device-option"
-        value="m5stack-atom-lite"
-      />
-      <img
-        src="/_static/projects/bluetooth-proxy/m5stack_atom_lite.png"
-        alt="M5Stack Atom Lite"
-      />
-    </label>
-    <label>
-      <input
-        type="radio"
-        name="bluetooth-device"
-        class="device-option"
         value="olimex-esp32-poe-iso"
       />
       <img
@@ -409,26 +397,6 @@
         <a
           href="https://store.gl-inet.com/collections/iot-gateway/products/gl-s10-bluetooth-iot-gateway"
           >GL.iNet Shop</a
-        >
-      </li>
-    </ul>
-  </div>
-
-  <div class="hidden info m5stack-atom-lite">
-    <h3>M5Stack Atom Lite</h3>
-    <p>Small ESP32 board with a case.</p>
-    <p>Buy</p>
-    <ul>
-      <li>
-        <a
-          href="https://shop.m5stack.com/products/atom-lite-esp32-development-kit?ref=NabuCasa"
-          >M5Stack Shop</a
-        >
-      </li>
-      <li>
-        <a
-          href="https://www.aliexpress.com/item/1005003299215808.html?aff_platform=portals-tool&sk=_A8G2YF&aff_trace_key=90326d2a90444b4887632f62dd533ce4-1654058373639-07963-_A8G2YF&terminal_id=c5517a8c9bb44b4fb32147398fbc2576&aff_fcid=90326d2a90444b4887632f62dd533ce4-1654058373639-07963-_A8G2YF&tt=CPS_NORMAL&aff_fsk=_A8G2YF"
-          >AliExpress</a
         >
       </li>
     </ul>


### PR DESCRIPTION
## Description:
The antenna is pretty poor on this device, making it not a good fit for a bluetooth proxy.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
