### PR TITLE
Fix components.json and api ref urls for beta/next

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -150,9 +150,10 @@ outputs:
   home:
     - HTML
     - RSS
+    - ComponentsJSON
 
 # Static file configuration
-staticDir: 
+staticDir:
   - static
 
 mediaTypes:
@@ -165,6 +166,12 @@ outputFormats:
     mediaType: image/svg+xml
     isPlainText: true
     isHTML: false
+  ComponentsJSON:
+    mediaType: application/json
+    baseName: components
+    isPlainText: true
+    isHTML: false
+    path: ""
 
 module:
   mounts:

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,19 +1,16 @@
 [build]
   publish = "public"
   command = "make netlify"
-  environment = { BASE_URL = "https://esphome.io", API_DOCS_URL = "https://api-docs.esphome.io", PYTHON_VERSION = "3.12", HUGO_VERSION = "0.147.8" }
+  environment = { HUGO_BASEURL = "https://esphome.io", HUGOxPARAMSxAPI_DOCS_URL = "https://api-docs.esphome.io", PYTHON_VERSION = "3.12", HUGO_VERSION = "0.147.8" }
 
 [context.beta]
-  environment = { BASE_URL = "https://beta.esphome.io", API_DOCS_URL = "https://api-docs-beta.esphome.io" }
+  environment = { HUGO_BASEURL = "https://beta.esphome.io", HUGOxPARAMSxAPI_DOCS_URL = "https://api-docs-beta.esphome.io" }
 
 [context.next]
-  environment = { BASE_URL = "https://next.esphome.io", API_DOCS_URL = "https://api-docs-dev.esphome.io" }
-
-[context.new]
-  environment = { BASE_URL = "https://new.esphome.io", API_DOCS_URL = "https://api-docs-dev.esphome.io" }
+  environment = { HUGO_BASEURL = "https://next.esphome.io", HUGOxPARAMSxAPI_DOCS_URL = "https://api-docs-dev.esphome.io" }
 
 [context.production]
-  environment = { BASE_URL = "https://esphome.io", API_DOCS_URL = "https://api-docs.esphome.io", PRODUCTION = "YES" }
+  environment = { HUGO_BASEURL = "https://esphome.io", HUGOxPARAMSxAPI_DOCS_URL = "https://api-docs.esphome.io" }
 
 
 # Caching HTML - 1 week
@@ -77,7 +74,7 @@ status = 301
 [[redirects]]
   from = "/devices/esp32.html"
   to = "/components/esp32.html"
-  status = 301 
+  status = 301
 
 
 [[redirects]]
@@ -96,17 +93,17 @@ status = 301
   status = 301
 
 [[redirects]]
-  from = "/components/ota_http_request.html"
+  from = "/components/ota_http_request*"
   to = "/components/ota/http_request.html"
   status = 301
 
 [[redirects]]
-  from = "/components/sensor/mmc5063.html"
+  from = "/components/sensor/mmc5063*"
   to = "/components/sensor/mmc5603.html"
   status = 301
 
 [[redirects]]
-  from = "/components/sensor/kalman_combinator.html"
+  from = "/components/sensor/kalman_combinator*"
   to = "/components/sensor/combination.html"
   status = 301
 
@@ -326,4 +323,3 @@ status = 301
   from = "/components/display/qspi_amoled.html"
   to = "/components/display/mipi_spi.html"
   status = 301
-

--- a/themes/esphome-theme/layouts/index.componentsjson
+++ b/themes/esphome-theme/layouts/index.componentsjson
@@ -5,23 +5,31 @@
 {{- end -}}
 
 {{- range .Site.Pages -}}
-  {{- if and (in .RelPermalink "/components/") (ne .Kind "section") (ne .File.BaseFileName "_index") -}}
+  {{- if (in .RelPermalink "/components/") -}}
     {{- $relPath := strings.TrimPrefix "/components/" .RelPermalink -}}
     {{- $relPath = strings.TrimSuffix "/" $relPath -}}
 
-    {{- $key := "" -}}
-    {{- $path := "" -}}
-    {{- $image := "" -}}
+    {{- if ne $relPath "" -}}
+      {{- $key := "" -}}
+      {{- $path := "" -}}
+      {{- $image := "" -}}
 
-    {{- if .Parent -}}
-      {{- if ne .Parent.File.BaseFileName "_index" -}}
-        {{- $key = printf "%s_%s" .Parent.File.BaseFileName .File.BaseFileName -}}
-        {{- $path = printf "components/%s" .Parent.File.BaseFileName -}}
-      {{- else -}}
-        {{- $key = .File.BaseFileName -}}
-        {{- $path = printf "components/%s" .File.BaseFileName -}}
+    {{- $pathParts := split $relPath "/" -}}
+    {{- if eq .File.BaseFileName "_index" -}}
+      {{- /* This is an _index page for a component category */ -}}
+      {{- if gt (len $pathParts) 0 -}}
+        {{- $parentDir := index $pathParts 0 -}}
+        {{- $key = $parentDir -}}
+        {{- $path = printf "components/%s" $parentDir -}}
       {{- end -}}
+    {{- else if gt (len $pathParts) 1 -}}
+      {{- /* This is a component page in a subfolder */ -}}
+      {{- $parentDir := index $pathParts 0 -}}
+      {{- $fileName := .File.BaseFileName -}}
+      {{- $key = printf "%s_%s" $parentDir $fileName -}}
+      {{- $path = printf "components/%s" $fileName -}}
     {{- else -}}
+      {{- /* This is a root-level component */ -}}
       {{- $key = .File.BaseFileName -}}
       {{- $path = printf "components/%s" .File.BaseFileName -}}
     {{- end -}}
@@ -37,6 +45,7 @@
          "image" $image -}}
 
     {{- $components = merge $components (dict $key $component) -}}
+    {{- end -}}
   {{- end -}}
 {{- end -}}
 

--- a/themes/esphome-theme/layouts/index.componentsjson
+++ b/themes/esphome-theme/layouts/index.componentsjson
@@ -1,0 +1,43 @@
+{{- $components := dict -}}
+{{- $baseURL := .Site.BaseURL -}}
+{{- if eq $baseURL "" -}}
+  {{- $baseURL = "https://esphome.io" -}}
+{{- end -}}
+
+{{- range .Site.Pages -}}
+  {{- if and (in .RelPermalink "/components/") (ne .Kind "section") (ne .File.BaseFileName "_index") -}}
+    {{- $relPath := strings.TrimPrefix "/components/" .RelPermalink -}}
+    {{- $relPath = strings.TrimSuffix "/" $relPath -}}
+
+    {{- $key := "" -}}
+    {{- $path := "" -}}
+    {{- $image := "" -}}
+
+    {{- if .Parent -}}
+      {{- if ne .Parent.File.BaseFileName "_index" -}}
+        {{- $key = printf "%s_%s" .Parent.File.BaseFileName .File.BaseFileName -}}
+        {{- $path = printf "components/%s" .Parent.File.BaseFileName -}}
+      {{- else -}}
+        {{- $key = .File.BaseFileName -}}
+        {{- $path = printf "components/%s" .File.BaseFileName -}}
+      {{- end -}}
+    {{- else -}}
+      {{- $key = .File.BaseFileName -}}
+      {{- $path = printf "components/%s" .File.BaseFileName -}}
+    {{- end -}}
+
+    {{- with .Params.seo.image -}}
+      {{- $image = printf "%simages/%s" $baseURL . -}}
+    {{- end -}}
+
+    {{- $component := dict
+         "title" .Title
+         "url" .Permalink
+         "path" $path
+         "image" $image -}}
+
+    {{- $components = merge $components (dict $key $component) -}}
+  {{- end -}}
+{{- end -}}
+
+{{- $components | jsonify (dict "indent" "  ") -}}


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
