### PR TITLE
[modbus_controller] add assumed_state option to switch (Fix 6613)

### DIFF
--- a/components/switch/modbus_controller.rst
+++ b/components/switch/modbus_controller.rst
@@ -19,6 +19,7 @@ Configuration variables:
     - ``read``: Read Input Registers - registers are 16-bit registers used for input, and may only be read. Modbus *Function Code 4 (Read Input Registers)* will be used.
 
 - **address** (**Required**, int): start address of the first register in a range (can be decimal or hexadecimal).
+- **assumed_state** (*Optional* boolean): Disables updates (periodic read commands) for this register.  Default is ``false``.
 - **skip_updates** (*Optional*, int): By default, all sensors of a modbus_controller are updated together. For data points that don't change very frequently, updates can be skipped. A value of 5 would only update this sensor range in every 5th update cycle. Note: The modbus_controller groups components by address ranges to reduce number of transactions. All components with the same starting address will be updated in one request. ``skip_updates`` applies for *all* components in the same range.
 - **register_count** (*Optional*, int): The number of consecutive registers this read request should span or skip in a single command. Default is 1. See :ref:`modbus_register_count` for more details.
 - **use_write_multiple** (*Optional*, boolean): By default the modbus command *Function Code 6 (Preset Single Registers)* is used for setting the holding register if only one register is set. If your device only supports *Function Code 16 (Preset Multiple Registers)* set this option to ``true``.


### PR DESCRIPTION
## Description:
Adds documentation for new modbus switch option `assumed_state` which disables updates / read polling

**Related issue (if applicable):** fixes https://github.com/esphome/feature-requests/issues/3159

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#8880

## Checklist:

  - [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
