### PR TITLE
[mapping] Update docs

### DIFF
--- a/content/components/mapping.md
+++ b/content/components/mapping.md
@@ -44,7 +44,6 @@ You can also map to a class. This is useful when you want to map to a more compl
 - `color`  : Maps to a predefined [Color](#config-color). The values should each be a color ID.
 - The name of a C++ class defined by ESPHome, e.g. `Component`. The values should each be a ID of that class.
 
-
 ## Using a mapping
 
 A mapping defined in this component can be used in lambdas in other components. The mapping can be accessed using

--- a/content/components/mapping.md
+++ b/content/components/mapping.md
@@ -3,7 +3,8 @@ description: "Mapping Component"
 title: "Mapping Component"
 ---
 
-The `mapping` component allows you to create a map or dictionary that allows a one-to-one translation from keys to values. This enables e.g. mapping a string to a number or vice versa, or mapping a string such as a weather condition to an image.
+The `mapping` component allows you to create a map or dictionary that allows a one-to-one translation from keys to
+values. This enables e.g. mapping a string to a number or vice versa, or mapping a string such as a weather condition to an image.
 
 ```yaml
 # Example configuration entry
@@ -43,9 +44,14 @@ You can also map to a class. This is useful when you want to map to a more compl
 - `color`  : Maps to a predefined [Color](#config-color). The values should each be a color ID.
 - The name of a C++ class defined by ESPHome, e.g. `Component`. The values should each be a ID of that class.
 
+
 ## Using a mapping
 
-A mapping defined in this component can be used in lambdas in other components. The mapping can be accessed using the `id` function, and the value can be looked up using the `[]` operator as per the above example.
+A mapping defined in this component can be used in lambdas in other components. The mapping can be accessed using
+the ``id`` function, and the value can be looked up using the ``[]`` operator as per the above example, or the ``get`` function.
+A map may be updated at run time using a lambda call, e.g. ``map.set("key", value)``.
+
+Maps are stored in RAM, but will use PSRAM if available.
 
 A more complex example follows:
 
@@ -84,8 +90,14 @@ display:
   - platform: ...
     # update the display drawing random text in random colors
     lambda: |-
-      auto color = color_map[random_uint32() % 3];
+      auto color = color_map.get(random_uint32() % 3]); # Uses get() to index the color_map
       it.printf(100, 100, id(roboto20), color, id(string_map)[random_uint32() % 3].c_str(), Color(0));
+
+    on_...:
+      then:
+        - lambda: |-
+              id(color_map).set(2, Color::random_color());
+
 ```
 
 ## See Also


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#9972

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
