### PR TITLE
[nextion] Add optional max_queue_size limit to prevent queue overflows

### DIFF
--- a/components/display/nextion.rst
+++ b/components/display/nextion.rst
@@ -90,6 +90,10 @@ Configuration variables:
 - **command_spacing** (*Optional*, :ref:`config-time`): Sets the minimum time between commands sent to the Nextion display.
   A higher value can help prevent buffer overflows but will result in slower interface updates.
   Range is ``0-255ms``. Defaults to ``0ms`` (disabled).
+- **max_queue_size** (*Optional*, integer): Sets the maximum number of commands that can be queued at once.
+  When the limit is reached, new commands will be dropped and a warning will be logged.
+  This helps prevent memory overflows or boot-time crashes in complex setups that issue a large number of commands
+  in rapid succession. If not set, the queue size is unlimited.
 
 .. _display-nextion_lambda:
 


### PR DESCRIPTION
## Description:

This introduces an optional `max_queue_size` parameter to the Nextion component, allowing users to limit the number of entries in the command queue (`nextion_queue_`). This can help prevent memory exhaustion or stack overflows in setups that queue many commands in a short period (e.g., during boot).

When the queue reaches this limit, new commands are dropped and a warning is logged.

This feature is opt-in and does not affect existing behavior unless explicitly enabled in YAML. The logic is compiled only when the `USE_NEXTION_MAX_QUEUE_SIZE` macro is defined.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#8976

## Checklist:

  - [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
