### PR TITLE
[CI] Add auto labelling workflow

### DIFF
--- a/.github/workflows/auto-label-pr.yml
+++ b/.github/workflows/auto-label-pr.yml
@@ -1,0 +1,205 @@
+name: Auto Label PR
+
+on:
+  # Runs only on pull_request_target due to having access to a App token.
+  # This means PRs from forks will not be able to alter this workflow to get the tokens
+  pull_request_target:
+    types: [labeled, opened, reopened, synchronize, edited]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    if: github.event.action != 'labeled' || github.event.sender.type != 'Bot'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@v2.0.6
+        with:
+          app-id: ${{ secrets.ESPHOME_GITHUB_APP_ID }}
+          private-key: ${{ secrets.ESPHOME_GITHUB_APP_PRIVATE_KEY }}
+
+      - name: Auto Label PR
+        uses: actions/github-script@v7.0.1
+        with:
+          github-token: ${{ steps.generate-token.outputs.token }}
+          script: |
+            const { owner, repo } = context.repo;
+            const pr_number = context.issue.number;
+
+            // Get current labels
+            const { data: currentLabelsData } = await github.rest.issues.listLabelsOnIssue({
+              owner,
+              repo,
+              issue_number: pr_number
+            });
+            const currentLabels = currentLabelsData.map(label => label.name);
+
+            // Define managed labels that this workflow controls
+            const managedLabels = currentLabels.filter(label =>
+              ['current', 'next', 'has-parent', 'wrong-base-branch'].includes(label) ||
+              label.startsWith('component: ')
+            );
+
+            console.log('Current labels:', currentLabels.join(', '));
+            console.log('Managed labels:', managedLabels.join(', '));
+
+            const labels = new Set();
+
+            // Strategy: Branch-based labeling
+            const baseRef = context.payload.pull_request.base.ref;
+            console.log('Target branch:', baseRef);
+
+            if (baseRef === 'current') {
+              labels.add('current');
+            } else if (baseRef === 'next') {
+              labels.add('next');
+            }
+
+            // Strategy: Parent PR detection
+            const prBody = context.payload.pull_request.body || '';
+
+            // Look for ESPHome PR links in PR body
+            // Patterns to match:
+            // - https://github.com/esphome/esphome/pull/1234
+            // - esphome/esphome#1234
+            const esphomePrPatterns = [
+              /https:\/\/github\.com\/esphome\/esphome\/pull\/(\d+)/,
+              /esphome\/esphome#(\d+)/
+            ];
+
+            const hasEsphomeLink = esphomePrPatterns.some(pattern =>
+              pattern.test(prBody)
+            );
+
+            console.log('PR Body contains ESPHome link:', hasEsphomeLink);
+
+            if (hasEsphomeLink) {
+              labels.add('has-parent');
+
+              // Extract parent PR number and fetch its labels
+              for (const pattern of esphomePrPatterns) {
+                const match = prBody.match(pattern);
+                if (!match) continue; // Skip to next pattern if no match
+
+                try {
+                  // Extract PR number from the capture group
+                  const parentPrNumber = match[1];
+
+                  console.log('Found parent PR number:', parentPrNumber);
+
+                  // Fetch labels from the parent PR in esphome/esphome repository
+                  const { data: parentLabels } = await github.rest.issues.listLabelsOnIssue({
+                    owner: 'esphome',
+                    repo: 'esphome',
+                    issue_number: parseInt(parentPrNumber)
+                  });
+
+                  console.log('Parent PR labels:', parentLabels.map(l => l.name).join(', '));
+
+                  // Add all "component: " labels from parent PR
+                  parentLabels.forEach(label => {
+                    if (label.name.startsWith('component: ')) {
+                      labels.add(label.name);
+                      console.log('Added component label from parent:', label.name);
+                    }
+                  });
+
+                  break; // Only process the first match
+                  } catch (error) {
+                    console.log('Failed to fetch parent PR labels:', error.message);
+                  }
+                }
+              }
+            }
+
+            // Convert Set to Array
+            const finalLabels = Array.from(labels);
+
+            // Strategy: Wrong base branch detection
+            const hasParent = finalLabels.includes('has-parent');
+            const isCurrent = finalLabels.includes('current');
+
+            if (hasParent && isCurrent) {
+              finalLabels.push('wrong-base-branch');
+              console.log('Added wrong-base-branch label: has-parent targeting current branch');
+            }
+
+            console.log('Computed labels:', finalLabels.join(', '));
+
+            // Add new labels
+            if (finalLabels.length > 0) {
+              console.log(`Adding labels: ${finalLabels.join(', ')}`);
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: pr_number,
+                labels: finalLabels
+              });
+            }
+
+            // Request changes if wrong base branch is detected
+            if (hasParent && isCurrent) {
+              console.log('Requesting changes due to wrong base branch');
+              await github.rest.pulls.createReview({
+                owner,
+                repo,
+                pull_number: pr_number,
+                event: 'REQUEST_CHANGES',
+                body: 'As this is a feature matched with a PR in https://github.com/esphome/esphome, please target your PR to the `next` branch and rebase.'
+              });
+            } else {
+              // Check if we should dismiss any existing review from this bot
+              const currentUserId = await github.rest.users.getAuthenticated().then(response => response.data.id);
+
+              const { data: reviews } = await github.rest.pulls.listReviews({
+                owner,
+                repo,
+                pull_number: pr_number
+              });
+
+              // Find the most recent review from this bot that requested changes for wrong base branch
+              const botReview = reviews
+                .filter(review =>
+                  review.user.id === currentUserId &&
+                  review.state === 'CHANGES_REQUESTED' &&
+                  review.body && review.body.includes('target your PR to the `next` branch')
+                )
+                .sort((a, b) => new Date(b.submitted_at) - new Date(a.submitted_at))[0];
+
+              if (botReview) {
+                console.log('Dismissing previous bot review as labels are now correct');
+                await github.rest.pulls.dismissReview({
+                  owner,
+                  repo,
+                  pull_number: pr_number,
+                  review_id: botReview.id,
+                  message: 'Base branch has been corrected - dismissing previous review.'
+                });
+              }
+            }
+
+            // Remove old managed labels that are no longer needed
+            const labelsToRemove = managedLabels.filter(label =>
+              !finalLabels.includes(label)
+            );
+
+            for (const label of labelsToRemove) {
+              console.log(`Removing label: ${label}`);
+              try {
+                await github.rest.issues.removeLabel({
+                  owner,
+                  repo,
+                  issue_number: pr_number,
+                  name: label
+                });
+              } catch (error) {
+                console.log(`Failed to remove label ${label}:`, error.message);
+              }
+            }


### PR DESCRIPTION
## Description:


Adds a workflow to automatically label PRs

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.
  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
