### PR TITLE
ESP_EXT1_WAKEUP_ANY_LOW is for s2/s3/c6/h2; ESP_EXT1_WAKEUP_ALL_LOW otherwise

### DIFF
--- a/components/deep_sleep.rst
+++ b/components/deep_sleep.rst
@@ -64,11 +64,14 @@ Advanced features:
 
   - **pins** (**Required**, list of pin numbers): The pins to wake up on.
   - **mode** (**Required**): The mode to use for the wakeup source. Must be one of ``ALL_LOW`` (wake up when
-    all pins go LOW) or ``ANY_HIGH`` (wake up when any pin goes HIGH).
+    all pins go LOW), ``ANY_LOW`` (wake up when any pin goes low), or ``ANY_HIGH`` (wake up when any pin goes HIGH).
 
 .. note::
 
     Only one deep sleep component may be configured.
+
+    ``ANY_LOW`` is available only for ESP32-S2, ESP32-S3, ESP32-C6 or ESP32-H2.
+    ``ALL_LOW`` is not available for ESP32-S2, ESP32-S3, ESP32-C6 or ESP32-H2.
 
 .. _deep_sleep-esp32_wakeup_pin_mode:
 


### PR DESCRIPTION
## Description:

From the documentation at https://docs.espressif.com/projects/esp-idf/en/v5.1.5/esp32/api-reference/system/sleep_modes.html

    level_mode -- Select logic function used to determine wakeup condition:

    When target chip is ESP32:

        ESP_EXT1_WAKEUP_ALL_LOW: wake up when all selected GPIOs are low
        ESP_EXT1_WAKEUP_ANY_HIGH: wake up when any of the selected GPIOs is high

    When target chip is ESP32-S2, ESP32-S3, ESP32-C6 or ESP32-H2:

        ESP_EXT1_WAKEUP_ANY_LOW: wake up when any of the selected GPIOs is low
        ESP_EXT1_WAKEUP_ANY_HIGH: wake up when any of the selected GPIOs is high`

**Related issue (if applicable):**

fixes https://github.com/esphome/issues/issues/6651

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- https://github.com/esphome/esphome/pull/9387

## Checklist:

  - [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
