### PR TITLE
Update openthread.rst to include mesh_local_prefix CV

### DIFF
--- a/components/openthread.rst
+++ b/components/openthread.rst
@@ -50,6 +50,7 @@ This example show how to configure Thread Dataset for a node.
       pan_id: 0x8f28
       ext_pan_id: 0xd63e8e3e495ebbc3
       pskc: 0xc23a76e98f1a6483639b1ac1271e2e27
+      mesh_local_prefix: 0xeD52135fed21bc80
       force_dataset: true
 
 Configuration variables:
@@ -60,6 +61,7 @@ Configuration variables:
 - **panid** (string): 2-byte Personal Area Network ID (PAN ID)
 - **extpanid** (string): 8-byte Extended Personal Area Network ID (XPAN ID)
 - **pskc** (string): PSKc is used to authenticate an external Thread Commissioner to a Thread network
+- **mesh_local_prefix** (string): is used for communication within a Thread network partition
 
 
 Configuration examples with dataset TLV


### PR DESCRIPTION
mesh_local_prefix is available in OpenThread component, but not in documentation

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [X ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
