### PR TITLE
Add documentation for new camera_sensor component

### DIFF
--- a/content/components/_index.md
+++ b/content/components/_index.md
@@ -1040,6 +1040,7 @@ ESPHome to cellular networks. **Does not encompass Wi-Fi.**
 
 {{< imgtable >}}
 "Camera Encoder","components/camera/camera_encoder","camera.svg","dark-invert"
+"Camera Sensor","components/camera/camera_sensor","camera.svg","dark-invert"
 "ESP32 Camera","components/esp32_camera","camera.svg","dark-invert"
 "Exposure Notifications","components/exposure_notifications","exposure_notifications.png",""
 "GPS","components/gps","crosshairs-gps.svg","dark-invert"

--- a/content/components/camera/camera_sensor.md
+++ b/content/components/camera/camera_sensor.md
@@ -1,0 +1,57 @@
+---
+description: "Instructions for setting up the camera_sensor component in ESPHome."
+title: "Camera Sensor"
+params:
+  seo:
+    description: Instructions for setting up the camera_sensor component in ESPHome.
+    image: camera.svg
+---
+
+The ``camera_sensor`` component represents the first stage in the camera pipeline in ESPHome.
+It provides a unified interface for camera sensor implementations, allowing both software
+and hardware sensors to produce images for the rest of the camera pipeline.
+
+ESPHome includes an initial software-based camera sensor which can be used for testing,
+visualization of data, thermal cameras, or situations where no physical camera is available.
+
+```yaml
+# Example configuration entry
+camera_sensor:
+    type: software
+    width: 256
+    height: 256
+    image_format: RGB565
+```
+
+## Configuration variables
+
+- **type** (*Optional*): ``software``
+
+## Software Options
+
+- **width** (**Required**, int): Width of the generated image.
+- **height** (**Required**, int): Height of the generated image.
+- **format** (**Required**, enum): Pixel format of the image. Options are:
+  - ``GRAYSCALE``: Each pixel is one byte representing grayscale values.
+  - ``RGB565``: Two bytes per pixel, encoded as 5-6-5 for red, green, and blue.
+{{< note >}}
+When combining camera sensors with encoders, it may be necessary to perform little-endian to big-endian
+transformations. This can easily be spotted if not only red and blue are swapped but also some static
+appears in the image.
+{{< /note >}}
+  - ``BGR888``: Three bytes per pixel; the first byte is blue, followed by green and red.
+
+- **buffer** (*Optional*, int): Number of allocated frame buffers. Using 2 framebuffers allows
+  the pipeline to start processing of the second buffer before the first one is entirely completed,
+  which can slightly improve throughput.
+  Valid values: ``1``–``2``. Default: ``1``.
+
+- **clear** (*Optional*, boolean): If the framebuffer should be cleared to zeros before processing
+  starts. This can be convenient to avoid manual clearing via automations; however,
+  skipping this can save time if the entire framebuffer is written anyway.
+  - Default: ``True``.
+
+## See Also
+
+- {{< apiref "camera/sensor.h" "camera/sensor.h" >}}
+- {{< apiref "camera_sensor/software_sensor.h" "camera_sensor/software_sensor.h" >}}


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#10716

## Checklist:

  - [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [X] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
