### PR TITLE
Permittivity is not available (any more?).

### DIFF
--- a/components/sensor/smt100.rst
+++ b/components/sensor/smt100.rst
@@ -31,8 +31,6 @@ board and the baud rate set to 9600.
       - platform: smt100
         counts:
             name: "Counts"
-        permittivity:
-            name: "Permittivity"
         temperature:
             name: "Temperature"
         moisture:


### PR DESCRIPTION
## Description:

When adding the ``Permittivity`` property to the sensor, ESPHome complains that it is not available. So, remove it from the documentation.

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
