### PR TITLE
Add device_id param documentation

### DIFF
--- a/components/binary_sensor/index.rst
+++ b/components/binary_sensor/index.rst
@@ -75,7 +75,8 @@ Advanced options:
 - **entity_category** (*Optional*, string): The category of the entity.
   See https://developers.home-assistant.io/docs/core/entity/#generic-properties
   for a list of available options.
-  Set to ``""`` to remove the default entity category.
+  Set to ``""`` to remove the default entity category. 
+- **device_id** (Optional, string): Identifier of the sub‑device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
 - If MQTT enabled, all other options from :ref:`MQTT Component <config-mqtt-component>`.
 - If Webserver enabled and version 3 is selected, All other options from Webserver Component.. See :ref:`Webserver Version 3 <config-webserver-version-3-options>`.
 

--- a/components/binary_sensor/index.rst
+++ b/components/binary_sensor/index.rst
@@ -75,7 +75,7 @@ Advanced options:
 - **entity_category** (*Optional*, string): The category of the entity.
   See https://developers.home-assistant.io/docs/core/entity/#generic-properties
   for a list of available options.
-  Set to ``""`` to remove the default entity category. 
+  Set to ``""`` to remove the default entity category.
 - **device_id** (*Optional*, string): Identifier of the sub‑device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
 - If MQTT enabled, all other options from :ref:`MQTT Component <config-mqtt-component>`.
 - If Webserver enabled and version 3 is selected, All other options from Webserver Component.. See :ref:`Webserver Version 3 <config-webserver-version-3-options>`.

--- a/components/binary_sensor/index.rst
+++ b/components/binary_sensor/index.rst
@@ -76,7 +76,7 @@ Advanced options:
   See https://developers.home-assistant.io/docs/core/entity/#generic-properties
   for a list of available options.
   Set to ``""`` to remove the default entity category. 
-- **device_id** (Optional, string): Identifier of the sub‑device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
+- **device_id** (*Optional*, string): Identifier of the sub‑device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
 - If MQTT enabled, all other options from :ref:`MQTT Component <config-mqtt-component>`.
 - If Webserver enabled and version 3 is selected, All other options from Webserver Component.. See :ref:`Webserver Version 3 <config-webserver-version-3-options>`.
 

--- a/components/binary_sensor/index.rst
+++ b/components/binary_sensor/index.rst
@@ -76,7 +76,7 @@ Advanced options:
   See https://developers.home-assistant.io/docs/core/entity/#generic-properties
   for a list of available options.
   Set to ``""`` to remove the default entity category.
-- **device_id** (*Optional*, string): Identifier of the sub‑device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
+- **device_id** (*Optional*, :ref:`config-id`): Identifier of the sub‑device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main device.
 - If MQTT enabled, all other options from :ref:`MQTT Component <config-mqtt-component>`.
 - If Webserver enabled and version 3 is selected, All other options from Webserver Component.. See :ref:`Webserver Version 3 <config-webserver-version-3-options>`.
 

--- a/components/button/index.rst
+++ b/components/button/index.rst
@@ -57,7 +57,7 @@ Configuration variables:
 - **entity_category** (*Optional*, string): The category of the entity.
   See https://developers.home-assistant.io/docs/core/entity/#generic-properties
   for a list of available options. Set to ``""`` to remove the default entity category.
-- **device_id** (Optional, string): Identifier of the sub‑device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
+- **device_id** (*Optional*, string): Identifier of the sub‑device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
 - **device_class** (*Optional*, string): The device class for the button.
   See https://www.home-assistant.io/integrations/button/#device-class
   for a list of available options.

--- a/components/button/index.rst
+++ b/components/button/index.rst
@@ -57,6 +57,7 @@ Configuration variables:
 - **entity_category** (*Optional*, string): The category of the entity.
   See https://developers.home-assistant.io/docs/core/entity/#generic-properties
   for a list of available options. Set to ``""`` to remove the default entity category.
+- **device_id** (Optional, string): Identifier of the sub‑device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
 - **device_class** (*Optional*, string): The device class for the button.
   See https://www.home-assistant.io/integrations/button/#device-class
   for a list of available options.

--- a/components/climate/index.rst
+++ b/components/climate/index.rst
@@ -86,7 +86,7 @@ Advanced options:
   See https://developers.home-assistant.io/docs/core/entity/#generic-properties
   for a list of available options.
   Set to ``""`` to remove the default entity category.
-- **device_id** (Optional, string): Identifier of the sub‑device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
+- **device_id** (*Optional*, string): Identifier of the sub‑device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
 - If Webserver enabled and version 3 is selected, All other options from Webserver Component.. See :ref:`Webserver Version 3 <config-webserver-version-3-options>`.
 
 MQTT options:

--- a/components/climate/index.rst
+++ b/components/climate/index.rst
@@ -86,6 +86,7 @@ Advanced options:
   See https://developers.home-assistant.io/docs/core/entity/#generic-properties
   for a list of available options.
   Set to ``""`` to remove the default entity category.
+- **device_id** (Optional, string): Identifier of the sub‑device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
 - If Webserver enabled and version 3 is selected, All other options from Webserver Component.. See :ref:`Webserver Version 3 <config-webserver-version-3-options>`.
 
 MQTT options:

--- a/components/cover/index.rst
+++ b/components/cover/index.rst
@@ -52,6 +52,7 @@ Advanced options:
   See https://developers.home-assistant.io/docs/core/entity/#generic-properties
   for a list of available options.
   Set to ``""`` to remove the default entity category.
+- **device_id** (Optional, string): Identifier of the sub‑device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
 - If Webserver enabled and version 3 is selected, All other options from Webserver Component.. See :ref:`Webserver Version 3 <config-webserver-version-3-options>`.
 
 

--- a/components/cover/index.rst
+++ b/components/cover/index.rst
@@ -52,7 +52,7 @@ Advanced options:
   See https://developers.home-assistant.io/docs/core/entity/#generic-properties
   for a list of available options.
   Set to ``""`` to remove the default entity category.
-- **device_id** (Optional, string): Identifier of the sub‑device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
+- **device_id** (*Optional*, string): Identifier of the sub‑device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
 - If Webserver enabled and version 3 is selected, All other options from Webserver Component.. See :ref:`Webserver Version 3 <config-webserver-version-3-options>`.
 
 

--- a/components/datetime/index.rst
+++ b/components/datetime/index.rst
@@ -48,6 +48,7 @@ Configuration variables:
   See https://developers.home-assistant.io/docs/core/entity/#generic-properties
   for a list of available options.
   Set to ``""`` to remove the default entity category.
+- **device_id** (Optional, string): Identifier of the sub‑device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
 - **time_id** (*Optional*, :ref:`config-id`): The ID of the time entity. Automatically set
   to the ID of a time component if only a single one is defined. Required if ``on_time`` is used.
 - If Webserver enabled and version 3 is selected, All other options from Webserver Component.. See :ref:`Webserver Version 3 <config-webserver-version-3-options>`.

--- a/components/datetime/index.rst
+++ b/components/datetime/index.rst
@@ -48,7 +48,7 @@ Configuration variables:
   See https://developers.home-assistant.io/docs/core/entity/#generic-properties
   for a list of available options.
   Set to ``""`` to remove the default entity category.
-- **device_id** (Optional, string): Identifier of the sub‑device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
+- **device_id** (*Optional*, string): Identifier of the sub‑device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
 - **time_id** (*Optional*, :ref:`config-id`): The ID of the time entity. Automatically set
   to the ID of a time component if only a single one is defined. Required if ``on_time`` is used.
 - If Webserver enabled and version 3 is selected, All other options from Webserver Component.. See :ref:`Webserver Version 3 <config-webserver-version-3-options>`.

--- a/components/esp32_camera.rst
+++ b/components/esp32_camera.rst
@@ -42,6 +42,7 @@ Configuration variables:
   See https://developers.home-assistant.io/docs/core/entity/#generic-properties
   for a list of available options.
   Set to ``""`` to remove the default entity category.
+- **device_id** (Optional, string): Identifier of the sub‑device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
 
 Connection Options:
 

--- a/components/esp32_camera.rst
+++ b/components/esp32_camera.rst
@@ -42,7 +42,7 @@ Configuration variables:
   See https://developers.home-assistant.io/docs/core/entity/#generic-properties
   for a list of available options.
   Set to ``""`` to remove the default entity category.
-- **device_id** (Optional, string): Identifier of the sub‑device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
+- **device_id** (*Optional*, string): Identifier of the sub‑device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
 
 Connection Options:
 

--- a/components/event/index.rst
+++ b/components/event/index.rst
@@ -65,7 +65,7 @@ One of ``id`` or ``name`` is required.
 - **entity_category** (*Optional*, string): The category of the entity.
   See https://developers.home-assistant.io/docs/core/entity/#generic-properties
   for a list of available options. Set to ``""`` to remove the default entity category.
-- **device_id** (Optional, string): Identifier of the sub-device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
+- **device_id** (*Optional*, string): Identifier of the sub-device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
 - **device_class** (*Optional*, string): The device class for the event. The following device classes are supported by event entities:
 
   - None: Generic event. This is the default and doesn't need to be set.

--- a/components/event/index.rst
+++ b/components/event/index.rst
@@ -65,7 +65,7 @@ One of ``id`` or ``name`` is required.
 - **entity_category** (*Optional*, string): The category of the entity.
   See https://developers.home-assistant.io/docs/core/entity/#generic-properties
   for a list of available options. Set to ``""`` to remove the default entity category.
-- **device_id** (Optional, string): Identifier of the sub‑device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
+- **device_id** (Optional, string): Identifier of the sub-device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
 - **device_class** (*Optional*, string): The device class for the event. The following device classes are supported by event entities:
 
   - None: Generic event. This is the default and doesn't need to be set.

--- a/components/event/index.rst
+++ b/components/event/index.rst
@@ -65,6 +65,7 @@ One of ``id`` or ``name`` is required.
 - **entity_category** (*Optional*, string): The category of the entity.
   See https://developers.home-assistant.io/docs/core/entity/#generic-properties
   for a list of available options. Set to ``""`` to remove the default entity category.
+- **device_id** (Optional, string): Identifier of the sub‑device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
 - **device_class** (*Optional*, string): The device class for the event. The following device classes are supported by event entities:
 
   - None: Generic event. This is the default and doesn't need to be set.

--- a/components/fan/index.rst
+++ b/components/fan/index.rst
@@ -55,7 +55,7 @@ Configuration variables:
   See https://developers.home-assistant.io/docs/core/entity/#generic-properties
   for a list of available options.
   Set to ``""`` to remove the default entity category.
-- **device_id** (Optional, string): Identifier of the sub‑device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
+- **device_id** (*Optional*, string): Identifier of the sub‑device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
 - If Webserver enabled and version 3 is selected, All other options from Webserver Component.. See :ref:`Webserver Version 3 <config-webserver-version-3-options>`.
 
 MQTT options:

--- a/components/fan/index.rst
+++ b/components/fan/index.rst
@@ -55,7 +55,7 @@ Configuration variables:
   See https://developers.home-assistant.io/docs/core/entity/#generic-properties
   for a list of available options.
   Set to ``""`` to remove the default entity category.
-- **device_id** (*Optional*, string): Identifier of the sub‑device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
+- **device_id** (*Optional*, string): Identifier of the sub-device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
 - If Webserver enabled and version 3 is selected, All other options from Webserver Component.. See :ref:`Webserver Version 3 <config-webserver-version-3-options>`.
 
 MQTT options:

--- a/components/fan/index.rst
+++ b/components/fan/index.rst
@@ -55,6 +55,7 @@ Configuration variables:
   See https://developers.home-assistant.io/docs/core/entity/#generic-properties
   for a list of available options.
   Set to ``""`` to remove the default entity category.
+- **device_id** (Optional, string): Identifier of the sub‑device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
 - If Webserver enabled and version 3 is selected, All other options from Webserver Component.. See :ref:`Webserver Version 3 <config-webserver-version-3-options>`.
 
 MQTT options:

--- a/components/light/index.rst
+++ b/components/light/index.rst
@@ -91,7 +91,7 @@ All light configuration schemas inherit these options.
 - **entity_category** (*Optional*, string): The category of the entity. See `this list
   <https://developers.home-assistant.io/docs/core/entity/#generic-properties>`__ for a list of available options. Set
   to ``""`` to remove the default entity category.
-- **device_id** (*Optional*, string): Identifier of the sub‑device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
+- **device_id** (*Optional*, string): Identifier of the sub-device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
 - If MQTT enabled, all other options from :ref:`MQTT Component <config-mqtt-component>`.
 - If Webserver enabled and :ref:`version 3 <config-webserver-version-3-options>` is selected, all other options from
   :doc:`/components/web_server`.

--- a/components/light/index.rst
+++ b/components/light/index.rst
@@ -91,6 +91,7 @@ All light configuration schemas inherit these options.
 - **entity_category** (*Optional*, string): The category of the entity. See `this list
   <https://developers.home-assistant.io/docs/core/entity/#generic-properties>`__ for a list of available options. Set
   to ``""`` to remove the default entity category.
+- **device_id** (Optional, string): Identifier of the sub‑device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
 - If MQTT enabled, all other options from :ref:`MQTT Component <config-mqtt-component>`.
 - If Webserver enabled and :ref:`version 3 <config-webserver-version-3-options>` is selected, all other options from
   :doc:`/components/web_server`.

--- a/components/light/index.rst
+++ b/components/light/index.rst
@@ -91,7 +91,7 @@ All light configuration schemas inherit these options.
 - **entity_category** (*Optional*, string): The category of the entity. See `this list
   <https://developers.home-assistant.io/docs/core/entity/#generic-properties>`__ for a list of available options. Set
   to ``""`` to remove the default entity category.
-- **device_id** (Optional, string): Identifier of the sub‑device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
+- **device_id** (*Optional*, string): Identifier of the sub‑device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
 - If MQTT enabled, all other options from :ref:`MQTT Component <config-mqtt-component>`.
 - If Webserver enabled and :ref:`version 3 <config-webserver-version-3-options>` is selected, all other options from
   :doc:`/components/web_server`.

--- a/components/lock/index.rst
+++ b/components/lock/index.rst
@@ -44,7 +44,7 @@ Configuration variables:
 - **entity_category** (*Optional*, string): The category of the entity.
   See https://developers.home-assistant.io/docs/core/entity/#generic-properties
   for a list of available options. Set to ``""`` to remove the default entity category.
-- **device_id** (*Optional*, string): Identifier of the sub‑device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
+- **device_id** (*Optional*, string): Identifier of the sub-device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
 - If MQTT enabled, All other options from :ref:`MQTT Component <config-mqtt-component>`.
 - If Webserver enabled and version 3 is selected, All other options from Webserver Component.. See :ref:`Webserver Version 3 <config-webserver-version-3-options>`.
 

--- a/components/lock/index.rst
+++ b/components/lock/index.rst
@@ -44,6 +44,7 @@ Configuration variables:
 - **entity_category** (*Optional*, string): The category of the entity.
   See https://developers.home-assistant.io/docs/core/entity/#generic-properties
   for a list of available options. Set to ``""`` to remove the default entity category.
+- **device_id** (Optional, string): Identifier of the sub‑device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
 - If MQTT enabled, All other options from :ref:`MQTT Component <config-mqtt-component>`.
 - If Webserver enabled and version 3 is selected, All other options from Webserver Component.. See :ref:`Webserver Version 3 <config-webserver-version-3-options>`.
 

--- a/components/lock/index.rst
+++ b/components/lock/index.rst
@@ -44,7 +44,7 @@ Configuration variables:
 - **entity_category** (*Optional*, string): The category of the entity.
   See https://developers.home-assistant.io/docs/core/entity/#generic-properties
   for a list of available options. Set to ``""`` to remove the default entity category.
-- **device_id** (Optional, string): Identifier of the sub‑device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
+- **device_id** (*Optional*, string): Identifier of the sub‑device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
 - If MQTT enabled, All other options from :ref:`MQTT Component <config-mqtt-component>`.
 - If Webserver enabled and version 3 is selected, All other options from Webserver Component.. See :ref:`Webserver Version 3 <config-webserver-version-3-options>`.
 

--- a/components/media_player/index.rst
+++ b/components/media_player/index.rst
@@ -44,7 +44,7 @@ Configuration variables:
 - **entity_category** (*Optional*, string): The category of the entity.
   See https://developers.home-assistant.io/docs/core/entity/#generic-properties
   for a list of available options. Set to ``""`` to remove the default entity category.
-- **device_id** (Optional, string): Identifier of the sub‑device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
+- **device_id** (*Optional*, string): Identifier of the sub‑device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
 
 .. _media_player-actions:
 

--- a/components/media_player/index.rst
+++ b/components/media_player/index.rst
@@ -44,7 +44,7 @@ Configuration variables:
 - **entity_category** (*Optional*, string): The category of the entity.
   See https://developers.home-assistant.io/docs/core/entity/#generic-properties
   for a list of available options. Set to ``""`` to remove the default entity category.
-- **device_id** (*Optional*, string): Identifier of the sub‑device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
+- **device_id** (*Optional*, string): Identifier of the sub-device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
 
 .. _media_player-actions:
 

--- a/components/media_player/index.rst
+++ b/components/media_player/index.rst
@@ -44,6 +44,7 @@ Configuration variables:
 - **entity_category** (*Optional*, string): The category of the entity.
   See https://developers.home-assistant.io/docs/core/entity/#generic-properties
   for a list of available options. Set to ``""`` to remove the default entity category.
+- **device_id** (Optional, string): Identifier of the sub‑device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
 
 .. _media_player-actions:
 

--- a/components/number/index.rst
+++ b/components/number/index.rst
@@ -49,6 +49,7 @@ Configuration variables:
   See https://developers.home-assistant.io/docs/core/entity/#generic-properties
   for a list of available options.
   Set to ``""`` to remove the default entity category.
+- **device_id** (Optional, string): Identifier of the sub‑device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
 - **unit_of_measurement** (*Optional*, string): Manually set the unit
   of measurement for the number.
 - **mode** (*Optional*, string): Defines how the number should be displayed in the frontend.

--- a/components/number/index.rst
+++ b/components/number/index.rst
@@ -49,7 +49,7 @@ Configuration variables:
   See https://developers.home-assistant.io/docs/core/entity/#generic-properties
   for a list of available options.
   Set to ``""`` to remove the default entity category.
-- **device_id** (Optional, string): Identifier of the sub‑device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
+- **device_id** (Optional, string): Identifier of the sub-device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
 - **unit_of_measurement** (*Optional*, string): Manually set the unit
   of measurement for the number.
 - **mode** (*Optional*, string): Defines how the number should be displayed in the frontend.

--- a/components/select/index.rst
+++ b/components/select/index.rst
@@ -49,7 +49,7 @@ Configuration variables:
   See https://developers.home-assistant.io/docs/core/entity/#generic-properties
   for a list of available options.
   Set to ``""`` to remove the default entity category.
-- **device_id** (*Optional*, string): Identifier of the sub‑device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
+- **device_id** (*Optional*, string): Identifier of the sub-device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
 - If Webserver enabled and version 3 is selected, All other options from Webserver Component.. See :ref:`Webserver Version 3 <config-webserver-version-3-options>`.
 
 Automations:

--- a/components/select/index.rst
+++ b/components/select/index.rst
@@ -49,6 +49,7 @@ Configuration variables:
   See https://developers.home-assistant.io/docs/core/entity/#generic-properties
   for a list of available options.
   Set to ``""`` to remove the default entity category.
+- **device_id** (Optional, string): Identifier of the sub‑device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
 - If Webserver enabled and version 3 is selected, All other options from Webserver Component.. See :ref:`Webserver Version 3 <config-webserver-version-3-options>`.
 
 Automations:

--- a/components/select/index.rst
+++ b/components/select/index.rst
@@ -49,7 +49,7 @@ Configuration variables:
   See https://developers.home-assistant.io/docs/core/entity/#generic-properties
   for a list of available options.
   Set to ``""`` to remove the default entity category.
-- **device_id** (Optional, string): Identifier of the sub‑device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
+- **device_id** (*Optional*, string): Identifier of the sub‑device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
 - If Webserver enabled and version 3 is selected, All other options from Webserver Component.. See :ref:`Webserver Version 3 <config-webserver-version-3-options>`.
 
 Automations:

--- a/components/sensor/index.rst
+++ b/components/sensor/index.rst
@@ -81,6 +81,7 @@ Configuration variables:
   See https://developers.home-assistant.io/docs/core/entity/#generic-properties
   for a list of available options.
   Set to ``""`` to remove the default entity category.
+- **device_id** (Optional, string): Identifier of the sub‑device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
 - If Webserver enabled and version 3 is selected, All other options from Webserver Component.. See :ref:`Webserver Version 3 <config-webserver-version-3-options>`.
 
 Automations:

--- a/components/sensor/index.rst
+++ b/components/sensor/index.rst
@@ -81,7 +81,7 @@ Configuration variables:
   See https://developers.home-assistant.io/docs/core/entity/#generic-properties
   for a list of available options.
   Set to ``""`` to remove the default entity category.
-- **device_id** (Optional, string): Identifier of the sub‑device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
+- **device_id** (Optional, string): Identifier of the sub-device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
 - If Webserver enabled and version 3 is selected, All other options from Webserver Component.. See :ref:`Webserver Version 3 <config-webserver-version-3-options>`.
 
 Automations:

--- a/components/sensor/index.rst
+++ b/components/sensor/index.rst
@@ -81,7 +81,7 @@ Configuration variables:
   See https://developers.home-assistant.io/docs/core/entity/#generic-properties
   for a list of available options.
   Set to ``""`` to remove the default entity category.
-- **device_id** (Optional, string): Identifier of the sub-device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
+- **device_id** (*Optional*, string): Identifier of the sub-device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
 - If Webserver enabled and version 3 is selected, All other options from Webserver Component.. See :ref:`Webserver Version 3 <config-webserver-version-3-options>`.
 
 Automations:

--- a/components/switch/index.rst
+++ b/components/switch/index.rst
@@ -65,7 +65,7 @@ Configuration variables:
   See https://developers.home-assistant.io/docs/core/entity/#generic-properties
   for a list of available options.
   Set to ``""`` to remove the default entity category.
-- **device_id** (Optional, string): Identifier of the sub‑device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
+- **device_id** (*Optional*, string): Identifier of the sub‑device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
 - **device_class** (*Optional*, string): The device class for the switch.
   See https://www.home-assistant.io/integrations/switch/#device-class
   for a list of available options.

--- a/components/switch/index.rst
+++ b/components/switch/index.rst
@@ -65,6 +65,7 @@ Configuration variables:
   See https://developers.home-assistant.io/docs/core/entity/#generic-properties
   for a list of available options.
   Set to ``""`` to remove the default entity category.
+- **device_id** (Optional, string): Identifier of the sub‑device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
 - **device_class** (*Optional*, string): The device class for the switch.
   See https://www.home-assistant.io/integrations/switch/#device-class
   for a list of available options.

--- a/components/switch/index.rst
+++ b/components/switch/index.rst
@@ -65,7 +65,7 @@ Configuration variables:
   See https://developers.home-assistant.io/docs/core/entity/#generic-properties
   for a list of available options.
   Set to ``""`` to remove the default entity category.
-- **device_id** (*Optional*, string): Identifier of the sub‑device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
+- **device_id** (*Optional*, string): Identifier of the sub-device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
 - **device_class** (*Optional*, string): The device class for the switch.
   See https://www.home-assistant.io/integrations/switch/#device-class
   for a list of available options.

--- a/components/text/index.rst
+++ b/components/text/index.rst
@@ -48,6 +48,7 @@ Configuration variables:
 - **entity_category** (*Optional*, string): The category of the entity.
   See https://developers.home-assistant.io/docs/core/entity/#generic-properties
   for a list of available options. Set to ``""`` to remove the default entity category.
+- **device_id** (Optional, string): Identifier of the sub‑device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
 - **mode** (**Required**, string): Defines how the text should be displayed in the frontend.
   One of ``text`` or ``password``.
 - If Webserver enabled and version 3 is selected, All other options from Webserver Component.. See :ref:`Webserver Version 3 <config-webserver-version-3-options>`.

--- a/components/text/index.rst
+++ b/components/text/index.rst
@@ -48,7 +48,7 @@ Configuration variables:
 - **entity_category** (*Optional*, string): The category of the entity.
   See https://developers.home-assistant.io/docs/core/entity/#generic-properties
   for a list of available options. Set to ``""`` to remove the default entity category.
-- **device_id** (*Optional*, string): Identifier of the sub‑device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
+- **device_id** (*Optional*, string): Identifier of the sub-device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
 - **mode** (**Required**, string): Defines how the text should be displayed in the frontend.
   One of ``text`` or ``password``.
 - If Webserver enabled and version 3 is selected, All other options from Webserver Component.. See :ref:`Webserver Version 3 <config-webserver-version-3-options>`.

--- a/components/text/index.rst
+++ b/components/text/index.rst
@@ -48,7 +48,7 @@ Configuration variables:
 - **entity_category** (*Optional*, string): The category of the entity.
   See https://developers.home-assistant.io/docs/core/entity/#generic-properties
   for a list of available options. Set to ``""`` to remove the default entity category.
-- **device_id** (Optional, string): Identifier of the sub‑device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
+- **device_id** (*Optional*, string): Identifier of the sub‑device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
 - **mode** (**Required**, string): Defines how the text should be displayed in the frontend.
   One of ``text`` or ``password``.
 - If Webserver enabled and version 3 is selected, All other options from Webserver Component.. See :ref:`Webserver Version 3 <config-webserver-version-3-options>`.

--- a/components/text_sensor/index.rst
+++ b/components/text_sensor/index.rst
@@ -47,7 +47,7 @@ Configuration variables:
   See https://developers.home-assistant.io/docs/core/entity/#generic-properties
   for a list of available options.
   Set to ``""`` to remove the default entity category.
-- **device_id** (*Optional*, string): Identifier of the sub‑device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
+- **device_id** (*Optional*, string): Identifier of the sub-device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
 - If MQTT enabled, All other options from :ref:`MQTT Component <config-mqtt-component>`.
 - If Webserver enabled and version 3 is selected, All other options from Webserver Component.. See :ref:`Webserver Version 3 <config-webserver-version-3-options>`.
 

--- a/components/text_sensor/index.rst
+++ b/components/text_sensor/index.rst
@@ -47,7 +47,7 @@ Configuration variables:
   See https://developers.home-assistant.io/docs/core/entity/#generic-properties
   for a list of available options.
   Set to ``""`` to remove the default entity category.
-- **device_id** (Optional, string): Identifier of the sub‑device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
+- **device_id** (*Optional*, string): Identifier of the sub‑device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
 - If MQTT enabled, All other options from :ref:`MQTT Component <config-mqtt-component>`.
 - If Webserver enabled and version 3 is selected, All other options from Webserver Component.. See :ref:`Webserver Version 3 <config-webserver-version-3-options>`.
 

--- a/components/text_sensor/index.rst
+++ b/components/text_sensor/index.rst
@@ -47,6 +47,7 @@ Configuration variables:
   See https://developers.home-assistant.io/docs/core/entity/#generic-properties
   for a list of available options.
   Set to ``""`` to remove the default entity category.
+- **device_id** (Optional, string): Identifier of the sub‑device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
 - If MQTT enabled, All other options from :ref:`MQTT Component <config-mqtt-component>`.
 - If Webserver enabled and version 3 is selected, All other options from Webserver Component.. See :ref:`Webserver Version 3 <config-webserver-version-3-options>`.
 

--- a/components/update/index.rst
+++ b/components/update/index.rst
@@ -35,7 +35,7 @@ Configuration variables:
   (usually Home Assistant) without the user manually enabling it (via the Home Assistant UI). Defaults to ``false``.
 - **entity_category** (*Optional*, string): The category of the update entity. See
   https://developers.home-assistant.io/docs/core/entity/#generic-properties for a list of available options.
-- **device_id** (Optional, string): Identifier of the sub‑device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
+- **device_id** (*Optional*, string): Identifier of the sub‑device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
 - **icon** (*Optional*, icon): The icon to use for the update entity in the frontend.
 - **internal** (*Optional*, boolean): Mark this component as internal. Internal components will
   not be exposed to the frontend (like Home Assistant). Specifying an ``id`` without a ``name`` will

--- a/components/update/index.rst
+++ b/components/update/index.rst
@@ -35,7 +35,7 @@ Configuration variables:
   (usually Home Assistant) without the user manually enabling it (via the Home Assistant UI). Defaults to ``false``.
 - **entity_category** (*Optional*, string): The category of the update entity. See
   https://developers.home-assistant.io/docs/core/entity/#generic-properties for a list of available options.
-- **device_id** (*Optional*, string): Identifier of the sub‑device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
+- **device_id** (*Optional*, string): Identifier of the sub-device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
 - **icon** (*Optional*, icon): The icon to use for the update entity in the frontend.
 - **internal** (*Optional*, boolean): Mark this component as internal. Internal components will
   not be exposed to the frontend (like Home Assistant). Specifying an ``id`` without a ``name`` will

--- a/components/update/index.rst
+++ b/components/update/index.rst
@@ -35,6 +35,7 @@ Configuration variables:
   (usually Home Assistant) without the user manually enabling it (via the Home Assistant UI). Defaults to ``false``.
 - **entity_category** (*Optional*, string): The category of the update entity. See
   https://developers.home-assistant.io/docs/core/entity/#generic-properties for a list of available options.
+- **device_id** (Optional, string): Identifier of the sub‑device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
 - **icon** (*Optional*, icon): The icon to use for the update entity in the frontend.
 - **internal** (*Optional*, boolean): Mark this component as internal. Internal components will
   not be exposed to the frontend (like Home Assistant). Specifying an ``id`` without a ``name`` will

--- a/components/valve/index.rst
+++ b/components/valve/index.rst
@@ -50,6 +50,7 @@ Advanced options:
   (usually Home Assistant) without the user manually enabling it (via the Home Assistant UI). Defaults to ``false``.
 - **entity_category** (*Optional*, string): The category of the entity. See
   https://developers.home-assistant.io/docs/core/entity/#generic-properties for a list of available options. Set to ``""`` to remove the default entity category.
+- **device_id** (Optional, string): Identifier of the sub‑device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
 - If Webserver enabled and version 3 is selected, All other options from Webserver Component.. See :ref:`Webserver Version 3 <config-webserver-version-3-options>`.
 
 MQTT options:

--- a/components/valve/index.rst
+++ b/components/valve/index.rst
@@ -50,7 +50,7 @@ Advanced options:
   (usually Home Assistant) without the user manually enabling it (via the Home Assistant UI). Defaults to ``false``.
 - **entity_category** (*Optional*, string): The category of the entity. See
   https://developers.home-assistant.io/docs/core/entity/#generic-properties for a list of available options. Set to ``""`` to remove the default entity category.
-- **device_id** (*Optional*, string): Identifier of the sub‑device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
+- **device_id** (*Optional*, string): Identifier of the sub-device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
 - If Webserver enabled and version 3 is selected, All other options from Webserver Component.. See :ref:`Webserver Version 3 <config-webserver-version-3-options>`.
 
 MQTT options:

--- a/components/valve/index.rst
+++ b/components/valve/index.rst
@@ -50,7 +50,7 @@ Advanced options:
   (usually Home Assistant) without the user manually enabling it (via the Home Assistant UI). Defaults to ``false``.
 - **entity_category** (*Optional*, string): The category of the entity. See
   https://developers.home-assistant.io/docs/core/entity/#generic-properties for a list of available options. Set to ``""`` to remove the default entity category.
-- **device_id** (Optional, string): Identifier of the sub‑device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
+- **device_id** (*Optional*, string): Identifier of the sub‑device this entity belongs to. Must match the id of an entry in :ref:`esphome.devices <esphome-devices>`. If omitted, the entity remains attached to the main ESP device.
 - If Webserver enabled and version 3 is selected, All other options from Webserver Component.. See :ref:`Webserver Version 3 <config-webserver-version-3-options>`.
 
 MQTT options:


### PR DESCRIPTION
## Description:
I noticed that we added documentation for esphome.devices and esphome.areas, but we did not add documentation for the device_id parameter that can be used on the entity.

This PR updates every entity-platform page to document the new optional device_id key for sub-device support. Up to now, the feature was only mentioned on the central Sub-Devices page; individual entity docs still lacked any reference to it.

Users reading an entity page now immediately see that sub-devices are supported and how to enable them for entities.
Every platform follows the same wording and link target, reducing confusion and copy-paste errors.

Follow up: https://github.com/esphome/esphome-docs/pull/4813

CC: @dala318

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
