### PR TITLE
[waveshare_epaper] Add compatible display type/board manufacturer

### DIFF
--- a/content/components/display/waveshare_epaper.md
+++ b/content/components/display/waveshare_epaper.md
@@ -108,7 +108,7 @@ lambda: |-
   - `2.90in-bV3` - B/W rendering only
   - `4.20in`
   - `4.20in-bV2` - B/W rendering only
-  - `gdey042t81` - GoodDisplay GDEY042T81 4.2" B/W
+  - `gdey042t81` - GoodDisplay GDEY042T81 4.2" B/W (WeAct 4.2")
   - `4.20in-bV2-bwr` - BWR rendering enabled (uses double the amount of RAM for the display buffer as B/W rendering)
   - `5.83in`
   - `5.83inv2`


### PR DESCRIPTION
## Description:
As previously trying to get it running with other types (after switching from one which was compatible with 4.20in def), a clarification on what display is used, is helpful and speeds up the tinkering. Seems to be a common board.

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
