### PR TITLE
Fix broken API references

### DIFF
--- a/content/components/binary_sensor/ble_presence.md
+++ b/content/components/binary_sensor/ble_presence.md
@@ -136,5 +136,5 @@ Alternatively you can:
 - {{< docref "/components/esp32_ble_tracker" >}}
 - {{< docref "/components/esp32_ble_beacon" >}}
 - {{< docref "/components/binary_sensor" >}}
-- {{< apiref "ble_presence/ble_presence.h" "ble_presence/ble_presence.h" >}}
+- {{< apiref "ble_presence/ble_presence_device.h" "ble_presence/ble_presence_device.h" >}}
 - [ESP32 BLE for Arduino](https://github.com/nkolban/ESP32_BLE_Arduino) by [Neil Kolban](https://github.com/nkolban).

--- a/content/components/button/factory_reset.md
+++ b/content/components/button/factory_reset.md
@@ -43,4 +43,4 @@ button:
 - {{< docref "safe_mode/" >}}
 - {{< docref "/components/switch/factory_reset" >}}
 - {{< docref "template/" >}}
-- {{< apiref "factory_reset/factory_reset_button.h" "factory_reset/factory_reset_button.h" >}}
+- {{< apiref "factory_reset/button/factory_reset_button.h" "factory_reset/button/factory_reset_button.h" >}}

--- a/content/components/button/safe_mode.md
+++ b/content/components/button/safe_mode.md
@@ -32,4 +32,4 @@ button:
 - {{< docref "factory_reset/" >}}
 - {{< docref "/components/switch/safe_mode" >}}
 - {{< docref "template/" >}}
-- {{< apiref "safe_mode/safe_mode_button.h" "safe_mode/safe_mode_button.h" >}}
+- {{< apiref "safe_mode/button/safe_mode_button.h" "safe_mode/button/safe_mode_button.h" >}}

--- a/content/components/button/shutdown.md
+++ b/content/components/button/shutdown.md
@@ -32,4 +32,4 @@ button:
 - {{< docref "factory_reset/" >}}
 - {{< docref "/components/switch/shutdown" >}}
 - {{< docref "template/" >}}
-- {{< apiref "shutdown/shutdown_button.h" "shutdown/shutdown_button.h" >}}
+- {{< apiref "shutdown/button/shutdown_button.h" "shutdown/button/shutdown_button.h" >}}

--- a/content/components/climate/bedjet.md
+++ b/content/components/climate/bedjet.md
@@ -211,4 +211,4 @@ ota:
 
 - {{< docref "/components/ble_client" >}}
 - {{< docref "/components/climate" >}}
-- {{< apiref "bedjet/bedjet.h" "bedjet/bedjet.h" >}}
+- {{< apiref "bedjet/bedjet_hub.h" "bedjet/bedjet_hub.h" >}}

--- a/content/components/climate/haier.md
+++ b/content/components/climate/haier.md
@@ -302,4 +302,4 @@ on_...:
 - {{< docref "/components/button/haier" "Haier Climate Buttons" >}}
 - {{< docref "/components/switch/haier" "Haier Climate Switches" >}}
 - {{< docref "/components/climate" >}}
-- {{< apiref "haier/climate/haier_base.h" "haier/climate/haier_base.h" >}}
+- {{< apiref "haier/haier_base.h" "haier/haier_base.h" >}}

--- a/content/components/climate/midea.md
+++ b/content/components/climate/midea.md
@@ -283,4 +283,4 @@ Special thanks to the project [IRremoteESP8266](https://github.com/crankyoldgit/
 ## See Also
 
 - {{< docref "/components/climate" >}}
-- {{< apiref "climate/midea_ac.h" "climate/midea_ac.h" >}}
+- {{< apiref "midea/air_conditioner.h" "midea/air_conditioner.h" >}}

--- a/content/components/cover/am43.md
+++ b/content/components/cover/am43.md
@@ -69,4 +69,4 @@ The BLE stack on the ESP32 has a limit of three connected devices.
 
 - {{< docref "index/" >}}
 - [Automation](#automation)
-- {{< apiref "am43/am43_cover.h" "am43/am43_cover.h" >}}
+- {{< apiref "am43/cover/am43_cover.h" "am43/cover/am43_cover.h" >}}

--- a/content/components/display/pcd8544.md
+++ b/content/components/display/pcd8544.md
@@ -60,6 +60,6 @@ To use a backlight LIGHT pin needs to be connected to ground. If connected to GP
 ## See Also
 
 - {{< docref "index/" >}}
-- {{< apiref "pcd8544/pcd8544.h" "pcd8544/pcd8544.h" >}}
+- {{< apiref "pcd8544/pcd_8544.h" "pcd8544/pcd_8544.h" >}}
 - [Tutorial from Adafruit](https://learn.adafruit.com/nokia-5110-3310-monochrome-lcd)
 - [PCD8544 Library](https://github.com/adafruit/Adafruit-PCD8544-Nokia-5110-LCD-library) by [Adafruit](https://www.adafruit.com/)

--- a/content/components/display/st7567.md
+++ b/content/components/display/st7567.md
@@ -172,4 +172,4 @@ display:
 - [Display Menu](#display_menu)
 - [I²C Bus](#i2c)
 - [SPI Bus](#spi)
-- {{< apiref "st7567/st7567.h" "st7567/st7567.h" >}}
+- {{< apiref "st7567_base/st7567_base.h" "st7567_base/st7567_base.h" >}}

--- a/content/components/display/st7789v.md
+++ b/content/components/display/st7789v.md
@@ -306,4 +306,4 @@ display:
 
 - {{< docref "index/" >}}
 - {{< docref "/components/power_supply" "Power Supply Component" >}}
-- {{< apiref "st7789v_base/st7789v_base.h" "st7789v_base/st7789v_base.h" >}}
+- {{< apiref "st7789v/st7789v.h" "st7789v/st7789v.h" >}}

--- a/content/components/espnow.md
+++ b/content/components/espnow.md
@@ -214,4 +214,4 @@ automatically add any peer that data is sent to.
 
 ## See Also
 
-- {{< apiref "espnow/espnow.h" "espnow/espnow.h" >}}
+- {{< apiref "espnow/espnow_component.h" "espnow/espnow_component.h" >}}

--- a/content/components/light/beken_spi_led_strip.md
+++ b/content/components/light/beken_spi_led_strip.md
@@ -55,4 +55,5 @@ light:
 
 - {{< docref "/components/light" >}}
 - {{< docref "/components/power_supply" >}}
-- {{< apiref "beken_spi_led_strip/beken_spi_led_strip.h" "beken_spi_led_strip/beken_spi_led_strip.h" >}}
+"beken_spi_led_strip/led_strip.h"
+- {{< apiref "beken_spi_led_strip/led_strip.h" "beken_spi_led_strip/led_strip.h" >}}

--- a/content/components/light/esp32_rmt_led_strip.md
+++ b/content/components/light/esp32_rmt_led_strip.md
@@ -92,4 +92,4 @@ please consider adding support to the codebase and add it to the list above.
 
 - {{< docref "/components/light" >}}
 - {{< docref "/components/power_supply" >}}
-- {{< apiref "esp32_rmt_led_strip/esp32_rmt_led_strip.h" "esp32_rmt_led_strip/esp32_rmt_led_strip.h" >}}
+- {{< apiref "esp32_rmt_led_strip/led_strip.h" "esp32_rmt_led_strip/led_strip.h" >}}

--- a/content/components/light/hbridge.md
+++ b/content/components/light/hbridge.md
@@ -45,4 +45,4 @@ As we are switching the H-bridge in software, the light may glitch every so ofte
 
 - {{< docref "/components/light" >}}
 - {{< docref "/components/output/esp8266_pwm" >}}
-- {{< apiref "hbridge/light/hbridge_light.h" "hbridge/light/hbridge_light.h" >}}
+- {{< apiref "hbridge/light/hbridge_light_output.h" "hbridge/light/hbridge_light_output.h" >}}

--- a/content/components/light/rgbw.md
+++ b/content/components/light/rgbw.md
@@ -88,4 +88,4 @@ the `color_mode` option of the [light control actions](#light-turn_on_action).
 - {{< docref "/components/output/tlc59208f" >}}
 - {{< docref "/components/output/my9231" >}}
 - {{< docref "/components/output/sm16716" >}}
-- {{< apiref "rgbw/rgb_light_output.h" "rgbw/rgb_light_output.h" >}}
+- {{< apiref "rgbw/rgbw_light_output.h" "rgbw/rgbw_light_output.h" >}}

--- a/content/components/light/shelly_dimmer.md
+++ b/content/components/light/shelly_dimmer.md
@@ -94,4 +94,4 @@ There is no action required by the user to flash the STM32. There is no way to r
 ## See Also
 
 - {{< docref "/components/light" >}}
-- {{< apiref "shelly_dimmer/light/shelly_dimmer.h" "shelly_dimmer/light/shelly_dimmer.h" >}}
+- {{< apiref "shelly_dimmer/shelly_dimmer.h" "shelly_dimmer/shelly_dimmer.h" >}}

--- a/content/components/mcp23Sxx.md
+++ b/content/components/mcp23Sxx.md
@@ -143,5 +143,5 @@ binary_sensor:
 - [SPI Bus](#spi)
 - {{< docref "switch/gpio" >}}
 - {{< docref "binary_sensor/gpio" >}}
-- {{< apiref "API Reference (MCP23S08)" "mcp23S08/mcp23S08.h" >}}
-- {{< apiref "API Reference (MCP23S17)" "mcp23S17/mcp23S17.h" >}}
+- {{< apiref "API Reference (MCP23S08)" "mcp23s08/mcp23s08.h" >}}
+- {{< apiref "API Reference (MCP23S17)" "mcp23s17/mcp23s17.h" >}}

--- a/content/components/opentherm.md
+++ b/content/components/opentherm.md
@@ -477,9 +477,9 @@ climate:
 
 - {{< apiref "API Reference: OpenthermHub" "opentherm/hub.h" >}}
 - {{< apiref "API Reference: OpenthermInput" "opentherm/input.h" >}}
-- {{< apiref "API Reference: OpenthermNumber" "opentherm/number/number.h" >}}
-- {{< apiref "API Reference: OpenthermOutput" "opentherm/output/output.h" >}}
-- {{< apiref "API Reference: OpenthermSwitch" "opentherm/switch/switch.h" >}}
+- {{< apiref "API Reference: OpenthermNumber" "opentherm/number/opentherm_number.h" >}}
+- {{< apiref "API Reference: OpenthermOutput" "opentherm/output/opentherm_output.h" >}}
+- {{< apiref "API Reference: OpenthermSwitch" "opentherm/switch/opentherm_switch.h" >}}
 - [OpenTherm thermostat with ESPHome and Home Assistant](https://olegtarasov.me/opentherm-thermostat-esphome/) —
   real-world use case for this component.
 

--- a/content/components/ota/_index.md
+++ b/content/components/ota/_index.md
@@ -161,5 +161,5 @@ expected. This is automatically enabled by the `ota` component, but it may be di
 
 ## See Also
 
-- {{< apiref "ota/ota_component.h" "ota/ota_component.h" >}}
+- {{< apiref "ota/ota_backend.h" "ota/ota_backend.h" >}}
 - {{< docref "/components/safe_mode" >}}

--- a/content/components/ota/esphome.md
+++ b/content/components/ota/esphome.md
@@ -86,7 +86,7 @@ If OTA is already enabled without a password, simply add a `password:` line to t
 
 ## See Also
 
-- {{< apiref "ota/ota_component.h" "ota/ota_component.h" >}}
+- {{< apiref "esphome/ota/ota_esphome.h" "esphome/ota/ota_esphome.h" >}}
 - {{< docref "/components/ota" >}}
 - {{< docref "/components/ota/http_request" >}}
 - {{< docref "/components/safe_mode" >}}

--- a/content/components/ota/http_request.md
+++ b/content/components/ota/http_request.md
@@ -109,7 +109,7 @@ on_...:
 
 ## See Also
 
-- {{< apiref "ota/ota_component.h" "ota/ota_component.h" >}}
+- {{< apiref "http_request/ota/ota_http_request.h" "http_request/ota/ota_http_request.h" >}}
 - {{< docref "/components/ota" >}}
 - {{< docref "/components/ota/esphome" >}}
 - {{< docref "/components/safe_mode" >}}

--- a/content/components/ota/web_server.md
+++ b/content/components/ota/web_server.md
@@ -118,7 +118,7 @@ ota:
 
 ## See Also
 
-- {{< apiref "ota/ota_component.h" "ota/ota_component.h" >}}
+- {{< apiref "web_server/ota/ota_web_server.h" "web_server/ota/ota_web_server.h" >}}
 - {{< docref "/components/ota" >}}
 - {{< docref "/components/ota/esphome" >}}
 - {{< docref "/components/web_server" >}}

--- a/content/components/output/sm16716.md
+++ b/content/components/output/sm16716.md
@@ -216,5 +216,5 @@ power_supply:
 - {{< docref "/components/light/rgbw" >}}
 - {{< docref "/components/light/rgbww" >}}
 - {{< docref "/components/power_supply" >}}
-- {{< apiref "output/sm16716_output_component.h" "output/sm16716_output_component.h" >}}
+- {{< apiref "sm16716/sm16716.h" "sm16716/sm16716.h" >}}
 - [An Arduino controller for SM16716-based LED strings.](https://github.com/sowbug/sm16716) by [@snowbug](https://github.com/sowbug)

--- a/content/components/output/sm2135.md
+++ b/content/components/output/sm2135.md
@@ -121,4 +121,4 @@ when using this driver.
 - {{< docref "/components/light/rgbw" >}}
 - {{< docref "/components/light/rgbww" >}}
 - {{< docref "/components/power_supply" >}}
-- {{< apiref "output/sm2135_output_component.h" "output/sm2135_output_component.h" >}}
+- {{< apiref "sm2135/sm2135.h" "sm2135/sm2135.h" >}}

--- a/content/components/output/sm2235.md
+++ b/content/components/output/sm2235.md
@@ -132,4 +132,4 @@ should be set to true when using this driver for safest operation.
 - {{< docref "/components/light/rgbw" >}}
 - {{< docref "/components/light/rgbww" >}}
 - {{< docref "/components/power_supply" >}}
-- {{< apiref "output/sm2235_output_component.h" "output/sm2235_output_component.h" >}}
+- {{< apiref "sm2235/sm2235.h" "sm2235/sm2235.h" >}}

--- a/content/components/remote_receiver.md
+++ b/content/components/remote_receiver.md
@@ -647,4 +647,4 @@ remote_transmitter:
 - [Setting up RF Devices](#remote-setting-up-rf)
 - {{< docref "/components/rf_bridge" >}}
 - [RCSwitch](https://github.com/sui77/rc-switch) by [Suat Özgür](https://github.com/sui77)
-- {{< apiref "remote/remote_receiver.h" "remote/remote_receiver.h" >}}
+- {{< apiref "remote_receiver/remote_receiver.h" "remote_receiver/remote_receiver.h" >}}

--- a/content/components/sensor/ade7953.md
+++ b/content/components/sensor/ade7953.md
@@ -306,4 +306,4 @@ sensor:
 ## See Also
 
 - [Sensor Filters](#sensor-filters)
-- {{< apiref "ade7953/ade7953.h" "ade7953/ade7953.h" >}}
+- {{< apiref "ade7953_base/ade7953_base.h" "ade7953_base/ade7953_base.h" >}}

--- a/content/components/sensor/am43.md
+++ b/content/components/sensor/am43.md
@@ -64,4 +64,4 @@ It is recommended to also setup the {{< docref "/components/cover/am43" >}}.
 - {{< docref "index/" >}}
 - {{< docref "/components/cover/am43" >}}
 - [Automation](#automation)
-- {{< apiref "sensor/am43/am43.h" "sensor/am43/am43.h" >}}
+- {{< apiref "am43/am43_base.h" "am43/am43_base.h" >}}

--- a/content/components/sensor/ble_client.md
+++ b/content/components/sensor/ble_client.md
@@ -128,4 +128,4 @@ Some common ones:
 - {{< docref "/components/ble_client" >}}
 - {{< docref "/components/text_sensor/ble_client" >}}
 - [Sensor Filters](#sensor-filters)
-- {{< apiref "ble_sensor/ble_sensor.h" "ble_sensor/ble_sensor.h" >}}
+- {{< apiref "ble_client/sensor/ble_sensor.h" "ble_client/sensor/ble_sensor.h" >}}

--- a/content/components/sensor/bme280.md
+++ b/content/components/sensor/bme280.md
@@ -99,6 +99,6 @@ configure this amount. Possible oversampling values:
 - {{< docref "absolute_humidity/" >}}
 - {{< docref "bme680/" >}}
 - {{< docref "bmp085/" >}}
-- {{< apiref "bme280/bme280.h" "bme280/bme280.h" >}}
+- {{< apiref "bme280_base/bme280_base.h" "bme280_base/bme280_base.h" >}}
 - [Adafruit BME280 Library](https://github.com/adafruit/Adafruit_BME280_Library) by [Adafruit](https://www.adafruit.com/)
 - [SparkFun BME280 Library](https://github.com/sparkfun/SparkFun_BME280_Arduino_Library) by [SparkFun](https://www.sparkfun.com/)

--- a/content/components/sensor/bmp280.md
+++ b/content/components/sensor/bmp280.md
@@ -92,5 +92,5 @@ configure this amount. Possible oversampling values:
 - {{< docref "bme280/" >}}
 - {{< docref "bme680/" >}}
 - {{< docref "bmp085/" >}}
-- {{< apiref "bmp280/bmp280.h" "bmp280/bmp280.h" >}}
+- {{< apiref "bmp280_base/bmp280_base.h" "bmp280_base/bmp280_base.h" >}}
 - [BMP280 Library](https://github.com/adafruit/Adafruit_BMP280_Library) by [Adafruit](https://www.adafruit.com/)

--- a/content/components/sensor/ct_clamp.md
+++ b/content/components/sensor/ct_clamp.md
@@ -76,4 +76,4 @@ Recompile and upload, now your CT clamp sensor is calibrated!
 - [CT Clamp Guide](https://learn.openenergymonitor.org/electricity-monitoring/ct-sensors/introduction)
 - {{< docref "adc/" >}}
 - {{< docref "ads1115/" >}}
-- {{< apiref "sensor/ct_clamp_sensor.h" "sensor/ct_clamp_sensor.h" >}}
+- {{< apiref "ct_clamp/ct_clamp_sensor.h" "ct_clamp/ct_clamp_sensor.h" >}}

--- a/content/components/sensor/ens160.md
+++ b/content/components/sensor/ens160.md
@@ -107,4 +107,4 @@ text_sensor:
 - [Sensor Filters](#sensor-filters)
 - {{< docref "ccs811/" >}}
 - {{< docref "sgp30/" >}}
-- {{< apiref "ens160/ens160.h" "ens160/ens160.h" >}}
+- {{< apiref "ens160_base/ens160_base.h" "ens160_base/ens160_base.h" >}}

--- a/content/components/sensor/ens210.md
+++ b/content/components/sensor/ens210.md
@@ -41,5 +41,5 @@ sensor:
 
 - [Sensor Filters](#sensor-filters)
 - {{< docref "absolute_humidity/" >}}
-- {{< apiref "ENS210/ENS210.h" "ENS210/ENS210.h" >}}
+- {{< apiref "ens210/ens210.h" "ens210/ens210.h" >}}
 - [ENS210 Library](https://github.com/maarten-pennings/ENS210) by [Maarten Pennings](https://github.com/maarten-pennings)

--- a/content/components/sensor/honeywellabp2_i2c.md
+++ b/content/components/sensor/honeywellabp2_i2c.md
@@ -52,4 +52,4 @@ datasheet indicates that the sensor does not measure temperature.
 ## See Also
 
 - [Sensor Filters](#sensor-filters)
-- {{< apiref "honeywellabp/honeywellabp2.h" "honeywellabp/honeywellabp2.h" >}}
+- {{< apiref "honeywellabp2_i2c/honeywellabp2.h" "honeywellabp2_i2c/honeywellabp2.h" >}}

--- a/content/components/sensor/max31856.md
+++ b/content/components/sensor/max31856.md
@@ -52,4 +52,4 @@ sensor:
 - {{< docref "max31855/" >}}
 - {{< docref "max31865/" >}}
 - [MAX31856 Library](https://github.com/adafruit/Adafruit_MAX31856) by [Adafruit](https://www.adafruit.com/)
-- {{< apiref "MAX31856/MAX31856.h" "MAX31856/MAX31856.h" >}}
+- {{< apiref "max31856/max31856.h" "max31856/max31856.h" >}}

--- a/content/components/sensor/msa3xx.md
+++ b/content/components/sensor/msa3xx.md
@@ -208,4 +208,4 @@ binary_sensor:
 ## See Also
 
 - [Sensor Filters](#sensor-filters)
-- {{< apiref "msa3xxx/msa3xxx.h" "msa3xxx/msa3xxx.h" >}}
+- {{< apiref "msa3xx/msa3xx.h" "msa3xx/msa3xx.h" >}}

--- a/content/components/sensor/sdm_meter.md
+++ b/content/components/sensor/sdm_meter.md
@@ -119,4 +119,4 @@ sensor:
 ## See Also
 
 - [Sensor Filters](#sensor-filters)
-- {{< apiref "sdm220m/sdm220m.h" "sdm220m/sdm220m.h" >}}
+- {{< apiref "sdm_meter/sdm_meter.h" "sdm_meter/sdm_meter.h" >}}

--- a/content/components/sensor/uptime.md
+++ b/content/components/sensor/uptime.md
@@ -34,4 +34,6 @@ sensor:
 
 - {{< docref "/components/text_sensor/uptime" >}}
 - [Sensor Filters](#sensor-filters)
-- {{< apiref "uptime/uptime_sensor.h" "uptime/uptime_sensor.h" >}}
+- {{< apiref "API Reference (Seconds)" "uptime/sensor/uptime_seconds_sensor.h" >}}
+- {{< apiref "API Reference (Timestamp)" "uptime/sensor/uptime_timestamp_sensor.h" >}}
+- {{< apiref "API Reference (Text)" "uptime/text_sensor/uptime_text_sensor.h" >}}

--- a/content/components/sensor/xiaomi_ble.md
+++ b/content/components/sensor/xiaomi_ble.md
@@ -637,7 +637,7 @@ You should at least protect your sensors with a custom pairing PIN code. Choose 
 - {{< docref "/components/esp32_ble_tracker" >}}
 - {{< docref "/components/sensor" >}}
 - {{< docref "/components/display/pvvx_mithermometer" >}}
-- {{< apiref "xiaomi_lywsd03mmc/xiaomi_ble.h" "xiaomi_lywsd03mmc/xiaomi_ble.h" >}}
+- {{< apiref "xiaomi_ble/xiaomi_ble.h" "xiaomi_ble/xiaomi_ble.h" >}}
 - {{< docref "/components/ethernet" >}}
 - {{< docref "/components/bluetooth_proxy" >}}
 - Passive BLE monitor integration for Home Assistant (ble_monitor custom component) `<https://github.com/custom-components/ble_monitor>`__

--- a/content/components/sn74hc165.md
+++ b/content/components/sn74hc165.md
@@ -60,4 +60,4 @@ Pin number 0 is Pin A on the SN74HC165 that is furthest away from the microcontr
 ### See Also
 
 - {{< docref "binary_sensor/gpio" >}}
-- {{< apiref "SN74HC165/SN74HC165.h" "SN74HC165/SN74HC165.h" >}}
+- {{< apiref "sn74hc165/sn74hc165.h" "sn74hc165/sn74hc165.h" >}}

--- a/content/components/switch/factory_reset.md
+++ b/content/components/switch/factory_reset.md
@@ -43,4 +43,4 @@ switch:
 - {{< docref "safe_mode/" >}}
 - {{< docref "/components/button/factory_reset" >}}
 - {{< docref "template/" >}}
-- {{< apiref "factory_reset/factory_reset_switch.h" "factory_reset/factory_reset_switch.h" >}}
+- {{< apiref "factory_reset/switch/factory_reset_switch.h" "factory_reset/switch/factory_reset_switch.h" >}}

--- a/content/components/switch/nextion.md
+++ b/content/components/switch/nextion.md
@@ -107,7 +107,7 @@ This action can also be written in lambdas. See [Lambda Calls](#nextion_switch_l
 ### Lambda Calls
 
 From [lambdas](#config-lambda), you can call several methods to access
-some more advanced functions (see the full {{< apiref "nextion/nextion_switch.h" "nextion/nextion_switch.h" >}} for more info).
+some more advanced functions (see the full {{< apiref "nextion/switch/nextion_switch.h" "nextion/switch/nextion_switch.h" >}} for more info).
 
 {{< anchor "nextion_switch_set_state" >}}
 

--- a/content/components/switch/safe_mode.md
+++ b/content/components/switch/safe_mode.md
@@ -31,4 +31,4 @@ switch:
 - {{< docref "factory_reset/" >}}
 - {{< docref "/components/button/safe_mode" >}}
 - {{< docref "template/" >}}
-- {{< apiref "safe_mode/safe_mode_switch.h" "safe_mode/safe_mode_switch.h" >}}
+- {{< apiref "safe_mode/switch/safe_mode_switch.h" "safe_mode/switch/safe_mode_switch.h" >}}

--- a/content/components/switch/shutdown.md
+++ b/content/components/switch/shutdown.md
@@ -32,4 +32,4 @@ switch:
 - {{< docref "factory_reset/" >}}
 - {{< docref "/components/button/shutdown" >}}
 - {{< docref "template/" >}}
-- {{< apiref "shutdown/shutdown_switch.h" "shutdown/shutdown_switch.h" >}}
+- {{< apiref "shutdown/switch/shutdown_switch.h" "shutdown/switch/shutdown_switch.h" >}}

--- a/content/components/tca9555.md
+++ b/content/components/tca9555.md
@@ -54,4 +54,4 @@ switch:
 - {{< docref "switch/gpio" >}}
 - {{< docref "binary_sensor/gpio" >}}
 - [TCA9555 Arduino Library](https://github.com/RobTillaart/TCA9555) by [Rob Tillaart](https://github.com/RobTillaart)
-- {{< apiref "TCA9555/TCA9555.h" "TCA9555/TCA9555.h" >}}
+- {{< apiref "tca9555/tca9555.h" "tca9555/tca9555.h" >}}

--- a/content/components/text_sensor/ble_client.md
+++ b/content/components/text_sensor/ble_client.md
@@ -61,4 +61,4 @@ A variable `x` of type `std::string` is passed to the automation for use in lamb
 - {{< docref "/components/ble_client" >}}
 - {{< docref "/components/sensor/ble_client" >}}
 - [Sensor Filters](#sensor-filters)
-- {{< apiref "ble_text_sensor/ble_text_sensor.h" "ble_text_sensor/ble_text_sensor.h" >}}
+- {{< apiref "ble_client/text_sensor/ble_text_sensor.h" "ble_client/text_sensor/ble_text_sensor.h" >}}

--- a/content/components/text_sensor/uptime.md
+++ b/content/components/text_sensor/uptime.md
@@ -42,4 +42,4 @@ The resolution of the reported uptime will be determined by the update interval.
 
 - {{< docref "/components/sensor/uptime" >}}
 - [Text Sensor Filters](#text_sensor-filters)
-- {{< apiref "uptime/uptime_text_sensor.h" "uptime/uptime_text_sensor.h" >}}
+- {{< apiref "uptime/text_sensor/uptime_text_sensor.h" "uptime/text_sensor/uptime_text_sensor.h" >}}

--- a/content/components/touchscreen/_index.md
+++ b/content/components/touchscreen/_index.md
@@ -215,7 +215,7 @@ This trigger provides two arguments named `touch` of type *touchpoint* and `touc
 
 This new automation will be triggered when the touchscreen detects an extra touch or that a touch has moved around on the screen.
 
-This trigger provides one argument named `touches` of type {{< apiref "touchscreen::TouchPoints_t" "touchscreen::TouchPoints_t" >}} which has a list of
+This trigger provides one argument named `touches` of type {{< apiref "touchscreen::TouchPoints_t" "touchscreen::TouchPoint" >}} which has a list of
  [`TouchPoint` Argument Type](#touchscreen-touchpoint).
 
 This trigger may be useful to detect gestures such as swiping across the display.

--- a/content/components/touchscreen/axs15231.md
+++ b/content/components/touchscreen/axs15231.md
@@ -29,4 +29,4 @@ touchscreen:
 
 ## See Also
 
-- {{< apiref "axs15231/touchscreen/axs15231.h" "axs15231/touchscreen/axs15231.h" >}}
+- {{< apiref "axs15231/touchscreen/axs15231_touchscreen.h" "axs15231/touchscreen/axs15231_touchscreen.h" >}}

--- a/content/components/touchscreen/ektf2232.md
+++ b/content/components/touchscreen/ektf2232.md
@@ -31,4 +31,4 @@ touchscreen:
 
 - {{< docref "index" "Touchscreen" >}}
 - {{< docref "/components/display/inkplate" "Inkplate 6 Plus" >}}
-- {{< apiref "ektf2232/ektf2232.h" "ektf2232/ektf2232.h" >}}
+- {{< apiref "ektf2232/touchscreen/ektf2232.h" "ektf2232/touchscreen/ektf2232.h" >}}

--- a/content/components/touchscreen/gt911.md
+++ b/content/components/touchscreen/gt911.md
@@ -57,5 +57,5 @@ binary_sensor:
 ## See Also
 
 - [Binary Sensor Filters](#binary_sensor-filters)
-- {{< apiref "gt911/touchscreen/gt911.h" "gt911/touchscreen/gt911.h" >}}
+- {{< apiref "gt911/touchscreen/gt911_touchscreen.h" "gt911/touchscreen/gt911_touchscreen.h" >}}
 - {{< apiref "gt911/binary_sensor/gt911_button.h" "gt911/binary_sensor/gt911_button.h" >}}

--- a/content/components/touchscreen/sdl.md
+++ b/content/components/touchscreen/sdl.md
@@ -28,4 +28,4 @@ touchscreen:
 ## See Also
 
 - [SDL display](#sdl)
-- {{< apiref "sdl/sdl_touchscreen.h" "sdl/sdl_touchscreen.h" >}}
+- {{< apiref "sdl/touchscreen/sdl_touchscreen.h" "sdl/touchscreen/sdl_touchscreen.h" >}}

--- a/content/components/touchscreen/xpt2046.md
+++ b/content/components/touchscreen/xpt2046.md
@@ -78,5 +78,5 @@ Base Configuration:
 ## See Also
 
 - [Binary Sensor Filters](#binary_sensor-filters)
-- {{< apiref "xpt2046/xpt2046.h" "xpt2046/xpt2046.h" >}}
+- {{< apiref "xpt2046/touchscreen/xpt2046.h" "xpt2046/touchscreen/xpt2046.h" >}}
 - [XPT2046 Library](https://platformio.org/lib/show/542/XPT2046_Touchscreen) by [Paul Stoffregen](https://github.com/PaulStoffregen)

--- a/content/components/weikai.md
+++ b/content/components/weikai.md
@@ -296,4 +296,4 @@ log file and the baud rate will automatically be decreased.
 - [SPI Bus](#spi)
 - {{< docref "switch/gpio" >}}
 - {{< docref "binary_sensor/gpio" >}}
-- {{< apiref "weika/weika.h" "weika/weika.h" >}}
+- {{< apiref "weikai/weikai.h" "weikai/weikai.h" >}}


### PR DESCRIPTION
## Description:

Using a horrible bash script, I found a bunch of places where API Reference links lead to a 404.

Note: This fixes _most_ of them, however there are some cases where `apiref` does not currently work (see [thread](https://discord.com/channels/429907082951524364/1418060509369860196)) but these should all work after esphome/esphome#10794 and #5387 merge.

**Related issue (if applicable):** *N/A*

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

*N/A*

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
