### PR TITLE
remove `throttle` from [ld2450] component config example

### DIFF
--- a/content/components/sensor/ld2450.md
+++ b/content/components/sensor/ld2450.md
@@ -475,7 +475,6 @@ uart:
 ld2450:
   id: ld2450_radar
   uart_id: uart_ld2450
-  throttle: 1000ms
 
 binary_sensor:
   - platform: ld2450


### PR DESCRIPTION
## Description:

Fix `ld2450` sensor example config removing `throttle` option as it has been removed in esphome version 2025.8.0

**Related issue (if applicable):** fixes #5289

## Checklist:

  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.
