### PR TITLE
Update uptime.rst

### DIFF
--- a/components/text_sensor/uptime.rst
+++ b/components/text_sensor/uptime.rst
@@ -25,7 +25,6 @@ Configuration variables:
 ------------------------
 
 - **update_interval** (*Optional*, :ref:`config-time`): The sensor reporting interval. Defaults to ``30s``.
-- **expand** (*Optional*, boolean): If set, the text will always include all elements, even if they are zero. Defaults to ``false``.
 - **format** (*Optional*, list): Allows the customization of the output format. The following options are available:
 
     - **days** (*Optional*, string): The string to use for the days element. Defaults to ``d``.
@@ -33,6 +32,7 @@ Configuration variables:
     - **minutes** (*Optional*, string): The string to use for the minutes element. Defaults to ``m``.
     - **seconds** (*Optional*, string): The string to use for the seconds element. Defaults to ``s``.
     - **separator** (*Optional*, string): The separator to use between the uptime values. Defaults to the empty string.
+    - **expand** (*Optional*, boolean): If set, the text will always include all elements, even if they are zero. Defaults to ``false``.
 - All other options from :ref:`Text Sensor <config-text_sensor>`.
 
 The resolution of the reported uptime will be determined by the update interval. For example, if the update interval is set to 30 seconds (the default), the uptime will be reported in minutes. More frequent updates will result in seconds being reported.


### PR DESCRIPTION
The configuration entry `expand` is on the wrong level, i.e. `esphome config myfile.yaml` throws an error. The entry `expand` belongs to the the list under the `format` entry.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
