### PR TITLE
Fix typos, remove duplicate config var

### DIFF
--- a/components/sensor/ld2410.rst
+++ b/components/sensor/ld2410.rst
@@ -86,7 +86,7 @@ Configuration variables:
     If you have defined other filters, this default will be overridden; you may of course add it back to your custom
     filter(s) as above if you wish.
     
-    To remove the default filter for a any given binary sensor instance, add ``filters: []`` to its configuration.
+    To remove the default filter for any given binary sensor instance, add ``filters: []`` to its configuration.
 
 Sensor
 ------
@@ -199,7 +199,7 @@ Configuration variables:
     If you have defined other filters, this default will be overridden; you may of course add it back to your custom
     filter(s) as above if you wish.
     
-    To remove the default filter for a any given sensor instance, add ``filters: []`` to its configuration.
+    To remove the default filter for any given sensor instance, add ``filters: []`` to its configuration.
 
 Switch
 ------

--- a/components/sensor/ld2412.rst
+++ b/components/sensor/ld2412.rst
@@ -59,8 +59,6 @@ Configuration variables:
   All options from :ref:`Binary Sensor <config-binary_sensor>`.
 - **has_moving_target** (*Optional*): True if a moving target is detected.
   All options from :ref:`Binary Sensor <config-binary_sensor>`.
-- **has_moving_target** (*Optional*): True if a moving target is detected.
-  All options from :ref:`Binary Sensor <config-binary_sensor>`.
 - **has_still_target** (*Optional*): True if a still target is detected.
   All options from :ref:`Binary Sensor <config-binary_sensor>`.
 - **dynamic_background_correction_status** (*Optional*): True while the sensor is performing dynamic background
@@ -80,7 +78,7 @@ Configuration variables:
     If you have defined other filters, this default will be overridden; you may of course add it back to your custom
     filter(s) as above if you wish.
 
-    To remove the default filter for a any given binary sensor instance, add ``filters: []`` to its configuration.
+    To remove the default filter for any given binary sensor instance, add ``filters: []`` to its configuration.
 
 Sensor
 ------
@@ -216,7 +214,7 @@ Configuration variables:
     If you have defined other filters, this default will be overridden; you may of course add it back to your custom
     filter(s) as above if you wish.
 
-    To remove the default filter for a any given sensor instance, add ``filters: []`` to its configuration.
+    To remove the default filter for any given sensor instance, add ``filters: []`` to its configuration.
 
 Switch
 ------

--- a/components/sensor/ld2450.rst
+++ b/components/sensor/ld2450.rst
@@ -97,7 +97,7 @@ Configuration variables:
     If you have defined other filters, this default will be overridden; you may of course add it back to your custom
     filter(s) as above if you wish.
     
-    To remove the default filter for a any given binary sensor instance, add ``filters: []`` to its configuration.
+    To remove the default filter for any given binary sensor instance, add ``filters: []`` to its configuration.
 
 .. _ld2450-sensors:
 
@@ -232,7 +232,7 @@ Configuration variables:
     If you have defined other filters, this default will be overridden; you may of course add it back to your custom
     filter(s) as above if you wish.
     
-    To remove the default filters for a any given sensor instance, add ``filters: []`` to its configuration.
+    To remove the default filters for any given sensor instance, add ``filters: []`` to its configuration.
 
 .. _ld2450-switch:
 


### PR DESCRIPTION
## Description:

SSIA...I copy/paste too much 🙈

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
