### PR TITLE
Remove mentions of rmt_channel from esp32_rmt_led_strip

### DIFF
--- a/components/light/esp32_rmt_led_strip.rst
+++ b/components/light/esp32_rmt_led_strip.rst
@@ -17,14 +17,6 @@ This is a component using the ESP32 RMT peripheral to drive most addressable LED
         chipset: ws2812
         name: "My Light"
 
-Only for Arduino platforms (and ESP-IDF <5 which was used until ESPHome 2025), the RMT channel must be defined.
-
-.. code-block:: yaml
-
-    light:
-      - platform: esp32_rmt_led_strip
-        ...
-
 Configuration variables
 -----------------------
 


### PR DESCRIPTION
This was supposed to have gone away already but was accidentally left behind.

https://discord.com/channels/429907082951524364/1403088738560774214/1403092458337992856

Delete it.

cc @swoboda1337

## Description:


**Related issue (if applicable):

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.