### PR TITLE
Add blob about the new builder wizard options

### DIFF
--- a/content/changelog/2025.9.0.md
+++ b/content/changelog/2025.9.0.md
@@ -21,6 +21,7 @@ developer tools while maintaining backward compatibility for most use cases.
 **Key Highlights:**
 
 - **MIPI RGB Display support** for high-performance color displays with dedicated hardware acceleration
+- **ESPHome Builder improvements** with support for uploading existing YAML files and blank configurations
 - **Camera JPEG encoder** enabling efficient image compression and streaming capabilities  
 - **Enhanced NRF52 features** including DFU (Device Firmware Update) support
 - **Extensive memory optimizations** reducing flash and RAM usage across all platforms
@@ -61,6 +62,15 @@ ESPHome 2025.9.0 introduces comprehensive support for MIPI RGB displays through 
 
 MIPI RGB displays offer superior performance for applications requiring high-quality graphics, smooth animations, and
 professional-grade user interfaces.
+
+## ESPHome Builder Enhancements
+
+The ESPHome Builder web interface now offers improved flexibility for getting started with your projects:
+
+**New Capabilities:**
+
+- **Upload existing YAML files** to continue working on configurations created elsewhere
+- **Start with a blank configuration** for complete customization from scratch
 
 ## Camera JPEG Encoder
 


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
