### PR TITLE
Use details/summary for collapsible content

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,10 +149,10 @@ Creates a button with an image that links to a URL.
 Creates a collapsible section with a title that can be clicked to show/hide content.
 
 ``` text
-{{< collapse "title" true >}}
+{{< collapse true >}}
 This content will be hidden by default and can be expanded by clicking the header.
 You can include any Markdown content here, including lists, code blocks, etc.
-the second parameter, if true, will have the content initially opened.
+the parameter, if present and set to true, will have the content initially opened. Note that False is a truthy string, not a boolean
 {{< /collapse >}}
 ```
 

--- a/content/changelog/2025.4.0.md
+++ b/content/changelog/2025.4.0.md
@@ -67,7 +67,7 @@ get the project picking up some steam again.
 
 ### All changes
 
-{{< collapse "Show" True >}}
+{{< collapse true >}}
 
 - [esp32] Allow pioarduino versions 5.3.2 and 5.4.0 {{< pr number="8440" repo="esphome" >}} by {{< ghuser name="swoboda1337" >}}
 - [cli] Add `--reset` and `--upload_speed` options {{< pr number="8380" repo="esphome" >}} by {{< ghuser name="clydebarrow" >}}
@@ -113,7 +113,7 @@ get the project picking up some steam again.
 
 ### Dependency Changes
 
-{{< collapse "Show" False >}}
+{{< collapse  >}}
 
 - Bump setuptools from 69.2.0 to 76.0.0 {{< pr number="8405" repo="esphome" >}} by {{< ghuser name="dependabot[bot]" >}}
 - Bump puremagic from 1.27 to 1.28 {{< pr number="8406" repo="esphome" >}} by {{< ghuser name="dependabot[bot]" >}}

--- a/content/changelog/2025.5.0.md
+++ b/content/changelog/2025.5.0.md
@@ -129,7 +129,7 @@ messages for each phase & frequency. An apparent power sensor was also added.
 
 ### Beta Changes
 
-{{< collapse "Show" False >}}
+{{< collapse  >}}
 
 - [media_player] Deprecate `MEDIA_PLAYER_SCHEMA` {{< pr number="8784" repo="esphome" >}} by {{< ghuser name="jesserockz" >}}
 - [schema] Get component name if available for deprecation warning {{< pr number="8785" repo="esphome" >}} by {{< ghuser name="jesserockz" >}}
@@ -171,7 +171,7 @@ messages for each phase & frequency. An apparent power sensor was also added.
 
 ### All changes
 
-{{< collapse "Show" True >}}
+{{< collapse true >}}
 
 - [esp32] Allow pioarduino version 5.3.3 and 5.5.0 {{< pr number="8526" repo="esphome" >}} by {{< ghuser name="swoboda1337" >}}
 - Update setup to make .temp directory {{< pr number="8558" repo="esphome" >}} by {{< ghuser name="calumapplepie" >}}
@@ -376,7 +376,7 @@ messages for each phase & frequency. An apparent power sensor was also added.
 
 ### Dependency Changes
 
-{{< collapse "Show" False >}}
+{{< collapse  >}}
 
 - Bump ruff from 0.11.2 to 0.11.4 {{< pr number="8538" repo="esphome" >}} by {{< ghuser name="dependabot[bot]" >}}
 - Bump pytest-cov from 6.0.0 to 6.1.1 {{< pr number="8537" repo="esphome" >}} by {{< ghuser name="dependabot[bot]" >}}
@@ -408,7 +408,7 @@ messages for each phase & frequency. An apparent power sensor was also added.
 
 ## Past Changelogs
 
-{{< collapse "Show" False >}}
+{{< collapse  >}}
 
 - {{< docref "2025.4.0/" >}}
 - {{< docref "2025.3.0/" >}}

--- a/content/changelog/2025.6.0.md
+++ b/content/changelog/2025.6.0.md
@@ -161,7 +161,7 @@ It does not apply to the older, now-outdated {{< docref "/components/sensor/bme6
 
 ## Release 2025.6.1 - June 23
 
-{{< collapse "Show" True >}}
+{{< collapse true >}}
 
 - Eliminate memory fragmentation with BLE event pool {{< pr number="9101" repo="esphome" >}} by {{< ghuser name="bdraco" >}}
 - [nextion] Fix command spacing double timing and response blocking issues {{< pr number="9134" repo="esphome" >}} by {{< ghuser name="edwardtfn" >}}
@@ -174,7 +174,7 @@ It does not apply to the older, now-outdated {{< docref "/components/sensor/bme6
 
 ## Release 2025.6.2 - June 27
 
-{{< collapse "Show" True >}}
+{{< collapse true >}}
 
 - [lvgl] Fix dangling pointer issue with qrcode {{< pr number="9190" repo="esphome" >}} by {{< ghuser name="clydebarrow" >}}
 - [audio] Bugfix: improve timeout handling {{< pr number="9221" repo="esphome" >}} by {{< ghuser name="kahrendt" >}}
@@ -188,7 +188,7 @@ It does not apply to the older, now-outdated {{< docref "/components/sensor/bme6
 
 ## Release 2025.6.3 - July 3
 
-{{< collapse "Show" True >}}
+{{< collapse true >}}
 
 - [uart] fix: missing uart_config_t struct initialisation {{< pr number="9235" repo="esphome" >}} by {{< ghuser name="Rezoran" >}}
 - Fix api log client crashing when api encryption is dynamic {{< pr number="9245" repo="esphome" >}} by {{< ghuser name="jesserockz" >}}
@@ -219,7 +219,7 @@ It does not apply to the older, now-outdated {{< docref "/components/sensor/bme6
 
 ### Beta Changes
 
-{{< collapse "Show" False >}}
+{{< collapse  >}}
 
 - Fix dashboard logging being escaped before parser {{< pr number="9054" repo="esphome" >}} by {{< ghuser name="bdraco" >}}
 - Always perform select() when loop duration exceeds interval {{< pr number="9058" repo="esphome" >}} by {{< ghuser name="bdraco" >}}
@@ -261,7 +261,7 @@ It does not apply to the older, now-outdated {{< docref "/components/sensor/bme6
 
 ### All changes
 
-{{< collapse "Show" True >}}
+{{< collapse true >}}
 
 - add actions to the MAX7219Component {{< pr number="6462" repo="esphome" >}} by {{< ghuser name="nielsnl68" >}}
 - [api] Update api proto to add legacy value {{< pr number="8802" repo="esphome" >}} by {{< ghuser name="jesserockz" >}}
@@ -430,7 +430,7 @@ It does not apply to the older, now-outdated {{< docref "/components/sensor/bme6
 
 ### Dependency Changes
 
-{{< collapse "Show" False >}}
+{{< collapse  >}}
 
 - Bump aioesphomeapi from 30.2.0 to 31.0.0 {{< pr number="8779" repo="esphome" >}} by {{< ghuser name="dependabot[bot]" >}}
 - Bump cairosvg from 2.7.1 to 2.8.0 {{< pr number="8780" repo="esphome" >}} by {{< ghuser name="dependabot[bot]" >}}
@@ -468,7 +468,7 @@ It does not apply to the older, now-outdated {{< docref "/components/sensor/bme6
 
 ## Past Changelogs
 
-{{< collapse "Show" False >}}
+{{< collapse  >}}
 
 - {{< docref "2025.5.0/" >}}
 - {{< docref "2025.4.0/" >}}

--- a/content/changelog/2025.7.0.md
+++ b/content/changelog/2025.7.0.md
@@ -381,7 +381,7 @@ For detailed migration information, see the [ArduinoJson migration guide](https:
 
 ## Release 2025.7.1 - July 17
 
-{{< collapse "Show" True >}}
+{{< collapse true >}}
 
 - [lvgl]: fix missing await keyword in meter tick_style width processing {{< pr number="9538" repo="esphome" >}} by {{< ghuser name="theshut" >}}
 - Fix compilation error when using string lambdas with homeassistant services {{< pr number="9543" repo="esphome" >}} by {{< ghuser name="bdraco" >}}
@@ -395,7 +395,7 @@ For detailed migration information, see the [ArduinoJson migration guide](https:
 
 ## Release 2025.7.2 - July 19
 
-{{< collapse "Show" True >}}
+{{< collapse true >}}
 
 - Fix template event web_server crash {{< pr number="9618" repo="esphome" >}} by {{< ghuser name="AzonInc" >}}
 - [api] Fix compilation error with char* lambdas in HomeAssistant services {{< pr number="9638" repo="esphome" >}} by {{< ghuser name="bdraco" >}}
@@ -416,7 +416,7 @@ For detailed migration information, see the [ArduinoJson migration guide](https:
 
 ## Release 2025.7.3 - July 23
 
-{{< collapse "Show" True >}}
+{{< collapse true >}}
 
 - [gpio] Auto-disable interrupts for shared GPIO pins in binary sensors {{< pr number="9701" repo="esphome" >}} by {{< ghuser name="bdraco" >}}
 - Fix format string error in ota_web_server.cpp {{< pr number="9711" repo="esphome" >}} by {{< ghuser name="tmpeh" >}}
@@ -433,7 +433,7 @@ For detailed migration information, see the [ArduinoJson migration guide](https:
 
 ## Release 2025.7.4 - July 28
 
-{{< collapse "Show" True >}}
+{{< collapse true >}}
 
 - [remote_receiver] Fix idle validation {{< pr number="9819" repo="esphome" >}} by {{< ghuser name="swoboda1337" >}}
 - [gt911] i2c fixes {{< pr number="9822" repo="esphome" >}} by {{< ghuser name="clydebarrow" >}}
@@ -446,7 +446,7 @@ For detailed migration information, see the [ArduinoJson migration guide](https:
 
 ## Release 2025.7.5 - August 5
 
-{{< collapse "Show" True >}}
+{{< collapse true >}}
 
 - [lvgl] Bugfix for tileview {{< pr number="9938" repo="esphome" >}} by {{< ghuser name="clydebarrow" >}}
 - [api] Fix OTA progress updates not being sent when main loop is blocked {{< pr number="10049" repo="esphome" >}} by {{< ghuser name="bdraco" >}}
@@ -500,7 +500,7 @@ For detailed migration information, see the [ArduinoJson migration guide](https:
 
 ### All changes
 
-{{< collapse "Show" False >}}
+{{< collapse  >}}
 
 - [core/pins] improve pins types {{< pr number="8848" repo="esphome" >}} by {{< ghuser name="ximex" >}}
 - [binary_sensor] Add action to invalidate state and pass to HA {{< pr number="8961" repo="esphome" >}} by {{< ghuser name="clydebarrow" >}} (breaking-change)
@@ -779,7 +779,7 @@ For detailed migration information, see the [ArduinoJson migration guide](https:
 
 ### Dependency Changes
 
-{{< collapse "Show" False >}}
+{{< collapse  >}}
 
 - Bump pytest-cov from 6.1.1 to 6.2.1 {{< pr number="9063" repo="esphome" >}} by {{< ghuser name="dependabot[bot]" >}}
 - Bump pytest-asyncio from 0.26.0 to 1.0.0 {{< pr number="9067" repo="esphome" >}} by {{< ghuser name="dependabot[bot]" >}}
@@ -806,7 +806,7 @@ For detailed migration information, see the [ArduinoJson migration guide](https:
 
 ## Past Changelogs
 
-{{< collapse "Show" False >}}
+{{< collapse  >}}
 
 - {{< docref "2025.6.0/" >}}
 - {{< docref "2025.5.0/" >}}

--- a/content/changelog/2025.8.0.md
+++ b/content/changelog/2025.8.0.md
@@ -211,7 +211,7 @@ or advanced configurations may need updates.
 
 ### All changes
 
-{{< collapse "Show" True >}}
+{{< collapse true >}}
 
 - [web_server] fix `Arudino` typo {{< pr number="9404" repo="esphome" >}} by {{< ghuser name="ximex" >}}
 - Speed up clang-tidy CI by 80%+ with incremental checking {{< pr number="9396" repo="esphome" >}} by {{< ghuser name="bdraco" >}}
@@ -584,7 +584,7 @@ or advanced configurations may need updates.
 
 ### Dependency Changes
 
-{{< collapse "Show" False >}}
+{{< collapse  >}}
 
 - Bump ruff from 0.12.2 to 0.12.3 {{< pr number="9446" repo="esphome" >}} by {{< ghuser name="dependabot[bot]" >}}
 - Bump aioesphomeapi from 34.2.1 to 35.0.1 {{< pr number="9474" repo="esphome" >}} by {{< ghuser name="dependabot[bot]" >}}
@@ -633,7 +633,7 @@ or advanced configurations may need updates.
 
 ## Past Changelogs
 
-{{< collapse "Show" False >}}
+{{< collapse  >}}
 
 - {{< docref "2025.7.0/" >}}
 - {{< docref "2025.6.0/" >}}

--- a/themes/esphome-theme/assets/css/main.css
+++ b/themes/esphome-theme/assets/css/main.css
@@ -912,63 +912,12 @@ main {
   margin-bottom: 3em;
 }
 
-.collapse-container {
-  border: 1px solid #ddd;
-  border-radius: 4px;
-  margin-bottom: 1em;
+summary::marker {
+    font-size: 1.5em;
 }
-
-.collapse-header {
-  padding: 0.75em 1em;
-  cursor: pointer;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-
-.collapse-container h4.shown {
-  margin: 0;
-  display: block;
-}
-
-.collapse-container.active h4.shown {
-  margin: 0;
-  display: none;
-}
-
-.collapse-container.active h4.collapsed {
-  margin: 0;
-  display: block;
-}
-
-.collapse-container h4.collapsed {
-  margin: 0;
-  display: none;
-}
-
-.collapse-content {
-  max-height: 0;
-  height: auto;
-  overflow: hidden;
-  transition: max-height,padding 0.6s ease;
-  padding-left: 1em;
-  padding-top: 0;
-  padding-bottom: 0;
-}
-
-.collapse-container.active .collapse-content {
-  max-height: 1000px;
-  padding-top: 1em;
-  padding-bottom: 1em;
-}
-
-.collapse-container.active .collapse-icon {
-  transform: rotate(45deg);
-}
-
-.collapse-icon {
-  font-size: 1.5em;
-  transition: transform 0.3s;
+summary h4.shown {
+  margin-left: 1em;
+  display: inline;
 }
 
 .admonition {
@@ -1404,6 +1353,32 @@ figcaption {
     left: 0;
     z-index: 1;
   }
+}
+
+details {
+    interpolate-size: allow-keywords;
+}
+details::details-content {
+    block-size: 0;
+    transition: content-visibility, block-size;
+    transition-duration: 0.5s;
+    transition-behavior: allow-discrete;
+    overflow: hidden;
+}
+details[open]::details-content {
+    block-size: auto;
+}
+details {
+    background-color: var(--sidebar-background);
+    padding: 1em;
+}
+
+>@media (prefers-reduced-motion) {
+    /* styles to apply if a user's device settings are set to reduced motion */
+
+    details::details-content {
+        transition-duration: 0.8s; /* slower speed */
+    }
 }
 
 .code-block {

--- a/themes/esphome-theme/assets/css/main.css
+++ b/themes/esphome-theme/assets/css/main.css
@@ -1373,7 +1373,7 @@ details {
     padding: 1em;
 }
 
->@media (prefers-reduced-motion) {
+@media (prefers-reduced-motion) {
     /* styles to apply if a user's device settings are set to reduced motion */
 
     details::details-content {

--- a/themes/esphome-theme/layouts/shortcodes/collapse.html
+++ b/themes/esphome-theme/layouts/shortcodes/collapse.html
@@ -1,30 +1,29 @@
 {{/*
   COLLAPSE SHORTCODE
-  Creates a collapsible section with a title that can be clicked to show/hide content.
+  Creates a collapsible section
   
   Usage: 
-  {{< collapse "Optional Configuration" >}}
+  {{< collapse  >}}
   This content will be hidden by default and can be expanded by clicking the header.
   You can include any Markdown content here, including lists, code blocks, etc.
   {{< /collapse >}}
   
   Parameters:
-  1. title (required) - The title text to display in the header
+  1. open (optional): If set to false, the content will be hidden initially
   
   Content:
   The content between the opening and closing shortcode tags will be hidden by default
   and can be toggled by clicking on the header.
 */}}
-{{ $title := .Get 0 }}
-{{ $is_open := .Get 1 }}
-<div class="collapse-container {{ if $is_open }}active{{ end }}">
-  <div class="collapse-header" onclick="this.parentElement.classList.toggle('active')">
-    <h4 class="shown">{{ $title }}</h4>
-    <h4 class="collapsed">Collapse</h4>
-    <span class="collapse-icon">+</span>
-  </div>
-  <div class="collapse-content">
-    {{ .Inner | markdownify }}
-  </div>
-</div>
+{{ $is_open := .Get 0 }}
+{{ if eq $is_open "False" }}
+    {{ $is_open = false }}
+{{ end }}
+<details {{ if $is_open }}open{{ end }}>
+    <summary>
+    </summary>
+    <div>
+        {{ .Inner | markdownify }}
+    </div>
+</details>
 


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
