### PR TITLE
Including DFRobot ESP32-S3 AI Cam

### DIFF
--- a/components/esp32_camera.rst
+++ b/components/esp32_camera.rst
@@ -502,6 +502,27 @@ Configuration examples
       name: My Camera
       # ...
 
+**DFRobot ESP32 S3 AI CAM**:
+
+.. code-block:: yaml
+
+esp32_camera:
+  external_clock:
+    pin: GPIO5
+    frequency: 20MHz
+  i2c_pins:
+    sda: GPIO8
+    scl: GPIO9
+  data_pins: [GPIO16, GPIO18, GPIO21, GPIO17, GPIO14, GPIO7, GPIO6, GPIO4]
+  vsync_pin: GPIO1
+  href_pin: GPIO2
+  pixel_clock_pin: GPIO15
+
+      # Image settings
+      name: My Camera
+      # ...
+
+
 See Also
 --------
 


### PR DESCRIPTION
Include camera pinout indicated in https://wiki.dfrobot.com/SKU_DFR1154_ESP32_S3_AI_CAM

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
