### PR TITLE
[ble_client] Add link to BLE Client Text Sensor

### DIFF
--- a/components/sensor/ble_client.rst
+++ b/components/sensor/ble_client.rst
@@ -8,6 +8,8 @@ BLE Client Sensor
 The ``ble_client`` component is a sensor platform that can query BLE devices for RSSI or specific
 values of service characteristics.
 
+For text/string values, see :doc:`/components/text_sensor/ble_client`.
+
 For more information on BLE services and characteristics, see :doc:`/components/ble_client`.
 
 .. warning::
@@ -129,6 +131,7 @@ See Also
 --------
 
 - :doc:`/components/ble_client`
+- :doc:`/components/text_sensor/ble_client`
 - :ref:`sensor-filters`
 - :apiref:`ble_sensor/ble_sensor.h`
 - :ghedit:`Edit`


### PR DESCRIPTION
Add a link to the text_sensor counterpart

## Description:
For me it was not clear that there was also a variant which handles text values specifically. This should prevent confusion for future visitors

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
