### PR TITLE
[esp32] Document LWIP core locking options for improved socket performance

### DIFF
--- a/components/esp32.rst
+++ b/components/esp32.rst
@@ -150,12 +150,6 @@ LWIP (Lightweight IP) behavior. Some options improve performance while others sa
   mDNS implementation, so this is rarely needed. Defaults to ``true``.
 - **enable_lwip_bridge_interface** (*Optional*, boolean): Enable bridge interface support for bridging multiple network
   interfaces. Defaults to ``false``.
-- **enable_lwip_igmp_snooping** (*Optional*, boolean): Enable IGMP snooping functionality for multicast traffic optimization.
-  This feature allows switches to intelligently forward multicast traffic only to hosts that have requested it. Defaults to ``false``.
-- **enable_lwip_tcp_input_performance_measurement** (*Optional*, boolean): Enable TCP input performance measurement and statistics.
-  This adds code for measuring TCP input processing performance. Defaults to ``false``.
-- **enable_lwip_tcp_dup_ack_retransmit** (*Optional*, boolean): Enable immediate retransmission on reception of duplicate ACKs.
-  This can improve TCP performance in certain network conditions but adds additional code. Defaults to ``false``.
 - **enable_lwip_tcpip_core_locking** (*Optional*, boolean): Enable LWIP TCP/IP core locking for better socket performance.
   This uses direct function calls with mutex protection instead of mailbox message passing between threads. Enabling this
   improves socket operation performance by 20-200% but may reduce multi-threaded scalability. Defaults to ``true``.

--- a/components/esp32.rst
+++ b/components/esp32.rst
@@ -157,8 +157,8 @@ LWIP (Lightweight IP) behavior. Some options improve performance while others sa
 - **enable_lwip_check_thread_safety** (*Optional*, boolean): Enable LWIP thread safety checks to detect incorrect usage of
   the TCP/IP stack from multiple threads. This helps catch thread safety issues when core locking is enabled. Defaults to ``true``.
 
-Some options can be disabled to save flash memory without affecting typical ESPHome functionality. The performance 
-options (defaulting to ``true``) improve socket operation performance but can be disabled if you need better 
+Some options can be disabled to save flash memory without affecting typical ESPHome functionality. The performance
+options (defaulting to ``true``) improve socket operation performance but can be disabled if you need better
 multi-threaded scalability (which is uncommon since ESPHome uses an event loop).
 
 **Example configuration with advanced LWIP options:**

--- a/components/esp32.rst
+++ b/components/esp32.rst
@@ -140,8 +140,8 @@ Advanced Configuration
 
 **LWIP Optimization Options (ESP-IDF only):**
 
-The following options are available under the ``advanced`` section when using the ESP-IDF framework to disable unused
-LWIP (Lightweight IP) features and save flash memory (approximately 4KB):
+The following options are available under the ``advanced`` section when using the ESP-IDF framework to optimize
+LWIP (Lightweight IP) behavior. Some options improve performance while others save flash memory:
 
 - **enable_lwip_dhcp_server** (*Optional*, boolean): Enable DHCP server functionality. Only needed if the device will act
   as a DHCP server (necessary for WiFi AP mode). When the WiFi component is used, it automatically handles enabling/disabling
@@ -150,9 +150,39 @@ LWIP (Lightweight IP) features and save flash memory (approximately 4KB):
   mDNS implementation, so this is rarely needed. Defaults to ``true``.
 - **enable_lwip_bridge_interface** (*Optional*, boolean): Enable bridge interface support for bridging multiple network
   interfaces. Defaults to ``false``.
+- **enable_lwip_igmp_snooping** (*Optional*, boolean): Enable IGMP snooping functionality for multicast traffic optimization.
+  This feature allows switches to intelligently forward multicast traffic only to hosts that have requested it. Defaults to ``false``.
+- **enable_lwip_tcp_input_performance_measurement** (*Optional*, boolean): Enable TCP input performance measurement and statistics.
+  This adds code for measuring TCP input processing performance. Defaults to ``false``.
+- **enable_lwip_tcp_dup_ack_retransmit** (*Optional*, boolean): Enable immediate retransmission on reception of duplicate ACKs.
+  This can improve TCP performance in certain network conditions but adds additional code. Defaults to ``false``.
+- **enable_lwip_tcpip_core_locking** (*Optional*, boolean): Enable LWIP TCP/IP core locking for better socket performance.
+  This uses direct function calls with mutex protection instead of mailbox message passing between threads. Enabling this
+  improves socket operation performance by 20-200% but may reduce multi-threaded scalability. Defaults to ``true``.
+- **enable_lwip_check_thread_safety** (*Optional*, boolean): Enable LWIP thread safety checks to detect incorrect usage of
+  the TCP/IP stack from multiple threads. This helps catch thread safety issues when core locking is enabled. Defaults to ``true``.
 
-These optimizations are applied automatically and save flash memory without affecting typical ESPHome functionality. The
-features can be enabled if needed by setting the corresponding option to ``true``.
+The memory-saving options (defaulting to ``false``) can be disabled to save flash memory without affecting typical ESPHome 
+functionality. The performance options (defaulting to ``true``) improve socket operation performance but can be disabled 
+if you need better multi-threaded scalability (which is uncommon since ESPHome uses an event loop).
+
+**Example configuration with advanced LWIP options:**
+
+.. code-block:: yaml
+
+    # Example configuration entry
+    esp32:
+      board: esp32dev
+      framework:
+        type: esp-idf
+        advanced:
+          # Performance options (enabled by default)
+          enable_lwip_tcpip_core_locking: true  # Better socket performance
+          enable_lwip_check_thread_safety: true  # Thread safety validation
+          
+          # Memory saving options (disabled by default)
+          enable_lwip_dhcp_server: false  # Only needed for AP mode
+          enable_lwip_mdns_queries: false  # ESPHome has its own mDNS
 
 .. _esp32-idf_components:
 

--- a/components/esp32.rst
+++ b/components/esp32.rst
@@ -146,8 +146,9 @@ LWIP (Lightweight IP) behavior. Some options improve performance while others sa
 - **enable_lwip_dhcp_server** (*Optional*, boolean): Enable DHCP server functionality. Only needed if the device will act
   as a DHCP server (necessary for WiFi AP mode). When the WiFi component is used, it automatically handles enabling/disabling
   the DHCP server based on whether AP mode is configured. When WiFi is not used, defaults to ``false``.
-- **enable_lwip_mdns_queries** (*Optional*, boolean): Enable mDNS query support in the DNS resolver. ESPHome uses its own
-  mDNS implementation, so this is rarely needed. Defaults to ``true``.
+- **enable_lwip_mdns_queries** (*Optional*, boolean): Enable mDNS query support in the DNS resolver. This allows resolving
+  local hostnames (like ``broker.local``) for MQTT brokers and other services. While ESPHome has its own mDNS responder
+  for advertising, this option is needed for resolving mDNS names. Defaults to ``true``.
 - **enable_lwip_bridge_interface** (*Optional*, boolean): Enable bridge interface support for bridging multiple network
   interfaces. Defaults to ``false``.
 - **enable_lwip_tcpip_core_locking** (*Optional*, boolean): Enable LWIP TCP/IP core locking for better socket performance.
@@ -156,9 +157,9 @@ LWIP (Lightweight IP) behavior. Some options improve performance while others sa
 - **enable_lwip_check_thread_safety** (*Optional*, boolean): Enable LWIP thread safety checks to detect incorrect usage of
   the TCP/IP stack from multiple threads. This helps catch thread safety issues when core locking is enabled. Defaults to ``true``.
 
-The memory-saving options (defaulting to ``false``) can be disabled to save flash memory without affecting typical ESPHome 
-functionality. The performance options (defaulting to ``true``) improve socket operation performance but can be disabled 
-if you need better multi-threaded scalability (which is uncommon since ESPHome uses an event loop).
+Some options can be disabled to save flash memory without affecting typical ESPHome functionality. The performance 
+options (defaulting to ``true``) improve socket operation performance but can be disabled if you need better 
+multi-threaded scalability (which is uncommon since ESPHome uses an event loop).
 
 **Example configuration with advanced LWIP options:**
 
@@ -174,9 +175,10 @@ if you need better multi-threaded scalability (which is uncommon since ESPHome u
           enable_lwip_tcpip_core_locking: true  # Better socket performance
           enable_lwip_check_thread_safety: true  # Thread safety validation
           
-          # Memory saving options (disabled by default)
-          enable_lwip_dhcp_server: false  # Only needed for AP mode
-          enable_lwip_mdns_queries: false  # ESPHome has its own mDNS
+          # Memory saving options
+          enable_lwip_dhcp_server: false  # Disabled by default, only needed for AP mode
+          enable_lwip_mdns_queries: false  # Enabled by default, can disable if not using .local hostnames
+          enable_lwip_bridge_interface: false  # Disabled by default
 
 .. _esp32-idf_components:
 


### PR DESCRIPTION
## Description:

This PR documents the new LWIP TCP/IP core locking options added to the ESP32 component's advanced configuration. These options enable significant socket performance improvements on ESP-IDF by using direct function calls with mutex protection instead of mailbox message passing.

The documentation explains:
- What the options do and their performance impact (20-200% improvement)
- Default values (both enabled by default)
- When users might want to disable them (uncommon, since ESPHome uses an event loop)
- Example configuration showing how to use the options

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#9857

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.