### PR TITLE
Fix devcontainer for markdown/hugo

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,11 @@
   "postAttachCommand": "make live-html",
   "forwardPorts": [8000],
   "features": {
-    "ghcr.io/devcontainers/features/github-cli:1": {}
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/devcontainers/features/node:1": {},
+    "ghcr.io/devcontainers/features/hugo:1": {
+      "version": "v0.147.8"
+    }
   },
   "customizations": {
     "vscode": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,9 @@
   "image": "mcr.microsoft.com/devcontainers/python:3.12",
   "postCreateCommand": ".devcontainer/postCreate.sh",
   "postAttachCommand": "make live-html",
-  "forwardPorts": [8000],
+  "forwardPorts": [
+    1313
+  ],
   "features": {
     "ghcr.io/devcontainers/features/github-cli:1": {},
     "ghcr.io/devcontainers/features/node:1": {},

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,7 +15,10 @@
   },
   "customizations": {
     "vscode": {
-      "extensions": ["ms-python.python"]
+      "extensions": [
+        "ms-python.python",
+        "DavidAnson.vscode-markdownlint"
+      ]
     }
   }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,7 @@
     "ghcr.io/devcontainers/features/github-cli:1": {},
     "ghcr.io/devcontainers/features/node:1": {},
     "ghcr.io/devcontainers/features/hugo:1": {
-      "version": "v0.147.8"
+      "version": "v0.147.8" // Matches version used in netlify.toml
     }
   },
   "customizations": {

--- a/.devcontainer/postCreate.sh
+++ b/.devcontainer/postCreate.sh
@@ -2,4 +2,3 @@
 
 
 pip3 install -r requirements.txt -r requirements_test.txt
-curl -L https://github.com/CloudCannon/pagefind/releases/download/v1.1.0/pagefind-v1.1.0-x86_64-unknown-linux-musl.tar.gz | tar -xz -C ~/.local/bin

--- a/.devcontainer/postCreate.sh
+++ b/.devcontainer/postCreate.sh
@@ -2,3 +2,5 @@
 
 
 pip3 install -r requirements.txt -r requirements_test.txt
+pip3 install --upgrade pre-commit
+pre-commit install


### PR DESCRIPTION
## Description:

With the docs conversion to markdown/hugo, the devcontainer didn't work anymore.
This PR solves that by:
- Installing npm (used by `Makefile` for `pagefind`)
- Installing hugo
- And installing the markdownlint vscode extension by default

Additionally pre-commit hooks are now installed by default.  

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
