### PR TITLE
Add section to PR template telling people about the image generator

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,3 +14,15 @@
   - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.
 
   - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
+
+## New Component images
+
+If you are adding a new component to ESPHome and you want to use the black and white component name images we use instead of a photo of the product,
+you can comment on this pull request with the following where the component name is written in upper case and with underscores (e.g. `COMPONENT_NAME`):
+
+```
+@esphomebot generate image <COMPONENT_NAME>
+```
+
+The workflow will comment back with a link to download the svg image inside a zip file. You can then copy that svg into the `images` folder and use it
+for the component index table.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,14 +15,25 @@
 
   - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
 
-## New Component images
+## New Component Images
 
-If you are adding a new component to ESPHome and you want to use the black and white component name images we use instead of a photo of the product,
-you can comment on this pull request with the following where the component name is written in upper case and with underscores (e.g. `COMPONENT_NAME`):
+If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.
 
+**To generate a component image:**
+
+1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):
+
+   ```
+   @esphomebot generate image COMPONENT_NAME
+   ```
+
+2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.
+
+3. Extract the SVG file and place it in the `images/` folder of this repository.
+
+4. Use the image in your component's index table entry in `/components/index.rst`.
+
+**Example:** For a component called "DHT22 Temperature Sensor", use:
 ```
-@esphomebot generate image COMPONENT_NAME
+@esphomebot generate image DHT22
 ```
-
-The workflow will comment back with a link to download the svg image inside a zip file. You can then copy that svg into the `images` folder and use it
-for the component index table.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,7 +15,8 @@
 
   - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
 
-## New Component Images
+<details>
+<summary><strong>New Component Images</strong></summary>
 
 If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.
 
@@ -37,3 +38,5 @@ If you are adding a new component to ESPHome, you can automatically generate a s
 ```
 @esphomebot generate image DHT22
 ```
+
+</details>

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,7 +21,7 @@ If you are adding a new component to ESPHome and you want to use the black and w
 you can comment on this pull request with the following where the component name is written in upper case and with underscores (e.g. `COMPONENT_NAME`):
 
 ```
-@esphomebot generate image <COMPONENT_NAME>
+@esphomebot generate image COMPONENT_NAME
 ```
 
 The workflow will comment back with a link to download the svg image inside a zip file. You can then copy that svg into the `images` folder and use it


### PR DESCRIPTION
## Description:

Added to this PR description to preview too =)

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>