### PR TITLE
Updated information to esp32 cam

### DIFF
--- a/content/components/esp32_camera.md
+++ b/content/components/esp32_camera.md
@@ -59,7 +59,8 @@ Connection Options:
   - **pin** (**Required**, pin): The pin the external clock line is connected to.
   - **frequency** (*Optional*, float): The frequency of the external clock, must be between 10
     and 20MHz. Defaults to `20MHz`.
-    Setting the frequency to 10MHz may help with stability issues on poor hardware.
+    
+    ***Information!*** Setting the frequency to 10MHz may help with stability issues on poor hardware.
 
 - **i2c_id** (**Required**, [ID](#config-id)): The ID of the [I²C bus](#i2c) the camera is connected to.
 - **reset_pin** (*Optional*, pin): The ESP pin the reset pin of the camera is connected to.

--- a/content/components/esp32_camera.md
+++ b/content/components/esp32_camera.md
@@ -59,6 +59,7 @@ Connection Options:
   - **pin** (**Required**, pin): The pin the external clock line is connected to.
   - **frequency** (*Optional*, float): The frequency of the external clock, must be between 10
     and 20MHz. Defaults to `20MHz`.
+    Setting the frequency to 10MHz may help with stability issues on poor hardware.
 
 - **i2c_id** (**Required**, [ID](#config-id)): The ID of the [I²C bus](#i2c) the camera is connected to.
 - **reset_pin** (*Optional*, pin): The ESP pin the reset pin of the camera is connected to.


### PR DESCRIPTION
## Description:

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

Just added a line of information in esp32cam. Setting the external frequency to 10MHz helped a lot with poor clones, which do not run stable on 20MHz.
