### PR TITLE
Update _index.md for Number

### DIFF
--- a/content/components/number/_index.md
+++ b/content/components/number/_index.md
@@ -132,12 +132,12 @@ Configuration variables:
 - **below** (*Optional*, float): The maximum for the trigger.
 - See [Automation](#automation).
 
-{{< anchor "Number-referencing" >}}
+{{< anchor "number-referencing" >}}
 
-## Referencing Numbers 
+## Referencing Numbers
 
-When calling these automations from other components you can access the most recent state of the number in [lambdas](#config-lambda) using
-`id(number_id).state`.
+In [lambdas](#config-lambda) from other components, you can read the current value with `id(number_id).state`.  
+See [lambda calls](#number-lambda_calls) for details.
 
 {{< anchor "number-in_range_condition" >}}
 

--- a/content/components/number/_index.md
+++ b/content/components/number/_index.md
@@ -82,9 +82,6 @@ MQTT Options:
 
 ## Number Automation
 
-You can access the most recent state of the number in [lambdas](#config-lambda) using
-`id(number_id).state`.
-
 {{< anchor "number-on_value" >}}
 
 ### `on_value`
@@ -134,6 +131,13 @@ Configuration variables:
 - **above** (*Optional*, float): The minimum for the trigger.
 - **below** (*Optional*, float): The maximum for the trigger.
 - See [Automation](#automation).
+
+{{< anchor "Number-referencing" >}}
+
+## Referencing Numbers 
+
+When calling these automations from other components you can access the most recent state of the number in [lambdas](#config-lambda) using
+`id(number_id).state`.
 
 {{< anchor "number-in_range_condition" >}}
 


### PR DESCRIPTION
## Description:
This is a minor change moving some of the documentation sections which refer to or use a Number to a new main heading, to separate them from the sections which define the configuration of a Binary Sensor.

This provides users with the same information, but should make it easier for less experienced users to see which sections go in the Binary Sensor configuration ... and which should be used in other sensors' configurations.

- https://github.com/orgs/esphome/discussions/3280

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
