### PR TITLE
Update _index.md Sensor

### DIFF
--- a/content/components/sensor/_index.md
+++ b/content/components/sensor/_index.md
@@ -304,10 +304,7 @@ unit_of_measurement: "°F"
 
 {{< anchor "sensor-automations" >}}
 
-## Sensor Automation
-
-You can access the most recent state of the sensor in [lambdas](#config-lambda) using
-`id(sensor_id).state` and the most recent raw state using `id(sensor_id).raw_state`.
+## Sensor Automations
 
 {{< anchor "sensor-on_value" >}}
 
@@ -387,6 +384,12 @@ sensor:
 ```
 
 Configuration variables: See [Automation](#automation).
+
+{{< anchor "sensor-referencing" >}}
+
+## Referencing Sensors
+
+When calling these automations from other components you can access the most recent state of the sensor in lambdas using id(sensor_id).state.
 
 {{< anchor "sensor-in_range_condition" >}}
 


### PR DESCRIPTION
## Description:

This is a minor change moving some of the documentation sections which _refer to_ or _use_ a Sensor to a new main heading, to separate them from the sections which _define_ the configuration of a Sensor.

This provides users with the same information, but should make it easier for less experienced users to see which sections go in the Sensor configuration ... and which should be used in other sensors' configurations.

per: https://github.com/orgs/esphome/discussions/3280


## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
