### PR TITLE
Clarify MCP23017 GPIO indexing in ESPHome docs

### DIFF
--- a/components/mcp230xx.rst
+++ b/components/mcp230xx.rst
@@ -147,7 +147,9 @@ and can therefore be used with many of ESPHome's components such as the GPIO
 binary sensor or GPIO switch.
 
 GPIO pins in the datasheet are labelled A0 to A7 and B0 to B7, these are mapped
-consecutively in this component to numbers from 0 to 15.
+consecutively in this component to numbers from 0 to 15. There are two parts to
+note here: port A is reverse-mapped (A7=0 to A0=7) and port B is forward-mapped
+(B0=8 to B7=15).
 
 .. code-block:: yaml
 
@@ -163,7 +165,7 @@ consecutively in this component to numbers from 0 to 15.
         pin:
           mcp23xxx: mcp23017_hub
           # Use pin A0
-          number: 0
+          number: 7
           mode:
             output: true
           inverted: false


### PR DESCRIPTION
This update fixes the MCP23017 component documentation. Changes were made to the description of the pin mapping, clarifying that the A port is reverse-mapped. Changes were made in the example to reflect the way the component actually works (A0 is actually pin 7, because it's reverse-mapped)

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
