### PR TITLE
[bluetooth_proxy] Update docs for active connections default change to true

### DIFF
--- a/content/components/bluetooth_proxy.md
+++ b/content/components/bluetooth_proxy.md
@@ -45,9 +45,12 @@ please search for it in the [Home Assistant Integrations](https://www.home-assis
 
 ```yaml
 bluetooth_proxy:
+  # Active connections are now enabled by default
+  # To disable active connections (previous default behavior), use:
+  # active: false
 ```
 
-- **active** (*Optional*, boolean): Enables proxying active connections. Defaults to `false`.
+- **active** (*Optional*, boolean): Enables proxying active connections. Defaults to `true`.
 - **cache_services** (*Optional*, boolean): Enables caching GATT services in NVS flash storage which significantly speeds up active connections. Defaults to `true` when using the ESP-IDF framework.
 - **connection_slots** (*Optional*, int): The maximum number of BLE connection slots to use.
   Each configured slot consumes ~1KB of RAM. This can only be adjusted when using


### PR DESCRIPTION
## Description:

Update Bluetooth proxy documentation to reflect the new default value for `active` connections changing from `false` to `true`. This is a breaking change that better aligns with user expectations - most users setting up a Bluetooth proxy expect it to be able to make connections to devices, not just passively listen to broadcasts.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#10546

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.