### PR TITLE
document change enable_lwip_mdns_queries default to True

### DIFF
--- a/components/esp32.rst
+++ b/components/esp32.rst
@@ -141,7 +141,7 @@ LWIP (Lightweight IP) features and save flash memory (approximately 4KB):
   as a DHCP server (necessary for WiFi AP mode). When the WiFi component is used, it automatically handles enabling/disabling
   the DHCP server based on whether AP mode is configured. When WiFi is not used, defaults to ``false``.
 - **enable_lwip_mdns_queries** (*Optional*, boolean): Enable mDNS query support in the DNS resolver. ESPHome uses its own
-  mDNS implementation, so this is rarely needed. Defaults to ``false``.
+  mDNS implementation, so this is rarely needed. Defaults to ``true``.
 - **enable_lwip_bridge_interface** (*Optional*, boolean): Enable bridge interface support for bridging multiple network
   interfaces. Defaults to ``false``.
 


### PR DESCRIPTION
## Description:

Document changing default of enable_lwip_mdns_queries to true as to not disable mDNS resolver by default.

**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/7130

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#9188

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
