### PR TITLE
Fix RP2040 (Pico W) chip documentation (CYW43455 -> CYW43439)

### DIFF
--- a/components/rp2040.rst
+++ b/components/rp2040.rst
@@ -11,7 +11,7 @@ This component contains platform-specific options for the RP2040 platform.
 
     Support for all aspects of ESPHome on the RP2040 is still in development.
 
-    Only the original model of Raspberry Pi Pico W board is supported, which has the Cypress **CYW43455** chip providing wireless connectivity. It can be identified by a metallic shield encapsulating the radio circuitry. Pico W boards with radio module chips like ESP8285 or similar (labelled as ``RP2040 Pico W-2023`` etc.), are not supported.
+    Only the original model of Raspberry Pi Pico W board is supported, which has the Cypress **CYW43439** chip providing wireless connectivity. It can be identified by a metallic shield encapsulating the radio circuitry. Pico W boards with radio module chips like ESP8285 or similar (labelled as ``RP2040 Pico W-2023`` etc.), are not supported.
 
     Please search for or create an `issue <https://github.com/esphome/issues/issues/new?assignees=&labels=&template=bug_report.yml>`__ if you encounter an unknown problem.
 


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/7061

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

NA

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
