### PR TITLE
Document upper limit of API batch_delay

### DIFF
--- a/components/api.rst
+++ b/components/api.rst
@@ -87,7 +87,8 @@ Configuration variables:
 - **actions** (*Optional*, list): A list of user-defined actions. See :ref:`api-device-actions`.
 - **batch_delay** (*Optional*, :ref:`config-time`): The delay time for batching multiple state update messages
   together to reduce network overhead. Lower values send updates sooner but use more network packets,
-  while higher values batch more efficiently but add latency. Defaults to ``100ms``.
+  while higher values batch more efficiently but add latency. Must be between ``0ms`` and ``65535ms``
+  (65.535 seconds). Defaults to ``100ms``.
 - **reboot_timeout** (*Optional*, :ref:`config-time`): The amount of time to wait before rebooting when no
   client connects to the API. This is needed because sometimes the low level ESP functions report that
   the ESP is connected to the network, when in fact it is not - only a full reboot fixes it.


### PR DESCRIPTION
## Description:

This PR updates the API component documentation to reflect the new maximum limit for the `batch_delay` configuration option. The implementation now uses a `uint16_t` instead of `uint32_t` to save memory, which limits the maximum value to 65535ms (65.535 seconds).

The documentation change adds clarity about the valid range for this configuration option, helping users understand the constraints when configuring API message batching delays.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#9252

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.