### PR TITLE
[waveshare_epaper] documentation for GDEY075T7 model

### DIFF
--- a/content/components/display/waveshare_epaper.md
+++ b/content/components/display/waveshare_epaper.md
@@ -113,6 +113,7 @@ lambda: |-
   - `5.83in`
   - `5.83inv2`
   - `gdey0583t81` - GoodDisplay GDEY0583T81 5.83" B/W
+  - `gdey075t7` - GoodDisplay GDEY075T7 7.5" B/W
   - `7.30in-f` - 7.3in 7-color display (black, white, red, yellow, blue, green, and orange)
   - `7.50in`
   - `7.50in-bV2` - also supports v3, B/W rendering only
@@ -129,7 +130,7 @@ lambda: |-
   - `13.3in-k` - 13.3in, with the K model, 960x680, B/W rendering only
 
 {{< warning >}}
-The BUSY pin on the `gdew0154m09`, the `Waveshare 7.30in-f` and the `Waveshare 7.50in V2` models must be inverted to prevent permanent display damage. Set the busy pin to `inverted: true` in the config.
+The BUSY pin on the `gdew0154m09`, the `Waveshare 7.30in-f`, the `Waveshare 7.50in V2` and the `gdey075t7` models must be inverted to prevent permanent display damage. Set the busy pin to `inverted: true` in the config.
 
 {{< /warning >}}
 


### PR DESCRIPTION
## Description:

Documentation for newly added waveshare_epaper model GDEY075T7.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#10863

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
