### PR TITLE
[CI] Move labeled trigger to its own workflow so the auto label status doesnt get messy

### DIFF
--- a/.github/workflows/auto-label-pr.yml
+++ b/.github/workflows/auto-label-pr.yml
@@ -4,7 +4,14 @@ on:
   # Runs only on pull_request_target due to having access to a App token.
   # This means PRs from forks will not be able to alter this workflow to get the tokens
   pull_request_target:
-    types: [labeled, opened, reopened, synchronize, edited]
+    types: [opened, reopened, synchronize, edited]
+  # Allow manual triggering for recheck functionality
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'Pull Request number to process'
+        required: true
+        type: number
 
 permissions:
   pull-requests: write
@@ -34,7 +41,11 @@ jobs:
           github-token: ${{ steps.generate-token.outputs.token }}
           script: |
             const { owner, repo } = context.repo;
-            const pr_number = context.issue.number;
+            const pr_number = github.event_name === 'workflow_dispatch'
+              ? context.payload.inputs.pr_number
+              : context.issue.number;
+
+            console.log('Processing PR #' + pr_number);
 
             // Get current labels
             const { data: currentLabelsData } = await github.rest.issues.listLabelsOnIssue({
@@ -62,7 +73,22 @@ jobs:
             const labels = new Set();
 
             // Strategy: Branch-based labeling
-            const baseRef = context.payload.pull_request.base.ref;
+            let baseRef, prBody;
+            if (github.event_name === 'workflow_dispatch') {
+              // Get PR details when called via workflow_dispatch
+              const { data: pr } = await github.rest.pulls.get({
+                owner,
+                repo,
+                pull_number: pr_number
+              });
+              baseRef = pr.base.ref;
+              prBody = pr.body || '';
+            } else {
+              // Use context when called via pull_request_target
+              baseRef = context.payload.pull_request.base.ref;
+              prBody = context.payload.pull_request.body || '';
+            }
+
             console.log('Target branch:', baseRef);
 
             if (baseRef === 'current') {
@@ -72,7 +98,7 @@ jobs:
             }
 
             // Strategy: Parent PR detection
-            const prBody = context.payload.pull_request.body || '';
+            // prBody is already set above based on event type
 
             // Look for ESPHome PR links in PR body
             // Patterns to match:

--- a/.github/workflows/labeller-recheck.yml
+++ b/.github/workflows/labeller-recheck.yml
@@ -1,0 +1,32 @@
+name: Labeller Recheck
+
+on:
+  pull_request_target:
+    types: [labeled]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  trigger-auto-label:
+    runs-on: ubuntu-latest
+    if: github.event.label.name == 'labeller-recheck'
+    steps:
+      - name: Call Auto Label workflow
+        uses: actions/github-script@v7.0.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            console.log('Labeller recheck triggered for PR #' + context.issue.number);
+
+            // Trigger the auto-label workflow
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'auto-label-pr.yml',
+              ref: context.payload.pull_request.base.ref,
+              inputs: {
+                pr_number: context.issue.number.toString()
+              }
+            });


### PR DESCRIPTION
## Description:

Everytime the workflow adds new labels it retrigger itself (due to using an app token so we get the esphome[bot] instead of github-actions[bot] - not strictly necessary)

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
