### PR TITLE
substitutions: Document !literal tag

### DIFF
--- a/content/components/substitutions.md
+++ b/content/components/substitutions.md
@@ -151,6 +151,21 @@ In addition to the Jinja expressions, ESPHome supports a number of built-in func
 
 {{< anchor "substitute-include-variables" >}}
 
+## Disabling Jinja and substitutions
+
+You can prevent ESPHome from substituting variables or processing Jinja by means of the `!literal` tag before any value:
+
+```yaml
+substitutions:
+  value: "Test Value"
+lvgl:
+  widgets:
+    - label:
+        text: !literal "This is a ${value}"
+```
+
+In the above example, the value of the `text` property will be, literally, `This is a ${value}`.
+
 ## Substitute !include variables
 
 ESPHome's `!include` accepts a list of variables that can be substituted within the included file.


### PR DESCRIPTION
## Description:

This PR documents the `!literal` YAML tag which replaces `!force`, which was undocumented and largely unused.

- esphome/esphome#10785

## Checklist:

  - [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

