### PR TITLE
Add support for custom request headers in online_image component

### DIFF
--- a/components/online_image.rst
+++ b/components/online_image.rst
@@ -32,8 +32,6 @@ This component has a dependency to :doc:`/components/http_request`; the configur
 
     online_image:
       - url: "https://example.com/example.png"
-        request_headers:
-          Authorization: !secret bearer_api_token
         format: png
         id: my_online_image
 

--- a/components/online_image.rst
+++ b/components/online_image.rst
@@ -32,6 +32,8 @@ This component has a dependency to :doc:`/components/http_request`; the configur
 
     online_image:
       - url: "https://example.com/example.png"
+        request_headers:
+          Authorization: !secret bearer_api_token
         format: png
         id: my_online_image
 
@@ -39,6 +41,7 @@ Configuration variables
 -----------------------
 
 - **url** (**Required**, url): The URL where the image will be downloaded from.
+- **request_headers** (*Optional*, mapping): Map of HTTP headers. Values are :ref:`templatable <config-templatable>`.
 - **id** (**Required**, :ref:`config-id`): The ID with which you will be able to reference the image later
   in your display code.
 - **format** (**Required**): The format that the image is encoded with.


### PR DESCRIPTION
## Description:

The `http_request` component is able to add custom request headers to the request, but the `online_image` is not. As I want to fetch a pre-computed image from a server requiring a bearer API token, I have added this possibility.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#8985

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
