### PR TITLE
zephyr debug

### DIFF
--- a/content/components/debug.md
+++ b/content/components/debug.md
@@ -88,6 +88,17 @@ sensor:
 
 - **cpu_frequency** (*Optional*): Reports the CPU frequency in Hz. All options from [Sensor](#config-sensor).
 
+## Zephyr
+
+The component enables debugging features for ESPHome devices running on the Zephyr RTOS.
+It helps with low-level firmware debugging using **SWD (Serial Wire Debug)**. It enables:
+
+- **Thread Awareness in GDB**  
+Injects Zephyr thread metadata so that all active threads can be inspected via GDB when connected over SWD.
+
+- **Real-Time Logging over RTT**  
+Enables logging output over **SEGGER RTT** (Real Time Transfer), allowing non-intrusive debug logs through SWD.
+
 ## See Also
 
 - [Sensor Filters](#sensor-filters)


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- https://github.com/esphome/esphome/pull/8319

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [x] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
