### PR TITLE
[deep_sleep] Update possible modes for esp32_ext1_wakeup

### DIFF
--- a/content/components/deep_sleep.md
+++ b/content/components/deep_sleep.md
@@ -68,9 +68,9 @@ Advanced features:
 
   - **pins** (**Required**, list of pin numbers): The pins to wake up on.
   - **mode** (**Required**): The mode to use for the wakeup source. Must be one of:
-    - `ANY_LOW` (ESP32‑S2/S3/C6/H2 only) — wake up when any selected pin is LOW
-    - `ALL_LOW` (ESP32 only) — wake up when all selected pins are LOW
-    - `ANY_HIGH` — wake up when any selected pin is HIGH
+    - `ANY_LOW`: wake up when any selected pin is LOW (ESP32‑S2/S3/C6/H2 only)
+    - `ALL_LOW`: wake up when all selected pins are LOW (ESP32 only)
+    - `ANY_HIGH`: wake up when any selected pin is HIGH
 
 {{< note >}}
 Only one deep sleep component may be configured.

--- a/content/components/deep_sleep.md
+++ b/content/components/deep_sleep.md
@@ -68,8 +68,10 @@ Advanced features:
   wake up on multiple pins. This cannot be used together with wakeup pin.
 
   - **pins** (**Required**, list of pin numbers): The pins to wake up on.
-  - **mode** (**Required**): The mode to use for the wakeup source. Must be one of `ANY_LOW` (wake up when any
-    pin goes LOW), `ALL_LOW` (wake up when all pins go LOW) or `ANY_HIGH` (wake up when any pin goes HIGH).
+  - **mode** (**Required**): The mode to use for the wakeup source. Must be one of:
+    - `ANY_LOW` (ESP32‑S2/S3/C6/H2 only) — wake up when any selected pin is LOW
+    - `ALL_LOW` (ESP32 only) — wake up when all selected pins are LOW
+    - `ANY_HIGH` — wake up when any selected pin is HIGH
 
 {{< note >}}
 Only one deep sleep component may be configured.

--- a/content/components/deep_sleep.md
+++ b/content/components/deep_sleep.md
@@ -68,8 +68,8 @@ Advanced features:
   wake up on multiple pins. This cannot be used together with wakeup pin.
 
   - **pins** (**Required**, list of pin numbers): The pins to wake up on.
-  - **mode** (**Required**): The mode to use for the wakeup source. Must be one of `ALL_LOW` (wake up when
-    all pins go LOW) or `ANY_HIGH` (wake up when any pin goes HIGH).
+  - **mode** (**Required**): The mode to use for the wakeup source. Must be one of `ANY_LOW` (wake up when any
+    pin goes LOW), `ALL_LOW` (wake up when all pins go LOW) or `ANY_HIGH` (wake up when any pin goes HIGH).
 
 {{< note >}}
 Only one deep sleep component may be configured.


### PR DESCRIPTION
## Description:

Add missing `ANY_LOW` option for `esp32_ext1_wakeup` modes in deep sleep module. See https://github.com/esphome/esphome/blob/dev/esphome/components/deep_sleep/__init__.py#L158C1-L162C2.

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.
