### PR TITLE
Fix online_image.set_url documentation

### DIFF
--- a/components/online_image.rst
+++ b/components/online_image.rst
@@ -76,7 +76,7 @@ A good example for that is to update the display component after the download su
 Actions
 -------
 
-**online_image.set_url**: Change the URL where the image is downloaded from. The image needs to be manually updated afterwards.
+**online_image.set_url**: Change the URL where the image is downloaded from. A re-download will be automatically triggered.
 
 Configuration variables:
 


### PR DESCRIPTION
## Description:

The documentation states "after setting an url, the image needs to be manually re-downloaded; while the code behaves exactly the opposite way.


**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

N/A

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
