### PR TITLE
Added docs for `!rel` (see PR #8701)

### DIFF
--- a/content/components/esphome.md
+++ b/content/components/esphome.md
@@ -229,6 +229,8 @@ This option behaves differently depending on what the included file is pointing 
    AND compiled into the binary. This way implementation of classes and functions in header files can
    be provided.
 
+- Directive `!rel` can be used to handle include files relative to the current yaml file.
+
 {{< anchor "esphome-libraries" >}}
 
 ## `libraries`

--- a/content/components/external_components.md
+++ b/content/components/external_components.md
@@ -34,6 +34,11 @@ external_components:
       type: local
       path: my_components
 
+# use all components from a local folder relative to current yaml file
+  - source:
+      type: local
+      path: !rel my_components
+
   # use a component from a local git repository
   - source:
       type: git
@@ -82,11 +87,15 @@ external_components:
 # shorthand
 external_components:
   - source: my_components
+
+# shorthand (relative to yaml file)
+external_components:
+  - source: !rel my_embedded_components
 ```
 
 Notice that relative paths are supported, so you can enter `my_components` as the source path and then
 ESPHome will load components from a `my_components` folder in the same folder where your YAML configuration
-is.
+is. You can also use `!rel` YAML directive if you need import components relative to your yaml file.
 
 ### Example of local components
 

--- a/content/guides/yaml.md
+++ b/content/guides/yaml.md
@@ -330,6 +330,27 @@ binary_sensor:
         id: 2
 ```
 
+### !rel
+
+- Prefix a relative path with the absolute path to current yaml file.
+- This should be usefull for `includes` (.h, .cpp files) which are placed in (external) package.
+- Useful for `external_components` too.
+- Can be used anywhere in esphome project yaml files.
+
+```yaml
+# Using !rel in cpp includes
+esphome:
+  includes:
+    - utils.h # relative to project yaml file
+    - !rel includes/colors.h # relative to current loaded yaml file
+
+# Using !rel for extrernal components placed in the local filesystem
+external_components:
+  - source:
+    path: !rel esphome_components
+    type: local
+```
+
 ### Packages
 
 The `packages:` feature allows you to define reusable and potentially partial configurations that can be included in


### PR DESCRIPTION
Added !rel to yaml docs

## Description:

This PR adds docs for new `!rel` YAML directive. See main esphome repository pull request.

**Related issue (if applicable):** -

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#8701

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
