### PR TITLE
Use "decimal" inputmode to show '.' on mobile keyboards.

### DIFF
--- a/components/sensor/hlw8012.rst
+++ b/components/sensor/hlw8012.rst
@@ -154,9 +154,9 @@ Calibration values on the ESP:
 .. raw:: html
 
     <table>
-    <tr><td>voltage_divider:</td><td><input type="text" inputmode="numeric" value="2351" id="voltage-divider" onchange="calc()" onkeypress="calc()" onpaste="calc()" oninput="calc()" style="width: 100px; max-width: 75vw;"></td></tr>
-    <tr><td>current_resistor:</td><td><input type="text" inputmode="numeric" value="0.001" id="current-resistor" onchange="calc()" onkeypress="calc()" onpaste="calc()" oninput="calc()" style="width: 100px; max-width: 75vw;"></td></tr>
-    <tr><td>current_multiply:</td><td><input type="text" inputmode="numeric" value="1" id="current-multiply" onchange="calc()" onkeypress="calc()" onpaste="calc()" oninput="calc()" style="width: 100px; max-width: 75vw;"></td></tr>
+    <tr><td>voltage_divider:</td><td><input type="text" inputmode="decimal" value="2351" id="voltage-divider" onchange="calc()" onkeypress="calc()" onpaste="calc()" oninput="calc()" style="width: 100px; max-width: 75vw;"></td></tr>
+    <tr><td>current_resistor:</td><td><input type="text" inputmode="decimal" value="0.001" id="current-resistor" onchange="calc()" onkeypress="calc()" onpaste="calc()" oninput="calc()" style="width: 100px; max-width: 75vw;"></td></tr>
+    <tr><td>current_multiply:</td><td><input type="text" inputmode="decimal" value="1" id="current-multiply" onchange="calc()" onkeypress="calc()" onpaste="calc()" oninput="calc()" style="width: 100px; max-width: 75vw;"></td></tr>
     </table>
 
 ESP measurements:
@@ -164,9 +164,9 @@ ESP measurements:
 .. raw:: html
 
     <table>
-    <tr><td>Voltage:</td><td><input type="text" inputmode="numeric" id="sensor-voltage" onchange="calc()" onkeypress="calc()" onpaste="calc()" oninput="calc()" style="width: 100px; max-width: 75vw;"> V</td></tr>
-    <tr><td>Power:</td><td><input type="text" inputmode="numeric" id="sensor-power" onchange="calc()" onkeypress="calc()" onpaste="calc()" oninput="calc()" style="width: 100px; max-width: 75vw;"> W</td></tr>
-    <tr><td>Current:</td><td><input type="text" inputmode="numeric" id="sensor-current" onchange="calc()" onkeypress="calc()" onpaste="calc()" oninput="calc()" style="width: 100px; max-width: 75vw;"> A</td></tr>
+    <tr><td>Voltage:</td><td><input type="text" inputmode="decimal" id="sensor-voltage" onchange="calc()" onkeypress="calc()" onpaste="calc()" oninput="calc()" style="width: 100px; max-width: 75vw;"> V</td></tr>
+    <tr><td>Power:</td><td><input type="text" inputmode="decimal" id="sensor-power" onchange="calc()" onkeypress="calc()" onpaste="calc()" oninput="calc()" style="width: 100px; max-width: 75vw;"> W</td></tr>
+    <tr><td>Current:</td><td><input type="text" inputmode="decimal" id="sensor-current" onchange="calc()" onkeypress="calc()" onpaste="calc()" oninput="calc()" style="width: 100px; max-width: 75vw;"> A</td></tr>
     </table>
 
 Power meter measurements:
@@ -174,9 +174,9 @@ Power meter measurements:
 .. raw:: html
 
     <table>
-    <tr><td>Voltage:</td><td><input type="text" inputmode="numeric" id="real-voltage" onchange="calc()" onkeypress="calc()" onpaste="calc()" oninput="calc()" style="width: 100px; max-width: 75vw;"> V</td></tr>
-    <tr><td>Power:</td><td><input type="text" inputmode="numeric" id="real-power" onchange="calc()" onkeypress="calc()" onpaste="calc()" oninput="calc()" style="width: 100px; max-width: 75vw;"> W</td></tr>
-    <tr><td>Current:</td><td><input type="text" inputmode="numeric" id="real-current" onchange="calc()" onkeypress="calc()" onpaste="calc()" oninput="calc()" style="width: 100px; max-width: 75vw;"> A</td></tr>
+    <tr><td>Voltage:</td><td><input type="text" inputmode="decimal" id="real-voltage" onchange="calc()" onkeypress="calc()" onpaste="calc()" oninput="calc()" style="width: 100px; max-width: 75vw;"> V</td></tr>
+    <tr><td>Power:</td><td><input type="text" inputmode="decimal" id="real-power" onchange="calc()" onkeypress="calc()" onpaste="calc()" oninput="calc()" style="width: 100px; max-width: 75vw;"> W</td></tr>
+    <tr><td>Current:</td><td><input type="text" inputmode="decimal" id="real-current" onchange="calc()" onkeypress="calc()" onpaste="calc()" oninput="calc()" style="width: 100px; max-width: 75vw;"> A</td></tr>
     </table>
 
 New calibration values:


### PR DESCRIPTION
## Description:

With inputmode `numeric`, entering small or precise numbers is impossible on iPhone because the keyboard doesn't show a decimal (`.`) key. Using `decimal` inputmode instead shows a decimal key on iPhone keyboards. 

### iPhone

#### Before

`inputmode="numeric"`
![numeric](https://github.com/user-attachments/assets/5b2e9493-abbf-4daa-be37-165672fc1a16)

#### After

`inputmode="decimal"`
![decimal](https://github.com/user-attachments/assets/6f264c10-5918-432f-a5ae-0a37fa622cb8)


### Android

I don't have an Android to be able to test, but [this](https://css-tricks.com/everything-you-ever-wanted-to-know-about-inputmode/#aa-decimal) seems to indicate that `decimal` vs `numeric` behave the same on Android.

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
