### PR TITLE
[zwave_proxy] Copy fixes

### DIFF
--- a/content/components/zwave_proxy.md
+++ b/content/components/zwave_proxy.md
@@ -47,7 +47,7 @@ Under near-ideal conditions:
 
 - With a direct serial connection to the Z-Wave modem SoC, latency may be as low as approximately 20 milliseconds (ms).
 - When introducing the Z-Wave proxy component, it's still possible to achieve low latency -- we've seen as low as 35
-  ms! however, in practice, it's more realistic to expect 50-60 ms, assuming decent RF conditions.
+  ms! However, in practice, it's more realistic to expect 50-60 ms, assuming decent RF conditions.
 
 In general, any duration less than 100 ms is quite acceptable in terms of latency; this value is generally a good
 target to keep in mind.
@@ -79,8 +79,8 @@ connectivity.
 If you choose to use Wi-Fi to bridge your Z-Wave modem to Z-Wave JS:
 
 - Confirm that there is a strong, stable Wi-Fi signal available in the location you'll place your Z-Wave proxy.
-- Do not attempt to place your Z-Wave proxy in or near the edge of the coverage area your Wi-Fi router/access point
-  provides.
+- Do not attempt to place your Z-Wave proxy at or near the edge of the coverage area your Wi-Fi router/access point
+  provides. If in doubt, move it closer to your Wi-Fi router/access point.
 - If you find that your Z-Wave devices are not operating reliably, you might try:
   - moving your Z-Wave proxy closer to your Wi-Fi router/access point.
   - changing the Wi-Fi channel your Wi-Fi router/access point is using.


### PR DESCRIPTION
## Description:

After a good night's sleep, I found a couple little things that were bothering me. 🙈

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
