### PR TITLE
Update installing_esphome.rst to mention git for extern. components

### DIFF
--- a/guides/installing_esphome.rst
+++ b/guides/installing_esphome.rst
@@ -42,7 +42,7 @@ with the following:
 
 
 .. note::
-   
+
     You may additionally need to install git for the external components feature.
     Download git from `the official link <https://git-scm.com/downloads>`_
 

--- a/guides/installing_esphome.rst
+++ b/guides/installing_esphome.rst
@@ -69,7 +69,7 @@ Verify the installation:
 .. code-block:: console
 
     $ esphome version
-    Version: 2024.12.0 
+    Version: 2025.5.2
 
 
 
@@ -151,7 +151,7 @@ At this point, you should be able to confirm that ESPHome has been successfully 
 .. code-block:: console
 
     $ esphome version
-    Version: 2022.11.4
+    Version: 2025.5.2
 
 If you get an error like "Command not found", you need to add the binary to
 your ``PATH`` using ``export PATH=$PATH:$HOME/.local/bin``.

--- a/guides/installing_esphome.rst
+++ b/guides/installing_esphome.rst
@@ -29,25 +29,25 @@ Looks good? You can go ahead and install ESPHome:
 
 .. code-block:: console
 
-    > pip3 install wheel
-    > pip3 install esphome
+    pip3 install wheel
+    pip3 install esphome
 
 And you should be good to go! You can test that things are properly installed
 with the following:
 
 .. code-block:: console
 
-    > esphome version
+    esphome version
+
+.. code-block:: console
+
     Version: 2025.5.2
 
 
 .. note::
-
-    - Don't copy the ``>``. That's used to show that this is a command that goes
-      in the console, and to let you see what the expected results are (shown on
-      the next line without a ``>``)    
-    - You may additionally need to install git for the external components feature.
-      Download git from `the official website <https://git-scm.com/downloads/win>`_
+   
+    You may additionally need to install git for the external components feature.
+    Download git from `the official link <https://git-scm.com/downloads>`_
 
 Mac
 ---

--- a/guides/installing_esphome.rst
+++ b/guides/installing_esphome.rst
@@ -22,7 +22,12 @@ In the terminal that comes up, check that Python is installed:
 
 .. code-block:: console
 
-    $ python --version
+    python --version
+
+It should show something like:
+
+.. code-block:: console
+
     Python 3.10.1
 
 Looks good? You can go ahead and install ESPHome:
@@ -33,11 +38,16 @@ Looks good? You can go ahead and install ESPHome:
     pip3 install esphome
 
 And you should be good to go! You can test that things are properly installed
-with the following:
+with:
 
 .. code-block:: console
 
-    $ esphome version
+    esphome version
+
+It should show something like:
+
+.. code-block:: console
+
     Version: 2025.5.2
 
 
@@ -68,7 +78,12 @@ Verify the installation:
 
 .. code-block:: console
 
-    $ esphome version
+    esphome version
+
+It should show something like:
+
+.. code-block:: console
+
     Version: 2025.5.2
 
 
@@ -115,7 +130,12 @@ least version 3.10:
 
 .. code-block:: console
 
-    $ python3 --version
+    python3 --version
+
+It should show something like:
+
+.. code-block:: console
+
     Python 3.10.1
 
 Looks good? Now create a virtual environment to contain ESPHome and it's dependencies.
@@ -150,7 +170,12 @@ At this point, you should be able to confirm that ESPHome has been successfully 
 
 .. code-block:: console
 
-    $ esphome version
+    esphome version
+
+It should show something like:
+
+.. code-block:: console
+
     Version: 2025.5.2
 
 If you get an error like "Command not found", you need to add the binary to

--- a/guides/installing_esphome.rst
+++ b/guides/installing_esphome.rst
@@ -38,7 +38,7 @@ with the following:
 .. code-block:: console
 
     > esphome version
-    Version: 2021.12.3
+    Version: 2025.5.2
 
 
 .. note::

--- a/guides/installing_esphome.rst
+++ b/guides/installing_esphome.rst
@@ -23,7 +23,7 @@ In the terminal that comes up, check that Python is installed:
 .. code-block:: console
 
     > python --version
-    Python 3.13.2
+    Python 3.10.1
 
 Looks good? You can go ahead and install ESPHome:
 

--- a/guides/installing_esphome.rst
+++ b/guides/installing_esphome.rst
@@ -23,13 +23,7 @@ In the terminal that comes up, check that Python is installed:
 .. code-block:: console
 
     > python --version
-    Python 3.10.1
-
-.. note::
-
-    Don't copy the ``>``. That's used to show that this is a command that goes
-    in the console, and to let you see what the expected results are (shown on
-    the next line without a ``>``)
+    Python 3.13.2
 
 Looks good? You can go ahead and install ESPHome:
 
@@ -45,6 +39,15 @@ with the following:
 
     > esphome version
     Version: 2021.12.3
+
+
+.. note::
+
+    - Don't copy the ``>``. That's used to show that this is a command that goes
+      in the console, and to let you see what the expected results are (shown on
+      the next line without a ``>``)    
+    - You may additionally need to install git for the external components feature.
+      Download git from `the official website <https://git-scm.com/downloads/win>`_
 
 Mac
 ---

--- a/guides/installing_esphome.rst
+++ b/guides/installing_esphome.rst
@@ -22,7 +22,7 @@ In the terminal that comes up, check that Python is installed:
 
 .. code-block:: console
 
-    > python --version
+    $ python --version
     Python 3.10.1
 
 Looks good? You can go ahead and install ESPHome:
@@ -37,10 +37,7 @@ with the following:
 
 .. code-block:: console
 
-    esphome version
-
-.. code-block:: console
-
+    $ esphome version
     Version: 2025.5.2
 
 
@@ -65,7 +62,7 @@ An easy way for installation is via `Homebrew <https://brew.sh/>`_:
 
 .. code-block:: console
 
-    $ brew install esphome
+    brew install esphome
 
 Verify the installation:
 
@@ -74,15 +71,16 @@ Verify the installation:
     $ esphome version
     Version: 2024.12.0 
 
-If you encounter any issues with Homebrew installation, please check the
-`ESPHome Homebrew Formula <https://formulae.brew.sh/formula/esphome>`_ page
-for additional information.
+
 
 .. note::
 
-    Homebrew may not always provide the latest version immediately. Updating Homebrew will 
-    automatically update ESPHome. If this is ok for you, Homebrew is the easiest way to 
-    install ESPHome.
+    - If you encounter any issues with Homebrew installation, please check the
+      `ESPHome Homebrew Formula <https://formulae.brew.sh/formula/esphome>`_ page
+      for additional information.
+    - Homebrew may not always provide the latest version immediately. Updating Homebrew will 
+      automatically update ESPHome. If this is ok for you, Homebrew is the easiest way to 
+      install ESPHome.
 
 **pip**
 
@@ -91,7 +89,7 @@ and may need additional dependencies and path settings. Setting up a virtual env
 highly recommended. If you are not familiar with Python virtual environments, Homebrew
 may be easier.
 
-You will require Python 3.9 or newer. While your Mac may have a version of Python installed it may not be up-to-date.
+You will require Python 3.10 or newer. While your Mac may have a version of Python installed it may not be up-to-date.
 Python can be installed from the `official site <https://www.python.org/downloads>`_
 or with Homebrew. Once Python is installed, create and activate a virtual environment and install ESPHome with pip:
 
@@ -113,19 +111,19 @@ Linux
 -----
 
 Your distribution probably already has Python installed. Confirm that it is at
-least version 3.9:
+least version 3.10:
 
 .. code-block:: console
 
     $ python3 --version
-    Python 3.9.15
+    Python 3.10.1
 
 Looks good? Now create a virtual environment to contain ESPHome and it's dependencies.
 
 .. code-block:: console
 
-    $ python3 -m venv venv
-    $ source venv/bin/activate
+    python3 -m venv venv
+    source venv/bin/activate
 
 You may or may not see ``(venv)`` at the beginning of your prompt depending on your shell configuration. This indicates that you are in the virtual environment.
 
@@ -138,7 +136,7 @@ You can go ahead and install ESPHome:
 .. caution::
 
     Don't use ``sudo`` with pip. If you do, you'll run into trouble updating
-    your OS down the road.
+    your Distro down the road.
 
     For details, see `DontBreakDebian
     <https://wiki.debian.org/DontBreakDebian#A.27make_install.27_can_conflict_with_packages>`_.
@@ -146,9 +144,9 @@ You can go ahead and install ESPHome:
     advice in the article applies to all Linux distributions, not just Debian.
 
     Some people install ESPHome without the virtual environment, which can lead to issues with PATHs etc.
-    Non virtual environment installations are considered not "supported" as people end up having to know your exact system setup.
+    Installations without `venv` are considered not "supported" as people end up having to know your exact system setup.
 
-At this point, you should be able confirm that ESPHome has been successfully installed:
+At this point, you should be able to confirm that ESPHome has been successfully installed:
 
 .. code-block:: console
 


### PR DESCRIPTION
## Description:
include a mention of installing git in notes for using external components
Also minor touchup of the overall guide
* Mentioned Python version bumped from 3.9 to 3.10
* ESPHome version mentioned bumped to 2025.5.2

**Related issue (if applicable):** fixes <link to issue> NONE

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** NONE

- esphome/esphome#<esphome PR number goes here> NONE

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
