### PR TITLE
Update _index.md for Binary Sensor

### DIFF
--- a/content/components/binary_sensor/_index.md
+++ b/content/components/binary_sensor/_index.md
@@ -79,7 +79,7 @@ Advanced options:
 
 - **trigger_on_initial_state** (*Optional*, boolean): If true, any applicable triggers will be fired when the binary sensor
   state changes from `unknown` to a valid state. This applies to the first valid state set, and any valid state set after
-  a `binary_sensor.invalidate_state` action has been excuted. The default is `false`.
+  a `binary_sensor.invalidate_state` action has been executed. The default is `false`.
   **publish_initial_state** (*Optional*, boolean): A deprecated equivalent to `trigger_on_initial_state`.
 
 - **entity_category** (*Optional*, string): The category of the entity.
@@ -88,7 +88,7 @@ Advanced options:
   Set to `""` to remove the default entity category.
 
 - If MQTT enabled, all other options from [MQTT Component](#config-mqtt-component).
-- If Webserver enabled and version 3 is selected, All other options from Webserver Component.. See [Webserver Version 3](#config-webserver-version-3-options).
+- If Webserver enabled and version 3 is selected, All other options from Webserver Component. See [Webserver Version 3](#config-webserver-version-3-options).
 
 {{< anchor "binary_sensor-filters" >}}
 
@@ -453,14 +453,7 @@ on_multi_click:
     - logger.log: "Single Short Clicked"
 ```
 
-{{< anchor "binary_sensor-is_on_condition" >}}
-{{< anchor "binary_sensor-is_off_condition" >}}
-
-
-
-
-
-## Referencing Binary Sensor
+## Referencing Binary Sensors
 
 {{< anchor "binary_sensor-invalidate_state-action" >}}
 
@@ -475,6 +468,9 @@ on_...:
 ```
 
 The state may also be invalidated by an API call in a lambda - see the API reference linked below.
+
+{{< anchor "binary_sensor-is_on_condition" >}}
+{{< anchor "binary_sensor-is_off_condition" >}}
 
 ### `binary_sensor.is_on` / `binary_sensor.is_off` Condition
 

--- a/content/components/binary_sensor/_index.md
+++ b/content/components/binary_sensor/_index.md
@@ -90,22 +90,6 @@ Advanced options:
 - If MQTT enabled, all other options from [MQTT Component](#config-mqtt-component).
 - If Webserver enabled and version 3 is selected, All other options from Webserver Component.. See [Webserver Version 3](#config-webserver-version-3-options).
 
-## Actions
-
-{{< anchor "binary_sensor-invalidate_state-action" >}}
-
-### `binary_sensor.invalidate_state` Action
-
-This action will invalidate the current state of the sensor. It is most useful with the Template binary sensor.
-After the state is invalidated, it will be reported to Home Assistant as `unknown`. Example:
-
-```yaml
-on_...:
-  binary_sensor.invalidate_state: my_binary_sensor_id
-```
-
-The state may also be invalidated by an API call in a lambda - see the API reference linked below.
-
 {{< anchor "binary_sensor-filters" >}}
 
 ## Binary Sensor Filters
@@ -471,6 +455,26 @@ on_multi_click:
 
 {{< anchor "binary_sensor-is_on_condition" >}}
 {{< anchor "binary_sensor-is_off_condition" >}}
+
+
+
+
+
+## Referencing Binary Sensor
+
+{{< anchor "binary_sensor-invalidate_state-action" >}}
+
+### `binary_sensor.invalidate_state` Action
+
+This action will invalidate the current state of the sensor. It is most useful with the Template binary sensor.
+After the state is invalidated, it will be reported to Home Assistant as `unknown`. Example:
+
+```yaml
+on_...:
+  binary_sensor.invalidate_state: my_binary_sensor_id
+```
+
+The state may also be invalidated by an API call in a lambda - see the API reference linked below.
 
 ### `binary_sensor.is_on` / `binary_sensor.is_off` Condition
 


### PR DESCRIPTION
## Description:
This is a minor change moving some of the documentation sections which _refer to_ or _use_ a Binary Sensor to a new main heading, to separate them from the sections which _define the configuration_ of a Binary Sensor.  

This provides users with the same information, but should make it easier for less experienced users to see which sections go in the Binary Sensor configuration ... but a few sections are actually used from other sensors' configuations.

- https://github.com/orgs/esphome/discussions/3280 

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
