### PR TITLE
Update homepage tagline to list more supported platforms

### DIFF
--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -6,7 +6,7 @@ head:
     content: "ESPHome - Smart Home Made Simple"
 template: splash
 hero:
-  tagline: Turn your ESP32, ESP8266, or RP2040 boards into powerful smart home devices with simple YAML configuration.
+  tagline: Turn your ESP32, ESP8266, BK72xx, RP2040, and other supported boards into powerful smart home devices with simple YAML configuration.
   image:
     alt: ESPHome dashboard showing connected devices
     file: ../../assets/hero.png


### PR DESCRIPTION
## Description:

Update the homepage hero tagline to mention BK72xx and other supported platforms alongside ESP32, ESP8266, and RP2040.

## Types of changes

- [x] Fix/improvement to existing documentation

## Checklist:

- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.