### PR TITLE
DHT Temperature Humidity Sensor: Adds instructions for sensor halting

### DIFF
--- a/content/components/sensor/dht.md
+++ b/content/components/sensor/dht.md
@@ -59,6 +59,7 @@ sensor:
 ## Sensor halting
 
 A possible solution is to use a GPIO port as power supply and restart the sensor on error.
+
 ```yaml
 switch:
   - platform: gpio
@@ -73,7 +74,7 @@ sensor:
     temperature:
       name: "Temperature"
       id: current_temperature
-      on_value: 
+      on_value:
         then:
           - if:
               condition:
@@ -88,7 +89,6 @@ sensor:
     update_interval: 30s
     model: AM2302
 ```
-
 
 {{< note >}}
 The default `accuracy_decimals` value of the *humidity* levels is `0`, as the DHT11 for which this was

--- a/content/components/sensor/dht.md
+++ b/content/components/sensor/dht.md
@@ -56,6 +56,40 @@ sensor:
 - **update_interval** (*Optional*, [Time](#config-time)): The interval to check the
   sensor. Defaults to `60s`.
 
+## Sensor halting
+
+A possible solution is to use a GPIO port as power supply and restart the sensor on error.
+```yaml
+switch:
+  - platform: gpio
+    pin: GPIO12
+    id: pwrsensor
+    name: "Power for sensor"
+    restore_mode: ALWAYS_ON
+
+sensor:
+  - platform: dht
+    pin: GPIO14
+    temperature:
+      name: "Temperature"
+      id: current_temperature
+      on_value: 
+        then:
+          - if:
+              condition:
+                - lambda: "return isnan(x);"
+              then:
+                - switch.turn_off: pwrsensor
+                - delay: 5s
+                - switch.turn_on: pwrsensor
+    humidity:
+      name: "Humidity"
+      id: current_humidity
+    update_interval: 30s
+    model: AM2302
+```
+
+
 {{< note >}}
 The default `accuracy_decimals` value of the *humidity* levels is `0`, as the DHT11 for which this was
 originally written does not have a higher resolution. All other DHT sensors have a higher resolution, it's worth


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
