### PR TITLE
[sensor] Delta fix

### DIFF
--- a/components/sensor/sensor-filter-delta.rst
+++ b/components/sensor/sensor-filter-delta.rst
@@ -7,7 +7,7 @@ This difference can be calculated in two ways an absolute difference or a percen
 
 If a number is specified, it will be used as the absolute difference required.
 For example if the filter were configured with a value of 2 and the last value passed through was 10,
-only values greater than 12 or less than 8 would be passed through.
+only values greater than or equal to 12 or less than or equal to 8 would be passed through.
 
 .. code-block:: yaml
 
@@ -16,8 +16,9 @@ only values greater than 12 or less than 8 would be passed through.
 
 If a percentage is specified a percentage of the last value will be used as the required difference.
 For example if the filter were configured with a value of 20% and the last value passed through was 10,
-only values greater than 12 or less than 8 would be passed through.
-However, if the last value passed through was 100 only values greater than 120 or less than 80 would be passed through.
+only values greater than or equal to 12 or less than or equal to 8 would be passed through.
+However, if the last value passed through was 100 only values greater than or equal to 120 or less than or
+equal to 80 would be passed through.
 
 .. code-block:: yaml
 


### PR DESCRIPTION
## Description:

Fix docs to match code

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#8157

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
