### PR TITLE
Update docs for Arduino as a Component

### DIFF
--- a/content/components/esp32.md
+++ b/content/components/esp32.md
@@ -49,7 +49,12 @@ suitable for that variant. Both may be specified (for backwards compatibility) b
 
 ## Framework
 
-This is the default framework for ESP32 chips at the moment.
+ESPHome supports two framework options for ESP32 chips:
+
+### Arduino Framework
+
+The Arduino framework is integrated as an ESP-IDF component. This provides Arduino API compatibility
+within the ESP-IDF build system. Arduino framework is available for ESP32 (classic), ESP32-C3, ESP32-S2, and ESP32-S3 variants.
 
 ```yaml
 # Example configuration entry
@@ -59,8 +64,11 @@ esp32:
     type: arduino
 ```
 
-This is an alternative base framework for ESP32 chips; it is recommended for variants of the ESP32 like ESP32S2,
-ESP32S3, ESP32P4 and single-core ESP32 chips.
+### ESP-IDF Framework
+
+ESP-IDF is Espressif's native development framework. It is required for ESP32-C2, ESP32-C5, ESP32-C6,
+ESP32-H2, and ESP32-P4 variants, as these do not support the Arduino framework. It is recommended for
+all ESP32 chips when possible. See the {{< docref "/guides/esp32_arduino_to_idf" "migration guide" >}} for help transitioning from Arduino.
 
 ```yaml
 # Example configuration entry
@@ -72,7 +80,7 @@ esp32:
 
 ### Configuration variables
 
-- **type** (*Optional*, string): The framework type, either `esp-idf` or `arduino`. Defaults to `arduino`
+- **type** (*Optional*, string): The framework type, either `esp-idf` or `arduino`. Defaults to `arduino` for ESP32 (classic), ESP32-C3, ESP32-S2, and ESP32-S3. Defaults to `esp-idf` for ESP32-C2, ESP32-C5, ESP32-C6, ESP32-H2, and ESP32-P4 (Arduino is not supported on these variants)
 
 - **version** (*Optional*, string): The base framework version number to use, from
   [ESP32 ESP-IDF releases](https://github.com/espressif/esp-idf/releases) or

--- a/content/components/esp32.md
+++ b/content/components/esp32.md
@@ -72,7 +72,7 @@ esp32:
 
 ### Configuration variables
 
-- **type** (*Optional*, string): The frameword type, either `esp-idf` or `arduino`. Defaults to `arduino`
+- **type** (*Optional*, string): The framework type, either `esp-idf` or `arduino`. Defaults to `arduino`
 
 - **version** (*Optional*, string): The base framework version number to use, from
   [ESP32 ESP-IDF releases](https://github.com/espressif/esp-idf/releases) or

--- a/content/components/esp32.md
+++ b/content/components/esp32.md
@@ -43,12 +43,11 @@ suitable for that variant. Both may be specified (for backwards compatibility) b
 - **partitions** (*Optional*, filename): The name of (optionally including the path to) the file containing the
   partitioning scheme to be used. When not specified, partitions are automatically generated based on `flash_size`.
 
-- **framework** (*Optional*): Options for the underlying framework used by ESPHome. See [Arduino framework](#esp32-arduino_framework)
-  and [ESP-IDF framework](#esp32-espidf_framework).
+- **framework** (*Optional*): Options for the underlying framework used by ESPHome. See [Framework](#esp32-framework).
 
-{{< anchor "esp32-arduino_framework" >}}
+{{< anchor "esp32-framework" >}}
 
-## Arduino framework
+## Framework
 
 This is the default framework for ESP32 chips at the moment.
 
@@ -59,30 +58,6 @@ esp32:
   framework:
     type: arduino
 ```
-
-### Configuration variables
-
-- **version** (*Optional*, string): The base framework version number to use, from
-  [ESP32 arduino releases](https://github.com/espressif/arduino-esp32/releases). Defaults to `recommended`.
-  Additional values are:
-
-  - `dev`  : Use the latest commit from <https://github.com/espressif/arduino-esp32>, note this may break at any time
-  - `latest`  : Use the latest *release* from <https://github.com/espressif/arduino-esp32/releases>, even if it hasn't
-    been recommended yet.
-
-  - `recommended`  : Use the recommended framework version.
-
-- **source** (*Optional*, string): The PlatformIO package or repository to use for framework. This can be used to use a
-  custom or patched version of the framework.
-
-- **platform_version** (*Optional*, string): The version of the
-  [pioarduino/espressif32](https://github.com/pioarduino/platform-espressif32/releases) package to use.
-
-- **advanced** (*Optional*, mapping): See [Advanced Configuration](#esp32-advanced_configuration) below.
-
-{{< anchor "esp32-espidf_framework" >}}
-
-## ESP-IDF framework
 
 This is an alternative base framework for ESP32 chips; it is recommended for variants of the ESP32 like ESP32S2,
 ESP32S3, ESP32P4 and single-core ESP32 chips.
@@ -97,14 +72,15 @@ esp32:
 
 ### Configuration variables
 
+- **type** (*Optional*, string): The frameword type, either `esp-idf` or `arduino`. Defaults to `arduino`
+
 - **version** (*Optional*, string): The base framework version number to use, from
-  [ESP32 ESP-IDF releases](https://github.com/espressif/esp-idf/releases). Defaults to `recommended`.
+  [ESP32 ESP-IDF releases](https://github.com/espressif/esp-idf/releases) or
+  [ESP32 arduino releases](https://github.com/espressif/arduino-esp32/releases). Defaults to `recommended`.
   Additional values are:
 
-  - `dev`  : Use the latest commit from <https://github.com/espressif/esp-idf>, note this may break at any time
-  - `latest`  : Use the latest *release* from <https://github.com/espressif/esp-idf/releases>, even if it hasn't been
-    recommended yet.
-
+  - `dev`  : Use the latest commit, note this may break at any time
+  - `latest`  : Use the latest *release*, even if it hasn't been recommended yet.
   - `recommended`  : Use the recommended framework version.
 
 - **source** (*Optional*, string): The PlatformIO package or repository to use for the framework. This can be used to
@@ -154,9 +130,8 @@ esp32:
   address is not consistent with the burned-in CRC for that MAC address, resulting in an error like
   `Base MAC address from BLK0 of EFUSE CRC error`. **Valid only on original ESP32 with** `esp-idf` **framework.**
 
-- **enable_idf_experimental_features** (*Optional*, boolean): Can be set to `true` to enable experimental features in
-  the ESP-IDF framework. Not valid for the Arduino framework. Use of experimental features may cause instability or
-  other issues.
+- **enable_idf_experimental_features** (*Optional*, boolean): Can be set to `true` to enable experimental features. Use of
+  experimental features may cause instability or other issues.
 
 **LWIP Optimization Options (ESP-IDF only):**
 

--- a/content/components/esp32.md
+++ b/content/components/esp32.md
@@ -67,7 +67,7 @@ esp32:
 ### ESP-IDF Framework
 
 ESP-IDF is Espressif's native development framework. It is required for ESP32-C2, ESP32-C5, ESP32-C6,
-ESP32-H2, and ESP32-P4 variants, as these do not support the Arduino framework. It is recommended for
+ESP32-H2, and ESP32-P4 variants, as these are not supported by the Arduino framework. It is recommended for
 all ESP32 chips when possible. See the {{< docref "/guides/esp32_arduino_to_idf" "migration guide" >}} for help transitioning from Arduino.
 
 ```yaml

--- a/content/components/logger.md
+++ b/content/components/logger.md
@@ -104,6 +104,7 @@ hardware interfaces for logging. Many newer boards based on ESP32 variants (such
 are using the ESP's on-board USB hardware peripheral while boards based on older processors (such as
 the original ESP32 or ESP8266) continue to use USB-to-serial bridge ICs for communication.
 
+|          | Interface |
 | -------- | --------- |
 | ESP8266  | `UART0`   |
 | ESP32    | `UART0`   |

--- a/content/components/logger.md
+++ b/content/components/logger.md
@@ -104,17 +104,16 @@ hardware interfaces for logging. Many newer boards based on ESP32 variants (such
 are using the ESP's on-board USB hardware peripheral while boards based on older processors (such as
 the original ESP32 or ESP8266) continue to use USB-to-serial bridge ICs for communication.
 
-|          | Arduino   | ESP-IDF           |
-| -------- | --------- | ----------------- |
-| ESP8266  | `UART0`   | N/A               |
-| ESP32    | `UART0`   | `UART0`           |
-| ESP32-C3 | `USB_CDC` | `USB_SERIAL_JTAG` |
-| ESP32-C5 | `USB_CDC` | `USB_SERIAL_JTAG` |
-| ESP32-C6 | `USB_CDC` | `USB_SERIAL_JTAG` |
-| ESP32-P4 | `USB_CDC` | `USB_SERIAL_JTAG` |
-| ESP32-S2 | `USB_CDC` | `USB_CDC`         |
-| ESP32-S3 | `USB_CDC` | `USB_SERIAL_JTAG` |
-| RP2040 | `USB_CDC` | N/A |
+| -------- | --------- |
+| ESP8266  | `UART0`   |
+| ESP32    | `UART0`   |
+| ESP32-C3 | `USB_SERIAL_JTAG` |
+| ESP32-C5 | `USB_SERIAL_JTAG` |
+| ESP32-C6 | `USB_SERIAL_JTAG` |
+| ESP32-P4 | `USB_SERIAL_JTAG` |
+| ESP32-S2 | `USB_CDC`         |
+| ESP32-S3 | `USB_SERIAL_JTAG` |
+| RP2040 | `USB_CDC` |
 
 {{< anchor "logger-log_levels" >}}
 

--- a/content/components/media_player/speaker.md
+++ b/content/components/media_player/speaker.md
@@ -17,7 +17,7 @@ It supports two different audio pipelines: announcement and media. Each audio pi
 
 On-device files built directly into the firmware are played without a network connection. Encode on-device files with the configured sample rate, 1 or 2 channels, and 16 bits per sample.
 
-This platform only works on ESP32 based chips using the [ESP-IDF framework](#esp32-framework).
+This platform only works on ESP32-based chips using the [ESP-IDF framework](#esp32-framework).
 
 {{< warning >}}
 Audio and voice components consume a significant amount of resources (RAM, CPU) on the device.

--- a/content/components/media_player/speaker.md
+++ b/content/components/media_player/speaker.md
@@ -17,7 +17,7 @@ It supports two different audio pipelines: announcement and media. Each audio pi
 
 On-device files built directly into the firmware are played without a network connection. Encode on-device files with the configured sample rate, 1 or 2 channels, and 16 bits per sample.
 
-This platform only works on ESP32 based chips using the [ESP-IDF framework](#esp32-espidf_framework).
+This platform only works on ESP32 based chips using the [ESP-IDF framework](#esp32-framework).
 
 {{< warning >}}
 Audio and voice components consume a significant amount of resources (RAM, CPU) on the device.

--- a/content/guides/esp32_arduino_to_idf.md
+++ b/content/guides/esp32_arduino_to_idf.md
@@ -10,6 +10,9 @@ params:
 Starting with ESPHome 2026.1.0, the default framework for ESP32 will change from Arduino to ESP-IDF. This guide will
 help you migrate your existing configurations or make an informed choice about which framework to use.
 
+Note: The Arduino framework is integrated as an ESP-IDF component, providing Arduino API compatibility
+within the ESP-IDF build system.
+
 {{< note >}}
 This change only affects ESP32, ESP32-S2, ESP32-S3, and ESP32-C3 variants.
 Newer variants (ESP32-C6, ESP32-H2, ESP32-P4, etc.) already default to ESP-IDF
@@ -32,7 +35,6 @@ advantages:
 
 While ESP-IDF offers many benefits, there are some trade-offs to consider:
 
-- **Compile Times**: Initial compilation takes approximately 25% longer
 - **Component Compatibility**: Some components may need to be replaced with ESP-IDF compatible alternatives
 - **Library Differences**: Arduino-specific libraries won't be available
 


### PR DESCRIPTION
## Description:

Update docs for Arduino as a Component

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#10647

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
