### PR TITLE
[sensor] Extend timeout filter with option to return last value received

### DIFF
--- a/components/sensor/sensor-filter-timeout.rst
+++ b/components/sensor/sensor-filter-timeout.rst
@@ -1,10 +1,14 @@
 ``timeout``
-************
+***********
 
-After the first value has been sent, if no subsequent value is published within the
-``specified time period``, send a templatable value which defaults to ``NaN``.
-Especially useful when data is derived from some other communication
-channel, e.g. a serial port, which can potentially be interrupted.
+After the first value has been sent, if no subsequent value is published within the specified ``timeout`` period, send
+a templatable value which defaults to ``NaN``. The value may also be set to ``last``, which will result in the last
+value received by the filter being sent again.
+
+This filter particularly is useful when:
+
+- data is derived from some communication channel (a serial port, for example) which can potentially be interrupted.
+- placed ahead of a throttle filter to ensure that the last value published will pass through the throttle.
 
 .. code-block:: yaml
 
@@ -14,4 +18,6 @@ channel, e.g. a serial port, which can potentially be interrupted.
       - timeout:
           timeout: 10s
           value: !lambda return 0;
-
+      - timeout:
+          timeout: 10s
+          value: last  # sent value will be the last value received by the filter


### PR DESCRIPTION
## Description:

SSIA

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#10115

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
