### PR TITLE
[esp32_ble] Add documentation for preferred_phy configuration

### DIFF
--- a/components/esp32_ble.rst
+++ b/components/esp32_ble.rst
@@ -23,6 +23,7 @@ can run.
     esp32_ble:
       io_capability: keyboard_only
       disable_bt_logs: true  # Default, saves flash
+      preferred_phy: 1m       # Default, best compatibility
 
 Configuration variables:
 ------------------------
@@ -43,6 +44,19 @@ Configuration variables:
     - Must be 13 characters or less when using ``name_add_mac_suffix: true`` - :ref:`esphome-mac_suffix`.
 
 - **disable_bt_logs** (*Optional*, boolean): When enabled, disables Bluetooth logging categories that are not used by the configured components. This saves flash memory by only including the loggers needed by your configuration. Defaults to ``true``.
+
+- **preferred_phy** (*Optional*, enum): The preferred BLE PHY (Physical Layer) mode for connections. Defaults to ``1m``.
+
+    - ``1m`` - 1 Mbps PHY (best compatibility, longer range)
+    - ``2m`` - 2 Mbps PHY (higher throughput, shorter range) - Only supported on ESP32-C3, S3, C6, and H2
+    - ``auto`` - Let the ESP32 auto-negotiate PHY mode
+
+    .. note::
+
+        The default ``1m`` PHY provides the best compatibility with older BLE devices and HomeKit accessories.
+        Many devices (especially older ones) do not support 2M PHY and will disconnect if the ESP32 tries to use it.
+        In practice, 2M PHY may also experience more connection issues when WiFi is active on the same ESP32.
+        Only change this setting if you need higher throughput and have confirmed all your devices support 2M PHY.
 
 .. note::
 


### PR DESCRIPTION
## Description:

Adds documentation for the new `preferred_phy` configuration option in the `esp32_ble` component.

This documentation explains:
- The new PHY configuration option with its three modes (1m, 2m, auto)
- Why 1M PHY is now the default (compatibility and reliability)
- Platform restrictions (2M PHY only available on ESP32-C3/S3/C6/H2)
- Practical guidance on when to use different PHY modes
- The connection issues that can occur with 2M PHY when WiFi is active

**Related issue (if applicable):** fixes esphome/issues#[BLE disconnection issues with ESP32-S3]

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#9968

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.