### PR TITLE
[gpio] Document LibreTiny interrupt mode default behavior

### DIFF
--- a/components/binary_sensor/gpio.rst
+++ b/components/binary_sensor/gpio.rst
@@ -44,7 +44,9 @@ Configuration variables:
 
 - **pin** (**Required**, :ref:`Pin Schema <config-pin_schema>`): The pin to monitor.
 - **use_interrupt** (*Optional*, boolean): Use hardware interrupts instead of polling for better 
-  performance and lower CPU usage. Defaults to ``true``. Only supported on internal GPIO pins.
+  performance and lower CPU usage. Defaults to ``true`` for most platforms, but defaults to ``false`` 
+  for LibreTiny-based platforms (BK72xx, RTL87xx, LN882x) due to hardware limitations. Only supported 
+  on internal GPIO pins.
 - **interrupt_type** (*Optional*, string): The type of interrupt to use. One of:
 
   - ``ANY`` (default): Trigger on any edge change (high to low or low to high)
@@ -78,6 +80,10 @@ The GPIO binary sensor supports two modes of operation:
 
     Interrupt mode is only available on internal GPIO pins. External GPIO 
     expanders (like PCF8574) will automatically fall back to polling mode.
+    
+    LibreTiny-based platforms (BK72xx, RTL87xx, LN882x) default to polling mode 
+    due to hardware limitations with edge interrupts. You can explicitly enable 
+    interrupt mode if needed, but it may not work reliably on all pins.
 
 Activating internal pullups
 ---------------------------


### PR DESCRIPTION
## Description:

Updates the GPIO binary sensor documentation to reflect the new default behavior for LibreTiny platforms (BK72xx, RTL87xx, LN882x), where `use_interrupt` now defaults to `false` due to hardware limitations with edge interrupts.

This documentation update explains:
- The different default values for `use_interrupt` based on platform
- Why LibreTiny platforms default to polling mode
- That users can still explicitly enable interrupt mode if needed (though it may not work reliably)

**Related issue (if applicable):** fixes https://github.com/esphome/esphome/issues/9665

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#9687

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.