### PR TITLE
[api] Document homeassistant_states option

### DIFF
--- a/components/api.rst
+++ b/components/api.rst
@@ -98,6 +98,7 @@ Configuration variables:
       WiFi performance with many rapidly-changing sensors. Only use this setting when necessary.
 
 - **custom_services** (*Optional*, boolean): Enable compilation of custom API services for external components that use the C++ ``CustomAPIDevice`` class. Only needed when external components register their own services via the native API. Defaults to ``false``.
+- **homeassistant_states** (*Optional*, boolean): Enable compilation of Home Assistant state subscription support for external components that use the C++ ``CustomAPIDevice::subscribe_homeassistant_state()`` method. This is automatically enabled when using any ``homeassistant`` platform components (sensor, binary_sensor, text_sensor, switch, or number). Only needs to be manually set when external components subscribe to Home Assistant states without using the built-in components. Defaults to ``false``.
 - **reboot_timeout** (*Optional*, :ref:`config-time`): The amount of time to wait before rebooting when no
   client connects to the API. This is needed because sometimes the low level ESP functions report that
   the ESP is connected to the network, when in fact it is not - only a full reboot fixes it.


### PR DESCRIPTION
## Description:

Document the new `homeassistant_states` configuration option for the API component. This option allows manual control over the compilation of Home Assistant state subscription support.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#9898

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

## Changes Made:

- Added documentation for the new `homeassistant_states` configuration variable in the API component
- Explains when it's automatically enabled (when using homeassistant platform components)
- Explains when manual configuration is needed (for external components using `CustomAPIDevice::subscribe_homeassistant_state()`)
- Notes that this is a breaking change for some external components