### PR TITLE
Update espnow documentation

### DIFF
--- a/components/espnow.rst
+++ b/components/espnow.rst
@@ -41,10 +41,10 @@ Actions:
 
 - **espnow.sendd**, send a packet to an other device. See :ref:`espnow-send-action`
 - **espnow.broadcast**, send a packet to all device within its surroundings. Use this action with care, you can corrupt other device that you maybe not aware of. See :ref:`espnow-broadcast-action`
-
-- **espnow.peer.del**, See :ref:`espnow-peer_del-action`
+  
 - **espnow.peer.add**, See :ref:`espnow-peer_add-action`
-
+- **espnow.peer.del**, See :ref:`espnow-peer_delete-action`
+  
 - **espnow.set_channel** with this action you can switch the channel where the packets are being send and received over. See :ref:`espnow-set_channel-action`
 
 Automations

--- a/components/espnow.rst
+++ b/components/espnow.rst
@@ -45,7 +45,7 @@ Actions:
 - **espnow.peer.add**, See :ref:`espnow-peer_add-action`
 - **espnow.peer.del**, See :ref:`espnow-peer_delete-action`
   
-- **espnow.set_channel** with this action you can switch the channel where the packets are being send and received over. See :ref:`espnow-set_channel-action`
+- **espnow.set_channel** with this action you can switch the channel where the packets are being send and received over. **This will only work when *WIFI* is not used**. See :ref:`espnow-set_channel-action`
 
 Automations
 -----------

--- a/components/espnow.rst
+++ b/components/espnow.rst
@@ -207,7 +207,7 @@ This is an :ref:`Action <config-action>` to change the channel that espnow is se
 
 Configuration variables:
 
-- **channel** (**Required**, int): This can be a value between ``0`` and ``15``. The max number depends on the country where you are using the device. ``0`` means that espnow will set the channel number itself (most of the time it would be ``1``).
+- **channel** (**Required**, int): This can be a value between ``0`` and ``15``. The maximum channel number depends on the country or region where you are using the device (for example, channels 1-11 are allowed in the US and most of Europe, 1-13 in many other countries, and 1-14 in Japan). For details, see the `Wi-Fi channel regulations by country <https://en.wikipedia.org/wiki/List_of_WLAN_channels>`__ or consult the `Espressif ESP-NOW documentation <https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/network/esp_now.html>`__. ``0`` means that espnow will set the channel number itself (most of the time it would be ``1``).
 
 
 .. _espnow-peers:

--- a/components/espnow.rst
+++ b/components/espnow.rst
@@ -127,13 +127,16 @@ Configuration variables:
 
 - **address** (**Required**, :ref:`templatable <config-templatable>`, MAC Address): The MAC address of the receiving device to send to.
 - **data** (**Required**, :ref:`templatable <config-templatable>`, string or list of bytes): The data to be sent.
-- **on_sent** (*Optional*, :ref:`Automation <automation>`): An automation to perform when the data is sent successfully.
 - **wait_for_sent** (*Optional*, boolean): The automation will wait for the data to be sent and for the ``on_sent`` or ``on_error``
   actions to be finished before continuing with the next action.
   Defaults to ``true``.
-- **on_error** (*Optional*, :ref:`Automation <automation>`): An automation to perform when the data could not be sent.
 - **continue_on_error** (*Optional*, boolean): If set to ``false``, the next action will not be triggered if the data could not be sent.
   Defaults to ``true``.
+
+Automations:
+
+- **on_sent** (*Optional*, :ref:`Automation <automation>`): An automation to perform when the data is sent successfully.
+- **on_error** (*Optional*, :ref:`Automation <automation>`): An automation to perform when the data could not be sent.
 
 
 .. _espnow-broadcast-action:
@@ -198,6 +201,7 @@ Configuration variables:
 
 - **address** (**Required**, MAC Address): The Peer address that needs to be removed from the list of allowed peers.
 
+.. _espnow-set_channel-action:
 
 ``espnow.set_channel`` Action
 *****************************

--- a/components/espnow.rst
+++ b/components/espnow.rst
@@ -37,16 +37,6 @@ Automations:
 - **on_broadcast** (*Optional*, :ref:`Automation <automation>`): An automation to perform when a broadcast packet is received.
   See :ref:`espnow-on_broadcast`.
 
-Actions:
-
-- **espnow.sendd**, send a packet to an other device. See :ref:`espnow-send-action`
-- **espnow.broadcast**, send a packet to all device within its surroundings. Use this action with care, you can corrupt other device that you maybe not aware of. See :ref:`espnow-broadcast-action`
-  
-- **espnow.peer.add**, See :ref:`espnow-peer_add-action`
-- **espnow.peer.del**, See :ref:`espnow-peer_delete-action`
-  
-- **espnow.set_channel** with this action you can switch the channel where the packets are being send and received over. **This will only work when *WIFI* is not used**. See :ref:`espnow-set_channel-action`
-
 Automations
 -----------
 
@@ -85,7 +75,7 @@ Configuration variables:
 ``on_unknown_peer``
 *******************
 
-This automation will be triggered when data is received from a peer that is not in the list of known peers. This trigger gives you on possiblity to decide if the unknown can be added or not. 
+This automation will be triggered when data is received from a peer that is not in the list of known peers. This trigger gives you one possibility to decide if the unknown peer can be added or not.
 
 .. _espnow-on_broadcast:
 
@@ -206,7 +196,7 @@ Configuration variables:
 ``espnow.set_channel`` Action
 *****************************
 
-This is an :ref:`Action <config-action>` to change the channel where espnow is working from.
+This is an :ref:`Action <config-action>` to change the channel that espnow is sending and receiving on.
 
 .. code-block:: yaml
 
@@ -217,7 +207,7 @@ This is an :ref:`Action <config-action>` to change the channel where espnow is w
 
 Configuration variables:
 
-- **channel** (**Required**, int): This can be a value between 0 and 15(*). The max number is depending on the country where you using the device. The 0 means that espnow will set the channel number it self (most of the time it would be 1).
+- **channel** (**Required**, int): This can be a value between ``0`` and ``15``. The max number depends on the country where you are using the device. ``0`` means that espnow will set the channel number itself (most of the time it would be ``1``).
 
 
 .. _espnow-peers:

--- a/components/espnow.rst
+++ b/components/espnow.rst
@@ -33,10 +33,19 @@ Configuration variables:
 Automations:
 
 - **on_receive** (*Optional*, :ref:`Automation <automation>`): An automation to perform when data is received. See :ref:`espnow-on_receive`.
-- **on_unknown_peer** (*Optional*, :ref:`Automation <automation>`): An automation to perform when data is received from an unknown peer.
-  Cannot be used when ``auto_add_peer`` is set to ``true``. See :ref:`espnow-on_unknown_peer`.
+- **on_unknown_peer** (*Optional*, :ref:`Automation <automation>`): An automation to perform when data is received from an unknown peer. See :ref:`espnow-on_unknown_peer`.
 - **on_broadcast** (*Optional*, :ref:`Automation <automation>`): An automation to perform when a broadcast packet is received.
   See :ref:`espnow-on_broadcast`.
+
+Actions:
+
+- **espnow.sendd**, send a packet to an other device. See :ref:`espnow-send-action`
+- **espnow.broadcast**, send a packet to all device within its surroundings. Use this action with care, you can corrupt other device that you maybe not aware of. See :ref:`espnow-broadcast-action`
+
+- **espnow.peer.del**, See :ref:`espnow-peer_del-action`
+- **espnow.peer.add**, See :ref:`espnow-peer_add-action`
+
+- **espnow.set_channel** with this action you can switch the channel where the packets are being send and received over. See :ref:`espnow-set_channel-action`
 
 Automations
 -----------
@@ -76,7 +85,7 @@ Configuration variables:
 ``on_unknown_peer``
 *******************
 
-This automation will be triggered when data is received from a peer that is not in the list of known peers.
+This automation will be triggered when data is received from a peer that is not in the list of known peers. This trigger gives you on possiblity to decide if the unknown can be added or not. 
 
 .. _espnow-on_broadcast:
 
@@ -190,6 +199,23 @@ Configuration variables:
 - **address** (**Required**, MAC Address): The Peer address that needs to be removed from the list of allowed peers.
 
 
+``espnow.set_channel`` Action
+*****************************
+
+This is an :ref:`Action <config-action>` to change the channel where espnow is working from.
+
+.. code-block:: yaml
+
+    on_...:
+      - espnow.set_channel:
+          channel: 1
+      - espnow.set_channel: 1
+
+Configuration variables:
+
+- **channel** (**Required**, int): This can be a value between 0 and 15(*). The max number is depending on the country where you using the device. The 0 means that espnow will set the channel number it self (most of the time it would be 1).
+
+
 .. _espnow-peers:
 
 Peers
@@ -203,6 +229,7 @@ will be an error when trying to send data to a peer.
 
 Setting ``auto_add_peer`` to ``true`` will allow the component to automatically add any incoming device as a peer, and will
 automatically add any peer that data is sent to.
+
 
 See Also
 --------


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#10014

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
