### PR TITLE
added CO5300 AMOLED driver in quad SPI display docs

### DIFF
--- a/components/display/qspi_dbi.rst
+++ b/components/display/qspi_dbi.rst
@@ -17,6 +17,7 @@ This driver has been tested with the following displays:
   - Lilygo T-Display S3 AMOLED
   - JC4832W535 board
   - JC3636W518 board
+  - Waveshare ESP32-S3-Touch-AMOLED-1.75 board
 
 Usage
 -----
@@ -65,6 +66,7 @@ Configuration variables:
     - ``JC4832W535``
     - ``JC3636W518``
     - ``AXS15231``
+    - ``CO5300``
     
 - **init_sequence** (*Optional*, A list of byte arrays): Specifies the init sequence for the display. This is required when using the ``CUSTOM`` model - but may be empty. If specified for other models this data will be sent after the pre-configured sequence.
 - **cs_pin** (**Required**, :ref:`Pin Schema <config-pin_schema>`): The chip select pin.
@@ -230,6 +232,36 @@ This rotates the display into landscape mode using software rotation.
       transform:
         swap_xy: true
         mirror_y: true
+
+
+Waveshare ESP32-S3-Touch-AMOLED-1.75 (CO5300 driver)
+************
+
+.. code-block:: yaml
+
+    spi:
+      id: quad_spi
+      type: quad
+      clk_pin: 38
+      data_pins: [4, 5, 6, 7]
+
+    display:
+      - platform: qspi_dbi
+        model: CO5300
+        dimensions:
+          height: 466
+          width: 466
+          offset_height: 0
+          offset_width: 6
+        brightness: 128
+        cs_pin: 12
+        reset_pin: 39
+        auto_clear_enabled: false
+        show_test_card: true
+
+    psram:
+      mode: octal
+      speed: 80MHz
 
 
 See Also

--- a/components/light/esp32_rmt_led_strip.rst
+++ b/components/light/esp32_rmt_led_strip.rst
@@ -56,21 +56,22 @@ Configuration variables
   sending commands as quickly as changes are made to the lights.
 - **use_psram** (*Optional*, boolean): Set to ``false`` to force internal RAM allocation even if you have the the PSRAM
   component enabled. This can be useful if you're experiencing issues like flickering with your leds strip. Defaults to ``true``.
-- **rmt_symbols** (*Optional*, int): The amount of RMT memory allocated to this component. Memory is shared by all
-  receivers and transmitters. On variants other than  ``ESP32`` and ``ESP32-S2`` only half the symbol memory is
-  available to transmitters. Each symbol is 32 bits and contains two values.
+- **rmt_symbols** (*Optional*, int): When ``use_dma`` is enabled, this sets the size of the driver's internal DMA
+  buffer. When DMA is disabled, it specifies how much RMT memory is allocated to the component. RMT memory is shared
+  across all components and should be allocated in multiples of the block size. On the ``ESP32`` and ``ESP32-S2``
+  variants, RMT memory is shared between RX and TX components. On other variants, RX and TX have dedicated RMT memory.
 
   .. csv-table::
-      :header: "ESP32 Variant", "Memory Size", "Block Size"
+      :header: "ESP32 Variant", "Available Memory", "Block Size"
 
       "ESP32", "512 symbols", "64 symbols"
-      "ESP32-C3", "192 symbols", "48 symbols"
-      "ESP32-C5", "192 symbols", "48 symbols"
-      "ESP32-C6", "192 symbols", "48 symbols"
-      "ESP32-H2", "192 symbols", "48 symbols"
-      "ESP32-P4", "384 symbols", "48 symbols"
+      "ESP32-C3", "96 symbols", "48 symbols"
+      "ESP32-C5", "96 symbols", "48 symbols"
+      "ESP32-C6", "96 symbols", "48 symbols"
+      "ESP32-H2", "96 symbols", "48 symbols"
+      "ESP32-P4", "192 symbols", "48 symbols"
       "ESP32-S2", "256 symbols", "64 symbols"
-      "ESP32-S3", "384 symbols", "48 symbols"
+      "ESP32-S3", "192 symbols", "48 symbols"
 
 - **use_dma** (*Optional*, boolean): Enable DMA on variants that support it. If enabled ``rmt_symbols`` controls
   the DMA buffer size and can be set to a large value.

--- a/components/light/esp32_rmt_led_strip.rst
+++ b/components/light/esp32_rmt_led_strip.rst
@@ -23,7 +23,6 @@ Only for Arduino platforms (and ESP-IDF <5 which was used until ESPHome 2025), t
 
     light:
       - platform: esp32_rmt_led_strip
-        rmt_channel: 0
         ...
 
 Configuration variables

--- a/components/remote_receiver.rst
+++ b/components/remote_receiver.rst
@@ -80,7 +80,7 @@ Configuration variables:
 - **filter** (*Optional*, :ref:`config-time`): Filter any pulses that are shorter than this. Useful for removing
   glitches from noisy signals. Allowed values are in range ``0`` to ``4294967295us``. Defaults to ``50us``.
 - **idle** (*Optional*, :ref:`config-time`): The amount of time that a signal should remain stable/unchanged for it to
-  be considered complete. Allowed values are in range ``0`` to ``4294967295us``. Defaults to ``10ms``.
+  be considered complete. The maximum value is ``65536us`` on ESP32, and ``4294967295us`` on other platforms. Defaults to ``10ms``.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID used for code generation. Useful when multiple
   receivers are configured on a single device.
 

--- a/components/remote_receiver.rst
+++ b/components/remote_receiver.rst
@@ -87,22 +87,22 @@ Configuration variables:
 ESP32 configuration variables:
 **********************************
 
-- **rmt_symbols** (*Optional*, int): If ``use_dma`` is enabled, ``rmt_symbols`` represents the size of the driver's
-  internal DMA buffer. If DMA is not enabled, ``rmt_symbols`` determines the amount of RMT memory allocated to this
-  component. Memory is shared by all receivers and transmitters. On variants other than  ``ESP32`` and ``ESP32-S2``,
-  only half of the symbol memory is available to receivers. Each symbol is 32 bits and contains two values.
+- **rmt_symbols** (*Optional*, int): When ``use_dma`` is enabled, this sets the size of the driver's internal DMA
+  buffer. When DMA is disabled, it specifies how much RMT memory is allocated to the component. RMT memory is shared
+  across all components and should be allocated in multiples of the block size. On the ``ESP32`` and ``ESP32-S2``
+  variants, RMT memory is shared between RX and TX components. On other variants, RX and TX have dedicated RMT memory.
 
   .. csv-table::
-      :header: "ESP32 Variant", "Memory Size", "Block Size"
+      :header: "ESP32 Variant", "Available Memory", "Block Size"
 
       "ESP32", "512 symbols", "64 symbols"
-      "ESP32-C3", "192 symbols", "48 symbols"
-      "ESP32-C5", "192 symbols", "48 symbols"
-      "ESP32-C6", "192 symbols", "48 symbols"
-      "ESP32-H2", "192 symbols", "48 symbols"
-      "ESP32-P4", "384 symbols", "48 symbols"
+      "ESP32-C3", "96 symbols", "48 symbols"
+      "ESP32-C5", "96 symbols", "48 symbols"
+      "ESP32-C6", "96 symbols", "48 symbols"
+      "ESP32-H2", "96 symbols", "48 symbols"
+      "ESP32-P4", "192 symbols", "48 symbols"
       "ESP32-S2", "256 symbols", "64 symbols"
-      "ESP32-S3", "384 symbols", "48 symbols"
+      "ESP32-S3", "192 symbols", "48 symbols"
 
 - **receive_symbols** (*Optional*, int): Maximum receive length in symbols. On some variants the maximum receive is
   limited to ``rmt_symbols``.

--- a/components/remote_transmitter.rst
+++ b/components/remote_transmitter.rst
@@ -41,22 +41,22 @@ Configuration variables:
 ESP32 configuration variables:
 **********************************
 
-- **rmt_symbols** (*Optional*, int): If ``use_dma`` is enabled, ``rmt_symbols`` represents the size of the driver's
-  internal DMA buffer. If DMA is not enabled, ``rmt_symbols`` determines the amount of RMT memory allocated to this
-  component. Memory is shared by all receivers and transmitters. On variants other than  ``ESP32`` and ``ESP32-S2``,
-  only half of the symbol memory is available to transmitters. Each symbol is 32 bits and contains two values.
+- **rmt_symbols** (*Optional*, int): When ``use_dma`` is enabled, this sets the size of the driver's internal DMA
+  buffer. When DMA is disabled, it specifies how much RMT memory is allocated to the component. RMT memory is shared
+  across all components and should be allocated in multiples of the block size. On the ``ESP32`` and ``ESP32-S2``
+  variants, RMT memory is shared between RX and TX components. On other variants, RX and TX have dedicated RMT memory.
 
   .. csv-table::
-      :header: "ESP32 Variant", "Memory Size", "Block Size"
+      :header: "ESP32 Variant", "Available Memory", "Block Size"
 
       "ESP32", "512 symbols", "64 symbols"
-      "ESP32-C3", "192 symbols", "48 symbols"
-      "ESP32-C5", "192 symbols", "48 symbols"
-      "ESP32-C6", "192 symbols", "48 symbols"
-      "ESP32-H2", "192 symbols", "48 symbols"
-      "ESP32-P4", "384 symbols", "48 symbols"
+      "ESP32-C3", "96 symbols", "48 symbols"
+      "ESP32-C5", "96 symbols", "48 symbols"
+      "ESP32-C6", "96 symbols", "48 symbols"
+      "ESP32-H2", "96 symbols", "48 symbols"
+      "ESP32-P4", "192 symbols", "48 symbols"
       "ESP32-S2", "256 symbols", "64 symbols"
-      "ESP32-S3", "384 symbols", "48 symbols"
+      "ESP32-S3", "192 symbols", "48 symbols"
 
 - **clock_resolution** (*Optional*, int): The clock resolution used by the RMT peripheral in Hz. Defaults to ``1000000``.
 - **use_dma** (*Optional*, boolean): Enable DMA on variants that support it. If enabled ``rmt_symbols`` controls

--- a/components/sx127x.rst
+++ b/components/sx127x.rst
@@ -61,7 +61,7 @@ LoRa configuration variables:
   packet size is fixed. If not configured explicit header mode is enabled and variable packet sizes can
   be used. Maximum length is 256. Must be greater than zero when using a ``spreading_factor`` of 6.
 - **crc_enable** (**Optional**, bool): Enables a payload CRC calculation/check.
-- **preamble_size** (**Optional**, int): Length of the preamble in symbols, minimum of 6. Defaults to 8.
+- **preamble_size** (**Required**, int): Length of the preamble in symbols, minimum of 6.
 - **spreading_factor** (**Optional**, int): Spreading factor, values range from 6 to 12. Defaults to 7.
 - **coding_rate** (**Optional**, enum): Coding rate, values can be ``CR_4_5``, ``CR_4_6``, ``CR_4_7``
   or ``CR_4_8``. Defaults to ``CR_4_5``.


### PR DESCRIPTION
## Description:
Adds CO5300 as display driver model in quad SPI docs along with an example for the Waveshare ESP32-S3-Touch-AMOLED-1.75 board

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 
- esphome/esphome#9739

## Checklist:
  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
