### PR TITLE
Fix some HA "my" buttons

### DIFF
--- a/content/components/api.md
+++ b/content/components/api.md
@@ -101,7 +101,8 @@ perform actions.
 
 Open the ESPHome integration page on your Home Assistant instance:
 
-{{< button href="<https://my.home-assistant.io/redirect/integration/?domain=esphome>" img="<https://my.home-assistant.io/badges/integration.svg>" alt="Open your Home Assistant instance and show an integration." >}}
+[![Open your Home Assistant instance and show the ESPHome integration.](https://my.home-assistant.io/badges/integration.svg)](https://my.home-assistant.io/redirect/integration/?domain=esphome)
+
 Then:
 
 1. Find your device in the device list

--- a/content/guides/getting_started_hassio.md
+++ b/content/guides/getting_started_hassio.md
@@ -178,9 +178,8 @@ installed on your device) it can update the device {{< docref "/components/ota/i
 Once your configuration is installed on your device and it's connected to your Wi-Fi, Home Assistant will automatically
 discover it (assuming your network permits this) and offer to configure it:
 
-{{< button href="<https://my.home-assistant.io/redirect/config_flow_start/?domain=esphome>"
-  img="<https://my.home-assistant.io/badges/config_flow_start.svg>"
-  alt="Open your Home Assistant instance and start setting up a new integration." >}}
+[![Open your Home Assistant instance and show the ESPHome integration.](https://my.home-assistant.io/badges/integration.svg)](https://my.home-assistant.io/redirect/integration/?domain=esphome)
+
 Alternatively, you can manually add the device on the Home Assistant Integrations page. To do so, click on the "Add
 Integration" button (bottom right), search for "ESPHome" and enter the ESPHome device's host name. The host name is
 based on the name you've given to the device; if you named your device "living-room-lamp", its host name will be


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
