### PR TITLE
Add Waveshare 3.7inch (G) to supported waveshare displays

### DIFF
--- a/components/display/waveshare_epaper.rst
+++ b/components/display/waveshare_epaper.rst
@@ -124,6 +124,7 @@ Configuration variables:
   - ``2.90inv2-r2`` - 2.9in V2 display, but with different initialization and full/partial display refresh management than ``2.90inv2``
   - ``2.90in-b`` - B/W rendering only
   - ``2.90in-bV3`` - B/W rendering only
+  - ``3.70in-g`` - Four color Black/White/Red/Yellow
   - ``4.20in``
   - ``4.20in-bV2`` - B/W rendering only
   - ``gdey042t81`` - GoodDisplay GDEY042T81 4.2" B/W


### PR DESCRIPTION
## Description:

This PR adds the Waveshare 3.7inch (G) display to the displays supported by the waveshare_epaper component.


**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#9316

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
