### PR TITLE
Packages: optional base path for remote git packages

### DIFF
--- a/components/packages.rst
+++ b/components/packages.rst
@@ -120,6 +120,7 @@ Configuration variables:
 For each package:
 
 - **url** (**Required**, string): The URL for the repository.
+- **path** (*Optional*, string): Base common path of included files.
 - **username** (*Optional*, string): Username to be used for authentication, if required.
 - **password** (*Optional*, string): Password to be used for authentication, if required.
 - **files** (**Required**): List of files to include. Can be one of:


### PR DESCRIPTION
## Description:

Adds an optional base path within the repository for a list of package files. Useful when you want to use multiple packages in a repository that share a common base path.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#9279

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
