### PR TITLE
[nrf52] adc doc

### DIFF
--- a/components/sensor/adc.rst
+++ b/components/sensor/adc.rst
@@ -11,6 +11,7 @@ ADC in your device to measure a voltage on certain pins.
 - ESP8266: Only pin A0 (GPIO17) can be used.
 - ESP32: Available pins vary by variant, see :ref:`adc-esp32_pins`.
 - RP2040: GPIO26 through GPIO29 can be used.
+- nRF52840: AIN0 through AIN7, VDD, VDDHDIV5 can be used.
 
 .. figure:: images/adc-ui.png
     :align: center


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

https://github.com/esphome/esphome/pull/9321

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
