### PR TITLE
[voice_assistant] document new intent progress trigger

### DIFF
--- a/components/voice_assistant.rst
+++ b/components/voice_assistant.rst
@@ -18,7 +18,7 @@ ESPHome devices with a microphone are able to stream the audio to Home Assistant
     **Crashes are likely to occur** if you include too many additional components in your device's
     configuration. In particular, Bluetooth/BLE components are known to cause issues when used in
     combination with Voice Assistant and/or other audio components.
-    
+
     If you experience crashes, see the :doc:`/guides/troubleshooting` guide for how to get a backtrace.
 
 Configuration variables:
@@ -43,6 +43,8 @@ Configuration variables:
 - **conversation_timeout** (*Optional*, :ref:`config-time`): How long to wait before resetting the ``conversation_id``
   sent to the voice assist pipeline, which contains the context of the current assist pipeline. Defaults to ``300s``.
 - **on_intent_start** (*Optional*, :ref:`Automation <automation>`): An automation to perform when intent processing starts.
+- **on_intent_progress** (*Optional*, :ref:`Automation <automation>`): An automation to perform when intent progress happens.
+  The variable ``x`` is a non-empty string containing the streaming TTS response URL only if it is sent to the media player.
 - **on_intent_end** (*Optional*, :ref:`Automation <automation>`): An automation to perform when intent processing ends.
 - **on_listening** (*Optional*, :ref:`Automation <automation>`): An automation to
   perform when the voice assistant microphone starts listening.


### PR DESCRIPTION
## Description:

Documents the new ``on_intent_progress`` trigger that indicates if a streaming TTS URL was sent to the media player.

**Related issue (if applicable):** not applicable

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#9224

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
