### PR TITLE
Add external component to receive & decode nexus433 sensors to the list.

### DIFF
--- a/guides/diy.rst
+++ b/guides/diy.rst
@@ -100,7 +100,7 @@ Custom Components & Code
 - `Garage Door Opener with position control using a relay and one or two reed sensors <https://github.com/tronikos/esphome-gdo>`__ by :ghuser:`tronikos`
 - `Medisana BS440 (and propably more scales) <https://github.com/bwynants/weegschaal>`__ by `bwynants <https://github.com/bwynants>`__
 - `Novy Pureline Pro extractor hood <https://github.com/bwynants/purelinepro>`__ by `bwynants <https://github.com/bwynants>`__
-- `Digoo DG-R8H and similar nexus433 to MQTT component <https://github.com/FreeBear-nc/esphome-nesux433>`__ by `FreeBear <https://github.com/FreeBear-nc>`__
+- `Digoo DG-R8H and similar nexus433 sensors to MQTT component <https://github.com/FreeBear-nc/esphome-nexus433>`__ by :ghuser:`FreeBear-nc`
 
 Sample Configurations
 ---------------------

--- a/guides/diy.rst
+++ b/guides/diy.rst
@@ -100,6 +100,7 @@ Custom Components & Code
 - `Garage Door Opener with position control using a relay and one or two reed sensors <https://github.com/tronikos/esphome-gdo>`__ by :ghuser:`tronikos`
 - `Medisana BS440 (and propably more scales) <https://github.com/bwynants/weegschaal>`__ by `bwynants <https://github.com/bwynants>`__
 - `Novy Pureline Pro extractor hood <https://github.com/bwynants/purelinepro>`__ by `bwynants <https://github.com/bwynants>`__
+- `Digoo DG-R8H and similar nexus433 to MQTT component <https://github.com/FreeBear-nc/esphome-nesux433>`__ by `FreeBear <https://github.com/FreeBear-nc>`__
 
 Sample Configurations
 ---------------------


### PR DESCRIPTION
An external component that receives data from DG-R8H (and other nexus433 compatible sensors).
The component makes use of the CustomMQTTDevice class to send data to HA, so provides a basic example of using mqtt publish.

Might be of interest to other people...