### PR TITLE
[lvgl] Update lambda color usage

### DIFF
--- a/components/lvgl/index.rst
+++ b/components/lvgl/index.rst
@@ -243,13 +243,21 @@ Colors can be specified anywhere in the LVGL configuration either by referencing
 
 You may also use any of the `standard CSS color names <https://developer.mozilla.org/en-US/docs/Web/CSS/named-color>`__, e.g. ``springgreen``.
 
-When using a lambda to provide a color you should use the ``lv_color_hex`` function, for example:
+When using a lambda to provide a color you can use the ``lv_color_hex`` function to convert a hex value, or
+return a :ref:`config-color` ID - this is useful when using the :doc:`/components/mapping`. Examples:
 
 .. code-block:: yaml
 
     label:
+      id: my_label
       text: 'Hello World!'
       color: !lambda return lv_color_hex(0xFF0000);
+
+    on_...:
+        lvgl.label.update:
+          id: my_label
+          text: 'Hello Mars!'
+          color: !lambda return id(mapping_color_map)[x];
 
 .. _lvgl-opacity:
 


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#10016

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
