### PR TITLE
[CI] Hardcode bot name instead of fetching id from api

### DIFF
--- a/.github/workflows/auto-label-pr.yml
+++ b/.github/workflows/auto-label-pr.yml
@@ -10,6 +10,9 @@ permissions:
   pull-requests: write
   contents: read
 
+env:
+  BOT_NAME: "esphome[bot]"
+
 jobs:
   label:
     runs-on: ubuntu-latest
@@ -161,8 +164,6 @@ jobs:
               });
             } else {
               // Check if we should dismiss any existing review from this bot
-              const currentUserId = await github.rest.users.getAuthenticated().then(response => response.data.id);
-
               const { data: reviews } = await github.rest.pulls.listReviews({
                 owner,
                 repo,
@@ -172,7 +173,7 @@ jobs:
               // Find the most recent review from this bot that requested changes for wrong base branch
               const botReview = reviews
                 .filter(review =>
-                  review.user.id === currentUserId &&
+                  review.user.login === '${{ env.BOT_NAME }}' &&
                   review.state === 'CHANGES_REQUESTED' &&
                   review.body && review.body.includes('target your PR to the `next` branch')
                 )


### PR DESCRIPTION
## Description:

The API is returning a 403, until I solve that, this solution should work


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
