### PR TITLE
add documentation for the advanced configuration option 'enable_lwip_tcp_sack'

### DIFF
--- a/components/esp32.rst
+++ b/components/esp32.rst
@@ -161,6 +161,8 @@ LWIP (Lightweight IP) behavior. Some options improve performance while others sa
   improves socket operation performance by 20-200% but may reduce multi-threaded scalability. Defaults to ``true``.
 - **enable_lwip_check_thread_safety** (*Optional*, boolean): Enable LWIP thread safety checks to detect incorrect usage of
   the TCP/IP stack from multiple threads. This helps catch thread safety issues when core locking is enabled. Defaults to ``true``.
+- **enable_lwip_tcp_sack** (*Optional*, boolean): Enable TCP selective acknowledgments
+  to improve performance on lossy or high latency networks. Defaults to ``true``.
 
 Some options can be disabled to save flash memory without affecting typical ESPHome functionality. The performance
 options (defaulting to ``true``) improve socket operation performance but can be disabled if you need better


### PR DESCRIPTION

## Description:

add documentation for the advanced configuration option 'enable_lwip_tcp_sack'

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#10211

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
