### PR TITLE
Initial documentation for new camera encoder component (md)

### DIFF
--- a/content/components/_index.md
+++ b/content/components/_index.md
@@ -1038,6 +1038,7 @@ ESPHome to cellular networks. **Does not encompass Wi-Fi.**
 ## Miscellaneous Components
 
 {{< imgtable >}}
+"Camera Encoder","components/camera/camera_encoder","camera.svg","dark-invert"
 "ESP32 Camera","components/esp32_camera","camera.svg","dark-invert"
 "Exposure Notifications","components/exposure_notifications","exposure_notifications.png",""
 "GPS","components/gps","crosshairs-gps.svg","dark-invert"

--- a/content/components/camera/camera_encoder.md
+++ b/content/components/camera/camera_encoder.md
@@ -29,7 +29,7 @@ camera-encoder:
 
 - **type** (*Optional*): ``esp32_camera``
 
-## esp32_camera Options:
+## esp32_camera Options
 
 - **quality** (*Optional*, int): Sets JPEG compression quality.
   Valid values range from ``1`` (lowest quality, highest compression) to ``100`` (best quality, least compression). Defaults: ``80``.

--- a/content/components/camera/camera_encoder.md
+++ b/content/components/camera/camera_encoder.md
@@ -1,0 +1,50 @@
+---
+description: "Instructions for setting up the camera encoder component in ESPHome."
+title: "Camera Encoder"
+params:
+  seo:
+    description: Instructions for setting up the camera encoder component in ESPHome.
+    image: camera.svg
+---
+
+The ``camera_encoder`` component provides image compression support for software-based cameras or cameras without
+internal compression. It allows raw camera frames to be compressed into a format suitable for transmission to API
+clients, such as Home Assistant, which expect JPEG-compressed images.
+
+It supports different encoder implementations, such as a ESP32 Camera software JPEG encoder that can be configured with
+options like image quality, subsampling, and incremental encoding. These settings make it possible to balance image
+quality and performance depending on the use case.
+
+{{< note >}}
+The default software JPEG encoder enables devices like the ESP32-S3 to stream images.
+It is primarily intended for smallar images due to limited processing power and memory.
+{{< /note >}}
+
+```yaml
+# Example configuration entry
+camera-encoder:
+```
+
+## Configuration variables
+
+- **type** (*Optional*): ``esp32_camera``
+
+## esp32_camera Options:
+
+- **quality** (*Optional*, int): Sets JPEG compression quality.
+  Valid values range from ``1`` (lowest quality, highest compression) to ``100`` (best quality, least compression). Defaults: ``80``.
+
+- **buffer_size** (*Optional*, int): Initial size of the output buffer in bytes, used to store the JPEG-encoded image data.
+  - Minimum: 1024 bytes
+  - Maximum: 2097152 bytes (2 MB), sufficient for ESP32-S3 and ESP32-P4
+  - Default: ``4096``.
+
+- **buffer_expand_size** (*Optional*, int): Number of bytes to expand the output buffer if it is too small to hold the JPEG-encoded image. A value of ``0`` disables expansion.
+  - Minimum: 1024 bytes
+  - Maximum: 2097152 bytes (2 MB), sufficient for ESP32-S3 and ESP32-P4
+  - Default: ``1024``.
+
+## See Also
+
+- {{< apiref "camera/encoder.h" "camera/encoder.h" >}}
+- {{< apiref "camera_encoder/esp32_camera_jpeg_encoder.h" "camera_encoder/esp32_camera_jpeg_encoder.h" >}}

--- a/content/components/camera/camera_encoder.md
+++ b/content/components/camera/camera_encoder.md
@@ -17,7 +17,8 @@ quality and performance depending on the use case.
 
 {{< note >}}
 The default software JPEG encoder enables devices like the ESP32-S3 to stream images.
-It is primarily intended for smallar images due to limited processing power and memory.
+It is primarily intended for smallar images due to limited processing power and memory,
+and supports only devices from the ESP32 family.
 {{< /note >}}
 
 ```yaml

--- a/content/components/camera/camera_encoder.md
+++ b/content/components/camera/camera_encoder.md
@@ -22,7 +22,7 @@ It is primarily intended for smallar images due to limited processing power and 
 
 ```yaml
 # Example configuration entry
-camera-encoder:
+camera_encoder:
 ```
 
 ## Configuration variables

--- a/content/components/camera/camera_encoder.md
+++ b/content/components/camera/camera_encoder.md
@@ -12,7 +12,7 @@ internal compression. It allows raw camera frames to be compressed into a format
 clients, such as Home Assistant, which expect JPEG-compressed images.
 
 It supports different encoder implementations, such as a ESP32 Camera software JPEG encoder that can be configured with
-options like image quality, subsampling, and incremental encoding. These settings make it possible to balance image
+options like image quality and incremental encoding. These settings make it possible to balance image
 quality and performance depending on the use case.
 
 {{< note >}}
@@ -40,7 +40,6 @@ camera-encoder:
   - Default: ``4096``.
 
 - **buffer_expand_size** (*Optional*, int): Number of bytes to expand the output buffer if it is too small to hold the JPEG-encoded image. A value of ``0`` disables expansion.
-  - Minimum: 1024 bytes
   - Maximum: 2097152 bytes (2 MB), sufficient for ESP32-S3 and ESP32-P4
   - Default: ``1024``.
 


### PR DESCRIPTION
## Description:

This PR adds the initial documentation for the new camera_encoder component, which provides image compression for software cameras or cameras without build-in compression.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#9459

## Checklist:

  - [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [X] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
