### PR TITLE
esp32_cam: add location option documentation

### DIFF
--- a/components/esp32_camera.rst
+++ b/components/esp32_camera.rst
@@ -72,6 +72,9 @@ Frame Settings:
   is requesting a full stream. Defaults to ``0.1 fps``.
 - **frame_buffer_count** (*Optional*, int): The number of frame buffers to use when reading from the camera sensor.
   Must be between 1 and 2.  Defaults to ``1``.
+- **frame_buffer_location** (*Optional*, enum): The memory area used for storing the frame buffers. Defaults to ``PSRAM``.
+  - ``PSRAM``
+  - ``DRAM``
 
 Image Settings:
 


### PR DESCRIPTION


## Description:

Documented the new “frame_buffer_location” option for the
 ESP32 camera component, listing the options “PSRAM” and
“DRAM”.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#9630

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

