### PR TITLE
[nrf52] dfu

### DIFF
--- a/content/components/nrf52.md
+++ b/content/components/nrf52.md
@@ -71,7 +71,7 @@ There are two ways to reference GPIO pins:
 1. By pin name, e.g., `P0.15` or `P1.11`.
 1. By pin number, e.g., `15` or `43`.
 
-## DFU Component
+## DFU (Device Firmware Update)
 
 The ``dfu`` component enables automatic entry into **DFU (Device Firmware Update)** mode by monitoring
 the USB CDC serial connection. When a host opens the port at **1200 baud**, the component triggers
@@ -91,8 +91,6 @@ nrf52:
     reset_pin:
       number: 14
       inverted: true
-      mode:
-        output: true
 ```
 
 ### Configuration variables

--- a/content/components/nrf52.md
+++ b/content/components/nrf52.md
@@ -97,7 +97,7 @@ nrf52:
 
 ### Configuration variables
 
-- **reset_pin** (**Required**, :ref:`Pin Schema <config-pin_schema>`): The pin to use for trigger a hardware reset. This pin should be connected to the MCU's reset line or to a circuit that causes the bootloader to enter DFU mode after reset.
+- **reset_pin** (*Required*, [Pin](#config-pin)): The pin to use for trigger a hardware reset. This pin should be connected to the MCU's reset line or to a circuit that causes the bootloader to enter DFU mode after reset.
 
 ## See Also
 

--- a/content/components/nrf52.md
+++ b/content/components/nrf52.md
@@ -95,7 +95,7 @@ nrf52:
         output: true
 ```
 
-### Configuration variables:
+### Configuration variables
 
 - **reset_pin** (**Required**, :ref:`Pin Schema <config-pin_schema>`): The pin to use for trigger a hardware reset. This pin should be connected to the MCU's reset line or to a circuit that causes the bootloader to enter DFU mode after reset.
 

--- a/content/components/nrf52.md
+++ b/content/components/nrf52.md
@@ -71,6 +71,34 @@ There are two ways to reference GPIO pins:
 1. By pin name, e.g., `P0.15` or `P1.11`.
 1. By pin number, e.g., `15` or `43`.
 
+## DFU Component
+
+The ``dfu`` component enables automatic entry into **DFU (Device Firmware Update)** mode by monitoring
+the USB CDC serial connection. When a host opens the port at **1200 baud**, the component triggers
+a reset via a GPIO pin to put the device into DFU mode.
+
+ESPHome uses this component internally when uploading firmware via:
+
+```bash
+    esphome upload d.yaml
+```
+
+### Example Configuration
+
+```yaml
+nrf52:
+  dfu:
+    reset_pin:
+      number: 14
+      inverted: true
+      mode:
+        output: true
+```
+
+### Configuration variables:
+
+- **reset_pin** (**Required**, :ref:`Pin Schema <config-pin_schema>`): The pin to use for trigger a hardware reset. This pin should be connected to the MCU's reset line or to a circuit that causes the bootloader to enter DFU mode after reset.
+
 ## See Also
 
 - {{< docref "esphome/" >}}

--- a/content/components/nrf52.md
+++ b/content/components/nrf52.md
@@ -80,7 +80,7 @@ a reset via a GPIO pin to put the device into DFU mode.
 ESPHome uses this component internally when uploading firmware via:
 
 ```bash
-    esphome upload d.yaml
+esphome upload d.yaml
 ```
 
 ### Example Configuration


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

https://github.com/esphome/esphome/pull/9319

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [x] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
