### PR TITLE
Update ready-made projects links to right YAML

### DIFF
--- a/projects/installer.html
+++ b/projects/installer.html
@@ -291,7 +291,7 @@
     </li>
     <li>
       The YAML configuration is on
-      <a href="https://github.com/esphome/firmware/tree/main/voice-assistant/"
+      <a href="https://github.com/esphome/wake-word-voice-assistants"
         >GitHub</a
       >
     </li>
@@ -524,7 +524,7 @@
     </li>
     <li>
       The YAML configuration is on
-      <a href="https://github.com/esphome/firmware/tree/main/bluetooth-proxy/">GitHub</a>
+      <a href="https://github.com/esphome/bluetooth-proxies">GitHub</a>
     </li>
   </ul>
 </div>
@@ -692,7 +692,7 @@
     </li>
     <li>
       The YAML configuration is on
-      <a href="https://github.com/esphome/firmware/tree/main/media-player/">GitHub</a>
+      <a href="https://github.com/esphome/media-players">GitHub</a>
     </li>
   </ul>
 </div>


### PR DESCRIPTION

## Description:

We had split the repo but forgot to update the links here.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
