### PR TITLE
[gt911] Add info about sleep on powerdown

### DIFF
--- a/components/touchscreen/gt911.rst
+++ b/components/touchscreen/gt911.rst
@@ -11,6 +11,7 @@ The :ref:`I²C <i2c>` is required to be set up in your configuration for this to
 
 This controller is used in the Espressif ESP32-S3-BOX-3 and the m5paper;
 
+The GT911 controller will automatically be put to sleep when the application is powered down.
 
 .. figure:: images/esp32_s3_box_3.png
     :align: center


### PR DESCRIPTION
## Description:

This update clarifies that the GT911 is automatically put to sleep when the device is powered down.

**Related issue (if applicable):** fixes https://github.com/esphome/feature-requests/issues/3200

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#9994

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.