### PR TITLE
Update location of ota backend code

### DIFF
--- a/components/ota/index.rst
+++ b/components/ota/index.rst
@@ -164,6 +164,6 @@ expected. This is automatically enabled by the ``ota`` component, but it may be 
 See Also
 --------
 
-- :apiref:`ota/ota_component.h`
+- :apiref:`ota_base/ota_backend.h`
 - :doc:`/components/safe_mode`
 - :ghedit:`Edit`


### PR DESCRIPTION
## Description:

Update OTA component documentation to reflect the architectural changes where OTA functionality has been split into `ota` (configuration/automation) and `ota_base` (backend implementation) components. Updates the API reference link to point to the correct header file.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#9274

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.