### PR TITLE
Remove legacy Google Site Verification

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -14,9 +14,6 @@ params:
     - logo.svg
   api_docs_url: https://api-docs.esphome.io
   math: true
-  seo:
-    webmaster_verifications:
-      google: Q5q5TFbCofxA8-cSa1Frv5Hj4RopF5zwEZf_zaNHqf4
 
 
   # Social media links

--- a/themes/esphome-theme/layouts/partials/site-verification.html
+++ b/themes/esphome-theme/layouts/partials/site-verification.html
@@ -1,14 +1,2 @@
-{{ if .Site.Params.seo.webmaster_verifications.google }}
-    <meta name="google-site-verification" content="{{ .Site.Params.seo.webmaster_verifications.google }}" />
-{{ end }}
-{{ if .Site.Params.seo.webmaster_verifications.bing }}
-    <meta name="msvalidate.01" content="{{ .Site.Params.seo.webmaster_verifications.bing }}">
-{{ end }}
-{{ if .Site.Params.seo.webmaster_verifications.alexa }}
-    <meta name="alexaVerifyID" content="{{ .Site.Params.seo.webmaster_verifications.alexa }}">
-{{ end }}
-{{ if .Site.Params.seo.webmaster_verifications.yandex }}
-    <meta name="yandex-verification" content="{{ .Site.Params.seo.webmaster_verifications.yandex }}">
-{{ end }}
 <link rel="me" href="https://fosstodon.org/@esphome">
 


### PR DESCRIPTION
## Description:
Removing the legacy verification code as it belonged to @OttoWinter. Added a new verification code at DNS level as a property within the Open Home Foundation.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
