### PR TITLE
[gpio] Update binary sensor docs for allow_other_uses interrupt handling

### DIFF
--- a/components/binary_sensor/gpio.rst
+++ b/components/binary_sensor/gpio.rst
@@ -99,7 +99,7 @@ The GPIO binary sensor supports two modes of operation:
     When a pin is configured with ``allow_other_uses: true`` (for sharing with
     other components), interrupts are automatically disabled to prevent conflicts.
     This ensures compatibility with components like ``duty_cycle`` sensors that
-    need to monitor pin state changes. The sensor will use polling mode instead
+    need to monitor pin state changes. The sensor will use polling mode instead.
 
 Activating internal pullups
 ---------------------------

--- a/components/binary_sensor/gpio.rst
+++ b/components/binary_sensor/gpio.rst
@@ -39,13 +39,22 @@ efficient state change detection with minimal CPU usage.
         name: "Legacy Sensor"
         use_interrupt: false  # Use polling instead of interrupts
 
+    # Example with shared pin (automatic polling mode)
+    binary_sensor:
+      - platform: gpio
+        pin:
+          number: GPIO15
+          allow_other_uses: true  # Pin is shared with other components
+        name: "Pump Status"
+        # Interrupts will be automatically disabled for compatibility
+
 Configuration variables:
 ------------------------
 
 - **pin** (**Required**, :ref:`Pin Schema <config-pin_schema>`): The pin to monitor.
 - **use_interrupt** (*Optional*, boolean): Use hardware interrupts instead of polling for better 
-  performance and lower CPU usage. Defaults to ``true`` for most platforms, but defaults to ``false`` 
-  for LibreTiny-based platforms (BK72xx, RTL87xx, LN882x) due to hardware limitations. Only supported 
+  performance and lower CPU usage. Defaults to ``true`` for most platforms, but defaults to ``false``
+  for LibreTiny-based platforms (BK72xx, RTL87xx, LN882x) due to hardware limitations. Only supported
   on internal GPIO pins.
 - **interrupt_type** (*Optional*, string): The type of interrupt to use. One of:
 
@@ -78,12 +87,19 @@ The GPIO binary sensor supports two modes of operation:
 
 .. note::
 
-    Interrupt mode is only available on internal GPIO pins. External GPIO 
+    Interrupt mode is only available on internal GPIO pins. External GPIO
     expanders (like PCF8574) will automatically fall back to polling mode.
     
-    LibreTiny-based platforms (BK72xx, RTL87xx, LN882x) default to polling mode 
-    due to hardware limitations with edge interrupts. You can explicitly enable 
+    LibreTiny-based platforms (BK72xx, RTL87xx, LN882x) default to polling mode
+    due to hardware limitations with edge interrupts. You can explicitly enable
     interrupt mode if needed, but it may not work reliably on all pins.
+
+.. note::
+
+    When a pin is configured with ``allow_other_uses: true`` (for sharing with
+    other components), interrupts are automatically disabled to prevent conflicts.
+    This ensures compatibility with components like ``duty_cycle`` sensors that
+    need to monitor pin state changes. The sensor will use polling mode instead
 
 Activating internal pullups
 ---------------------------


### PR DESCRIPTION
## Description:

This PR updates the GPIO binary sensor documentation to reflect the automatic interrupt disabling behavior when pins are shared with other components (using `allow_other_uses: true`).

The documentation now:
- Explains that interrupts are automatically disabled when `allow_other_uses: true` is set
- Includes an example configuration showing a shared pin scenario
- Clarifies that the sensor will use polling mode for compatibility with other components

**Related issue (if applicable):** fixes esphome/esphome#9700

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#9701

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.