### PR TITLE
esp32_camera: Remove remaining references to i2c_pins-option from examples

### DIFF
--- a/components/esp32_camera.rst
+++ b/components/esp32_camera.rst
@@ -486,23 +486,20 @@ Configuration examples
 .. code-block:: yaml
 
     # Example configuration entry
-    external_components:
-      - source:
-          type: git
-          url: https://github.com/MichaKersloot/esphome_custom_components
-        components: [ esp32_camera ]
-
+    i2c:
+      - id: camera_i2c
+        sda: GPIO4
+        scl: GPIO5
     esp32_camera:
       external_clock:
         pin: GPIO15
         frequency: 20MHz
-      i2c_pins:
-        sda: GPIO4
-        scl: GPIO5
+      i2c_id: camera_i2c
       data_pins: [GPIO11, GPIO9, GPIO8, GPIO10, GPIO12, GPIO18, GPIO17, GPIO16]
       vsync_pin: GPIO6
       href_pin: GPIO7
       pixel_clock_pin: GPIO13
+      frame_buffer_location: DRAM
 
       # Image settings
       name: My Camera
@@ -535,13 +532,15 @@ Configuration examples
 
 .. code-block:: yaml
 
+    i2c:
+      - id: camera_i2c
+        sda: GPIO48
+        scl: GPIO47
     esp32_camera:
       external_clock:
         pin: GPIO3
         frequency: 20MHz
-      i2c_pins:
-        sda: GPIO48
-        scl: GPIO47
+      i2c_id: camera_i2c
       data_pins: [GPIO41, GPIO45, GPIO46, GPIO42, GPIO40, GPIO38, GPIO15, GPIO18]
       vsync_pin: GPIO1
       href_pin: GPIO2


### PR DESCRIPTION
Supersedes #5115 (which was onto `current`)

## Description:

- Remove deprecated configuration option
- Rework example for Freenove ESP32-S3-DevKitC-1 to use new `frame_buffer_location: PSRAM` option instead of external component

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

