### PR TITLE
added command_code, boiler lockout reset

### DIFF
--- a/components/opentherm.rst
+++ b/components/opentherm.rst
@@ -223,6 +223,8 @@ The following numerical values are available:
   * Supports ``auto_min_value``
   * Supports ``auto_max_value``
 
+
+- ``cc_request``: COMMAND_CODE send
 Switch
 ******
 
@@ -339,7 +341,7 @@ available:
 - ``device_id``: Device ID code
 - ``otc_hc_ratio_ub``: OTC heat curve ratio upper bound
 - ``otc_hc_ratio_lb``: OTC heat curve ratio lower bound
-
+- ``cc_response``: COMMAND_CODE response
 .. _on-the-fly-message-editing:
 
 On-the-fly Message Editing
@@ -376,6 +378,39 @@ for Daikin D2C boiler:
                     }
 
 You can check the :apistruct:`OpenthermData <opentherm::OpenthermData>` for the list of all available fields.
+
+
+
+Boiler lockout reset
+--------------------------
+
+.. code-block:: yaml
+
+    #lockout reset example
+    number:
+      - platform: opentherm
+        cc_request:
+          name: cc request
+          id: Rr
+          internal: false 
+    
+    
+    
+    button:
+      - platform: template
+        name: "boiler error reset"
+        on_press:
+          - number.set:
+              id: Rr
+              value: 1
+          - delay: 2s
+          - number.set:
+              id: Rr
+              value: 0
+
+
+
+
 
 Examples
 --------


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#9752

## Checklist:

  - [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
