### PR TITLE
Ethernet add duplex and link speed option

### DIFF
--- a/components/ethernet.rst
+++ b/components/ethernet.rst
@@ -132,6 +132,15 @@ Advanced common configuration variables:
 - **domain** (*Optional*, string): Set the domain of the node hostname used for uploading.
   For example, if it's set to ``.local``, all uploads will be sent to ``<HOSTNAME>.local``.
   Defaults to ``.local``.
+- **duplex** (*Optional*, string): Set the duplex mode and disables auto negotiation. Must be one of the following values:
+
+  - ``DUPLEX_HALF`` - Half Duplex Mode
+  - ``DUPLEX_FULL`` - Full Duplex Mode
+- **speed** (*Optional*, string): Set the link speed and disables auto negotiation. Must be one of the following values:
+
+  - ``SPEED_10M`` - 10Mbps
+  - ``SPEED_100M`` - 100Mbps
+
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation.
 
 


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/5100

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#8995

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
