### PR TITLE
Document batch_delay: 0 option for immediate state updates with IR remotes

### DIFF
--- a/components/api.rst
+++ b/components/api.rst
@@ -96,6 +96,7 @@ Configuration variables:
       applications that require real-time responsiveness, such as IR remote binary sensors where rapid
       ON→OFF transitions must be preserved. However, this will increase network traffic and may impact
       WiFi performance with many rapidly-changing sensors. Only use this setting when necessary.
+
 - **reboot_timeout** (*Optional*, :ref:`config-time`): The amount of time to wait before rebooting when no
   client connects to the API. This is needed because sometimes the low level ESP functions report that
   the ESP is connected to the network, when in fact it is not - only a full reboot fixes it.

--- a/components/api.rst
+++ b/components/api.rst
@@ -91,7 +91,7 @@ Configuration variables:
   (65.535 seconds). Defaults to ``100ms``.
   
   .. note::
-  
+
       Setting ``batch_delay: 0ms`` enables immediate sending mode for state updates. This is useful for
       applications that require real-time responsiveness, such as IR remote binary sensors where rapid
       ON→OFF transitions must be preserved. However, this will increase network traffic and may impact

--- a/components/api.rst
+++ b/components/api.rst
@@ -89,6 +89,13 @@ Configuration variables:
   together to reduce network overhead. Lower values send updates sooner but use more network packets,
   while higher values batch more efficiently but add latency. Must be between ``0ms`` and ``65535ms``
   (65.535 seconds). Defaults to ``100ms``.
+  
+  .. note::
+  
+      Setting ``batch_delay: 0ms`` enables immediate sending mode for state updates. This is useful for
+      applications that require real-time responsiveness, such as IR remote binary sensors where rapid
+      ON→OFF transitions must be preserved. However, this will increase network traffic and may impact
+      WiFi performance with many rapidly-changing sensors. Only use this setting when necessary.
 - **reboot_timeout** (*Optional*, :ref:`config-time`): The amount of time to wait before rebooting when no
   client connects to the API. This is needed because sometimes the low level ESP functions report that
   the ESP is connected to the network, when in fact it is not - only a full reboot fixes it.

--- a/components/remote_receiver.rst
+++ b/components/remote_receiver.rst
@@ -248,6 +248,17 @@ The ``remote_receiver`` binary sensor lets you track when a button on a remote c
 
 Each time the pre-defined signal is received, the binary sensor will briefly go ON and then immediately OFF.
 
+.. note::
+
+    **For IR Remote Binary Sensors**: If you're using binary sensors to track IR remote button presses and
+    experiencing issues with rapid button presses not being detected (e.g., quick ON→OFF transitions being missed),
+    consider setting ``batch_delay: 0ms`` in your :doc:`API configuration </components/api>`. This will send state
+    changes immediately instead of batching them, ensuring rapid transitions are preserved. However, this increases
+    network traffic and should only be used when necessary.
+    
+    For new projects, consider using automations with the ``on_*`` triggers (described above)
+    instead of binary sensors, as they are better suited for handling momentary button press events.
+
 .. code-block:: yaml
 
     # Example configuration entry
@@ -257,6 +268,23 @@ Each time the pre-defined signal is received, the binary sensor will briefly go 
         panasonic:
           address: 0x4004
           command: 0x100BCBD
+
+.. code-block:: yaml
+
+    # Example with batch_delay: 0 for rapid button presses
+    api:
+      batch_delay: 0ms  # Send state changes immediately
+    
+    remote_receiver:
+      pin: GPIOXX
+      dump: all
+    
+    binary_sensor:
+      - platform: remote_receiver
+        name: "TV Remote Power"
+        nec:
+          address: 0x1234
+          command: 0x5678
 
 Configuration variables:
 ************************


### PR DESCRIPTION
## Description:

This PR documents the new behavior of the `batch_delay: 0` configuration option for the API component, which enables immediate sending of state updates when the transmit buffer has space available. This is particularly useful for IR remote binary sensors where rapid ON→OFF transitions need to be preserved.

The documentation updates include:
- Added explanation of `batch_delay: 0` behavior in the API component configuration
- Added a note and example in the remote_receiver component for IR remote binary sensor users
- Recommended using automations instead of binary sensors for new IR remote projects

**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/7154

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#9298

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.