### PR TITLE
[remote_receiver] Fix idle time for newer ESP32 variants

### DIFF
--- a/components/remote_receiver.rst
+++ b/components/remote_receiver.rst
@@ -80,7 +80,12 @@ Configuration variables:
 - **filter** (*Optional*, :ref:`config-time`): Filter any pulses that are shorter than this. Useful for removing
   glitches from noisy signals. Allowed values are in range ``0`` to ``4294967295us``. Defaults to ``50us``.
 - **idle** (*Optional*, :ref:`config-time`): The amount of time that a signal should remain stable/unchanged for it to
-  be considered complete. The maximum value is ``65536us`` on ESP32, and ``4294967295us`` on other platforms. Defaults to ``10ms``.
+  be considered complete. The maximum allowable value is:
+
+  - ``65536us`` on the ``ESP32`` and ``ESP32-S2`` variants
+  - ``32767us`` on all other ESP32 variants
+  - ``4294967295us`` on all other platforms
+
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation. Useful when multiple
   receivers are configured on a single device.
 

--- a/components/remote_receiver.rst
+++ b/components/remote_receiver.rst
@@ -86,6 +86,9 @@ Configuration variables:
   - ``32767us`` on all other ESP32 variants
   - ``4294967295us`` on all other platforms
 
+  Note: The ESP32 values listed above assume the default ``clock_resolution``. If a different ``clock_resolution`` is used,
+  the values are scaled by 1000000 / ``clock_resolution``.
+
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation. Useful when multiple
   receivers are configured on a single device.
 


### PR DESCRIPTION
## Description:

Fix idle time docs for newer ESP32 variants, did not know they were different. 

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#9819

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
