### PR TITLE
Document multiple device address support in CLI commands

### DIFF
--- a/guides/cli.rst
+++ b/guides/cli.rst
@@ -85,6 +85,7 @@ The ``esphome run <CONFIG>`` command is the most common command for ESPHome. It
     .. code-block:: console
     
         esphome run my-device.yaml --device 192.168.1.100 --device 2001:db8::1 --device fe80::1234:5678:90ab:cdef
+    
 
 .. option:: --upload_speed BAUD_RATE
 
@@ -160,6 +161,7 @@ The ``esphome upload <CONFIG>`` validates the configuration and uploads the most
     .. code-block:: console
     
         esphome upload my-device.yaml --device 192.168.1.100 --device 2001:db8::1
+    
 
 .. option:: --upload_speed BAUD_RATE
 
@@ -296,6 +298,7 @@ The ``esphome logs <CONFIG>`` command validates the configuration and shows all 
     .. code-block:: console
     
         esphome logs my-device.yaml --device 192.168.1.100 --device 2001:db8::1
+    
 
 .. option:: --reset
 

--- a/guides/cli.rst
+++ b/guides/cli.rst
@@ -84,7 +84,7 @@ The ``esphome run <CONFIG>`` command is the most common command for ESPHome. It
     
     .. code-block:: console
 
-        esphome run my-device.yaml --device 192.168.1.100 --device 2001:db8::1 --device fe80::1234:5678:90ab:cdef
+        esphome run my-device.yaml --device 192.168.1.100 --device 2001:db8::1
 
 .. option:: --upload_speed BAUD_RATE
 

--- a/guides/cli.rst
+++ b/guides/cli.rst
@@ -77,6 +77,7 @@ The ``esphome run <CONFIG>`` command is the most common command for ESPHome. It
     to perform an OTA.
     
     .. versionadded:: 2025.8
+    
         Multiple ``--device`` options can be specified to provide fallback addresses. ESPHome will 
         try each address in order until one succeeds. This is particularly useful for devices with 
         multiple IP addresses (IPv4/IPv6).
@@ -86,6 +87,7 @@ The ``esphome run <CONFIG>`` command is the most common command for ESPHome. It
         .. code-block:: console
         
             esphome run my-device.yaml --device 192.168.1.100 --device 2001:db8::1 --device fe80::1234:5678:90ab:cdef
+        
 
 .. option:: --upload_speed BAUD_RATE
 
@@ -154,6 +156,7 @@ The ``esphome upload <CONFIG>`` validates the configuration and uploads the most
     to perform an OTA.
     
     .. versionadded:: 2025.8
+    
         Multiple ``--device`` options can be specified to provide fallback addresses. ESPHome will 
         try each address in order until one succeeds.
         
@@ -162,6 +165,7 @@ The ``esphome upload <CONFIG>`` validates the configuration and uploads the most
         .. code-block:: console
         
             esphome upload my-device.yaml --device 192.168.1.100 --device 2001:db8::1
+        
 
 .. option:: --upload_speed BAUD_RATE
 
@@ -290,6 +294,7 @@ The ``esphome logs <CONFIG>`` command validates the configuration and shows all 
     Manually specify a serial port/IP to use. For example ``/dev/cu.SLAB_USBtoUART``.
     
     .. versionadded:: 2025.8
+    
         Multiple ``--device`` options can be specified to provide fallback addresses. When using the 
         native API for logs, all addresses are passed to the API client which uses the Happy Eyeballs 
         algorithm (RFC 8305) to efficiently connect using the fastest available address.
@@ -299,6 +304,7 @@ The ``esphome logs <CONFIG>`` command validates the configuration and shows all 
         .. code-block:: console
         
             esphome logs my-device.yaml --device 192.168.1.100 --device 2001:db8::1
+        
 
 .. option:: --reset
 

--- a/guides/cli.rst
+++ b/guides/cli.rst
@@ -85,7 +85,6 @@ The ``esphome run <CONFIG>`` command is the most common command for ESPHome. It
     .. code-block:: console
     
         esphome run my-device.yaml --device 192.168.1.100 --device 2001:db8::1 --device fe80::1234:5678:90ab:cdef
-    
 
 .. option:: --upload_speed BAUD_RATE
 
@@ -161,7 +160,6 @@ The ``esphome upload <CONFIG>`` validates the configuration and uploads the most
     .. code-block:: console
     
         esphome upload my-device.yaml --device 192.168.1.100 --device 2001:db8::1
-    
 
 .. option:: --upload_speed BAUD_RATE
 
@@ -298,7 +296,6 @@ The ``esphome logs <CONFIG>`` command validates the configuration and shows all 
     .. code-block:: console
     
         esphome logs my-device.yaml --device 192.168.1.100 --device 2001:db8::1
-    
 
 .. option:: --reset
 

--- a/guides/cli.rst
+++ b/guides/cli.rst
@@ -83,7 +83,6 @@ The ``esphome run <CONFIG>`` command is the most common command for ESPHome. It
     Example:
     
     .. code-block:: console
-    
         esphome run my-device.yaml --device 192.168.1.100 --device 2001:db8::1 --device fe80::1234:5678:90ab:cdef
 
 .. option:: --upload_speed BAUD_RATE
@@ -158,7 +157,6 @@ The ``esphome upload <CONFIG>`` validates the configuration and uploads the most
     Example:
     
     .. code-block:: console
-    
         esphome upload my-device.yaml --device 192.168.1.100 --device 2001:db8::1
 
 .. option:: --upload_speed BAUD_RATE
@@ -294,7 +292,6 @@ The ``esphome logs <CONFIG>`` command validates the configuration and shows all 
     Example:
     
     .. code-block:: console
-    
         esphome logs my-device.yaml --device 192.168.1.100 --device 2001:db8::1
 
 .. option:: --reset

--- a/guides/cli.rst
+++ b/guides/cli.rst
@@ -75,6 +75,17 @@ The ``esphome run <CONFIG>`` command is the most common command for ESPHome. It
 
     Manually specify the upload port/IP to use. For example ``/dev/cu.SLAB_USBtoUART``, or ``192.168.1.176``
     to perform an OTA.
+    
+    .. versionadded:: 2025.8
+        Multiple ``--device`` options can be specified to provide fallback addresses. ESPHome will 
+        try each address in order until one succeeds. This is particularly useful for devices with 
+        multiple IP addresses (IPv4/IPv6).
+        
+        Example:
+        
+        .. code-block:: console
+        
+            esphome run my-device.yaml --device 192.168.1.100 --device 2001:db8::1 --device fe80::1234:5678:90ab:cdef
 
 .. option:: --upload_speed BAUD_RATE
 
@@ -141,6 +152,16 @@ The ``esphome upload <CONFIG>`` validates the configuration and uploads the most
 
     Manually specify the upload port/IP address to use. For example ``/dev/cu.SLAB_USBtoUART``, or ``192.168.1.176``
     to perform an OTA.
+    
+    .. versionadded:: 2025.8
+        Multiple ``--device`` options can be specified to provide fallback addresses. ESPHome will 
+        try each address in order until one succeeds.
+        
+        Example:
+        
+        .. code-block:: console
+        
+            esphome upload my-device.yaml --device 192.168.1.100 --device 2001:db8::1
 
 .. option:: --upload_speed BAUD_RATE
 
@@ -267,6 +288,17 @@ The ``esphome logs <CONFIG>`` command validates the configuration and shows all 
 .. option:: --device SERIAL_PORT
 
     Manually specify a serial port/IP to use. For example ``/dev/cu.SLAB_USBtoUART``.
+    
+    .. versionadded:: 2025.8
+        Multiple ``--device`` options can be specified to provide fallback addresses. When using the 
+        native API for logs, all addresses are passed to the API client which uses the Happy Eyeballs 
+        algorithm (RFC 8305) to efficiently connect using the fastest available address.
+        
+        Example:
+        
+        .. code-block:: console
+        
+            esphome logs my-device.yaml --device 192.168.1.100 --device 2001:db8::1
 
 .. option:: --reset
 

--- a/guides/cli.rst
+++ b/guides/cli.rst
@@ -76,18 +76,15 @@ The ``esphome run <CONFIG>`` command is the most common command for ESPHome. It
     Manually specify the upload port/IP to use. For example ``/dev/cu.SLAB_USBtoUART``, or ``192.168.1.176``
     to perform an OTA.
     
-    .. versionadded:: 2025.8
+    Multiple ``--device`` options can be specified to provide fallback addresses. ESPHome will 
+    try each address in order until one succeeds. This is particularly useful for devices with 
+    multiple IP addresses (IPv4/IPv6).
     
-        Multiple ``--device`` options can be specified to provide fallback addresses. ESPHome will 
-        try each address in order until one succeeds. This is particularly useful for devices with 
-        multiple IP addresses (IPv4/IPv6).
-        
-        Example:
-        
-        .. code-block:: console
-        
-            esphome run my-device.yaml --device 192.168.1.100 --device 2001:db8::1 --device fe80::1234:5678:90ab:cdef
-        
+    Example:
+    
+    .. code-block:: console
+    
+        esphome run my-device.yaml --device 192.168.1.100 --device 2001:db8::1 --device fe80::1234:5678:90ab:cdef
 
 .. option:: --upload_speed BAUD_RATE
 
@@ -155,17 +152,14 @@ The ``esphome upload <CONFIG>`` validates the configuration and uploads the most
     Manually specify the upload port/IP address to use. For example ``/dev/cu.SLAB_USBtoUART``, or ``192.168.1.176``
     to perform an OTA.
     
-    .. versionadded:: 2025.8
+    Multiple ``--device`` options can be specified to provide fallback addresses. ESPHome will 
+    try each address in order until one succeeds.
     
-        Multiple ``--device`` options can be specified to provide fallback addresses. ESPHome will 
-        try each address in order until one succeeds.
-        
-        Example:
-        
-        .. code-block:: console
-        
-            esphome upload my-device.yaml --device 192.168.1.100 --device 2001:db8::1
-        
+    Example:
+    
+    .. code-block:: console
+    
+        esphome upload my-device.yaml --device 192.168.1.100 --device 2001:db8::1
 
 .. option:: --upload_speed BAUD_RATE
 
@@ -293,18 +287,15 @@ The ``esphome logs <CONFIG>`` command validates the configuration and shows all 
 
     Manually specify a serial port/IP to use. For example ``/dev/cu.SLAB_USBtoUART``.
     
-    .. versionadded:: 2025.8
+    Multiple ``--device`` options can be specified to provide fallback addresses. When using the 
+    native API for logs, all addresses are passed to the API client which uses the Happy Eyeballs 
+    algorithm (RFC 8305) to efficiently connect using the fastest available address.
     
-        Multiple ``--device`` options can be specified to provide fallback addresses. When using the 
-        native API for logs, all addresses are passed to the API client which uses the Happy Eyeballs 
-        algorithm (RFC 8305) to efficiently connect using the fastest available address.
-        
-        Example:
-        
-        .. code-block:: console
-        
-            esphome logs my-device.yaml --device 192.168.1.100 --device 2001:db8::1
-        
+    Example:
+    
+    .. code-block:: console
+    
+        esphome logs my-device.yaml --device 192.168.1.100 --device 2001:db8::1
 
 .. option:: --reset
 

--- a/guides/cli.rst
+++ b/guides/cli.rst
@@ -83,6 +83,7 @@ The ``esphome run <CONFIG>`` command is the most common command for ESPHome. It
     Example:
     
     .. code-block:: console
+
         esphome run my-device.yaml --device 192.168.1.100 --device 2001:db8::1 --device fe80::1234:5678:90ab:cdef
 
 .. option:: --upload_speed BAUD_RATE
@@ -157,6 +158,7 @@ The ``esphome upload <CONFIG>`` validates the configuration and uploads the most
     Example:
     
     .. code-block:: console
+
         esphome upload my-device.yaml --device 192.168.1.100 --device 2001:db8::1
 
 .. option:: --upload_speed BAUD_RATE
@@ -292,6 +294,7 @@ The ``esphome logs <CONFIG>`` command validates the configuration and shows all 
     Example:
     
     .. code-block:: console
+
         esphome logs my-device.yaml --device 192.168.1.100 --device 2001:db8::1
 
 .. option:: --reset


### PR DESCRIPTION
## Description:

This PR documents the new multiple device address support in ESPHome CLI commands. The `--device` option in `run`, `upload`, and `logs` commands now accepts multiple values, allowing ESPHome to try each address in order until one succeeds. This improves connection reliability for devices with multiple IP addresses (IPv4/IPv6) and ensures that `use_address` configuration is properly prioritized.

**Related issue (if applicable):** fixes https://github.com/esphome/dashboard/issues/774

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#10003

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
