### PR TITLE
[output] Add `set_min_power` & `set_max_power` actions for `FloatOutput`

### DIFF
--- a/components/output/index.rst
+++ b/components/output/index.rst
@@ -49,6 +49,10 @@ Float outputs only:
 - **zero_means_zero** (*Optional*, boolean): Sets the output to use actual 0 instead of ``min_power``.
   Defaults to ``false``.
 
+.. note::
+
+    The ``min_power`` and ``max_power`` values are automatically clamped to ensure ``0.0 ≤ min_power ≤ max_power ≤ 1.0``. 
+    This prevents invalid configurations and ensures stable output behavior.
 
 .. _output-turn_on_action:
 
@@ -97,8 +101,13 @@ This action turns the output with the given ID off when executed.
 ``output.set_level`` Action
 ***************************
 
-This action sets the float output to the given level when executed. Note: This only
-works with floating point outputs like :doc:`/components/output/esp8266_pwm`, :doc:`/components/output/ledc`, :doc:`/components/output/sigma_delta_output`, :doc:`/components/output/slow_pwm`.
+This action sets the float output to the given level when executed.
+
+.. note::
+
+    This only works with floating point outputs like :doc:`/components/output/ac_dimmer`, 
+    :doc:`/components/output/esp8266_pwm`, :doc:`/components/output/ledc`, 
+    :doc:`/components/output/sigma_delta_output`, :doc:`/components/output/slow_pwm`.
 
 .. code-block:: yaml
 
@@ -116,6 +125,68 @@ works with floating point outputs like :doc:`/components/output/esp8266_pwm`, :d
 
         // range is 0.0 (off) to 1.0 (on)
         id(light_1).set_level(0.5);
+
+.. _output-set_min_power_action:
+
+``output.set_min_power`` Action
+***************************
+
+This action sets the minimum output power level for the specified float output platform. 
+It allows you to dynamically adjust the ``min_power`` configuration variable at runtime.
+
+.. note::
+
+    This only works with floating point outputs like :doc:`/components/output/ac_dimmer`, 
+    :doc:`/components/output/esp8266_pwm`, :doc:`/components/output/ledc`, 
+    :doc:`/components/output/sigma_delta_output`, :doc:`/components/output/slow_pwm`.
+
+.. code-block:: yaml
+
+    on_...:
+      then:
+        - output.set_min_power:
+            id: light_1
+            min_power: 20%
+
+.. note::
+
+    This action can also be expressed in :ref:`lambdas <config-lambda>`:
+
+    .. code-block:: cpp
+
+        // range is 0.0 (off) to 1.0 (on)
+        id(light_1).set_min_power(0.2);
+
+.. _output-set_max_power_action:
+
+``output.set_max_power`` Action
+***************************
+
+This action sets the maximum output power level for the specified float output platform. 
+It allows you to dynamically adjust the ``max_power`` configuration variable at runtime.
+
+.. note::
+
+    This only works with floating point outputs like :doc:`/components/output/ac_dimmer`, 
+    :doc:`/components/output/esp8266_pwm`, :doc:`/components/output/ledc`, 
+    :doc:`/components/output/sigma_delta_output`, :doc:`/components/output/slow_pwm`.
+
+.. code-block:: yaml
+
+    on_...:
+      then:
+        - output.set_max_power:
+            id: light_1
+            max_power: 80%
+
+.. note::
+
+    This action can also be expressed in :ref:`lambdas <config-lambda>`:
+
+    .. code-block:: cpp
+
+        // range is 0.0 (off) to 1.0 (on)
+        id(light_1).set_max_power(0.8);
 
 Full Output Index
 -----------------

--- a/components/output/index.rst
+++ b/components/output/index.rst
@@ -129,7 +129,7 @@ This action sets the float output to the given level when executed.
 .. _output-set_min_power_action:
 
 ``output.set_min_power`` Action
-***************************
+*******************************
 
 This action sets the minimum output power level for the specified float output platform. 
 It allows you to dynamically adjust the ``min_power`` configuration variable at runtime.
@@ -160,7 +160,7 @@ It allows you to dynamically adjust the ``min_power`` configuration variable at 
 .. _output-set_max_power_action:
 
 ``output.set_max_power`` Action
-***************************
+*******************************
 
 This action sets the maximum output power level for the specified float output platform. 
 It allows you to dynamically adjust the ``max_power`` configuration variable at runtime.


### PR DESCRIPTION
## Description:

SSIA

**Related issue (if applicable):** fixes https://github.com/esphome/feature-requests/issues/2978

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#8934

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
