### PR TITLE
[remote_base] add decoder for Dyson cool AM07 tower fan IR codes

### DIFF
--- a/all_automations.json
+++ b/all_automations.json
@@ -287,6 +287,7 @@
     "remote_transmitter.transmit_dish",
     "remote_transmitter.transmit_dooya",
     "remote_transmitter.transmit_drayton",
+    "remote_transmitter.transmit_dyson",
     "remote_transmitter.transmit_haier",
     "remote_transmitter.transmit_jvc",
     "remote_transmitter.transmit_keeloq",

--- a/components/remote_receiver.rst
+++ b/components/remote_receiver.rst
@@ -44,6 +44,7 @@ Configuration variables:
   - **dish**: Decode and dump Dish infrared codes.
   - **dooya**: Decode and dump Dooya RF codes.
   - **drayton**: Decode and dump Drayton Digistat RF codes.
+  - **dyson**: Decode and dump Dyson Cool AM7 tower fan codes.
   - **jvc**: Decode and dump JVC infrared codes.
   - **gobox**: Decode and dump Go-Box infrared codes.
   - **keeloq**: Decode and dump KeeLoq RF codes.
@@ -153,6 +154,9 @@ Automations:
   is passed to the automation for use in lambdas.
 - **on_drayton** (*Optional*, :ref:`Automation <automation>`): An automation to perform when a
   Drayton Digistat RF code has been decoded. A variable ``x`` of type :apistruct:`remote_base::DraytonData`
+  is passed to the automation for use in lambdas.
+- **on_dyson** (*Optional*, :ref:`Automation <automation>`): An automation to perform when a
+  Dyson cool AM07 code has been decoded. A variable ``x`` of type :apistruct:`remote_base::DysonData`
   is passed to the automation for use in lambdas.
 - **on_gobox** (*Optional*, :ref:`Automation <automation>`): An automation to perform when a
   Go-Box remote code has been decoded. A variable ``x`` of type :apistruct:`remote_base::GoboxData`
@@ -366,6 +370,11 @@ Remote code selection (exactly one of these has to be included):
   - **address** (**Required**, int): The 16-bit ID code to trigger on, see dumper output for more info.
   - **channel** (**Required**, int): The 7-bit switch/channel to listen for.
   - **command** (**Required**, int): The 5-bit command to listen for.
+
+- **dyson**: Trigger on a decoded dyson cool AM07 infrared remote code with the given data.
+
+  - **code** (**Required**, int): The 16-bit code to trigger on, e.g. 0x1200=power, 0x1215=fan++,0x122a=swing..., see dumper output for more info.
+  - **index** (**Required**, int): The 8-bit rolling index [0..3], to be increased with every transmit, see dumper output for more info.
 
 - **gobox**: Trigger on a decoded Go-Box remote code with the given data.
 

--- a/components/remote_transmitter.rst
+++ b/components/remote_transmitter.rst
@@ -193,6 +193,7 @@ companies.
 .. _remote_transmitter-transmit_beo4:
 
 ``remote_transmitter.transmit_beo4`` **Action**
+***********************************************
 
 This :ref:`action <config-action>` sends a B&O Beo4 infrared protocol code to a remote transmitter.
 
@@ -377,9 +378,30 @@ Configuration variables:
 - **command** (**Required**, int): The command to send, between 0 and 63 inclusive.
 - All other options from :ref:`remote_transmitter-transmit_action`.
 
+.. _remote_transmitter-transmit_dyson:
+
+``remote_transmitter.transmit_dyson`` **Action**
+************************************************
+
+This :ref:`action <config-action>` sends a Dyson cool AM07 infrared protocol code to a remote transmitter.
+
+.. code-block:: yaml
+
+    on_...:
+      - remote_transmitter.transmit_dyson:
+          code: '0x1200'
+          index: '0'
+
+Configuration variables:
+
+- **code** (**Required**, int): The 16-bit code to trigger on, e.g. 0x1200=power, 0x1215=fan++,0x122a=swing..., see dumper output for more info.
+- **index** (**Required**, int): The 8-bit rolling index [0..3], to be increased with every transmit, see dumper output for more info.
+- All other options from :ref:`remote_transmitter-transmit_action`.
+
 .. _remote_transmitter-transmit_gobox:
 
 ``remote_transmitter.transmit_gobox`` **Action**
+************************************************
 
 This :ref:`action <config-action>` sends a command to a Go-Box via the IR transmitter.
 

--- a/components/remote_transmitter.rst
+++ b/components/remote_transmitter.rst
@@ -390,12 +390,15 @@ This :ref:`action <config-action>` sends a Dyson cool AM07 infrared protocol cod
     on_...:
       - remote_transmitter.transmit_dyson:
           code: '0x1200'
-          index: '0'
+          index: !lambda |-
+            uint8_t rolling_idx = id(idx);
+            id(idx) = (id(idx) < 3) ? id(idx) + 1 : 0;
+            return rolling_idx;
 
 Configuration variables:
 
 - **code** (**Required**, int): The 16-bit code to trigger on, e.g. 0x1200=power, 0x1215=fan++,0x122a=swing..., see dumper output for more info.
-- **index** (**Required**, int): The 8-bit rolling index [0..3], to be increased with every transmit, see dumper output for more info.
+- **index** (**Required**, int): The 8-bit rolling index (range=0..3), must change on each transmit, e.g. with global variable `idx` and lambda code
 - All other options from :ref:`remote_transmitter-transmit_action`.
 
 .. _remote_transmitter-transmit_gobox:

--- a/components/remote_transmitter.rst
+++ b/components/remote_transmitter.rst
@@ -391,15 +391,22 @@ This :ref:`action <config-action>` sends a Dyson cool AM07 infrared protocol cod
       - remote_transmitter.transmit_dyson:
           code: '0x1200'
           index: !lambda |-
-            uint8_t rolling_idx = id(idx);
-            id(idx) = (id(idx) < 3) ? id(idx) + 1 : 0;
-            return rolling_idx;
+            uint8_t idx = id(idx);
+            id(idx) = (id(idx) + 1) & 3;
+            return idx;
 
 Configuration variables:
 
 - **code** (**Required**, int): The 16-bit code to trigger on, e.g. 0x1200=power, 0x1215=fan++,0x122a=swing..., see dumper output for more info.
-- **index** (**Required**, int): The 8-bit rolling index (range=0..3), must change on each transmit, e.g. with global variable `idx` and lambda code
+- **index** (**Required**, int): The 8-bit rolling index (range=0..3)
 - All other options from :ref:`remote_transmitter-transmit_action`.
+
+.. note::
+
+    The **dyson** devices use rolling codes, i.e. each remote button generates 4 different codes in a pseudo random manner.
+    On every transmit the **index** variable must loop to let the **..transmit_dyson** function generate a code that differ
+    from the previous one.
+
 
 .. _remote_transmitter-transmit_gobox:
 


### PR DESCRIPTION
## Description:
IR decoder for Dyson Cool AM07 tower fan. The Dyson code has a 2-bit rolling index [range 0..3] that is stored in bit[0..1], which must be increased with each transmission.

**Related issue (if applicable):** fixes -

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#10163

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
