### PR TITLE
Update esphome.md - OTA file information

### DIFF
--- a/content/components/ota/esphome.md
+++ b/content/components/ota/esphome.md
@@ -87,6 +87,7 @@ If OTA is already enabled without a password, simply add a `password:` line to t
 ## OTA file
 
 Use the OTA-format binary: `firmware.ota.bin` (do not use `firmware.factory.bin`). From the ESPHome dashboard, download in "OTA format". From the CLI, after building (for example, `esphome run <project>.yaml`), find the file at `.esphome/build/project/.pioenvs/project/firmware.ota.bin`, where "project" is your device name.
+
 ## See Also
 
 - {{< apiref "ota/ota_component.h" "ota/ota_component.h" >}}

--- a/content/components/ota/esphome.md
+++ b/content/components/ota/esphome.md
@@ -85,10 +85,7 @@ If OTA is already enabled without a password, simply add a `password:` line to t
   - Execute the OTA update directly via the ESP web server.
 
 ## OTA file
-For an ESPHome OTA update, you generally need to use a firmware file with a `.bin` or `.ota.bin` extension, not `.factory.bin` files.
-
-These files are created during build, typically by running `esphome run project` in your terminal (where "project" is the name of your project and is in yaml). After a build, , the `.ota.bin` file is found in the build environment directory: `.esphome/build/project/.pioenvs/project/firmware.ota.bin` 
-
+Use the OTA-format binary: `firmware.ota.bin` (do not use `firmware.factory.bin`). From the ESPHome dashboard, download in "OTA format". From the CLI, after building (for example, `esphome run <project>.yaml`), find the file at `.esphome/build/project/.pioenvs/project/firmware.ota.bin`, where "project" is your device name.
 ## See Also
 
 - {{< apiref "ota/ota_component.h" "ota/ota_component.h" >}}

--- a/content/components/ota/esphome.md
+++ b/content/components/ota/esphome.md
@@ -84,6 +84,11 @@ If OTA is already enabled without a password, simply add a `password:` line to t
   - Build a new image locally.
   - Execute the OTA update directly via the ESP web server.
 
+## OTA file
+For an ESPHome OTA update, you generally need to use a firmware file with a `.bin` or `.ota.bin` extension, not `.factory.bin` files.
+
+These files are created during build, typically by running `esphome run project` in your terminal (where "project" is the name of your project and is in yaml). After a build, , the `.ota.bin` file is found in the build environment directory: `.esphome/build/project/.pioenvs/project/firmware.ota.bin` 
+
 ## See Also
 
 - {{< apiref "ota/ota_component.h" "ota/ota_component.h" >}}

--- a/content/components/ota/esphome.md
+++ b/content/components/ota/esphome.md
@@ -85,6 +85,7 @@ If OTA is already enabled without a password, simply add a `password:` line to t
   - Execute the OTA update directly via the ESP web server.
 
 ## OTA file
+
 Use the OTA-format binary: `firmware.ota.bin` (do not use `firmware.factory.bin`). From the ESPHome dashboard, download in "OTA format". From the CLI, after building (for example, `esphome run <project>.yaml`), find the file at `.esphome/build/project/.pioenvs/project/firmware.ota.bin`, where "project" is your device name.
 ## See Also
 


### PR DESCRIPTION
OTA file explanation, think this can help people.

## Description:
adding some text around the file to use for OTA, typically how it is created and where it may be found.

**Related issue (if applicable):** fixes <link to issue>
difficult to find this information as to the appropriate file type and where to find it

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
