### PR TITLE
[speaker mediaplayer] add option for initial volume

### DIFF
--- a/components/media_player/speaker.rst
+++ b/components/media_player/speaker.rst
@@ -47,8 +47,8 @@ Configuration variables:
 - **buffer_size** (*Optional*, positive integer): The buffer size in bytes for each pipeline. Must be between ``4000`` and ``4000000``. Defaults to ``1000000``.
 - **codec_support_enabled** (*Optional*, boolean): Enables the MP3 and FLAC decoders and optimizes the WiFi configuration for streaming high quality audio. Defaults to ``true``.
 - **task_stack_in_psram** (*Optional*, boolean): Run the audio tasks in external memory. Defaults to ``false``.
-- **volume_first_boot** (*Optional*, percentage): The default volume that mediaplayer uses for first boot where a volume has not been previously saved. Defaults to ``50%``.
 - **volume_increment** (*Optional*, percentage): Increment amount that the ``media_player.volume_up`` and ``media_player.volume_down`` actions will increase or decrease volume by. Defaults to ``5%``.
+- **volume_initial** (*Optional*, percentage): The default volume that mediaplayer uses for first boot where a volume has not been previously saved. Defaults to ``50%``.
 - **volume_min** (*Optional*, percentage): The minimum volume allowed. Defaults to ``0%``.
 - **volume_max** (*Optional*, percentage): The maximum volume allowed. Defaults to ``100%``.
 - **files** (*Optional*, list): A list of media files to build into the firmware for on-device playback.

--- a/components/media_player/speaker.rst
+++ b/components/media_player/speaker.rst
@@ -47,6 +47,7 @@ Configuration variables:
 - **buffer_size** (*Optional*, positive integer): The buffer size in bytes for each pipeline. Must be between ``4000`` and ``4000000``. Defaults to ``1000000``.
 - **codec_support_enabled** (*Optional*, boolean): Enables the MP3 and FLAC decoders and optimizes the WiFi configuration for streaming high quality audio. Defaults to ``true``.
 - **task_stack_in_psram** (*Optional*, boolean): Run the audio tasks in external memory. Defaults to ``false``.
+- **volume_first_boot** (*Optional*, percentage): The default volume that mediaplayer uses for first boot where a volume has not been previously saved. Defaults to ``50%``.
 - **volume_increment** (*Optional*, percentage): Increment amount that the ``media_player.volume_up`` and ``media_player.volume_down`` actions will increase or decrease volume by. Defaults to ``5%``.
 - **volume_min** (*Optional*, percentage): The minimum volume allowed. Defaults to ``0%``.
 - **volume_max** (*Optional*, percentage): The maximum volume allowed. Defaults to ``100%``.


### PR DESCRIPTION
## Description:
Add option for initial volume (for first boot)

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#8898

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
