### PR TITLE
Update _index.md to mention nRF52

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -91,7 +91,7 @@ smart home exactly how you want it.
   {
     "icon": "bolt",
     "title": "Others",
-    "description": "Nordic Semiconductor nrf52xx/nrf52xxx, Realtek RTL87xx, and Beken BK72xx chips are supported."
+    "description": "Nordic Semiconductor nRF52, Realtek RTL87xx, and Beken BK72xx chips are supported."
   },
   {
     "icon": "computer",

--- a/content/_index.md
+++ b/content/_index.md
@@ -91,7 +91,7 @@ smart home exactly how you want it.
   {
     "icon": "bolt",
     "title": "Others",
-    "description": "Realtek RTL87xx and Beken BK72xx chips are supported."
+    "description": "Nordic Semiconductor nrf52xx/nrf52xxx, Realtek RTL87xx, and Beken BK72xx chips are supported."
   },
   {
     "icon": "computer",


### PR DESCRIPTION
## Description:

Update main index to also mention [nRF52 platform](https://esphome.io/components/nrf52/) which had initial support added in ESPHome 2025.8.0 (by [tomaszduda23](https://github.com/tomaszduda23)):

* https://esphome.io/changelog/2025.8.0/

  * https://esphome.io/changelog/2025.8.0/#nrf52-platform-support

Follow-up question is if the nRF52 platform should also be added in the top description as well or not? 

i.e. "_**Turn your ESP32, ESP8266, nRF52, or RP2040 boards into powerful smart home devices with simple YAML configuration**_"

That is, if nRF52 is now a first-class platform, then it should prrobably be reflected there at the top as well, or what do you think?

ESPHome 2025.8 changelog said it introduces comprehensive but if support is still “initial/”experimental” then maybe add it later?

<img width="1093" height="365" alt="image" src="https://github.com/user-attachments/assets/69da872b-5d7c-499f-800a-30ada8b1c61d" />

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
