### PR TITLE
Fix parameter names of touchscreen::TouchPoint

### DIFF
--- a/components/touchscreen/index.rst
+++ b/components/touchscreen/index.rst
@@ -83,8 +83,8 @@ The integer members for the touch positions below are in relation to the display
 - ``state`` indicates the state of the touch. This can be **1**, indicating it is an initial touch, or **2** indicating the touch position has changed/moved.
 
 - ``x`` and ``y`` are the current position.
-- ``x_last`` and ``y_last`` are the previous position.
-- ``x_first`` and ``y_first`` are the position of the touch when it was first detected.
+- ``x_prev`` and ``y_prev`` are the previous position.
+- ``x_org`` and ``y_org`` are the position of the touch when it was first detected.
 - ``x_raw`` and ``y_raw`` are for calibrating the touchscreen in relation of the display. This replaces the properties with the same name in the touchscreen classes.
 
 .. _touchscreen-calibration:


### PR DESCRIPTION
## Description:

The TouchPoint parameter names in the docs of the touchscreen component don't match the actual names in the code.

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
