### PR TITLE
Note ESP32C6 incompatibility

### DIFF
--- a/content/components/i2s_audio.md
+++ b/content/components/i2s_audio.md
@@ -10,7 +10,7 @@ params:
 {{< anchor "i2s_audio" >}}
 
 The `i2s_audio` component allows for sending and receiving audio via I²S.
-This component only works on ESP32 based chips.
+This component only works on ESP32 based chips. It is not currently compatible with ESP32C6.
 
 ```yaml
 # Example configuration entry


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** notifies users of [issue #2481](https://github.com/esphome/feature-requests/issues/2481)

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>Note ESP32C6 incompatibility with i2s_audio</strong></summary>

Currently, the documentation for the i2s_audio component states that the component "only works on ESP32 based chips". The component is not currently compatible with the ESP32C6 variant. Issue #2481 (add i2s support for esp32-c6) indicates that this has caused confusion for some users. Adding this note may provide clarity until the ESP32C6 variant is supported.
</details>
