### PR TITLE
[esp32_rmt] Improve rmt_symbols docs

### DIFF
--- a/components/light/esp32_rmt_led_strip.rst
+++ b/components/light/esp32_rmt_led_strip.rst
@@ -56,21 +56,22 @@ Configuration variables
   sending commands as quickly as changes are made to the lights.
 - **use_psram** (*Optional*, boolean): Set to ``false`` to force internal RAM allocation even if you have the the PSRAM
   component enabled. This can be useful if you're experiencing issues like flickering with your leds strip. Defaults to ``true``.
-- **rmt_symbols** (*Optional*, int): The amount of RMT memory allocated to this component. Memory is shared by all
-  receivers and transmitters. On variants other than  ``ESP32`` and ``ESP32-S2`` only half the symbol memory is
-  available to transmitters. Each symbol is 32 bits and contains two values.
+- **rmt_symbols** (*Optional*, int): When ``use_dma`` is enabled, this sets the size of the driver's internal DMA
+  buffer. When DMA is disabled, it specifies how much RMT memory is allocated to the component. RMT memory is shared
+  across all components and should be allocated in multiples of the block size. On the ``ESP32`` and ``ESP32-S2``
+  variants, RMT memory is shared between RX and TX components. On other variants, RX and TX have dedicated RMT memory.
 
   .. csv-table::
-      :header: "ESP32 Variant", "Memory Size", "Block Size"
+      :header: "ESP32 Variant", "Available Memory", "Block Size"
 
       "ESP32", "512 symbols", "64 symbols"
-      "ESP32-C3", "192 symbols", "48 symbols"
-      "ESP32-C5", "192 symbols", "48 symbols"
-      "ESP32-C6", "192 symbols", "48 symbols"
-      "ESP32-H2", "192 symbols", "48 symbols"
-      "ESP32-P4", "384 symbols", "48 symbols"
+      "ESP32-C3", "96 symbols", "48 symbols"
+      "ESP32-C5", "96 symbols", "48 symbols"
+      "ESP32-C6", "96 symbols", "48 symbols"
+      "ESP32-H2", "96 symbols", "48 symbols"
+      "ESP32-P4", "192 symbols", "48 symbols"
       "ESP32-S2", "256 symbols", "64 symbols"
-      "ESP32-S3", "384 symbols", "48 symbols"
+      "ESP32-S3", "192 symbols", "48 symbols"
 
 - **use_dma** (*Optional*, boolean): Enable DMA on variants that support it. If enabled ``rmt_symbols`` controls
   the DMA buffer size and can be set to a large value.

--- a/components/remote_receiver.rst
+++ b/components/remote_receiver.rst
@@ -87,22 +87,22 @@ Configuration variables:
 ESP32 configuration variables:
 **********************************
 
-- **rmt_symbols** (*Optional*, int): If ``use_dma`` is enabled, ``rmt_symbols`` represents the size of the driver's
-  internal DMA buffer. If DMA is not enabled, ``rmt_symbols`` determines the amount of RMT memory allocated to this
-  component. Memory is shared by all receivers and transmitters. On variants other than  ``ESP32`` and ``ESP32-S2``,
-  only half of the symbol memory is available to receivers. Each symbol is 32 bits and contains two values.
+- **rmt_symbols** (*Optional*, int): When ``use_dma`` is enabled, this sets the size of the driver's internal DMA
+  buffer. When DMA is disabled, it specifies how much RMT memory is allocated to the component. RMT memory is shared
+  across all components and should be allocated in multiples of the block size. On the ``ESP32`` and ``ESP32-S2``
+  variants, RMT memory is shared between RX and TX components. On other variants, RX and TX have dedicated RMT memory.
 
   .. csv-table::
-      :header: "ESP32 Variant", "Memory Size", "Block Size"
+      :header: "ESP32 Variant", "Available Memory", "Block Size"
 
       "ESP32", "512 symbols", "64 symbols"
-      "ESP32-C3", "192 symbols", "48 symbols"
-      "ESP32-C5", "192 symbols", "48 symbols"
-      "ESP32-C6", "192 symbols", "48 symbols"
-      "ESP32-H2", "192 symbols", "48 symbols"
-      "ESP32-P4", "384 symbols", "48 symbols"
+      "ESP32-C3", "96 symbols", "48 symbols"
+      "ESP32-C5", "96 symbols", "48 symbols"
+      "ESP32-C6", "96 symbols", "48 symbols"
+      "ESP32-H2", "96 symbols", "48 symbols"
+      "ESP32-P4", "192 symbols", "48 symbols"
       "ESP32-S2", "256 symbols", "64 symbols"
-      "ESP32-S3", "384 symbols", "48 symbols"
+      "ESP32-S3", "192 symbols", "48 symbols"
 
 - **receive_symbols** (*Optional*, int): Maximum receive length in symbols. On some variants the maximum receive is
   limited to ``rmt_symbols``.

--- a/components/remote_transmitter.rst
+++ b/components/remote_transmitter.rst
@@ -41,22 +41,22 @@ Configuration variables:
 ESP32 configuration variables:
 **********************************
 
-- **rmt_symbols** (*Optional*, int): If ``use_dma`` is enabled, ``rmt_symbols`` represents the size of the driver's
-  internal DMA buffer. If DMA is not enabled, ``rmt_symbols`` determines the amount of RMT memory allocated to this
-  component. Memory is shared by all receivers and transmitters. On variants other than  ``ESP32`` and ``ESP32-S2``,
-  only half of the symbol memory is available to transmitters. Each symbol is 32 bits and contains two values.
+- **rmt_symbols** (*Optional*, int): When ``use_dma`` is enabled, this sets the size of the driver's internal DMA
+  buffer. When DMA is disabled, it specifies how much RMT memory is allocated to the component. RMT memory is shared
+  across all components and should be allocated in multiples of the block size. On the ``ESP32`` and ``ESP32-S2``
+  variants, RMT memory is shared between RX and TX components. On other variants, RX and TX have dedicated RMT memory.
 
   .. csv-table::
-      :header: "ESP32 Variant", "Memory Size", "Block Size"
+      :header: "ESP32 Variant", "Available Memory", "Block Size"
 
       "ESP32", "512 symbols", "64 symbols"
-      "ESP32-C3", "192 symbols", "48 symbols"
-      "ESP32-C5", "192 symbols", "48 symbols"
-      "ESP32-C6", "192 symbols", "48 symbols"
-      "ESP32-H2", "192 symbols", "48 symbols"
-      "ESP32-P4", "384 symbols", "48 symbols"
+      "ESP32-C3", "96 symbols", "48 symbols"
+      "ESP32-C5", "96 symbols", "48 symbols"
+      "ESP32-C6", "96 symbols", "48 symbols"
+      "ESP32-H2", "96 symbols", "48 symbols"
+      "ESP32-P4", "192 symbols", "48 symbols"
       "ESP32-S2", "256 symbols", "64 symbols"
-      "ESP32-S3", "384 symbols", "48 symbols"
+      "ESP32-S3", "192 symbols", "48 symbols"
 
 - **clock_resolution** (*Optional*, int): The clock resolution used by the RMT peripheral in Hz. Defaults to ``1000000``.
 - **use_dma** (*Optional*, boolean): Enable DMA on variants that support it. If enabled ``rmt_symbols`` controls


### PR DESCRIPTION
## Description:

Reword rmt_symbols docs and change the table to show only the memory available to RX or TX instead of the total. 

The esp32_rmt_led_strip docs didn't mention use_dma, make that constistent. 

**Related issue (if applicable):** fixes https://github.com/esphome/esphome/issues/9666

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
