### PR TITLE
Document custom_services configuration option for API component

### DIFF
--- a/components/api.rst
+++ b/components/api.rst
@@ -97,6 +97,7 @@ Configuration variables:
       ON→OFF transitions must be preserved. However, this will increase network traffic and may impact
       WiFi performance with many rapidly-changing sensors. Only use this setting when necessary.
 
+- **custom_services** (*Optional*, boolean): Enable compilation of custom API services for external components that use the C++ ``CustomAPIDevice`` class. Only needed when external components register their own services via the native API. Defaults to ``false``.
 - **reboot_timeout** (*Optional*, :ref:`config-time`): The amount of time to wait before rebooting when no
   client connects to the API. This is needed because sometimes the low level ESP functions report that
   the ESP is connected to the network, when in fact it is not - only a full reboot fixes it.


### PR DESCRIPTION
## Description:

This PR documents the new `custom_services` configuration option for the API component. This option enables compilation of custom API services for external components that use the C++ `CustomAPIDevice` class.

The change saves approximately 4.3KB of flash memory by conditionally compiling API service-related code only when needed.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#9451

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.