### PR TITLE
Update scd4x with current CO2 levels

### DIFF
--- a/components/sensor/scd4x.rst
+++ b/components/sensor/scd4x.rst
@@ -89,14 +89,16 @@ Actions:
 
 This :ref:`action <config-action>` manually calibrates the sensor to the provided value in ppm.
 Operate the SCD4x in the operation mode later used in normal sensor operation (periodic measurement, low power periodic measurement or single shot) for > 3 minutes in an environment with homogenous and constant CO2 concentration before performing a forced recalibration.
-As of April 2022 the average fresh air Co² concentration is 419 ppm.
+As of March 2025 the global monthly mean CO2 concentration is 426 ppm.
 
 .. code-block:: yaml
 
     on_...:
       then:
         - scd4x.perform_forced_calibration:
-            value: 419   # outside average April 2022
+            # Global Monthly Mean CO2
+            # https://gml.noaa.gov/ccgg/trends/global.html
+            value: 426
             id: my_scd41
 
 value can also be a template, for example to define a Home Assistant calibration action:

--- a/components/sensor/scd4x.rst
+++ b/components/sensor/scd4x.rst
@@ -89,14 +89,14 @@ Actions:
 
 This :ref:`action <config-action>` manually calibrates the sensor to the provided value in ppm.
 Operate the SCD4x in the operation mode later used in normal sensor operation (periodic measurement, low power periodic measurement or single shot) for > 3 minutes in an environment with homogenous and constant CO2 concentration before performing a forced recalibration.
-As of March 2025 the global monthly mean CO2 concentration is 426 ppm.
+As of March 2025, the global monthly mean CO₂ concentration is 426 ppm.
 
 .. code-block:: yaml
 
     on_...:
       then:
         - scd4x.perform_forced_calibration:
-            # Global Monthly Mean CO2
+            # Global Monthly Mean CO₂
             # https://gml.noaa.gov/ccgg/trends/global.html
             value: 426
             id: my_scd41


### PR DESCRIPTION
## Description:
Update scd4x with current CO2 levels and add a link to noaa.gov for up-to-date levels.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
