### PR TITLE
[image] Update schema docs

### DIFF
--- a/components/image.rst
+++ b/components/image.rst
@@ -83,14 +83,39 @@ Configuration variables:
     additionally need to have the python ``cairosvg`` package installed. These are automatically installed when
     setting up ESPHome via the usual methods.
 
-Grouping images by type
------------------------
 
-You can group images by type to make it easier to manage them. This is useful when you have a lot of images to be encoded in the same way, and avoids having to repeat the same type for each image. The type name is used as the key for the group. For example:
+Setting defaults
+----------------
+
+For the situation where most or all of your images share common attributes, you can use another schema style to provide default values. In this case
+the ``defaults:`` option will provide fallback values for all images. When using this format the ``images:`` key takes a list of image definitions.
 
 .. code-block:: yaml
 
     image:
+      defaults:
+        type: rgb565
+        transparency: opaque
+        resize: 100x100
+      images:
+        - file: "image1.png"
+          id: image1
+        - file: "image2.png"
+          id: image2
+          resize: 200x200  # overrides the default resize
+
+Grouping images by type
+-----------------------
+
+You can group images by type to make it easier to manage them. This is useful when you have a lot of images to be encoded in the same way,
+and avoids having to repeat the same type for each image. A ``defaults:`` group can be used to specify default values other than the type.
+The type name is used as the key for the group. For example:
+
+.. code-block:: yaml
+
+    image:
+      defaults:
+        resize: 100x100
       grayscale:
         - file: "image1.png"
           id: image1
@@ -118,23 +143,6 @@ In addition, the default transparency type can be set within a type group by usi
           id: image2
         opaque:
         - file: "image2.png"
-
-For the situation where most or all of your images share common attributes, you can use another schema style to provide default values. In this case
-the ``defaults:`` option will provide fallback values for all images. When using this format the ``images:`` key takes only a list of image definitions.
-
-.. code-block:: yaml
-
-    image:
-      defaults:
-        type: rgb565
-        transparency: opaque
-        resize: 100x100
-      images:
-        - file: "image1.png"
-          id: image1
-        - file: "image2.png"
-          id: image2
-          resize: 200x200  # overrides the default resize
 
 Displaying Images
 -----------------


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
