### PR TITLE
[spi] Document limitation on octal mode

### DIFF
--- a/components/spi.rst
+++ b/components/spi.rst
@@ -27,6 +27,7 @@ It is also possible to configure a quad SPI interface using 4 output data lines,
 use with certain components.
 
 .. note::
+
     - Software mode supports only single-bit SPI.
     - Quad mode SPI is available only on on ESP32 devices (all variants).
     - Octal mode is available only on ESP32-S3, -S2 and -P4 variants.

--- a/components/spi.rst
+++ b/components/spi.rst
@@ -26,6 +26,11 @@ In some cases one of **MOSI** or **MISO** does not exist as the receiving device
 It is also possible to configure a quad SPI interface using 4 output data lines, and an octal interface using 8 data output lines. This is required only for
 use with certain components.
 
+.. note::
+    - Software mode supports only single-bit SPI.
+    - Quad mode SPI is available only on on ESP32 devices (all variants).
+    - Octal mode is available only on ESP32-S3, -S2 and -P4 variants.
+
 To set up SPI devices in ESPHome, you first need to place a top-level SPI component which defines the pins to
 use for the functions described above. The **CS** pins are individually managed by the other components that
 reference the ``spi`` component.


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#9041

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
