### PR TITLE
Add codefile reference to configuration-types.rst

### DIFF
--- a/guides/configuration-types.rst
+++ b/guides/configuration-types.rst
@@ -164,6 +164,10 @@ There are several ways of doing this. See below examples to see how you can spec
       update_interval: 0ms  # update in every loop() iteration
       update_interval: always # same as 0ms
 
+.. note::
+
+    For config reference, see file: https://github.com/esphome/esphome/blob/dev/esphome/config_validation.py
+
 See Also
 --------
 

--- a/guides/configuration-types.rst
+++ b/guides/configuration-types.rst
@@ -166,7 +166,7 @@ There are several ways of doing this. See below examples to see how you can spec
 
 .. note::
 
-    For config reference, see file: https://github.com/esphome/esphome/blob/dev/esphome/config_validation.py
+    For config reference, `See File <https://github.com/esphome/esphome/blob/dev/esphome/config_validation.py>`_
 
 See Also
 --------
@@ -175,3 +175,4 @@ See Also
 - :doc:`getting_started_command_line`
 - :doc:`faq`
 - :ghedit:`Edit`
+- `Reference file for Config validation <https://github.com/esphome/esphome/blob/dev/esphome/config_validation.py>`_


### PR DESCRIPTION
## Description:
Add a reference link to the file 
https://github.com/esphome/esphome/blob/dev/esphome/config_validation.py
IN
https://esphome.io/guides/configuration-types

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
