### PR TITLE
Update opentherm.md

### DIFF
--- a/content/components/opentherm.md
+++ b/content/components/opentherm.md
@@ -460,7 +460,8 @@ switch:
   - platform: opentherm
     ch_enable:
       name: "Boiler Central Heating enabled"
-      #restore_mode: RESTORE_DEFAULT_ON # no longer supported
+      #restore_mode: RESTORE_DEFAULT_ON
+      #restore_mode no longer supported
       id: boiler_central_heating
 
 climate:
@@ -476,6 +477,7 @@ climate:
 
 ## Add default state on boot in esphome section instead of RESTORE_DEFAULT_ON or OFF
 The OpenTherm switches don't support the standard switch modes like restore_default_on and restore_default_off.
+
 ```yaml
 esphome:
   name: thermostat-pid-complete

--- a/content/components/opentherm.md
+++ b/content/components/opentherm.md
@@ -460,7 +460,8 @@ switch:
   - platform: opentherm
     ch_enable:
       name: "Boiler Central Heating enabled"
-      restore_mode: RESTORE_DEFAULT_ON
+      #restore_mode: RESTORE_DEFAULT_ON # no longer supported
+      id: boiler_central_heating
 
 climate:
   - platform: pid
@@ -471,6 +472,17 @@ climate:
     control_parameters:
       kp: 0.4
       ki: 0.004
+```
+
+## Add default state on boot in esphome section instead of RESTORE_DEFAULT_ON or OFF
+The OpenTherm switches don't support the standard switch modes like restore_default_on and restore_default_off.
+```yaml
+esphome:
+  name: thermostat-pid-complete
+  on_boot:
+    priority: -100  # Run after everything is initialized
+    then:
+      - switch.turn_on: boiler_central_heating  # Enable CH by default
 ```
 
 ## See Also


### PR DESCRIPTION
## Description: The OpenTherm switches don't support the standard switch modes like restore_default_on and restore_default_off.


**Related issue (if applicable):** fixes [url](https://github.com/Gucioo/esphome-opentherm/commit/8c2a5b275a9db026045344643b5a7ddd8d64955f)

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
