### PR TITLE
[mipi_spi] Add doc line for jc3636w518v2

### DIFF
--- a/content/components/display/mipi_spi.md
+++ b/content/components/display/mipi_spi.md
@@ -58,27 +58,28 @@ using an octal SPI bus, so references here to parallel and octal SPI are equival
 ### Boards with integrated displays
 
 | Model                                | Manufacturer | Product Description                                               |
-| ------------------------------------ | ------------ | ----------------------------------------------------------------- |
+|--------------------------------------| ------------ | ----------------------------------------------------------------- |
 | ADAFRUIT-S2-TFT-FEATHER              | Adafruit     | <https://www.adafruit.com/product/6312>                           |
 | ADAFRUIT-FUNHOUSE                    | Adafruit     | <https://www.adafruit.com/product/4985>                           |
-| M5CORE | M5Stack | <https://docs.m5stack.com/en/core/BASIC%20v2.6> |
-| S3BOX | Espressif | <https://www.espressif.com/en/products/devkits/esp32-s3-box> |
-| S3BOXLITE | Espressif | <https://www.espressif.com/en/products/devkits/esp32-s3-box-lite> |
-| WAVESHARE-4-TFT | Waveshare | <https://www.waveshare.com/4inch-tft-touch-shield.htm> |
-| PICO-RESTOUCH-LCD-3.5 | Waveshare | <https://www.waveshare.com/pico-restouch-lcd-3.5.htm> |
+| M5CORE                               | M5Stack | <https://docs.m5stack.com/en/core/BASIC%20v2.6> |
+| S3BOX                                | Espressif | <https://www.espressif.com/en/products/devkits/esp32-s3-box> |
+| S3BOXLITE                            | Espressif | <https://www.espressif.com/en/products/devkits/esp32-s3-box-lite> |
+| WAVESHARE-4-TFT                      | Waveshare | <https://www.waveshare.com/4inch-tft-touch-shield.htm> |
+| PICO-RESTOUCH-LCD-3.5                | Waveshare | <https://www.waveshare.com/pico-restouch-lcd-3.5.htm> |
 | WAVESHARE-ESP32-S3-TOUCH-AMOLED-1.75 | Waveshare | <https://www.waveshare.com/esp32-s3-touch-amoled-1.75.htm> |
-| WT32-SC01-PLUS | Wireless-Tag | <https://www.wireless-tag.com/portfolio/wt32-sc01-plus/> |
-| ESP32-2432S028 | Sunton | <https://www.espressif.com/en/products/devkits/esp32-2432s028> |
-| JC3248W535 | Guition | <https://www.aliexpress.com/item/1005007566332450.html> |
-| JC3636W518 | Guition | <https://www.aliexpress.com/item/1005007890666293.html> |
-| LANBON-L8 | Lanbon | <https://www.lanbon.cn/product/lanbon-l8> |
-| T4-S3-AMOLED | Lilygo | <https://www.lilygo.cc/products/t4-s3> |
-| T-EMBED | Lilygo | <https://www.lilygo.cc/products/t-embed> |
-| T-DISPLAY | Lilygo | <https://www.lilygo.cc/products/t-display> |
-| T-DISPLAY-S3 | Lilygo | <https://www.lilygo.cc/products/t-display-s3> |
-| T-DISPLAY-S3-PRO | Lilygo | <https://www.lilygo.cc/products/t-display-s3-pro> |
-| T-DISPLAY-S3-AMOLED | Lilygo | <https://www.lilygo.cc/products/t-display-s3-amoled> |
-| T-DISPLAY-S3-AMOLED-PLUS | Lilygo | <https://www.lilygo.cc/products/t-display-s3-amoled-plus> |
+| WT32-SC01-PLUS                       | Wireless-Tag | <https://www.wireless-tag.com/portfolio/wt32-sc01-plus/> |
+| ESP32-2432S028                       | Sunton | <https://www.espressif.com/en/products/devkits/esp32-2432s028> |
+| JC3248W535                           | Guition | <https://www.aliexpress.com/item/1005007566332450.html> |
+| JC3636W518                           | Guition | <https://www.aliexpress.com/item/1005007890666293.html> |
+| JC3636W518V2                         | Guition | <https://www.aliexpress.com/item/1005007890666293.html> |
+| LANBON-L8                            | Lanbon | <https://www.lanbon.cn/product/lanbon-l8> |
+| T4-S3-AMOLED                         | Lilygo | <https://www.lilygo.cc/products/t4-s3> |
+| T-EMBED                              | Lilygo | <https://www.lilygo.cc/products/t-embed> |
+| T-DISPLAY                            | Lilygo | <https://www.lilygo.cc/products/t-display> |
+| T-DISPLAY-S3                         | Lilygo | <https://www.lilygo.cc/products/t-display-s3> |
+| T-DISPLAY-S3-PRO                     | Lilygo | <https://www.lilygo.cc/products/t-display-s3-pro> |
+| T-DISPLAY-S3-AMOLED                  | Lilygo | <https://www.lilygo.cc/products/t-display-s3-amoled> |
+| T-DISPLAY-S3-AMOLED-PLUS             | Lilygo | <https://www.lilygo.cc/products/t-display-s3-amoled-plus> |
 
 ## SPI Bus
 


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#10392

## Checklist:

  - [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
