### PR TITLE
Add note about Studio Code Server Addon

### DIFF
--- a/guides/getting_started_hassio.rst
+++ b/guides/getting_started_hassio.rst
@@ -113,7 +113,7 @@ configuration for the "Bedroom Light" node in the picture above can be found in 
     a pre-installed 
     `ESPHome VSCode extension <https://marketplace.visualstudio.com/items?itemName=ESPHome.esphome-vscode>`__.
 
-    Home Assistant add-ons run as individual containers, and building files are not available to other containers, 
+    Home Assistant add-ons run as individual containers, and build files are not available to other containers, 
     including the Visual Studio Server add-on. If you want them to be available in Visual Studio Code as well, then 
     you need to move them to the shared directory. To do that, add the following entry:
 

--- a/guides/getting_started_hassio.rst
+++ b/guides/getting_started_hassio.rst
@@ -109,8 +109,9 @@ configuration for the "Bedroom Light" node in the picture above can be found in 
 .. note::
 
     If you have a project that consists of many files, you can also use Home Assistant's 
-    `Visual Studio Server add-on <https://github.com/hassio-addons/addon-vscode/tree/main`__, which has 
-    a pre-installed [ESPHome VSCode extension](https://marketplace.visualstudio.com/items?itemName=ESPHome.esphome-vscode).
+    `Visual Studio Server add-on <https://github.com/hassio-addons/addon-vscode/tree/main>`__, which has 
+    a pre-installed 
+    `ESPHome VSCode extension <https://marketplace.visualstudio.com/items?itemName=ESPHome.esphome-vscode>`__.
 
     Home Assistant add-ons run as individual containers, and building files are not available to other containers, 
     including the Visual Studio Server add-on. If you want them to be available in Visual Studio Code as well, then 

--- a/guides/getting_started_hassio.rst
+++ b/guides/getting_started_hassio.rst
@@ -108,7 +108,22 @@ configuration for the "Bedroom Light" node in the picture above can be found in 
 
 .. note::
 
-    Home Assistant add-ons run as individual containers; this can make accessing your configuration files/logs a bit
+    If you have a project that consists of many files, you can also use Home Assistant's 
+    `Visual Studio Server add-on <https://github.com/hassio-addons/addon-vscode/tree/main`__, which has 
+    a pre-installed [ESPHome VSCode extension](https://marketplace.visualstudio.com/items?itemName=ESPHome.esphome-vscode).
+
+    Home Assistant add-ons run as individual containers, and building files are not available to other containers, 
+    including the Visual Studio Server add-on. If you want them to be available in Visual Studio Code as well, then 
+    you need to move them to the shared directory. To do that, add the following entry:
+
+    .. code-block:: yaml
+
+        esphome:
+          build_path: /config/esphome/build/project-name/
+
+.. note::
+
+    Home Assistant add-ons run as individual containers; this can make accessing ESPHome CLI a bit
     challenging. If you wish to do so, you'll need to install Home Assistant's
     `SSH add-on <https://www.home-assistant.io/common-tasks/os/#installing-and-using-the-ssh-add-on>`__, configure it
     with a username and password and also disable "Protection Mode" (please assess the risks associated with doing so).


### PR DESCRIPTION
## Description:

I’m still pretty new, but I’ve found Studio Code Server to be the most convenient environment, even if it took a bit to get access to the build files I need to be productive. I used to preview files in the terminal; using a browser is far more efficient, so I’ve written a short guide on how to do it.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
