### PR TITLE
[substitutions] Add some safe built-in functions to jinja parsing

### DIFF
--- a/components/substitutions.rst
+++ b/components/substitutions.rst
@@ -147,9 +147,9 @@ Built-in functions
 
 In addition to the Jinja expressions, ESPHome supports a number of built-in functions that can be used in substitutions.
 
-- ``ord`` Returns the Unicode code point for a given character. eg: ``ord("A") == 65``.
-- ``chr`` Returns the character for a given Unicode code point. eg: ``chr(65) == "A"``.
-- ``len`` Returns the length of the string. eg: ``len("Hello") == 5``.
+- ``ord`` Returns the Unicode code point for a given character. Example: ``ord("A") == 65``.
+- ``chr`` Returns the character for a given Unicode code point. Example: ``chr(65) == "A"``.
+- ``len`` Returns the length of the string. Example: ``len("Hello") == 5``.
 
 .. _substitute-include-variables:
 

--- a/components/substitutions.rst
+++ b/components/substitutions.rst
@@ -87,7 +87,7 @@ Lists can be indexed: ``${ unused_pins[2] }``
       scale: 1.5
       sensor_pin:
         number: 3
-        inverted: true      
+        inverted: true
       debug_label:
         width: 200
         height: 20
@@ -114,7 +114,7 @@ Lists can be indexed: ``${ unused_pins[2] }``
         name: Binary sensor on pin ${sensor_pin.number}
         pin: ${sensor_pin}
 
-Note that in other projects Jinja uses the ``{{ ... }}`` syntax for expression delimiters. 
+Note that in other projects Jinja uses the ``{{ ... }}`` syntax for expression delimiters.
 In ESPHome we have configured Jinja to use ``${...}`` instead, so it is the same as the
 existing substitution syntax and to avoid conflicts with Home Assistant's own use of Jinja.
 
@@ -141,6 +141,15 @@ library is exposed as a module:
 
 To see what mathematical functions ara available,
 refer to `Python math library <https://docs.python.org/3/library/math.html>`_ documentation.
+
+Built-in functions
+^^^^^^^^^^^^^^^^^^
+
+In addition to the Jinja expressions, ESPHome supports a number of built-in functions that can be used in substitutions.
+
+- ``ord`` Returns the Unicode code point for a given character. eg: ``ord("A") == 65``.
+- ``chr`` Returns the character for a given Unicode code point. eg: ``chr(65) == "A"``.
+- ``len`` Returns the length of the string. eg: ``len("Hello") == 5``.
 
 .. _substitute-include-variables:
 

--- a/components/substitutions.rst
+++ b/components/substitutions.rst
@@ -147,9 +147,9 @@ Built-in functions
 
 In addition to the Jinja expressions, ESPHome supports a number of built-in functions that can be used in substitutions.
 
-- ``ord`` Returns the Unicode code point for a given character. Example: ``ord("A") == 65``.
-- ``chr`` Returns the character for a given Unicode code point. Example: ``chr(65) == "A"``.
-- ``len`` Returns the length of the string. Example: ``len("Hello") == 5``.
+- ``ord`` Returns the Unicode code point for a given character. Example: ``ord("A") == 65``
+- ``chr`` Returns the character for a given Unicode code point. Example: ``chr(65) == "A"``
+- ``len`` Returns the length of the string. Example: ``len("Hello") == 5``
 
 .. _substitute-include-variables:
 


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#10178

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
