### PR TITLE
[ld2450] Update docs for removal of ``throttle``

### DIFF
--- a/components/sensor/ld2450.rst
+++ b/components/sensor/ld2450.rst
@@ -47,7 +47,6 @@ properly support the default 256000 baud rate of the LD2450 module.
     # ld2450 configuration
     ld2450:
       id: ld2450_radar
-      throttle: 1000ms
 
 Configuration variables:
 ************************
@@ -55,8 +54,6 @@ Configuration variables:
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID for this :doc:`ld2450` component.
 - **uart_id** (*Optional*, :ref:`config-id`): Manually specify the ID of the :ref:`UART Component <uart>` to use.
   Required if you have multiple UARTs configured.
-- **throttle** (*Optional*, int): Time in milliseconds to control the rate of data updates. Defaults to ``1000ms``.
-
 
 .. _ld2450-binary-sensors:
 
@@ -87,6 +84,20 @@ Configuration variables:
   All options from :ref:`Binary Sensor <config-binary_sensor>`.
 - **has_still_target** (*Optional*): True if a still target is detected.
   All options from :ref:`Binary Sensor <config-binary_sensor>`.
+
+.. note::
+
+    By default, each of the :doc:`Binary Sensor </components/binary_sensor/index>` components above includes the
+    following :ref:`filter<binary_sensor-filters>` by default to prevent flooding Home Assistant with state updates:
+
+    .. code-block:: yaml
+
+      - settle: 1000ms
+    
+    If you have defined other filters, this default will be overridden; you may of course add it back to your custom
+    filter(s) as above if you wish.
+    
+    To remove the default filter for a any given binary sensor instance, add ``filters: []`` to its configuration.
 
 .. _ld2450-sensors:
 
@@ -205,6 +216,23 @@ Configuration variables:
       :ref:`Sensor <config-sensor>`.
     - **moving_target_count** (*Optional*, int): Count of moving targets in the zone. All options from
       :ref:`Sensor <config-sensor>`.
+
+.. note::
+
+    By default, each of the :doc:`Sensor </components/sensor/index>` components above includes the following
+    :ref:`filters<sensor-filters>` by default to prevent flooding Home Assistant with state updates:
+
+    .. code-block:: yaml
+
+        - timeout:
+            - timeout: 1s
+            - value: last
+        - throttle_with_priority: 1000ms
+    
+    If you have defined other filters, this default will be overridden; you may of course add it back to your custom
+    filter(s) as above if you wish.
+    
+    To remove the default filters for a any given sensor instance, add ``filters: []`` to its configuration.
 
 .. _ld2450-switch:
 

--- a/components/sensor/ld2450.rst
+++ b/components/sensor/ld2450.rst
@@ -225,8 +225,8 @@ Configuration variables:
     .. code-block:: yaml
 
         - timeout:
-              timeout: 1s
-              value: last
+            timeout: 1s
+            value: last
         - throttle_with_priority: 1000ms
     
     If you have defined other filters, this default will be overridden; you may of course add it back to your custom

--- a/components/sensor/ld2450.rst
+++ b/components/sensor/ld2450.rst
@@ -225,8 +225,8 @@ Configuration variables:
     .. code-block:: yaml
 
         - timeout:
-            - timeout: 1s
-            - value: last
+              timeout: 1s
+              value: last
         - throttle_with_priority: 1000ms
     
     If you have defined other filters, this default will be overridden; you may of course add it back to your custom

--- a/components/sensor/ld2450.rst
+++ b/components/sensor/ld2450.rst
@@ -92,7 +92,7 @@ Configuration variables:
 
     .. code-block:: yaml
 
-      - settle: 1000ms
+        - settle: 1000ms
     
     If you have defined other filters, this default will be overridden; you may of course add it back to your custom
     filter(s) as above if you wish.


### PR DESCRIPTION
## Description:

SSIA

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#10196

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
