### PR TITLE
fix white on white text in getting-started-heading

### DIFF
--- a/content/components/nrf52.md
+++ b/content/components/nrf52.md
@@ -17,7 +17,7 @@ Support for all aspects of ESPHome on the NRF52 is still in development.
 ```yaml
 # Example configuration entry
 nrf52:
-    board: adafruit_feather_nrf52840
+  board: adafruit_feather_nrf52840
 ```
 
 ## Configuration variables
@@ -41,7 +41,7 @@ Flashing this bootloader requires an SWD connection, for which a programmer is n
 ```yaml
 # Example configuration entry
 nrf52:
-    board: adafruit_feather_nrf52840
+  board: adafruit_feather_nrf52840
 ```
 
 ## Flashing with Adafruit nRF52 Bootloader
@@ -61,7 +61,7 @@ This bootloader supports updates over USB CDC.
 ```yaml
 # Example configuration entry
 nrf52:
-    board: adafruit_itsybitsy_nrf52840
+  board: adafruit_itsybitsy_nrf52840
 ```
 
 ## GPIO Pin Numbering

--- a/themes/esphome-theme/assets/css/main.css
+++ b/themes/esphome-theme/assets/css/main.css
@@ -104,7 +104,7 @@ a:hover {
   text-decoration: underline;
 }
 
-h1, h2, h3, h4, h5, h6, .footer-heading, .ding {
+h1, h2, h3, h4, h5, h6, .footer-heading, .getting-started-heading {
   font-family: Figtree, system, -apple-system, ".SFNSText-Regular", "San Francisco", "Roboto", "Segoe UI", "Helvetica Neue", "Lucida Grande", sans-serif;
   font-weight: 600;
   margin: 1em 0 0.5em 0;
@@ -778,6 +778,7 @@ img.align-right, figure.align-right, .figure.align-right, object.align-right {
 }
 
 .getting-started-heading {
+  font-size: 1.5em;
   color: var(--feature-card-text);
 }
 

--- a/themes/esphome-theme/assets/css/main.css
+++ b/themes/esphome-theme/assets/css/main.css
@@ -1448,19 +1448,6 @@ details {
   left: 0.5rem;
 }
 
-.print-button {
-  background-color: rgba(255, 255, 255, 0.1);
-  position: absolute;
-  top: 0.5rem;
-  left: 0.5rem;
-  width: 3rem;
-  padding: 0.5rem;
-}
-
-.print-button:hover {
-  background-color: rgba(255, 255, 255, 0.2);
-}
-
 .build-info-button {
   background-color: rgba(255, 255, 255, 0.1);
   color: #ffffff;

--- a/themes/esphome-theme/assets/css/main.css
+++ b/themes/esphome-theme/assets/css/main.css
@@ -104,7 +104,7 @@ a:hover {
   text-decoration: underline;
 }
 
-h1, h2, h3, h4, h5, h6, .footer-heading, .getting-started-heading {
+h1, h2, h3, h4, h5, h6, .footer-heading, .ding {
   font-family: Figtree, system, -apple-system, ".SFNSText-Regular", "San Francisco", "Roboto", "Segoe UI", "Helvetica Neue", "Lucida Grande", sans-serif;
   font-weight: 600;
   margin: 1em 0 0.5em 0;
@@ -778,8 +778,7 @@ img.align-right, figure.align-right, .figure.align-right, object.align-right {
 }
 
 .getting-started-heading {
-  font-size: 1.5em;
-  color: #000;
+  color: var(--feature-card-text);
 }
 
 .footer-heading {

--- a/themes/esphome-theme/assets/css/main.css
+++ b/themes/esphome-theme/assets/css/main.css
@@ -239,7 +239,7 @@ img.align-right, figure.align-right, .figure.align-right, object.align-right {
 }
 
 .sidebar-content.scroll-trap {
-  top: var(--nav-height);
+  top: calc(var(--nav-height) + 1em);
   max-height: calc(100vh - var(--nav-height) - 2em);
   position: sticky;
   overflow-y: auto;
@@ -798,7 +798,10 @@ main {
   max-width: var(--max-page-width);
   width: 100%;
   margin: 0 auto;
-  padding: 2em;
+  padding-bottom: 2em;
+  padding-left: 2em;
+  padding-right: 2em;
+  padding-top: 0;
   margin-top: var(--nav-height); /* Add space for the fixed header */
   flex: 1;
 }
@@ -809,10 +812,9 @@ main {
 }
 
 .sidebar {
-  background: var(--sidebar-background);
   width: 300px;
   flex-shrink: 0;
-  background: var(--sidebar-background);
+  background-color: var(--sidebar-background);
   color: var(--text-color);
   border-color: var(--border-color);
 }

--- a/themes/esphome-theme/assets/css/main.css
+++ b/themes/esphome-theme/assets/css/main.css
@@ -777,7 +777,12 @@ img.align-right, figure.align-right, .figure.align-right, object.align-right {
   }
 }
 
-.getting-started-heading, .footer-heading {
+.getting-started-heading {
+  font-size: 1.5em;
+  color: #fff;
+}
+
+.footer-heading {
   font-size: 1.5em;
   color: white;
 }

--- a/themes/esphome-theme/assets/css/main.css
+++ b/themes/esphome-theme/assets/css/main.css
@@ -779,7 +779,7 @@ img.align-right, figure.align-right, .figure.align-right, object.align-right {
 
 .getting-started-heading {
   font-size: 1.5em;
-  color: #fff;
+  color: #000;
 }
 
 .footer-heading {

--- a/themes/esphome-theme/assets/css/main.css
+++ b/themes/esphome-theme/assets/css/main.css
@@ -779,11 +779,11 @@ img.align-right, figure.align-right, .figure.align-right, object.align-right {
 
 .footer-heading {
   font-size: 1.5em;
-     color: var(--footer-text);
+  color: var(--footer-text);
 }
 .getting-started-heading {
-    font-size: 1.5em;
-    color: var(--getting-started-text);
+  font-size: 1.5em;
+  color: var(--getting-started-text);
 }
 
 .page-container {
@@ -1492,6 +1492,7 @@ details {
 
 .build-info-content {
   background-color: var(--background-color);
+  color: var(--text-color);
   margin: 15% auto;
   padding: 20px;
   border: 1px solid var(--border-color);

--- a/themes/esphome-theme/assets/css/main.css
+++ b/themes/esphome-theme/assets/css/main.css
@@ -26,7 +26,7 @@
   --dropdown-bg: #fff;
   --dropdown-text: #333;
   --footer-bg: #111;
-  --footer-text: #333;
+  --footer-text: #e1e1e1;
   --border-color: #e0e0e0;
   --link-accent: #007070;
   --component-card-bg: #fff;
@@ -777,14 +777,13 @@ img.align-right, figure.align-right, .figure.align-right, object.align-right {
   }
 }
 
-.getting-started-heading {
-  font-size: 1.5em;
-  color: var(--feature-card-text);
-}
-
 .footer-heading {
   font-size: 1.5em;
-  color: white;
+     color: var(--footer-text);
+}
+.getting-started-heading {
+    font-size: 1.5em;
+    color: var(--getting-started-text);
 }
 
 .page-container {
@@ -1238,6 +1237,12 @@ figcaption {
     display: none;
   }
 }
+
+@media (max-width: 700px) {
+    .desktop-only {
+        display: none;
+    }
+}
 /* Responsive */
 /* @media (max-width: var(--mobile-width-stop)) {  // sadly does not work */
 @media (max-width: 1000px) {
@@ -1245,7 +1250,7 @@ figcaption {
     display: none;
   }
   .sidebar-mobile {
-    margin-top: calc(var(--nav-height) + 32px); /* Add space for the fixed header */
+    margin-top: var(--nav-height); /* Add space for the fixed header */
   }
   .sticky-nav {
     padding: 0.5em 1em;
@@ -1439,7 +1444,7 @@ details {
 .build-info {
   position: absolute;
   text-align: left;
-  bottom: 0.5rem;
+  top: 0.5rem;
   left: 0.5rem;
 }
 

--- a/themes/esphome-theme/layouts/_default/baseof.html
+++ b/themes/esphome-theme/layouts/_default/baseof.html
@@ -199,7 +199,7 @@
                         <line x1="12" y1="16" x2="12" y2="12"></line>
                         <line x1="12" y1="8" x2="12" y2="8"></line>
                     </svg>
-                    <span>Release {{ .Site.Data.version.release }}</span>
+                    <span class="desktop-only">Release</span><span> {{ .Site.Data.version.release }}</span>
                 </button>
             </div>
         </div>


### PR DESCRIPTION
## Description:
Context 
https://discord.com/channels/429907082951524364/930955987584684102/1408333730577125376

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
