### PR TITLE
[esp32_ble] Document connection_timeout configuration option

### DIFF
--- a/components/esp32_ble.rst
+++ b/components/esp32_ble.rst
@@ -51,7 +51,7 @@ Configuration variables:
 
 - **connection_timeout** (*Optional*, :ref:`config-time`): The maximum time to wait for a BLE connection to be established. Only available when using ESP-IDF framework. Defaults to ``20s``.
 
-  - Range: 1 to 180 seconds
+  - Range: 10 to 180 seconds
   - This timeout should align with the timeout used by your BLE client software to prevent connection slot waste
 
 .. note::

--- a/components/esp32_ble.rst
+++ b/components/esp32_ble.rst
@@ -23,6 +23,7 @@ can run.
     esp32_ble:
       io_capability: keyboard_only
       disable_bt_logs: true  # Default, saves flash
+      connection_timeout: 20s  # Default, matches client timeout
 
 Configuration variables:
 ------------------------
@@ -47,6 +48,15 @@ Configuration variables:
 .. note::
 
     The ``disable_bt_logs`` option intelligently disables only the Bluetooth logging categories that are not required by your configuration. Each Bluetooth component registers the specific loggers it needs, and all unused loggers are automatically disabled during compilation. This includes loggers for Classic Bluetooth features (like RFCOMM, A2DP, HID) that are not used by ESPHome's BLE implementation.
+
+- **connection_timeout** (*Optional*, :ref:`config-time`): The maximum time to wait for a BLE connection to be established. Only available when using ESP-IDF framework. Defaults to ``20s``.
+
+  - Range: 1 to 180 seconds
+  - This timeout should align with the timeout used by your BLE client software to prevent connection slot waste
+
+.. note::
+
+    The ``connection_timeout`` option is particularly important when using ESPHome as a Bluetooth proxy. The default of 20 seconds matches the timeout used by aioesphomeapi and bleak-retry-connector. If a connection attempt times out on the client side but ESP-IDF continues trying to connect, the connection slot remains occupied and unavailable for new connections. Setting this to match your client timeout ensures connection slots are freed immediately when a connection fails.
 
 ``ble.disable`` Action
 -----------------------


### PR DESCRIPTION
## Description:

This PR documents the new `connection_timeout` configuration option added to the `esp32_ble` component in esphome/esphome#10013. This option allows users to configure the BLE connection establishment timeout, which defaults to 20 seconds to match client-side timeouts and prevent connection slot waste.

The documentation explains:
- The new configuration variable and its parameters (ESP-IDF only, 10-180 second range, default 20s)
- Why this timeout is important for Bluetooth proxy usage
- How it prevents connection slots from being wasted when clients timeout

**Related issue (if applicable):** Documents feature added in esphome/esphome#10013

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#10013

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

