### PR TITLE
[esp32-camera] document new psram dma config option

### DIFF
--- a/components/esp32_camera.rst
+++ b/components/esp32_camera.rst
@@ -75,6 +75,7 @@ Frame Settings:
 - **frame_buffer_location** (*Optional*, enum): The memory area used for storing the frame buffers. Defaults to ``PSRAM``.
   - ``PSRAM``
   - ``DRAM``
+- **psram_dma** (*Optional*, boolean): Enable DMA access between camera and the PSRAM frame buffer. (experimental)
 
 Image Settings:
 


### PR DESCRIPTION
## Description:

Adds documentation for the esp32-camera config option psram_dma

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#9771

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

