### PR TITLE
[esp32] Add c5, c6 and p4 to docs

### DIFF
--- a/components/esp32.rst
+++ b/components/esp32.rst
@@ -24,13 +24,13 @@ Configuration variables:
 - **flash_size** (*Optional*, string): The amount of flash memory available on the ESP32 board/module. One of ``2MB``,
   ``4MB``, ``8MB``, ``16MB`` or ``32MB``. Defaults to ``4MB``. **Warning: specifying a size larger than that available
   on your board will cause the ESP32 to fail to boot.**
-- **cpu_frequency** (*Optional*, string): The CPU frequency to use. One of ``40MHz``, ``80MHz``, ``160MHz`` or ``240MHz``. Defaults to
-  ``160MHz``. Not all values are available for all chips.
+- **cpu_frequency** (*Optional*, string): The CPU frequency to use. One of ``40MHz``, ``80MHz``, ``160MHz``, ``240MHz``,
+  ``360MHz`` or ``400MHz``. Defaults to ``160MHz``. Not all values are available for all chips.
 - **partitions** (*Optional*, filename): The name of (optionally including the path to) the file containing the
   partitioning scheme to be used. When not specified, partitions are automatically generated based on ``flash_size``.
 - **variant** (*Optional*, string): The variant of the ESP32 that is used on this board. One of ``esp32``,
-  ``esp32s2``, ``esp32s3``, ``esp32c3`` and ``esp32h2``. Defaults to the variant that is detected from the board; if
-  a board that's unknown to ESPHome is used, this option is mandatory.
+  ``esp32s2``, ``esp32s3``, ``esp32c2``, ``esp32c3``, ``esp32c5``, ``esp32c6``, ``esp32h2`` and ``esp32p4``. Defaults
+  to the variant that is detected from the board; if a board that's unknown to ESPHome is used, this option is mandatory.
 - **framework** (*Optional*): Options for the underlying framework used by ESPHome. See :ref:`esp32-arduino_framework`
   and :ref:`esp32-espidf_framework`.
 
@@ -73,7 +73,7 @@ ESP-IDF framework
 -----------------
 
 This is an alternative base framework for ESP32 chips; it is recommended for variants of the ESP32 like ESP32S2,
-ESP32S3, ESP32C3 and single-core ESP32 chips.
+ESP32S3, ESP32P4 and single-core ESP32 chips.
 
 .. code-block:: yaml
 

--- a/components/logger.rst
+++ b/components/logger.rst
@@ -106,6 +106,13 @@ Default UART GPIO Pins
       - N/A
       - N/A
       - 18/19
+    * - ESP32-C5
+      - TX: 10, RX: 11
+      - N/A
+      - Undefined
+      - N/A
+      - N/A
+      - 13/14
     * - ESP32-C6
       - TX: 16, RX: 17
       - N/A
@@ -113,6 +120,13 @@ Default UART GPIO Pins
       - N/A
       - N/A
       - 12/13
+    * - ESP32-P4
+      - TX: 37, RX: 38
+      - N/A
+      - TX: 10, RX: 11
+      - N/A
+      - N/A
+      - 24/25
     * - ESP32-S2
       - TX: 43, RX: 44
       - N/A
@@ -155,7 +169,13 @@ the original ESP32 or ESP8266) continue to use USB-to-serial bridge ICs for comm
     * - ESP32-C3
       - ``USB_CDC``
       - ``USB_SERIAL_JTAG``
+    * - ESP32-C5
+      - ``USB_CDC``
+      - ``USB_SERIAL_JTAG``
     * - ESP32-C6
+      - ``USB_CDC``
+      - ``USB_SERIAL_JTAG``
+    * - ESP32-P4
       - ``USB_CDC``
       - ``USB_SERIAL_JTAG``
     * - ESP32-S2


### PR DESCRIPTION
## Description:

Add c5, c6 and p4 to docs

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [1] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
