### PR TITLE
[remote_transmitter] Add digital_write automation

### DIFF
--- a/components/remote_transmitter.rst
+++ b/components/remote_transmitter.rst
@@ -1039,8 +1039,9 @@ This :ref:`action <config-action>` sets the output value of the pin.
 
 Configuration variables:
 
+- **transmitter_id** (*Optional*, :ref:`config-id`): The remote transmitter to send the remote code with. Defaults to
+  the first one defined in the configuration.
 - **value** (**Required**, bool): The output value of the pin.
-- Does not inherit other options from :ref:`remote_transmitter-transmit_action`.
 
 .. _remote_transmitter-rc_switch-protocol:
 

--- a/components/remote_transmitter.rst
+++ b/components/remote_transmitter.rst
@@ -1024,6 +1024,23 @@ Configuration variables:
 
     Toto remotes repeat all codes three times at a 36ms interval. This behavior will occur by default, but may be overridden by specifying ``repeat`` and ``wait time`` configuration variables.
 
+.. _remote_transmitter-digital_write:
+
+``remote_transmitter.digital_write`` **Action**
+***********************************************
+
+This :ref:`action <config-action>` sets the output value of the pin.
+
+.. code-block:: yaml
+
+    on_...:
+      - remote_transmitter.digital_write:
+          value: true
+
+Configuration variables:
+
+- **value** (**Required**, bool): The output value of the pin.
+- Does not inherit other options from :ref:`remote_transmitter-transmit_action`.
 
 .. _remote_transmitter-rc_switch-protocol:
 

--- a/components/remote_transmitter.rst
+++ b/components/remote_transmitter.rst
@@ -1039,7 +1039,7 @@ This :ref:`action <config-action>` sets the output value of the pin.
 
 Configuration variables:
 
-- **transmitter_id** (*Optional*, :ref:`config-id`): The remote transmitter to send the remote code with. Defaults to
+- **transmitter_id** (*Optional*, :ref:`config-id`): The remote transmitter to set the pin value on. Defaults to
   the first one defined in the configuration.
 - **value** (**Required**, bool): The output value of the pin.
 

--- a/components/sx127x.rst
+++ b/components/sx127x.rst
@@ -367,7 +367,6 @@ the pin should be driven low before ``set_mode_tx`` and pulled high / released b
       pa_power: 17
 
     remote_receiver:
-      id: rx_id
       pin:
         number: GPIO32
         mode:
@@ -379,7 +378,6 @@ the pin should be driven low before ``set_mode_tx`` and pulled high / released b
       dump: raw
 
     remote_transmitter:
-      id: tx_id
       pin:
         number: GPIO32
         mode:
@@ -393,12 +391,12 @@ the pin should be driven low before ``set_mode_tx`` and pulled high / released b
       on_transmit:
         then:
           - sx127x.set_mode_standby
-          - lambda: 'id(tx_id)->digital_write(false);'
+          - remote_transmitter.digital_write: false
           - sx127x.set_mode_tx
       on_complete:
         then:
           - sx127x.set_mode_standby
-          - lambda: 'id(tx_id)->digital_write(true);'
+          - remote_transmitter.digital_write: true
           - sx127x.set_mode_rx
 
     button:


### PR DESCRIPTION
## Description:

Add digital_write automation which is useful when the pin is configured as open drain. At least two rf chips need this: sx127x and cc1101. 

In this example the pin is an open drain. The pin needs to be false when in entering transmit mode but needs to be set to true when finished (to release the pin) before entering receive mode:
```
remote_transmitter:
  pin:
    number: GPIO32
    mode:
      input: true
      output: true
      pullup: true
      open_drain: true
    allow_other_uses: true
  eot_level: false
  carrier_duty_percent: 100%
  on_transmit:
    then:
      - sx127x.set_mode_standby
      - remote_transmitter.digital_write: false
      - sx127x.set_mode_tx
  on_complete:
    then:
      - sx127x.set_mode_standby
      - remote_transmitter.digital_write: true
      - sx127x.set_mode_rx
      
remote_receiver:
  id: rx_id
  pin:
    number: GPIO32
    mode:
      input: true
      output: true
      pullup: true
      open_drain: true
    allow_other_uses: true
  dump: raw
```

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#10069

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
