### PR TITLE
Document rfc2217:// (remote serial) syntax for upload/run

### DIFF
--- a/guides/cli.rst
+++ b/guides/cli.rst
@@ -73,8 +73,11 @@ The ``esphome run <CONFIG>`` command is the most common command for ESPHome. It
 
 .. option:: --device UPLOAD_PORT
 
-    Manually specify the upload port/IP to use. For example ``/dev/cu.SLAB_USBtoUART``, or ``192.168.1.176``
-    to perform an OTA.
+    Manually specify the upload port/IP to use. For example:
+
+    * ``/dev/cu.SLAB_USBtoUART`` for serial,
+    * ``192.168.1.176`` to perform an OTA,
+    * ``rfc2217://remote_host:4000`` for `remote serial  <rfc2217_>`_.
 
 .. option:: --upload_speed BAUD_RATE
 
@@ -139,8 +142,11 @@ The ``esphome upload <CONFIG>`` validates the configuration and uploads the most
 
 .. option:: --device UPLOAD_PORT
 
-    Manually specify the upload port/IP address to use. For example ``/dev/cu.SLAB_USBtoUART``, or ``192.168.1.176``
-    to perform an OTA.
+    Manually specify the upload port/IP to use. For example:
+
+    * ``/dev/cu.SLAB_USBtoUART`` for serial,
+    * ``192.168.1.176`` to perform an OTA,
+    * ``rfc2217://remote_host:4000`` for `remote serial  <rfc2217_>`_.
 
 .. option:: --upload_speed BAUD_RATE
 
@@ -335,3 +341,5 @@ See Also
 
 - :doc:`Guides </guides/index>`
 - :ghedit:`Edit`
+
+.. _rfc2217: https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-guides/tools/idf-docker-image.html#using-remote-serial-port


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome/pull/9686

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
