### PR TITLE
Fix the table with examples in Wireguard component

### DIFF
--- a/content/components/wireguard.md
+++ b/content/components/wireguard.md
@@ -156,16 +156,16 @@ Incoming connections are not affected by `netmask`.
 
 Let's explain with some examples:
 
-| address      | netmask                      | allowed ips                                    | working outgoing connections                                                                                                               |
-| ------------ | ---------------------------- | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| 172.16.0.100 | *omitted* or 255.255.255.255 | *omitted* or any other value                   | **none**, no routes are created                                                                                                            |
-|              | 255.255.255.0                | *omitted*                                      | only to `172.16.0.0/24`                                                                                                                    |
-|              |                              | - 172.16.0.0/24 - 192.168.0.0/24 - *any other* | and any other network will be outside `172.16.0.0/24`                                                                                      |
-|              |                              | - 192.168.0.0/24                               | **none** because `192.168.0.0/24` is not part of `172.16.0.0/24`                                                                           |
-| 10.44.0.100  | 255.0.0.0                    | *omitted*                                      | to `10.0.0.0/8` network                                                                                                                    |
-|              |                              | - 10.44.0.0/16 - 10.10.0.0/16                  | only to the networks in the allowed list because the netmask will route the whole `10.0.0.0/8` but wireguard allows only those two subnets |
-| any          | 0.0.0.0                      | *omitted*                                      | **any**                                                                                                                                    |
-|              |                              | - 172.16.0.0/24 - 10.44.0.0/16 - 10.10.0.0/16  | to any network that is in the list of allowed IPs because the netmask will route any traffic but wireguard allows only its own list        |
+| address      | netmask                      | allowed ips                                                                   | working outgoing connections                                                                                                               |
+| ------------ | ---------------------------- | ----------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| 172.16.0.100 | *omitted* or 255.255.255.255 | *omitted* or any other value                                                  | **none**, no routes are created                                                                                                            |
+| 172.16.0.100 | 255.255.255.0                | *omitted*                                                                     | to `172.16.0.0/24` network                                                                                                                 |
+| 172.16.0.100 | 255.255.255.0                | `- 172.16.0.0/24`{{< break >}}`- 192.168.0.0/24`{{< break >}} *`- any other`* | only to `172.16.0.0/24` because `192.168.0.0/24` and any other network will be outside of `172.16.0.0/24`                                  |
+| 172.16.0.100 | 255.255.255.0                | `- 192.168.0.0/24`                                                            | **none** because `192.168.0.0/24` is not part of `172.16.0.0/24`                                                                           |
+| 10.44.0.100  | 255.0.0.0                    | *omitted*                                                                     | to `10.0.0.0/8` network                                                                                                                    |
+| 10.44.0.100  | 255.0.0.0                    | `- 10.44.0.0/16`{{< break >}}`- 10.10.0.0/16`                                 | only to the networks in the allowed list because the netmask will route the whole `10.0.0.0/8` but wireguard allows only those two subnets |
+| any          | 0.0.0.0                      | *omitted*                                                                     | **any**                                                                                                                                    |
+| any          | 0.0.0.0                      | `- 172.16.0.0/24`{{< break >}}`- 10.44.0.0/16`{{< break >}}`- 10.10.0.0/16`   | to any network that is in the list of allowed IPs because the netmask will route any traffic but wireguard allows only its own list        |
 
 > [!NOTE]
 > Setting the `netmask` to `0.0.0.0` has the effect of routing

--- a/themes/esphome-theme/layouts/shortcodes/break.html
+++ b/themes/esphome-theme/layouts/shortcodes/break.html
@@ -1,0 +1,5 @@
+{{/*
+    Shortcode: break
+    Output: Inserts <br>
+*/}}
+<br>


### PR DESCRIPTION
## Description:

[Previously](https://raw.githubusercontent.com/esphome/esphome-docs/4d6c6291c2974a629d44bf220d3786be6f74c63f/content/components/wireguard.md) the table was a bit complex:

<img width="741" height="555" alt="image" src="https://github.com/user-attachments/assets/07edd93f-d6aa-4b24-9db2-9ef9f8249493" />

[Recent conversion to Markdown](https://github.com/esphome/esphome-docs/pull/5242) broke the table: no newlines, even some text was lost:

<img width="1070" height="544" alt="image" src="https://github.com/user-attachments/assets/6c691b78-5c43-479d-a79b-9965653974f9" />

As there's no possibility to use `rowspan` in Markdown, converting the table to HTML manually:

<img width="961" height="625" alt="image" src="https://github.com/user-attachments/assets/977c8ef0-0cb6-4f21-96bc-339a7c29f900" />

**Related issue (if applicable):** fixes <link to issue>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
