### PR TITLE
[ld2410, ld2412] Formatting tweaks, fix typo

### DIFF
--- a/components/sensor/ld2410.rst
+++ b/components/sensor/ld2410.rst
@@ -79,7 +79,9 @@ Configuration variables:
     By default, each of the :doc:`Binary Sensor </components/binary_sensor/index>` components above includes the
     following :ref:`filter<binary_sensor-filters>` by default to prevent flooding Home Assistant with state updates:
 
-    - ``settle: 1000ms``
+    .. code-block:: yaml
+
+        - settle: 1000ms
     
     If you have defined other filters, this default will be overridden; you may of course add it back to your custom
     filter(s) as above if you wish.
@@ -190,7 +192,9 @@ Configuration variables:
     By default, each of the :doc:`Sensor </components/sensor/index>` components above includes the following
     :ref:`filter<sensor-filters>` by default to prevent flooding Home Assistant with state updates:
 
-    - ``throttle_with_priority: 1000ms``
+    .. code-block:: yaml
+
+        - throttle_with_priority: 1000ms
     
     If you have defined other filters, this default will be overridden; you may of course add it back to your custom
     filter(s) as above if you wish.

--- a/components/sensor/ld2412.rst
+++ b/components/sensor/ld2412.rst
@@ -25,7 +25,6 @@ Use of a hardware UART is highly recommended as it best supports the default 115
 
     # Example configuration entry
     ld2412:
-      id: ld2412
 
 Configuration variables:
 ************************
@@ -64,8 +63,8 @@ Configuration variables:
   All options from :ref:`Binary Sensor <config-binary_sensor>`.
 - **has_still_target** (*Optional*): True if a still target is detected.
   All options from :ref:`Binary Sensor <config-binary_sensor>`.
-- **dynamic_background_correction_status** (*Optional*): True while a the dynamic background correction is in progress.
-  All options from :ref:`Binary Sensor <config-binary_sensor>`.
+- **dynamic_background_correction_status** (*Optional*): True while the sensor is performing dynamic background
+  correction. All options from :ref:`Binary Sensor <config-binary_sensor>`.
 - **ld2412_id** (*Optional*, :ref:`config-id`): Manually specify the ID for the component. Required when using multiple
   components.
 


### PR DESCRIPTION
## Description:

SSIA

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
