### PR TITLE
2025.8.1

### DIFF
--- a/content/changelog/2025.8.0.md
+++ b/content/changelog/2025.8.0.md
@@ -158,7 +158,8 @@ or advanced configurations may need updates.
 
 ## Release 2025.8.1 - August 25
 
-{{< collapse true >}}
+<details open>
+<summary></summary>
 
 - [api] Add zero-copy StringRef methods for compilation_time and effect_name [esphome#10257](https://github.com/esphome/esphome/pull/10257) by [@bdraco](https://github.com/bdraco)
 - [esp32_ble_client] Add log helper functions to reduce flash usage by 120 bytes [esphome#10243](https://github.com/esphome/esphome/pull/10243) by [@bdraco](https://github.com/bdraco)
@@ -176,7 +177,7 @@ or advanced configurations may need updates.
 - [test] Add integration test for light effect memory corruption fix [esphome#10417](https://github.com/esphome/esphome/pull/10417) by [@bdraco](https://github.com/bdraco)
 - [web_server] Use oi.esphome.io for css and js assets [esphome#10296](https://github.com/esphome/esphome/pull/10296) by [@clydebarrow](https://github.com/clydebarrow)
 
-{{< /collapse >}}
+</details>
 
 ## Full list of changes
 
@@ -233,7 +234,8 @@ or advanced configurations may need updates.
 
 ### All changes
 
-{{< collapse >}}
+<details>
+<summary></summary>
 
 - [web_server] fix `Arudino` typo {{< pr number="9404" repo="esphome" >}} by {{< ghuser name="ximex" >}}
 - Speed up clang-tidy CI by 80%+ with incremental checking {{< pr number="9396" repo="esphome" >}} by {{< ghuser name="bdraco" >}}
@@ -602,11 +604,12 @@ or advanced configurations may need updates.
 - [pipsolar] fix faults_present, fix update interval {{< pr number="10289" repo="esphome" >}} by {{< ghuser name="patagonaa" >}}
 - [bluetooth_proxy] Fix connection slot race by deferring slot release until GATT close {{< pr number="10303" repo="esphome" >}} by {{< ghuser name="bdraco" >}}
 
-{{< /collapse >}}
+</details>
 
 ### Dependency Changes
 
-{{< collapse  >}}
+<details>
+<summary></summary>
 
 - Bump ruff from 0.12.2 to 0.12.3 {{< pr number="9446" repo="esphome" >}} by {{< ghuser name="dependabot[bot]" >}}
 - Bump aioesphomeapi from 34.2.1 to 35.0.1 {{< pr number="9474" repo="esphome" >}} by {{< ghuser name="dependabot[bot]" >}}
@@ -649,13 +652,14 @@ or advanced configurations may need updates.
 - Bump aioesphomeapi from 38.2.1 to 39.0.0 {{< pr number="10222" repo="esphome" >}} by {{< ghuser name="dependabot[bot]" >}}
 - Bump esphome-dashboard from 20250514.0 to 20250814.0 {{< pr number="10227" repo="esphome" >}} by {{< ghuser name="dependabot[bot]" >}}
 
-{{< /collapse >}}
+</details>
 
 <!-- markdownlint-enable MD013 -->
 
 ## Past Changelogs
 
-{{< collapse  >}}
+<details>
+<summary></summary>
 
 - {{< docref "2025.7.0/" >}}
 - {{< docref "2025.6.0/" >}}
@@ -716,4 +720,4 @@ or advanced configurations may need updates.
 - {{< docref "v1.8.0/" >}}
 - {{< docref "v1.7.0/" >}}
 
-{{< /collapse >}}
+</details>

--- a/content/changelog/2025.8.0.md
+++ b/content/changelog/2025.8.0.md
@@ -156,6 +156,28 @@ or advanced configurations may need updates.
 
 <!-- markdownlint-disable MD013 -->
 
+## Release 2025.8.1 - August 25
+
+{{< collapse true >}}
+
+- [api] Add zero-copy StringRef methods for compilation_time and effect_name [esphome#10257](https://github.com/esphome/esphome/pull/10257) by [@bdraco](https://github.com/bdraco)
+- [esp32_ble_client] Add log helper functions to reduce flash usage by 120 bytes [esphome#10243](https://github.com/esphome/esphome/pull/10243) by [@bdraco](https://github.com/bdraco)
+- [api] Add ``USE_API_HOMEASSISTANT_SERVICES`` if using ``tag_scanned`` action [esphome#10316](https://github.com/esphome/esphome/pull/10316) by [@jesserockz](https://github.com/jesserockz)
+- [http_request] Fix for host after ArduinoJson library bump [esphome#10348](https://github.com/esphome/esphome/pull/10348) by [@clydebarrow](https://github.com/clydebarrow)
+- [core] Improve error reporting for entity name conflicts with non-ASCII characters [esphome#10329](https://github.com/esphome/esphome/pull/10329) by [@bdraco](https://github.com/bdraco)
+- [pvvx_mithermometer] Fix race condition with BLE authentication [esphome#10327](https://github.com/esphome/esphome/pull/10327) by [@bdraco](https://github.com/bdraco)
+- [esp32_ble_client] Optimize BLE connection parameters for different connection types [esphome#10356](https://github.com/esphome/esphome/pull/10356) by [@bdraco](https://github.com/bdraco)
+- [esp32_ble] Increase GATT connection retry count to use full timeout window [esphome#10376](https://github.com/esphome/esphome/pull/10376) by [@bdraco](https://github.com/bdraco)
+- [script] Fix parallel mode scripts with delays cancelling each other [esphome#10324](https://github.com/esphome/esphome/pull/10324) by [@bdraco](https://github.com/bdraco)
+- [deep_sleep] Fix ESP32-C6 compilation error with gpio_deep_sleep_hold_en() [esphome#10345](https://github.com/esphome/esphome/pull/10345) by [@bdraco](https://github.com/bdraco)
+- [esp32_ble_client] Reduce log level for harmless BLE timeout race conditions [esphome#10339](https://github.com/esphome/esphome/pull/10339) by [@bdraco](https://github.com/bdraco)
+- [lvgl] Fix meter rotation [esphome#10342](https://github.com/esphome/esphome/pull/10342) by [@clydebarrow](https://github.com/clydebarrow)
+- [esp32_ble_tracker] Fix on_scan_end trigger compilation without USE_ESP32_BLE_DEVICE [esphome#10399](https://github.com/esphome/esphome/pull/10399) by [@bdraco](https://github.com/bdraco)
+- [test] Add integration test for light effect memory corruption fix [esphome#10417](https://github.com/esphome/esphome/pull/10417) by [@bdraco](https://github.com/bdraco)
+- [web_server] Use oi.esphome.io for css and js assets [esphome#10296](https://github.com/esphome/esphome/pull/10296) by [@clydebarrow](https://github.com/clydebarrow)
+
+{{< /collapse >}}
+
 ## Full list of changes
 
 ### New Features
@@ -211,7 +233,7 @@ or advanced configurations may need updates.
 
 ### All changes
 
-{{< collapse true >}}
+{{< collapse >}}
 
 - [web_server] fix `Arudino` typo {{< pr number="9404" repo="esphome" >}} by {{< ghuser name="ximex" >}}
 - Speed up clang-tidy CI by 80%+ with incremental checking {{< pr number="9396" repo="esphome" >}} by {{< ghuser name="bdraco" >}}

--- a/content/guides/supporters.md
+++ b/content/guides/supporters.md
@@ -980,6 +980,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Jeroen van Oort (@JeroenVanOort)](https://github.com/JeroenVanOort)
 - [jerome992 (@jerome992)](https://github.com/jerome992)
 - [Jérôme Laban (@jeromelaban)](https://github.com/jeromelaban)
+- [jerryyip (@jerryyip)](https://github.com/jerryyip)
 - [Jesse Hills (@jesserockz)](https://github.com/jesserockz)
 - [Jessica Hamilton (@jessicah)](https://github.com/jessicah)
 - [Andrzej Skowroński (@jesterret)](https://github.com/jesterret)
@@ -1330,6 +1331,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Marco (@Melkor82)](https://github.com/Melkor82)
 - [Melopero (@melopero)](https://github.com/melopero)
 - [melyux (@melyux)](https://github.com/melyux)
+- [Merikei (@Merikei)](https://github.com/Merikei)
 - [Merlin Schumacher (@merlinschumacher)](https://github.com/merlinschumacher)
 - [Marco Lusini (@met67)](https://github.com/met67)
 - [Martin Flasskamp (@MFlasskamp)](https://github.com/MFlasskamp)
@@ -1543,6 +1545,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Maxime Dufour (@outscale-mdr)](https://github.com/outscale-mdr)
 - [Odd-Roar Wangen (@owangen)](https://github.com/owangen)
 - [Ben Owen (@owenb321)](https://github.com/owenb321)
+- [owine (@owine)](https://github.com/owine)
 - [Oxan van Leeuwen (@oxan)](https://github.com/oxan)
 - [oxynatOr (@oxynatOr)](https://github.com/oxynatOr)
 - [p-jean (@p-jean)](https://github.com/p-jean)
@@ -1629,6 +1632,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [pplucky (@pplucky)](https://github.com/pplucky)
 - [Peter Provost (@PProvost)](https://github.com/PProvost)
 - [pre-commit-ci[bot] (@pre-commit-ci[bot])](https://github.com/pre-commit-ci[bot])
+- [Andrew Klaus (@precurse)](https://github.com/precurse)
 - [Q. Marchi (@preeefix)](https://github.com/preeefix)
 - [PricelessToolkit (@PricelessToolkit)](https://github.com/PricelessToolkit)
 - [Francesco Ciocchetti (@primeroz)](https://github.com/primeroz)
@@ -2210,4 +2214,4 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Christian Zufferey (@zuzu59)](https://github.com/zuzu59)
 - [Zynth-dev (@Zynth-dev)](https://github.com/Zynth-dev)
 
-*This page was last updated August 20, 2025.*
+*This page was last updated August 25, 2025.*

--- a/data/version.yaml
+++ b/data/version.yaml
@@ -1,2 +1,2 @@
-release: 2025.8.0
+release: 2025.8.1
 version: '2025.8'


### PR DESCRIPTION
**Do not merge, release script will automatically merge**

- [psram] document disabled option [docs#5239](https://github.com/esphome/esphome-docs/pull/5239)
- Convert current to Markdown [docs#5242](https://github.com/esphome/esphome-docs/pull/5242)
- Markdownlint [docs#5262](https://github.com/esphome/esphome-docs/pull/5262)
- Restore webapp in Ready Made Projects [docs#5265](https://github.com/esphome/esphome-docs/pull/5265)
- Use details/summary for collapsible content [docs#5267](https://github.com/esphome/esphome-docs/pull/5267)
- [guides/yaml] 4→2 space indent [docs#5269](https://github.com/esphome/esphome-docs/pull/5269)
- fix link to TEMT6000 [docs#5268](https://github.com/esphome/esphome-docs/pull/5268)
- [graph] Add missing documentation for legend feature [docs#5266](https://github.com/esphome/esphome-docs/pull/5266)
- fix white on white text in getting-started-heading [docs#5272](https://github.com/esphome/esphome-docs/pull/5272)
- Changes from user feedback [docs#5278](https://github.com/esphome/esphome-docs/pull/5278)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
