### PR TITLE
Remove extra whitespace in ld2410 docs

### DIFF
--- a/components/sensor/ld2410.rst
+++ b/components/sensor/ld2410.rst
@@ -84,7 +84,7 @@ measurements.
         light:
           name: light
         moving_distance:
-          name : Moving Distance
+          name: Moving Distance
         still_distance:
           name: Still Distance
         moving_energy:


### PR DESCRIPTION
## Description:
Remove extra whitespace in ld2410 docs

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
