### PR TITLE
Docs for new Toshiba AC IR

### DIFF
--- a/content/components/climate/climate_ir.md
+++ b/content/components/climate/climate_ir.md
@@ -216,7 +216,7 @@ climate:
 
 ### `toshiba`
 
-- **model** (*Optional*, string): There are four valid models
+- **model** (*Optional*, string): There are four valid models:
 
   - `GENERIC`  : Temperature range is from 17 to 30 (default)
   - `RAC-PT1411HWRU-C`  : Temperature range is from 16 to 30; unit displays temperature in degrees Celsius

--- a/content/components/climate/climate_ir.md
+++ b/content/components/climate/climate_ir.md
@@ -216,11 +216,12 @@ climate:
 
 ### `toshiba`
 
-- **model** (*Optional*, string): There are two valid models
+- **model** (*Optional*, string): There are four valid models
 
   - `GENERIC`  : Temperature range is from 17 to 30 (default)
   - `RAC-PT1411HWRU-C`  : Temperature range is from 16 to 30; unit displays temperature in degrees Celsius
   - `RAC-PT1411HWRU-F`  : Temperature range is from 16 to 30; unit displays temperature in degrees Fahrenheit
+  - `RAS-2819T`  : Temperature range is from 18 to 30; supports two-packet IR protocol
 
 > [!NOTE]
 >
@@ -237,8 +238,21 @@ climate:
 >   internal temperature sensor; a value of 30 seconds seems to work well. See {{< docref "/components/sensor" >}}
 >   for more information.
 >
+> - The `RAS-2819T` model uses a two-packet IR protocol where most commands send a primary packet (containing
+>   temperature, mode, and fan speed) followed by a secondary packet (containing fan speed confirmation and
+>   mode-specific data). Single-packet commands are used for power-off and swing toggle operations.
+>
 > - This climate IR component is also known to work with Midea model MAP14HS1TBL and may work with other similar
 >   models, as well. (Midea acquired Toshiba's product line and re-branded it.)
+
+```yaml
+# Example configuration entry for RAS-2819T
+climate:
+  - platform: toshiba
+    name: "Toshiba AC"
+    model: RAS-2819T
+    sensor: room_temperature
+```
 
 {{< anchor "whirlpool" >}}
 


### PR DESCRIPTION
## Description:

First PRs, but adding docs to support the PR I've raised over [thataway](https://github.com/esphome/esphome#9490). 

**Related issue (if applicable):** 

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#9490

## Checklist:

  - [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
