### PR TITLE
[esp32_ble_server] Remove invalid advertise from characteristic

### DIFF
--- a/components/esp32_ble_server.rst
+++ b/components/esp32_ble_server.rst
@@ -89,7 +89,6 @@ Characteristics can also have multiple descriptors to provide additional informa
         characteristics:
           - id: test_characteristic
             uuid: cad48e28-7fbe-41cf-bae9-d77a6c233423
-            advertise: true
             description: "Sample description"
             read: true
             value:

--- a/components/esp32_ble_server.rst
+++ b/components/esp32_ble_server.rst
@@ -86,6 +86,7 @@ Characteristics can also have multiple descriptors to provide additional informa
     esp32_ble_server:
       services:
         # ...
+        advertise: true
         characteristics:
           - id: test_characteristic
             uuid: cad48e28-7fbe-41cf-bae9-d77a6c233423


### PR DESCRIPTION
[advertise] is an invalid option for [characteristics].

## Description:
Remove the invalid advertise proprery in the example code block.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
