### PR TITLE
[image] Document `byte_order` config option

### DIFF
--- a/components/image.rst
+++ b/components/image.rst
@@ -31,10 +31,12 @@ For showing images downloaded at runtime, take a look at the :ref:`Online Image 
 .. code-block:: yaml
 
     image:
-      - file: https://esphome.io/_images/logo.png
+      defaults:
         type: rgb565
-        id: esphome_logo
         resize: 200x162
+      images:
+        - file: https://esphome.io/_images/logo.png
+          id: esphome_logo
 
 Configuration variables:
 ------------------------
@@ -69,6 +71,10 @@ Configuration variables:
 
   - ``NONE``: Every pixel converts to its nearest color.
   - ``FLOYDSTEINBERG``: Uses Floyd-Steinberg dither to approximate the original image luminosity levels.
+
+- **byte_order** (*Optional*, string): For RGB565 images, the pixels are converted to 16 bit values. By default these will be stored in big endian byte order (MSB first),
+  but you can override this by setting ``byte_order`` to ``little_endian``. Options are ``big_endian`` (default) and ``little_endian``.
+  Not applicable to other image formats.
 
 .. note::
 
@@ -112,6 +118,23 @@ In addition, the default transparency type can be set within a type group by usi
           id: image2
         opaque:
         - file: "image2.png"
+
+For the situation where most or all of your images share common attributes, you can use another schema style to provide default values. In this case
+the ``defaults:`` option will provide fallback values for all images. When using this format the ``images:`` key takes only a list of image definitions.
+
+.. code-block:: yaml
+
+    image:
+      defaults:
+        type: rgb565
+        transparency: opaque
+        resize: 100x100
+      images:
+        - file: "image1.png"
+          id: image1
+        - file: "image2.png"
+          id: image2
+          resize: 200x200  # overrides the default resize
 
 Displaying Images
 -----------------


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#9326

## Checklist:

  - [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
