### PR TITLE
add c4001 sensor

### DIFF
--- a/content/components/dfrobot_c4001.md
+++ b/content/components/dfrobot_c4001.md
@@ -1,0 +1,69 @@
+---
+title: "DFRobot C4001 Radar Sensor"
+description: "Support for the DFRobot C4001 mmWave radar sensor in ESPHome."
+---
+
+## Example configuration
+
+```yaml
+uart:
+  id: uart_bus
+  tx_pin: GPIO1
+  rx_pin: GPIO3
+  baud_rate: 9600
+
+external_components:
+  - source:
+      type: git
+      url: https://github.com/96liuzhixin/esphome
+      ref: dev
+    components:
+      dfrobot_c4001
+
+dfrobot_c4001:
+  id: my_c4001
+  uart_id: uart_bus
+
+select:
+  - platform: dfrobot_c4001
+    operating_mode:
+      name: "Mode Select"
+
+number:
+  - platform: dfrobot_c4001
+    max_range:
+      name: "Max detection distance"
+    trig_range:
+      name: "Trigger range"
+    keep_sensitivity:
+      name: "Keep sensitivity"
+    trig_sensitivity:
+      name: "Trigger sensitivity"
+    confirm_delay:
+      name: "Confirm delay"
+    disappear_delay:
+      name: "Disappear delay"
+    threshold_factor:
+      name: "Threshold factor"
+    min_range:
+      name: "Min detection distance"
+
+switch:
+  - platform: dfrobot_c4001
+    motion_switch:
+      name: "Motion Switch"
+
+sensor:
+  - platform: dfrobot_c4001
+    c4001_id: my_c4001
+    speed:
+      name: "Speed"
+      id: c4001_speed
+    distance:
+      name: "Distance"
+      id: c4001_distance
+
+binary_sensor:
+  - platform: dfrobot_c4001
+    exist_state:
+      name: "Presence"


### PR DESCRIPTION
## Description:

This is the documentation for the new **DFRobot C4001 Radar Sensor** component for ESPHome.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#10675      https://github.com/esphome/esphome/pull/10675
## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/96liuzhixin/esphome) as linked above.  

  - [x] Link added in `/components/index.rst` for this new component.
         my  https://github.com/96liuzhixin/esphome
<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**  

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **DFROBOT_C4001** 
@esphomebot generate image DFRobot_C4001


2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:


@esphomebot generate image DHT22


</details>
