### PR TITLE
[host platform] add hint about firewall settings on local host computer

### DIFF
--- a/components/host.rst
+++ b/components/host.rst
@@ -15,9 +15,10 @@ configuration to Home Assistant (the native MAC address is not readily available
 
     HA will not automatically discover an ESPHome instance running on ``host`` using mDNS, and you will need
     to add it explicitly using the IP address of your host computer. If HA cannot establish a connection when
-    adding the device manually, the firewall settings of the local host computer may be the cause. Port 6053 
-    must not be blocked. 
-
+    adding the device manually, the firewall settings of the local host computer may be the cause. The
+    ESPHome *API* port (``6053``) must be allowed through the firewall.
+    See :doc:`/components/api` for details.
+ 
 Many components, especially those interfacing to actual hardware, will not be available when using ``host``. Do not
 configure wifi - network will automatically be available using the host computer.
 

--- a/components/host.rst
+++ b/components/host.rst
@@ -14,7 +14,8 @@ configuration to Home Assistant (the native MAC address is not readily available
 .. note::
 
     HA will not automatically discover an ESPHome instance running on ``host`` using mDNS, and you will need
-    to add it explicitly using the IP address of your host computer.
+    to add it explicitly using the IP address of your host computer. If HA cannot establish a connection when
+    adding the device manually, the firewall settings of the local host computer may be the cause. Port 6053
 
 Many components, especially those interfacing to actual hardware, will not be available when using ``host``. Do not
 configure wifi - network will automatically be available using the host computer.

--- a/components/host.rst
+++ b/components/host.rst
@@ -15,7 +15,8 @@ configuration to Home Assistant (the native MAC address is not readily available
 
     HA will not automatically discover an ESPHome instance running on ``host`` using mDNS, and you will need
     to add it explicitly using the IP address of your host computer. If HA cannot establish a connection when
-    adding the device manually, the firewall settings of the local host computer may be the cause. Port 6053
+    adding the device manually, the firewall settings of the local host computer may be the cause. Port 6053 
+    must not be blocked. 
 
 Many components, especially those interfacing to actual hardware, will not be available when using ``host``. Do not
 configure wifi - network will automatically be available using the host computer.


### PR DESCRIPTION
## Description:
Hint added to note. If HA cannot connect to the local host computer, the firewall setting might be the cause, the port 6053 must not be blocked. 

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- none

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
