### PR TITLE
[uart] Add clock source selection for ESP32 Arduino framework

### DIFF
--- a/components/uart.rst
+++ b/components/uart.rst
@@ -66,6 +66,121 @@ Configuration variables:
 - **stop_bits** (*Optional*, int): The number of stop bits to send. Options: 1, 2. Defaults to 1.
 - **id** (*Optional*, :ref:`config-id`): Manually specify the ID for this UART hub if you need multiple UART hubs.
 - **debug** (*Optional*, mapping): Options for debugging communication on the UART hub, see :ref:`uart-debugging`.
+- **clock_source** (*Optional*, enum): Clock source for UART baud rate generation. ESP32 Arduino framework only. See :ref:`uart-clock-source`. Defaults to ``DEFAULT``.
+
+.. _uart-clock-source:
+
+Clock Source (ESP32 Arduino Framework Only)
+--------------------------------------------
+
+For ESP32 variants using the Arduino framework, you can specify the UART clock source to improve baud rate precision:
+
+.. code-block:: yaml
+
+    # Example configuration entry
+    uart:
+      baud_rate: 921600
+      tx_pin: GPIO17
+      rx_pin: GPIO16
+      clock_source: APB  # Use APB clock for higher precision
+
+- **clock_source** (*Optional*, enum): The clock source for UART baud rate generation. Only available on ESP32 with Arduino framework. Options vary by chip variant:
+
+.. list-table::
+    :header-rows: 1
+
+    * - Variant
+      - DEFAULT
+      - APB
+      - REF_TICK
+      - XTAL
+      - RTC
+      - PLL_F40M
+      - PLL_F48M
+      - PLL_F80M
+    * - ESP32
+      - ✅
+      - ✅
+      - ✅
+      - ❌
+      - ❌
+      - ❌
+      - ❌
+      - ❌
+    * - ESP32-S2
+      - ✅
+      - ✅
+      - ✅
+      - ❌
+      - ❌
+      - ❌
+      - ❌
+      - ❌
+    * - ESP32-S3
+      - ✅
+      - ✅
+      - ❌
+      - ✅
+      - ✅
+      - ❌
+      - ❌
+      - ❌
+    * - ESP32-C2
+      - ✅
+      - ❌
+      - ❌
+      - ✅
+      - ✅
+      - ✅
+      - ❌
+      - ❌
+    * - ESP32-C3
+      - ✅
+      - ✅
+      - ❌
+      - ✅
+      - ✅
+      - ❌
+      - ❌
+      - ❌
+    * - ESP32-C5
+      - ✅
+      - ❌
+      - ❌
+      - ✅
+      - ✅
+      - ❌
+      - ❌
+      - ✅
+    * - ESP32-C6
+      - ✅
+      - ❌
+      - ❌
+      - ✅
+      - ✅
+      - ❌
+      - ❌
+      - ✅
+    * - ESP32-H2
+      - ✅
+      - ❌
+      - ❌
+      - ✅
+      - ✅
+      - ❌
+      - ✅
+      - ❌
+    * - ESP32-P4
+      - ✅
+      - ❌
+      - ❌
+      - ✅
+      - ✅
+      - ❌
+      - ❌
+      - ✅
+
+Defaults to ``DEFAULT``. Use ``APB`` or ``PLL_F80M`` for high baud rates (≥115200) when available.
 
 .. _uart-hardware_uarts:
 


### PR DESCRIPTION
## Description:

Adds support for configuring UART clock source on ESP32 variants when using the Arduino framework, addressing baud rate precision issues at higher speeds.

**Problem**: ESP32 Arduino framework defaults vary by chip and can cause significant baud rate deviations, particularly at speeds ≥115200 baud, breaking communication with connected devices.

**Solution**: Implement a `clock_source` configuration option supporting all ESP32 variants:
- ESP32/S2: `APB`, `REF_TICK`
- ESP32-S3: `APB`, `XTAL`, `RTC`
- ESP32-C2: `XTAL`, `RTC`, `PLL_F40M`
- ESP32-C3: `APB`, `XTAL`, `RTC`
- ESP32-C5/C6/P4: `XTAL`, `RTC`, `PLL_F80M`
- ESP32-H2: `XTAL`, `RTC`, `PLL_F48M`
- All variants: `DEFAULT` (framework default)

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#10238

## Checklist:

  - [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
