### PR TITLE
raise log level for one component

### DIFF
--- a/components/logger.rst
+++ b/components/logger.rst
@@ -233,18 +233,11 @@ Possible log levels are (sorted by severity):
 Manual Tag-Specific Log Levels
 ------------------------------
 
-If some component is spamming the logs and you want to manually set the
-log level for it, first identify the tag of the log messages in question
-and then disable them in your configuration.
+If some component is spamming the logs and you want to adjust its log
+level, first identify the tag of the log messages (text before the first
+colon) and set its level in your configuration.
 
-Suppose we want to have verbose log messages globally, but the MQTT
-client spams too much. In the following example, we'd first see that the
-tag of the MQTT client is ``mqtt.client`` (before the first colon) and
-the tag for MQTT components is ``mqtt.component``.
-
-.. figure:: images/logger-manual_log_level.png
-
-Next, we can manually set the log levels in the configuration like this:
+Example: verbose logs globally, but reduce MQTT noise:
 
 .. code-block:: yaml
 
@@ -254,11 +247,22 @@ Next, we can manually set the log levels in the configuration like this:
         mqtt.component: DEBUG
         mqtt.client: ERROR
 
-Please note that the global log level determines what log messages are
-saved in the binary. So for example an ``INFO`` global log message will
-purge all ``DEBUG`` log statements from the binary in order to conserve
-space. This however means that you cannot set tag-specific log levels
-that have a lower severity than the global log level.
+The `level` option controls which log statements are included in the
+firmware. Normally, you cannot set a tag to a more detailed level than
+the global one, because logs below that level are not compiled in.  
+However, you can override this by using `initial_level`:
+
+.. code-block:: yaml
+
+    logger:
+      level: VERBOSE
+      initial_level: ERROR
+      logs:
+        wifi: VERBOSE
+
+Here, `VERBOSE` logs are compiled in, but only the `wifi` tag starts
+with verbose output while all others start at `ERROR`.
+
 
 .. _logger-log_action:
 

--- a/components/logger.rst
+++ b/components/logger.rst
@@ -249,7 +249,7 @@ Example: verbose logs globally, but reduce MQTT noise:
 The `level` option controls which log statements are included in the
 firmware. You cannot set a tag to a more detailed level than
 the global one, because logs higher that level are not compiled in.  
-However, you can silent them using `initial_level`, and raise them for specifics logs tags:
+However, you can suppress them using `initial_level`, and enable them for specific tags:
 
 .. code-block:: yaml
 

--- a/components/logger.rst
+++ b/components/logger.rst
@@ -248,7 +248,7 @@ Example: verbose logs globally, but reduce MQTT noise:
 
 The `level` option controls which log statements are included in the
 firmware. You cannot set a tag to a more detailed level than
-the global one, because logs higher that level are not compiled in.  
+the global one, because log statements with lower severity than that level are not compiled in.  
 However, you can suppress them using `initial_level`, and enable them for specific tags:
 
 .. code-block:: yaml

--- a/components/logger.rst
+++ b/components/logger.rst
@@ -234,8 +234,7 @@ Manual Tag-Specific Log Levels
 ------------------------------
 
 If some component is spamming the logs and you want to adjust its log
-level, first identify the tag of the log messages (text before the first
-colon) and set its level in your configuration.
+level, you can set its level in your configuration, by identifiying its tag.
 
 Example: verbose logs globally, but reduce MQTT noise:
 
@@ -248,9 +247,9 @@ Example: verbose logs globally, but reduce MQTT noise:
         mqtt.client: ERROR
 
 The `level` option controls which log statements are included in the
-firmware. Normally, you cannot set a tag to a more detailed level than
-the global one, because logs below that level are not compiled in.  
-However, you can override this by using `initial_level`:
+firmware. You cannot set a tag to a more detailed level than
+the global one, because logs higher that level are not compiled in.  
+However, you can silent them using `initial_level`, and raise them for specifics logs tags:
 
 .. code-block:: yaml
 
@@ -260,8 +259,8 @@ However, you can override this by using `initial_level`:
       logs:
         wifi: VERBOSE
 
-Here, `VERBOSE` logs are compiled in, but only the `wifi` tag starts
-with verbose output while all others start at `ERROR`.
+Here, `VERBOSE` logs are compiled, but not shown (because of `initial_level: ERROR`)
+However, the `wifi` tag has `VERBOSE` level enabled, and shown.
 
 
 .. _logger-log_action:


### PR DESCRIPTION
## Description:

Add logger documentation to raise the log level of specific component by doing:
```yaml
    logger:
      level: VERBOSE
      initial_level: ERROR
      logs:
        wifi: VERBOSE
```

Before this PR, only lowering the verbosity of a component was documented. Using `initial_level` and `level` allow to increase the verbosity of specifics tags.



**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
