### PR TITLE
2025.9.0b2

### DIFF
--- a/content/changelog/2025.9.0.md
+++ b/content/changelog/2025.9.0.md
@@ -163,6 +163,29 @@ and advanced setups may require updates.
 - [core] Store component source strings in flash on ESP8266 (breaking change) [esphome#10621](https://github.com/esphome/esphome/pull/10621) by [@bdraco](https://github.com/bdraco) (breaking-change)
 - [inkplate] Rename component and fix grayscale [esphome#10200](https://github.com/esphome/esphome/pull/10200) by [@JosipKuci](https://github.com/JosipKuci) (breaking-change)
 
+### Beta Changes
+
+- Update webserver local assets to 20250910-110003 [esphome#10668](https://github.com/esphome/esphome/pull/10668) by [@esphomebot](https://github.com/esphomebot)
+- [adc] Fix `FILTER_SOURCE_FILES` location [esphome#10673](https://github.com/esphome/esphome/pull/10673) by [@jesserockz](https://github.com/jesserockz)
+- Openthread Fix Factory Reset [esphome#9281](https://github.com/esphome/esphome/pull/9281) by [@rwrozelle](https://github.com/rwrozelle)
+- [core] Add millisecond precision to logging timestamps [esphome#10677](https://github.com/esphome/esphome/pull/10677) by [@bdraco](https://github.com/bdraco)
+- Add comprehensive tests for choose_upload_log_host to prevent regressions [esphome#10679](https://github.com/esphome/esphome/pull/10679) by [@bdraco](https://github.com/bdraco)
+- Add some more coverage for dashboard web_server [esphome#10682](https://github.com/esphome/esphome/pull/10682) by [@bdraco](https://github.com/bdraco)
+- [tests] Add upload_program and show_logs test coverage to prevent regressions [esphome#10684](https://github.com/esphome/esphome/pull/10684) by [@bdraco](https://github.com/bdraco)
+- Add additional dashboard and main tests [esphome#10688](https://github.com/esphome/esphome/pull/10688) by [@bdraco](https://github.com/bdraco)
+- [core] fix upload to device via MQTT IP lookup (e.g. when mDNS is disable) [esphome#10632](https://github.com/esphome/esphome/pull/10632) by [@Links2004](https://github.com/Links2004)
+- Bump aioesphomeapi from 40.1.0 to 40.2.0 [esphome#10703](https://github.com/esphome/esphome/pull/10703) by [@dependabot[bot]](https://github.com/apps/dependabot)
+- [ethernet] Fix permanent component failure from undocumented ESP_FAIL in IPv6 setup [esphome#10708](https://github.com/esphome/esphome/pull/10708) by [@bdraco](https://github.com/bdraco)
+- [core] Optimize MAC address formatting to eliminate sprintf dependency [esphome#10713](https://github.com/esphome/esphome/pull/10713) by [@bdraco](https://github.com/bdraco)
+- [api] Revert unneeded GetTime bidirectional support added in #9790 [esphome#10702](https://github.com/esphome/esphome/pull/10702) by [@bdraco](https://github.com/bdraco)
+- [api] Optimize HelloResponse server_info to reduce memory usage [esphome#10701](https://github.com/esphome/esphome/pull/10701) by [@bdraco](https://github.com/bdraco)
+- [scheduler] Fix timing accumulation in scheduler causing incorrect execution measurements [esphome#10719](https://github.com/esphome/esphome/pull/10719) by [@bdraco](https://github.com/bdraco)
+- ina2xx should be total increasing for energy sensor [esphome#10711](https://github.com/esphome/esphome/pull/10711) by [@mikelawrence](https://github.com/mikelawrence)
+- Bump aioesphomeapi from 40.2.0 to 40.2.1 [esphome#10721](https://github.com/esphome/esphome/pull/10721) by [@dependabot[bot]](https://github.com/apps/dependabot)
+- [md5] Optimize MD5::get_hex() to eliminate sprintf dependency [esphome#10710](https://github.com/esphome/esphome/pull/10710) by [@bdraco](https://github.com/bdraco)
+- [wifi] Optimize WiFi MAC formatting to eliminate sprintf dependency [esphome#10715](https://github.com/esphome/esphome/pull/10715) by [@bdraco](https://github.com/bdraco)
+- [esp32_ble] Optimize BLE hex formatting to eliminate sprintf dependency [esphome#10714](https://github.com/esphome/esphome/pull/10714) by [@bdraco](https://github.com/bdraco)
+
 ### All changes
 
 <details>

--- a/content/guides/supporters.md
+++ b/content/guides/supporters.md
@@ -2227,4 +2227,4 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Christian Zufferey (@zuzu59)](https://github.com/zuzu59)
 - [Zynth-dev (@Zynth-dev)](https://github.com/Zynth-dev)
 
-*This page was last updated September 10, 2025.*
+*This page was last updated September 15, 2025.*

--- a/data/version.yaml
+++ b/data/version.yaml
@@ -1,2 +1,2 @@
-release: 2025.9.0b1
+release: 2025.9.0b2
 version: '2025.9'


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
## Full list of changes

### All changes

- Fix components.json and api ref urls for beta/next [docs#5348](https://github.com/esphome/esphome-docs/pull/5348)
- Remove legacy Google Site Verification [docs#5351](https://github.com/esphome/esphome-docs/pull/5351)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
