### PR TITLE
[switch] Add `control()` method to API

### DIFF
--- a/components/switch/index.rst
+++ b/components/switch/index.rst
@@ -138,14 +138,6 @@ advanced stuff (see the full API Reference for more info).
 - ``publish_state()``: Manually cause the switch to publish a new state and store it internally.
   If it's different from the last internal state, it's additionally published to the frontend.
   
-  .. note::
-
-    Keep in mind that this does not change the actual state of the switch. It only changes the state in the frontend and the internal state.
-    If you want to change the actual state of the switch, you need to call ``turn_on()``, ``turn_off()``, ``toggle()``, or ``control()``.
-
-    For example, if you are using a GPIO Switch, calling ``publish_state()`` will not change the GPIO pin level.
-    To do that, you need to call ``turn_on()``, ``turn_off()``, ``toggle()``, or ``control()``. The same applies to other switch platforms.
-
   .. code-block:: yaml
 
       // Within lambda, make the switch report a specific state

--- a/components/switch/index.rst
+++ b/components/switch/index.rst
@@ -149,11 +149,11 @@ advanced stuff (see the full API Reference for more info).
       Keep in mind that this does not change the actual state of the switch. It only
       changes the state in the frontend and the internal state. If you want to
       change the actual state of the switch, you need to call ``turn_on()``, 
-      ``turn_off()`` or ``toggle()``.
+      ``turn_off()``, ``toggle()``, or ``control()``.
 
       For example, if you are using a :doc:`/components/switch/gpio`, calling ``publish_state()`` will
       not change the GPIO pin level. To do that, you need to call ``turn_on()``, 
-      ``turn_off()`` or ``toggle()``. The same applies to other switch platforms.
+      ``turn_off()``, ``toggle()``, or ``control()``. The same applies to other switch platforms.
 
 - ``state``: Retrieve the current state of the switch.
 

--- a/components/switch/index.rst
+++ b/components/switch/index.rst
@@ -137,6 +137,14 @@ advanced stuff (see the full API Reference for more info).
 
 - ``publish_state()``: Manually cause the switch to publish a new state and store it internally.
   If it's different from the last internal state, it's additionally published to the frontend.
+  
+  .. note::
+
+    Keep in mind that this does not change the actual state of the switch. It only changes the state in the frontend and the internal state.
+    If you want to change the actual state of the switch, you need to call ``turn_on()``, ``turn_off()``, ``toggle()``, or ``control()``.
+
+    For example, if you are using a GPIO Switch, calling ``publish_state()`` will not change the GPIO pin level.
+    To do that, you need to call ``turn_on()``, ``turn_off()``, ``toggle()``, or ``control()``. The same applies to other switch platforms.
 
   .. code-block:: yaml
 
@@ -176,6 +184,16 @@ advanced stuff (see the full API Reference for more info).
       id(my_switch).turn_on();
       // Toggle the switch
       id(my_switch).toggle();
+
+- ``control()``: Control the switch state using a boolean parameter.
+  This provides a unified interface for setting switch state dynamically.
+
+  .. code-block:: yaml
+
+      // Within lambda, control switch based on a condition
+      id(my_switch).control(true);   // Turn ON
+      id(my_switch).control(false);  // Turn OFF
+      id(my_switch).control(some_condition);  // Set based on condition
 
 .. _switch-on_turn_on_off_trigger:
 


### PR DESCRIPTION
## Description:

> [!IMPORTANT]
> This requires PR#10105 to be merged first as it was based on that and changes things introduced by that PR.
> If that PR is not going to be merged I will be happy to remove from this one the conflicting parts.

Adds a new `control(bool target_state)` method to the Switch class API, providing a unified interface for setting switch state based on a boolean parameter.

### Additional context
This PR adds a new public API method to the Switch class that complements the existing `turn_on()`, `turn_off()`, and `toggle()` methods. The `control()` method is particularly useful when:

- The desired switch state is determined dynamically at runtime
- Writing lambda expressions that need to set switch state based on conditions
- API integrations where a boolean state parameter is more convenient

The method internally delegates to the existing `turn_on()` and `turn_off()` methods, ensuring consistency with the current implementation and maintaining all existing behavior. This is a companion PR to #10105 which adds the `switch.control` automation action that utilizes this new API method.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#10118

## Checklist:

  - [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
