### PR TITLE
fix link to TEMT6000

### DIFF
--- a/content/components/_index.md
+++ b/content/components/_index.md
@@ -525,8 +525,8 @@ Sensors are organized into categories; if a given sensor fits into more than one
 "Xiaomi Miscale","components/sensor/xiaomi_miscale","xiaomi_miscale1&2.jpg",""
 {{< /imgtable >}}
 Looking for a sensor that outputs its values as an analog voltage? Have a look at the
-{{< docref "/components/sensor/adc" "ADC Sensor" >}} together with a formula like in the `TEMT6000
-configuration <https://devices.esphome.io/devices/temt6000>`__.
+{{< docref "/components/sensor/adc" "ADC Sensor" >}} together with a formula like in the
+[TEMT6000 configuration](https://devices.esphome.io/devices/temt6000).
 
 ## Binary Sensor Components
 


### PR DESCRIPTION
## Description:

in components index

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.