### PR TITLE
[adc] Add P4

### DIFF
--- a/components/sensor/adc.rst
+++ b/components/sensor/adc.rst
@@ -114,11 +114,14 @@ ESP32 pins and Hardware Details
     * - ESP32-S3
       - GPIO1 - GPIO10
       - GPIO11 - GPIO20
+    * - ESP32-P3
+      - GPIO16 - GPIO23
+      - GPIO49 - GPIO54
 
 Different ESP32 variants use different ADC calibration methods:
 
 * Original ESP32 (non-variant) & ESP32-S2: Use line-fitting calibration
-* ESP32-C3, ESP32-C5, ESP32-C6, ESP32-H2 & ESP32-S3: Use curve-fitting calibration
+* ESP32-C3, ESP32-C5, ESP32-C6, ESP32-H2, ESP32-S3 & ESP32-P4: Use curve-fitting calibration
 
 This is handled automatically by the code, but it's worth noting if you're debugging ADC readings or need to understand the calibration process.
 

--- a/components/sensor/adc.rst
+++ b/components/sensor/adc.rst
@@ -114,7 +114,7 @@ ESP32 pins and Hardware Details
     * - ESP32-S3
       - GPIO1 - GPIO10
       - GPIO11 - GPIO20
-    * - ESP32-P3
+    * - ESP32-P4
       - GPIO16 - GPIO23
       - GPIO49 - GPIO54
 


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#9954
## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
