### PR TITLE
Add PI4IOE5V6408 8-bit I2C I/O expander documentation

### DIFF
--- a/components/index.rst
+++ b/components/index.rst
@@ -181,6 +181,7 @@ I/O Expanders/Multiplexers
     PCA6416A, components/pca6416a, pca6416a.svg
     PCA9554, components/pca9554, pca9554a.jpg
     PCF8574, components/pcf8574, pcf8574.jpg
+    PI4IOE5V6408, components/pi4ioe5v6408, pca9554a.jpg
     SN74HC165, components/sn74hc165, sn74hc595.jpg
     SN74HC595, components/sn74hc595, sn74hc595.jpg
     SX1509, components/sx1509, sx1509.jpg

--- a/components/pi4ioe5v6408.rst
+++ b/components/pi4ioe5v6408.rst
@@ -38,8 +38,8 @@ the GPIO binary sensor or GPIO switch.
           pi4ioe5v6408: pi4ioe_hub
           number: 1
 
-Configuration variables:
-************************
+Configuration variables
+***********************
 
 - **id** (**Required**, :ref:`config-id`): The id to use for this ``pi4ioe5v6408`` component.
 - **address** (*Optional*, int): The I²C address of the device. Defaults to ``0x43``.
@@ -47,8 +47,8 @@ Configuration variables:
   all pins are configured as inputs with high impedance during setup. When ``false``, the component will
   read the current state from the device registers. Defaults to ``true``.
 
-Pin configuration variables:
-****************************
+Pin configuration variables
+***************************
 
 - **pi4ioe5v6408** (**Required**, :ref:`config-id`): The id of the ``pi4ioe5v6408`` component of the pin.
 - **number** (**Required**, int): The pin number. Valid range is 0-7.
@@ -64,8 +64,8 @@ Pin configuration variables:
 Examples:
 *********
 
-GPIO Switch Example:
-^^^^^^^^^^^^^^^^^^^^
+GPIO Switch Example
+^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: yaml
 
@@ -78,8 +78,8 @@ GPIO Switch Example:
           mode:
             output: true
 
-GPIO Binary Sensor Example:
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
+GPIO Binary Sensor Example
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: yaml
 
@@ -93,8 +93,8 @@ GPIO Binary Sensor Example:
             input: true
             pullup: true
 
-GPIO Output with Inverted Logic:
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+GPIO Output with Inverted Logic
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: yaml
 

--- a/components/pi4ioe5v6408.rst
+++ b/components/pi4ioe5v6408.rst
@@ -1,0 +1,119 @@
+PI4IOE5V6408 8-Bit I2C I/O Expander
+=====================================
+
+.. seo::
+    :description: Instructions for setting up PI4IOE5V6408 8-bit I2C I/O expander in ESPHome.
+
+The PI4IOE5V6408 component allows you to use the Diodes Incorporated PI4IOE5V6408 8-bit I2C I/O
+expander in ESPHome using the :ref:`I²C Bus <i2c>` for communication.
+
+The PI4IOE5V6408 is a low-voltage 8-bit I/O port expander that operates at 1.65V to 5.5V. It provides
+general-purpose remote I/O expansion for most microcontroller families via the I2C interface. The device
+supports both pull-up and pull-down resistors on all I/O pins, and includes interrupt capability for
+input changes.
+
+Once configured, you can use any of the **8** pins (0-7) within your projects. Within ESPHome they
+emulate a real internal GPIO pin and can therefore be used with many of ESPHome's components such as
+the GPIO binary sensor or GPIO switch.
+
+.. code-block:: yaml
+
+    # Example configuration entry
+    pi4ioe5v6408:
+      - id: 'pi4ioe_hub'
+
+    # Individual outputs
+    switch:
+      - platform: gpio
+        name: "PI4IOE5V6408 Pin 0"
+        pin:
+          pi4ioe5v6408: pi4ioe_hub
+          number: 0
+
+    # Individual inputs
+    binary_sensor:
+      - platform: gpio
+        name: "PI4IOE5V6408 Pin 1"
+        pin:
+          pi4ioe5v6408: pi4ioe_hub
+          number: 1
+
+Configuration variables:
+************************
+
+- **id** (**Required**, :ref:`config-id`): The id to use for this ``pi4ioe5v6408`` component.
+- **address** (*Optional*, int): The I²C address of the device. Defaults to ``0x43``.
+- **reset** (*Optional*, boolean): Whether to reset the device state during setup. When ``true`` (default),
+  all pins are configured as inputs with high impedance during setup. When ``false``, the component will
+  read the current state from the device registers. Defaults to ``true``.
+
+Pin configuration variables:
+****************************
+
+- **pi4ioe5v6408** (**Required**, :ref:`config-id`): The id of the ``pi4ioe5v6408`` component of the pin.
+- **number** (**Required**, int): The pin number. Valid range is 0-7.
+- **inverted** (*Optional*, boolean): If all read and written values should be treated as inverted.
+  Defaults to ``false``.
+- **mode** (*Optional*, :ref:`Pin Mode <config-pin_schema>`): A pin mode to set for the pin. One of:
+
+  - ``INPUT`` - Configure the pin as an input.
+  - ``OUTPUT`` - Configure the pin as an output.
+  - ``PULLUP`` - Enable internal pull-up resistor (input mode only).
+  - ``PULLDOWN`` - Enable internal pull-down resistor (input mode only).
+
+Examples:
+*********
+
+GPIO Switch Example:
+^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: yaml
+
+    switch:
+      - platform: gpio
+        name: "Relay 1"
+        pin:
+          pi4ioe5v6408: pi4ioe_hub
+          number: 0
+          mode:
+            output: true
+
+GPIO Binary Sensor Example:
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: yaml
+
+    binary_sensor:
+      - platform: gpio
+        name: "Button 1"
+        pin:
+          pi4ioe5v6408: pi4ioe_hub
+          number: 1
+          mode:
+            input: true
+            pullup: true
+
+GPIO Output with Inverted Logic:
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: yaml
+
+    switch:
+      - platform: gpio
+        name: "LED Strip"
+        pin:
+          pi4ioe5v6408: pi4ioe_hub
+          number: 2
+          mode:
+            output: true
+          inverted: true
+
+See Also
+--------
+
+- :ref:`i2c`
+- :doc:`switch/gpio`
+- :doc:`binary_sensor/gpio`
+- `PI4IOE5V6408 datasheet <https://www.diodes.com/assets/Datasheets/PI4IOE5V6408.pdf>`__
+- :apiref:`pi4ioe5v6408/pi4ioe5v6408.h`
+- :ghedit:`Edit`


### PR DESCRIPTION
## Description:

Documentation for the PI4IOE5V6408 8-bit I2C I/O expander component based on the implementation in ESPHome PR #8888.

### Changes:
- Added comprehensive documentation for PI4IOE5V6408 component
- Documented all configuration variables and pin options
- Added practical examples for GPIO switches, binary sensors, and inverted logic
- Updated components index to include the new component
- Documentation follows ESPHome standards and formatting

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#8888

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [x] Link added in `/components/index.rst` when creating new documents for new components or cookbook.