### PR TITLE
Separate referring actions from configuration actions

### DIFF
--- a/content/components/text/_index.md
+++ b/content/components/text/_index.md
@@ -69,9 +69,6 @@ MQTT Options:
 
 ## Text Automation
 
-You can access the most recent state of the text in [lambdas](#config-lambda) using
-`id(text_id).state`.
-
 {{< anchor "text-on_value" >}}
 
 ### `on_value`
@@ -91,6 +88,13 @@ text:
 ```
 
 Configuration variables: See [Automation](#automation).
+
+{{< anchor "text-referencing" >}}
+
+## Referencing Texts
+
+You can access the most recent state of the text in [lambdas](#config-lambda) using
+`id(text_id).state`.
 
 {{< anchor "text-set_action" >}}
 


### PR DESCRIPTION
## Description:

This is a minor change moving some of the documentation sections which refer to or use a Text to a new main heading, to separate them from the sections which define the configuration of a Text Sensor.

This provides users with the same information, but should make it easier for less experienced users to see which sections go in the Binary Sensor configuration ... and which should be used in other sensors' configurations.

per: https://github.com/orgs/esphome/discussions/3280

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
