### PR TITLE
Add support for LCMEN2R13EFC1 2.13in display in waveshare_epaper docu…

### DIFF
--- a/components/display/waveshare_epaper.rst
+++ b/components/display/waveshare_epaper.rst
@@ -114,6 +114,7 @@ Configuration variables:
   - ``2.13in-ttgo-dke`` - T5_V2.3 with DKE group display (DEPG0213BN) tested
   - ``2.13inv2`` - 2.13in V2 display (Pico e-Paper 2.13v2 and Cloud Module)
   - ``2.13inv3`` - 2.13in V3 display (Pico e-Paper 2.13v3)
+  - ``lcmen2r13efc1`` - LCMEN2R13EFC1 2.13in display, used in the Vision Master E213
   - ``2.70in`` - currently not working with the HAT Rev 2.1 version
   - ``2.70inv2``
   - ``2.70in-b`` - Black/White/Red

--- a/components/light/esp32_rmt_led_strip.rst
+++ b/components/light/esp32_rmt_led_strip.rst
@@ -17,14 +17,6 @@ This is a component using the ESP32 RMT peripheral to drive most addressable LED
         chipset: ws2812
         name: "My Light"
 
-Only for Arduino platforms (and ESP-IDF <5 which was used until ESPHome 2025), the RMT channel must be defined.
-
-.. code-block:: yaml
-
-    light:
-      - platform: esp32_rmt_led_strip
-        ...
-
 Configuration variables
 -----------------------
 


### PR DESCRIPTION
This PR adds the LCMEN2R13EFC1 2.13in display to the displays supported by the waveshare_epaper component.

## Description:

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#10210

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
