### PR TITLE
[esp32] Add IDF log_level option

### DIFF
--- a/components/esp32.rst
+++ b/components/esp32.rst
@@ -108,6 +108,8 @@ Configuration variables:
 - **sdkconfig_options** (*Optional*, mapping): Custom sdkconfig
   `compiler options <https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/kconfig.html#compiler-options>`__
   to set in the ESP-IDF project.
+- **log_level** (*Optional*, string): Log level of the framework, one of ``ERROR`` (default), ``NONE``, ``WARN``, ``INFO``,
+  ``DEBUG`` or ``VERBOSE``.
 - **advanced** (*Optional*, mapping): See :ref:`esp32-advanced_configuration` below.
 - **components** (*Optional*, list of components): See :ref:`esp32-idf_components` below.
 


### PR DESCRIPTION
## Description:

Add a way to configure the idf log level and set the default to ERROR. The current default is INFO so this is technically a breaking change:
```
esp32:
  board: esp32dev
  framework:
    type: esp-idf
    log_level: ERROR
```
    
If ERROR (the default for Arduino) is configured instead of the default INFO it saves 23k of flash when building a BT proxy:
```
RAM:   [==        ]  17.4% (used 57160 bytes from 327680 bytes)
Flash: [======    ]  64.8% (used 1189530 bytes from 1835008 bytes)
```
vs
```
RAM:   [==        ]  17.4% (used 57128 bytes from 327680 bytes)
Flash: [======    ]  63.5% (used 1165602 bytes from 1835008 bytes)
```

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#10134

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
