### PR TITLE
[esp32_camera] Fix broken external_component reference

### DIFF
--- a/components/esp32_camera.rst
+++ b/components/esp32_camera.rst
@@ -484,9 +484,7 @@ Configuration examples
 
     # Example configuration entry
     external_components:
-      - source:
-          type: git
-          url: https://github.com/MichaKersloot/esphome_custom_components
+      - source: github://pr#9630
         components: [ esp32_camera ]
 
     esp32_camera:
@@ -500,6 +498,7 @@ Configuration examples
       vsync_pin: GPIO6
       href_pin: GPIO7
       pixel_clock_pin: GPIO13
+      frame_buffer_location: DRAM
 
       # Image settings
       name: My Camera


### PR DESCRIPTION
## Description:

ESPHome dev has a PR merged to allow dram on the esp32_camera, but the current documentation for a specific board points to an external_component that no longer compiles correctly. This fixes that by updating the external_component which can be removed after the 2025.8.0 release.

**Related issue (if applicable):** fixes https://github.com/esphome/esphome-docs/issues/5167

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
