### PR TITLE
Feedback addressed

### DIFF
--- a/content/components/nrf52.md
+++ b/content/components/nrf52.md
@@ -17,7 +17,7 @@ Support for all aspects of ESPHome on the NRF52 is still in development.
 ```yaml
 # Example configuration entry
 nrf52:
-    board: adafruit_feather_nrf52840
+  board: adafruit_feather_nrf52840
 ```
 
 ## Configuration variables
@@ -41,7 +41,7 @@ Flashing this bootloader requires an SWD connection, for which a programmer is n
 ```yaml
 # Example configuration entry
 nrf52:
-    board: adafruit_feather_nrf52840
+  board: adafruit_feather_nrf52840
 ```
 
 ## Flashing with Adafruit nRF52 Bootloader
@@ -61,7 +61,7 @@ This bootloader supports updates over USB CDC.
 ```yaml
 # Example configuration entry
 nrf52:
-    board: adafruit_itsybitsy_nrf52840
+  board: adafruit_itsybitsy_nrf52840
 ```
 
 ## GPIO Pin Numbering

--- a/themes/esphome-theme/assets/css/main.css
+++ b/themes/esphome-theme/assets/css/main.css
@@ -779,7 +779,7 @@ img.align-right, figure.align-right, .figure.align-right, object.align-right {
 
 .getting-started-heading, .footer-heading {
   font-size: 1.5em;
-  color: white;
+  color: var(--feature-card-text) !important;
 }
 
 .page-container {
@@ -1233,6 +1233,12 @@ figcaption {
     display: none;
   }
 }
+
+@media (max-width: 700px) {
+    .desktop-only {
+        display: none;
+    }
+}
 /* Responsive */
 /* @media (max-width: var(--mobile-width-stop)) {  // sadly does not work */
 @media (max-width: 1000px) {
@@ -1434,7 +1440,7 @@ details {
 .build-info {
   position: absolute;
   text-align: left;
-  bottom: 0.5rem;
+  top: 0.5rem;
   left: 0.5rem;
 }
 

--- a/themes/esphome-theme/layouts/_default/baseof.html
+++ b/themes/esphome-theme/layouts/_default/baseof.html
@@ -199,7 +199,7 @@
                         <line x1="12" y1="16" x2="12" y2="12"></line>
                         <line x1="12" y1="8" x2="12" y2="8"></line>
                     </svg>
-                    <span>Release {{ .Site.Data.version.release }}</span>
+                    <span class="desktop-only">Release</span><span> {{ .Site.Data.version.release }}</span>
                 </button>
             </div>
         </div>


### PR DESCRIPTION
## Description:

Cleanups from feedback in Discord.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
