### PR TITLE
[sx127x] Update preamble_size docs

### DIFF
--- a/components/sx127x.rst
+++ b/components/sx127x.rst
@@ -61,7 +61,7 @@ LoRa configuration variables:
   packet size is fixed. If not configured explicit header mode is enabled and variable packet sizes can
   be used. Maximum length is 256. Must be greater than zero when using a ``spreading_factor`` of 6.
 - **crc_enable** (**Optional**, bool): Enables a payload CRC calculation/check.
-- **preamble_size** (**Optional**, int): Length of the preamble in symbols, minimum of 6. Defaults to 8.
+- **preamble_size** (**Required**, int): Length of the preamble in symbols, minimum of 6.
 - **spreading_factor** (**Optional**, int): Spreading factor, values range from 6 to 12. Defaults to 7.
 - **coding_rate** (**Optional**, enum): Coding rate, values can be ``CR_4_5``, ``CR_4_6``, ``CR_4_7``
   or ``CR_4_8``. Defaults to ``CR_4_5``.


### PR DESCRIPTION
## Description:

Docs should say required not optional and remove the default.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
