### PR TITLE
Update globals.rst

### DIFF
--- a/components/globals.rst
+++ b/components/globals.rst
@@ -1,7 +1,7 @@
 Global Variables
 ----------------
 
-In some cases you might need to share a global variable across multiple lambdas. For example, global variables can be
+In some cases you might need to share a global variable across multiple lambdas, or to remember between periods of deep_sleep. For example, global variables can be
 used to store the state of a garage door.
 
 .. code-block:: yaml
@@ -45,6 +45,8 @@ Configuration variables:
 - **initial_value** (*Optional*, string): The value with which to initialize this variable if the state
   can not be restored or if state restoration is not enabled. This needs to be wrapped in quotes! Defaults to
   the C++ default value for this type (for example ``0`` for integers).
+
+Within lambdas globals don’t have a state attribute, just a value. Note in the example above the use of id(my_global_int) where other components would require id(my_component).state.
 
 .. _globals-set_action:
 


### PR DESCRIPTION
Highlight that globals do not use the state attribute. 

It is an important but subtle difference from other ESPHome components.  The example does show the correct usage - but a new user is unlikely spot the difference until they know what to look for.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
