### PR TITLE
Fix a bunch of line lengths

### DIFF
--- a/content/components/alarm_control_panel/_index.md
+++ b/content/components/alarm_control_panel/_index.md
@@ -197,8 +197,9 @@ alarm_control_panel:
 
 ### `on_ready` Trigger
 
-This trigger is activated when the logical 'and' of all the alarm sensors change state. This is useful for implementing "alarm ready" LEDs.
-Once this trigger is called, you can get the ready state by calling get_all_sensors_ready() in a lambda block.
+This trigger is activated when the logical 'and' of all the alarm sensors change state. This is useful for implementing
+"alarm ready" LEDs. Once this trigger is called, you can get the ready state by calling get_all_sensors_ready() in a
+lambda block.
 
 ```yaml
 alarm_control_panel:
@@ -213,8 +214,8 @@ alarm_control_panel:
 
 ### `on_chime` Trigger
 
-This trigger is activated when a zone sensor marked with chime:true changes from closed to open. This is useful for implementing keypad chimes when a zone
-opens.
+This trigger is activated when a zone sensor marked with chime:true changes from closed to open. This is useful for
+implementing keypad chimes when a zone opens.
 
 ```yaml
 alarm_control_panel:

--- a/content/components/alarm_control_panel/template.md
+++ b/content/components/alarm_control_panel/template.md
@@ -25,21 +25,29 @@ alarm_control_panel:
 
 ## Configuration variables
 
-- **codes** (*Optional*, list of string): A list of codes for disarming the alarm, if *requires_code_to_arm* set to true then for arming the alarm too.
+- **codes** (*Optional*, list of string): A list of codes for disarming the alarm, if *requires_code_to_arm* set to true
+  then for arming the alarm too.
 - **requires_code_to_arm** (*Optional*, boolean): Code required for arming the alarm, *codes* must be provided.
-- **arming_away_time** (*Optional*, [Time](#config-time)): The exit delay before the alarm is armed to away mode. Defaults to `0s`.
+- **arming_away_time** (*Optional*, [Time](#config-time)): The exit delay before the alarm is armed to away mode.
+  Defaults to `0s`.
 - **arming_home_time** (*Optional*, [Time](#config-time)): The exit delay before the alarm is armed to home mode.
 - **arming_night_time** (*Optional*, [Time](#config-time)): The exit delay before the alarm is armed to night mode.
 - **pending_time** (*Optional*, [Time](#config-time)): The entry delay before the alarm is triggered. Defaults to `0s`.
-- **trigger_time** (*Optional*, [Time](#config-time)): The time after a triggered alarm before resetting to previous state if the sensors are cleared/off. Defaults to `0s`.
+- **trigger_time** (*Optional*, [Time](#config-time)): The time after a triggered alarm before resetting to previous
+  state if the sensors are cleared/off. Defaults to `0s`.
 - **binary_sensors** (*Optional*, *list*): A list of binary sensors the panel should use. Each consists of:
 
   - **input** (**Required**, string): The id of the binary sensor component
-  - **bypass_armed_home** (*Optional*, boolean): This binary sensor will not trigger the alarm when in `armed_home` state.
-  - **bypass_armed_night** (*Optional*, boolean): This binary sensor will not trigger the alarm when in `armed_night` state.
-  - **bypass_auto** (*Optional*, boolean): This binary sensor will be automatically bypassed if left on/open at the time of arming.
-  - **trigger_mode** (*Optional*, string): Sets the trigger mode for this sensor. One of `delayed`, `instant`, `instant_always`, or `delayed_follower`. (`delayed` is the default if not specified)
-  - **chime** (*Optional*, boolean): When set `true`, the chime callback will be called whenever the sensor goes from closed to open. (`false` is the default if not specified)
+  - **bypass_armed_home** (*Optional*, boolean): This binary sensor will not trigger the alarm when in
+    `armed_home` state.
+  - **bypass_armed_night** (*Optional*, boolean): This binary sensor will not trigger the alarm when in `armed_night`
+    state.
+  - **bypass_auto** (*Optional*, boolean): This binary sensor will be automatically bypassed if left on/open at the
+    time of arming.
+  - **trigger_mode** (*Optional*, string): Sets the trigger mode for this sensor. One of `delayed`, `instant`,
+    `instant_always`, or `delayed_follower`. (`delayed` is the default if not specified)
+  - **chime** (*Optional*, boolean): When set `true`, the chime callback will be called whenever the sensor goes from
+    closed to open. (`false` is the default if not specified)
 
 - **restore_mode** (*Optional*, enum):
 
@@ -64,21 +72,33 @@ Each binary sensor "zone" supports 4 trigger modes. The modes are:
 - instant_always
 - delayed_follower
 
-The `delayed` trigger mode is typically specified for exterior doors where entry is required to access an alarm keypad or other arm/disarm method. If the alarm panel is armed, and a zone set to `delayed` is "faulted" (i.e. the zone state is `true`  ) the alarm state will change from the `armed` state to the `pending` state. During the `pending` state, the user has a preset time to disarm the alarm before it changes to the `triggered` state. This is the default trigger mode if not specified.
+The `delayed` trigger mode is typically specified for exterior doors where entry is required to access an alarm keypad
+or other arm/disarm method. If the alarm panel is armed, and a zone set to `delayed` is "faulted" (i.e. the zone state
+is `true`  ) the alarm state will change from the `armed` state to the `pending` state. During the `pending` state, the
+user has a preset time to disarm the alarm before it changes to the `triggered` state. This is the default trigger mode
+if not specified.
 
-The `instant` trigger mode is typically used for exterior zones (e.g. windows, and glass break detectors). If the alarm control panel is armed, a fault on this type of zone will cause the alarm to go from the `armed` state directly to the `triggered` state.
+The `instant` trigger mode is typically used for exterior zones (e.g. windows, and glass break detectors). If the alarm
+control panel is armed, a fault on this type of zone will cause the alarm to go from the `armed` state directly to the
+`triggered` state.
 
-The `instant_always` trigger mode is typically used for tamper inputs. Irrespective of whether the alarm control panel is armed, a fault will always cause the alarm to go directly to the `triggered` state.
+The `instant_always` trigger mode is typically used for tamper inputs. Irrespective of whether the alarm control panel
+is armed, a fault will always cause the alarm to go directly to the `triggered` state.
 
-The `delayed_follower` trigger mode is typically specifed for interior passive infared (PIR) or microwave sensors. One of two things happen when a `delayed_follower` zone is faulted:
+The `delayed_follower` trigger mode is typically specifed for interior passive infared (PIR) or microwave sensors. One
+of two things happen when a `delayed_follower` zone is faulted:
 
-1. When the alarm panel is in the armed state, a fault on a zone with `delayed_follower` specified will cause the alarm control panel to go directly to the `triggered` state.
+1. When the alarm panel is in the armed state, a fault on a zone with `delayed_follower` specified will cause the alarm
+   control panel to go directly to the `triggered` state.
 
-1. When the alarm panel is in the pending state, a fault on a zone with `delayed_follower` specified will remain in the `pending` state.
+1. When the alarm panel is in the pending state, a fault on a zone with `delayed_follower` specified will remain in
+   the `pending` state.
 
-The `delayed_follower` trigger mode offers better protection if someone enters a premises via an unprotected window or door. If there is a PIR guarding the main hallway, it will cause an instant trigger of the alarm panel as someone
-entered the premises in a unusual manner. Likewise, if someone enters the premises though a door set to the `delayed` trigger mode, and then triggers the PIR, the alarm will stay in the `pending` state until either they disarm the alarm, or
-the pending timer expires.
+The `delayed_follower` trigger mode offers better protection if someone enters a premises via an unprotected window
+or door. If there is a PIR guarding the main hallway, it will cause an instant trigger of the alarm panel as someone
+entered the premises in a unusual manner. Likewise, if someone enters the premises though a door set to the `delayed`
+trigger mode, and then triggers the PIR, the alarm will stay in the `pending` state until either they disarm the alarm,
+or the pending timer expires.
 
 {{< anchor "template_alarm_control_panel-state_flow" >}}
 
@@ -224,4 +244,5 @@ switch:
 
 - {{< docref "index/" >}}
 - {{< docref "/components/binary_sensor" >}}
-- {{< apiref "template/alarm_control_panel/template_alarm_control_panel.h" "template/alarm_control_panel/template_alarm_control_panel.h" >}}
+- {{< apiref "template/alarm_control_panel/template_alarm_control_panel.h"
+      "template/alarm_control_panel/template_alarm_control_panel.h" >}}

--- a/content/components/animation.md
+++ b/content/components/animation.md
@@ -18,7 +18,8 @@ animation:
 
 The animation can be rendered just like the image component with the `image()` function of the display component.
 
-To show the next frame of the animation call `id(my_animation).next_frame()`, to show the previous picture use `id(my_animation).prev_frame()`. To show a specific picture use `id(my_animation).set_frame(int frame)`.
+To show the next frame of the animation call `id(my_animation).next_frame()`, to show the previous picture use
+`id(my_animation).prev_frame()`. To show a specific picture use `id(my_animation).set_frame(int frame)`.
 This can be combined with all Lambdas:
 
 ```yaml
@@ -55,7 +56,8 @@ interval:
 - **resize** (*Optional*, string): If set, this will resize all the frames to fit inside the given dimensions `WIDTHxHEIGHT`
   and preserve the aspect ratio.
 
-- **type** (**Required**): Specifies how to encode image internally. See the [image component](#display-image) for more information.
+- **type** (**Required**): Specifies how to encode image internally. See the [image component](#display-image) for
+  more information.
 
   - `BINARY`  : Two colors, suitable for 1 color displays or 2 color image in color displays. Uses 1 bit
     per pixel, 8 pixels per byte. Only `chroma_key` transparency is available.
@@ -64,24 +66,33 @@ interval:
   - `RGB565`  : Lossy RGB color stored. Uses 2 bytes per pixel, 3 with an alpha channel.
   - `RGB`  : Full RGB color stored. Uses 3 bytes per pixel, 4 with an alpha channel.
 
-- **transparency** (*Optional*): If set the alpha channel of the input image will be taken into account. The possible values are `opaque` (default), `chroma_key` and `alpha_channel`. See discussion on transparency in the [image component](#display-image).
-- **loop** (*Optional*): If you want to loop over a subset of your animation (e.g. a fire animation where the fire "starts", then "burns" and "dies") you can specify some frames to loop over.
+- **transparency** (*Optional*): If set the alpha channel of the input image will be taken into account. The possible
+  values are `opaque` (default), `chroma_key` and `alpha_channel`. See discussion on transparency in the [image component](#display-image).
+- **loop** (*Optional*): If you want to loop over a subset of your animation (e.g. a fire animation where the fire
+  "starts", then "burns" and "dies") you can specify some frames to loop over.
 
-  - **start_frame** (*Optional*, int): The frame to loop back to when `end_frame` is reached. Defaults to the first frame in the animation.
-  - **end_frame** (*Optional*, int): The last frame to show in the loop; when this frame is reached it will loop back to `start_frame`. Defaults to the last frame in the animation.
-  - **repeat** (*Optional*, int): Specifies how many times the loop will run. When the count is reached, the animation will continue with the next frame after `end_frame`, or restart from the beginning if `end_frame` was the last frame. Defaults to "loop forever".
+  - **start_frame** (*Optional*, int): The frame to loop back to when `end_frame` is reached. Defaults to the first
+    frame in the animation.
+  - **end_frame** (*Optional*, int): The last frame to show in the loop; when this frame is reached it will loop back
+    to `start_frame`. Defaults to the last frame in the animation.
+  - **repeat** (*Optional*, int): Specifies how many times the loop will run. When the count is reached, the animation
+    will continue with the next frame after `end_frame`, or restart from the beginning if `end_frame` was the last
+    frame. Defaults to "loop forever".
 
 ## Actions
 
-- **animation.next_frame**: Moves the animation to the next frame. This is equivalent to the `id(my_animation).next_frame();` lambda call.
+- **animation.next_frame**: Moves the animation to the next frame. This is equivalent to the
+  `id(my_animation).next_frame();` lambda call.
 
   - **id** (**Required**, [ID](#config-id)): The ID of the animation to animate.
 
-- **animation.prev_frame**: Moves the animation to the previous frame. This is equivalent to the `id(my_animation).prev_frame();` lambda call.
+- **animation.prev_frame**: Moves the animation to the previous frame. This is equivalent to the
+  `id(my_animation).prev_frame();` lambda call.
 
   - **id** (**Required**, [ID](#config-id)): The ID of the animation to animate.
 
-- **animation.set_frame**: Moves the animation to a specific frame. This is equivalent to the `id(my_animation).set_frame(frame);` lambda call.
+- **animation.set_frame**: Moves the animation to a specific frame. This is equivalent to the
+  `id(my_animation).set_frame(frame);` lambda call.
 
   - **id** (**Required**, [ID](#config-id)): The ID of the animation to animate.
   - **frame** (**Required**, int): The frame index to show next.

--- a/content/components/pylontech.md
+++ b/content/components/pylontech.md
@@ -31,7 +31,7 @@ If you have multiple batteries you need to connect to the master battery's conso
 | -------- | -------------- | -------------- | ------------ | -------------------------- |
 | 3        | White/Green    | White/Orange   | Pylontech TX | ESPHome RX via transceiver |
 | 6        | Green          | Orange         | Pylontech RX | ESPHome TX via transceiver |
-| 8 | Brown | Brown | GND | GND |
+| 8        | Brown          | Brown          | GND          | GND                        |
 
 {{< img src="rj45_pinout.jpg" alt="Image" caption="RJ45 pinout" width="70.0%" class="align-center" >}}
 
@@ -41,7 +41,7 @@ If you have multiple batteries you need to connect to the master battery's conso
 | -------- | ------------ | -------------------------- |
 | 2        | Pylontech RX | ESPHome TX via transceiver |
 | 3        | Pylontech TX | ESPHome RX via transceiver |
-| 4 | GND | GND |
+| 4        | GND          | GND                        |
 
 ## Component/Hub
 
@@ -113,8 +113,10 @@ text_sensor:
 
 ## Energy Monitoring
 
-By combining {{< docref "/components/sensor/template" "template sensors" >}} and {{< docref "/components/sensor/integration" "integration sensors" >}}
-one can monitor the energy flowing into and out of all batteries combined, ready for [Homeassistant Energy Monitoring](https://www.home-assistant.io/docs/energy/battery/).
+By combining {{< docref "/components/sensor/template" "template sensors" >}} and
+{{< docref "/components/sensor/integration" "integration sensors" >}}
+one can monitor the energy flowing into and out of all batteries combined, ready for
+[Homeassistant Energy Monitoring](https://www.home-assistant.io/docs/energy/battery/).
 
 ```yaml
 sensor:

--- a/content/components/qr_code.md
+++ b/content/components/qr_code.md
@@ -23,7 +23,8 @@ qr_code:
   in your display code.
 
 - **value** (**Required**, string): The string which you want to encode in the QR-code.
-- **ecc** (*Optional*, string): The error correction code level you want to use. Defaults to `LOW`. You can use one of the following values:
+- **ecc** (*Optional*, string): The error correction code level you want to use. Defaults to `LOW`. You can use one of
+  the following values:
 
   - `LOW`  : The QR Code can tolerate about 7% erroneous codewords
   - `MEDIUM`  : The QR Code can tolerate about 15% erroneous codewords

--- a/content/components/rp2040.md
+++ b/content/components/rp2040.md
@@ -12,9 +12,12 @@ This component contains platform-specific options for the RP2040 platform.
 {{< note >}}
 Support for all aspects of ESPHome on the RP2040 is still in development.
 
-Only the original model of Raspberry Pi Pico W board is supported, which has the Cypress **CYW43439** chip providing wireless connectivity. It can be identified by a metallic shield encapsulating the radio circuitry. Pico W boards with radio module chips like ESP8285 or similar (labelled as `RP2040 Pico W-2023` etc.), are not supported.
+Only the original model of Raspberry Pi Pico W board is supported, which has the Cypress **CYW43439** chip providing
+wireless connectivity. It can be identified by a metallic shield encapsulating the radio circuitry. Pico W boards with
+radio module chips like ESP8285 or similar (labelled as `RP2040 Pico W-2023` etc.), are not supported.
 
-Please search for or create an [issue](https://github.com/esphome/esphome/issues/new/choose) if you encounter an unknown problem.
+Please search for or create an [issue](https://github.com/esphome/esphome/issues/new/choose) if you encounter an
+unknown problem.
 
 {{< /note >}}
 

--- a/content/components/rtttl.md
+++ b/content/components/rtttl.md
@@ -8,7 +8,8 @@ params:
 ---
 
 The `rtttl`, component allows you to easily connect a passive piezo buzzer to your microcontroller
-and play monophonic songs. It accepts the Ring Tone Text Transfer Language, rtttl format ([Wikipedia](https://en.wikipedia.org/wiki/Ring_Tone_Transfer_Language)) which allows to store simple melodies.
+and play monophonic songs. It accepts the Ring Tone Text Transfer Language, rtttl format
+([Wikipedia](https://en.wikipedia.org/wiki/Ring_Tone_Transfer_Language)) which allows to store simple melodies.
 
 {{< img src="buzzer.jpg" alt="Image" caption="Buzzer Module" width="50.0%" class="align-center" >}}
 

--- a/content/components/spi.md
+++ b/content/components/spi.md
@@ -27,8 +27,8 @@ The SPI bus usually consists of 4 wires:
 - **MISO** (also SDI - Serial Data In): Is used to receive data. All devices on the bus share this line.
 
 In some cases one of **MOSI** or **MISO** does not exist as the receiving device only accepts data or sends data.
-It is also possible to configure a quad SPI interface using 4 output data lines, and an octal interface using 8 data output lines. This is required only for
-use with certain components.
+It is also possible to configure a quad SPI interface using 4 output data lines, and an octal interface using 8 data
+output lines. This is required only for use with certain components.
 
 {{< note >}}
 
@@ -171,8 +171,8 @@ of the specific peripheral chip.
 | ---- | ------------------- | ----------- | ------------------------------ | --------------- |
 | 0    | low                 | leading     | /CS activation and falling CLK | rising CLK      |
 | 1    | low                 | trailing    | rising CLK                     | falling CLK     |
-| 2 | high | leading | /CS activation and rising CLK | falling CLK |
-| 3 | high | trailing | falling CLK | rising CLK |
+| 2    | high                | leading     | /CS activation and rising CLK  | falling CLK     |
+| 3    | high                | trailing    | falling CLK                    | rising CLK      |
 
 ## ESP-IDF limit on bus devices
 

--- a/content/components/statsd.md
+++ b/content/components/statsd.md
@@ -6,8 +6,9 @@ params:
     description: Instructions for setting up a StatsD
 ---
 
-StatsD is a [protocol](https://github.com/statsd/statsd/blob/master/docs/metric_types.md) to send metrics to a Daemon to store and aggregate them.
-Today there are many monitoring solutions that support receiving metrics via the StatsD protocol.
+StatsD is a [protocol](https://github.com/statsd/statsd/blob/master/docs/metric_types.md) to send metrics to a Daemon
+to store and aggregate them. Today there are many monitoring solutions that support receiving metrics via the StatsD
+protocol.
 
 ```yaml
 # Example configuration entry

--- a/content/components/status_led.md
+++ b/content/components/status_led.md
@@ -27,7 +27,9 @@ status_led:
 ```
 
 {{< note >}}
-If your device has a single LED that needs to be shared use {{< docref "/components/light/status_led" "status_led light platform" >}} instead.
+
+If your device has a single LED that needs to be shared use
+{{< docref "/components/light/status_led" "status_led light platform" >}} instead.
 
 {{< /note >}}
 

--- a/content/components/substitutions.md
+++ b/content/components/substitutions.md
@@ -74,7 +74,8 @@ Simple Jinja expressions and filters can be used inside `${ ... }` syntax.
 
 All substitution variables become accessible within Jinja expressions by their name.
 
-If the substitution variable is a key-value dictionary, you can access members with a dot notation: `${ device.name }`, or indexed `${ device["name"] }`
+If the substitution variable is a key-value dictionary, you can access members with a dot notation: `${ device.name }`,
+or indexed `${ device["name"] }`
 
 Lists can be indexed: `${ unused_pins[2] }`
 

--- a/content/components/sun.md
+++ b/content/components/sun.md
@@ -52,12 +52,14 @@ sun:
 - **on_sunrise** (*Optional*, [Automation](#automation)): An automation to perform at sunrise
   when the sun crosses a specified angle.
 
-  - **elevation** (*Optional*, float): The elevation to cross. Defaults to -0.833° (the horizon, slightly less than 0° to compensate for atmospheric refraction).
+  - **elevation** (*Optional*, float): The elevation to cross. Defaults to -0.833° (the horizon, slightly less than 0°
+    to compensate for atmospheric refraction).
 
 - **on_sunset** (*Optional*, [Automation](#automation)): An automation to perform at sunset
   when the sun crosses a specified angle.
 
-  - **elevation** (*Optional*, float): The elevation to cross. Defaults to -0.833° (the horizon, slightly less than 0° to compensate for atmospheric refraction).
+  - **elevation** (*Optional*, float): The elevation to cross. Defaults to -0.833° (the horizon, slightly less than 0°
+    to compensate for atmospheric refraction).
 
 ## Sensor
 

--- a/content/components/sun_gtil2.md
+++ b/content/components/sun_gtil2.md
@@ -16,11 +16,14 @@ inverter via the (more limited) external RS232 interface you should use the
 {{< docref "/components/modbus_controller" "Modbus" >}} component instead.
 
 {{< /note >}}
-{{< img src="sun_gtil2_controller_board.png" alt="Image" caption="Pinout of the inverter's controller board" width="50.0%" class="align-center" >}}
+{{< img src="sun_gtil2_controller_board.png" alt="Image" caption="Pinout of the inverter's controller board"
+    width="50.0%" class="align-center" >}}
 
-{{< img src="sun_gtil2_display_board.png" alt="Image" caption="Pinout of the inverter's display board" width="50.0%" class="align-center" >}}
+{{< img src="sun_gtil2_display_board.png" alt="Image" caption="Pinout of the inverter's display board"
+    width="50.0%" class="align-center" >}}
 
-{{< img src="sun_gtil2_schematic.png" alt="Image" caption="Simplified connection diagram" width="75.0%" class="align-center" >}}
+{{< img src="sun_gtil2_schematic.png" alt="Image" caption="Simplified connection diagram"
+    width="75.0%" class="align-center" >}}
 
 As the data is read from the inverter using UART, you need to have an [UART bus](#uart) in your
 configuration with the `rx_pin` connected to the TX pin of the inverter's controller board. Additionally, you

--- a/content/components/syslog.md
+++ b/content/components/syslog.md
@@ -24,8 +24,10 @@ syslog:
 ## Configuration Options
 
 - **id** (*Optional*, [ID](#config-id)): Manually specify the ID used for code generation.
-- **udp_id** (**Required**, [ID](#config-id)): The ID of the UDP client to use for sending logs. May be omitted if only one UDP client is configured.
-- **time_id** (**Required**, [ID](#config-id)): The ID of the time client to use for time-stamping logs. May be omitted if only one time client is configured.
+- **udp_id** (**Required**, [ID](#config-id)): The ID of the UDP client to use for sending logs. May be omitted if only
+  one UDP client is configured.
+- **time_id** (**Required**, [ID](#config-id)): The ID of the time client to use for time-stamping logs. May be omitted
+  if only one time client is configured.
 - **port** (*Optional*, int): The port to send logs to. Defaults to `514`.
 - **facility** (*Optional*, int): The syslog facility to use. Defaults to `16` (corresponding to `local0`  ).
 - **level** (*Optional*, string): The highest log level to send to the syslog server. Defaults to `DEBUG`.

--- a/content/components/time/_index.md
+++ b/content/components/time/_index.md
@@ -31,7 +31,8 @@ All time configuration schemas inherit these options.
 - **on_time_sync** (*Optional*, [Automation](#automation)): Automation to run when the time source
   could be (re-)synchronized.. See [`on_time_sync` Trigger](#time-on_time_sync).
 
-- **update_interval** (*Optional*, [Time](#config-time)): How often to synchronize the device time from the source. Defaults to `15min`.
+- **update_interval** (*Optional*, [Time](#config-time)): How often to synchronize the device time from the source.
+  Defaults to `15min`.
 
 {{< anchor "time-has_time_condition" >}}
 
@@ -65,7 +66,8 @@ specific times of day. The syntax is a subset of the [crontab](https://crontab.g
 There are two ways to specify time intervals: Either with using the `seconds:`, `minutes:`, ...
 keys as seen below or using a cron alike expression like `* /5 * * * *`.
 
-Be aware normal cron implementations does not know about seconds like this esphome implementation, therefore you got 6 fields (seconds,minutes,hours,dayofmonth,month,dayofweek).
+Be aware normal cron implementations does not know about seconds like this esphome implementation, therefore you got 6
+fields (seconds,minutes,hours,dayofmonth,month,dayofweek).
 
 Basically, the automation engine looks at your configured time schedule every second and
 evaluates if the automation should run.
@@ -118,7 +120,9 @@ Configuration variables:
   Range is from 1 (Sunday) to 7 (Saturday).
 
 - **cron** (*Optional*, string): Alternatively, you can specify a whole cron expression like
-  `* /5 * * * *`. Please note that years and some special characters like `L`, `#` are currently not supported. Also, the day of week field is interpreted like the **days_of_week** variable (range from 1 (Sunday) to 7 (Saturday)) and not like other cron implementations would do it (range from 0 (Sunday) to 7 (Sunday)).
+  `* /5 * * * *`. Please note that years and some special characters like `L`, `#` are currently not supported. Also,
+  the day of week field is interpreted like the **days_of_week** variable (range from 1 (Sunday) to 7 (Saturday)) and
+  not like other cron implementations would do it (range from 0 (Sunday) to 7 (Sunday)).
 
 - See [Automation](#automation).
 

--- a/content/components/time/sntp.md
+++ b/content/components/time/sntp.md
@@ -23,14 +23,15 @@ time:
 - All other options from [Base Time Configuration](#base_time_config).
 
 {{< note >}}
-If your are using [Manual IPs](#wifi-manual_ip) make sure to configure a DNS Server (dns1, dns2) or use only IP addresses for the NTP servers.
+If your are using [Manual IPs](#wifi-manual_ip) make sure to configure a DNS Server (dns1, dns2) or use only IP
+addresses for the NTP servers.
 
 {{< /note >}}
 {{< warning >}}
-Due to limitations of the SNTP implementation, on platforms other than ESP8266 and ESP32 this component will trigger `on_time_sync`
-only once when it detects that the system clock has been set, even if the update was not done by the SNTP implementation!
-This must be taken into consideration when SNTP is used together with other real time components, where another time source could
-update the time before SNTP synchronizes.
+Due to limitations of the SNTP implementation, on platforms other than ESP8266 and ESP32 this component will trigger
+`on_time_sync` only once when it detects that the system clock has been set, even if the update was not done by the
+SNTP implementation! This must be taken into consideration when SNTP is used together with other real time components,
+where another time source could update the time before SNTP synchronizes.
 
 {{< /warning >}}
 

--- a/content/components/tuya.md
+++ b/content/components/tuya.md
@@ -58,11 +58,13 @@ Here is another example output for a Tuya ME-81H thermostat:
 - **time_id** (*Optional*, [ID](#config-id)): Some Tuya devices support obtaining local time from ESPHome.
   Specify the ID of the {{< docref "time/" >}} which will be used.
 
-- **status_pin** (*Optional*, [Pin Schema](#config-pin_schema)): Some Tuya devices support WiFi status reporting ONLY through gpio pin.
+- **status_pin** (*Optional*, [Pin Schema](#config-pin_schema)): Some Tuya devices support WiFi status reporting ONLY
+  through gpio pin.
   Specify the pin reported in the config dump or leave empty otherwise.
   More about this on the [Tuya Developer Documentation](https://developer.tuya.com/en/docs/iot/tuya-cloud-universal-serial-port-access-protocol?id=K9hhi0xxtn9cb#title-6-Query%20working%20mode).
 
-- **ignore_mcu_update_on_datapoints** (*Optional*, list): A list of datapoints to ignore MCU updates for. Useful for certain broken/erratic hardware and debugging.
+- **ignore_mcu_update_on_datapoints** (*Optional*, list): A list of datapoints to ignore MCU updates for. Useful for
+  certain broken/erratic hardware and debugging.
 
 Automations:
 
@@ -122,7 +124,8 @@ tuya:
 ### Configuration variables
 
 - **sensor_datapoint** (**Required**, int): The datapoint id number of the sensor.
-- **datapoint_type** (**Required**, string): The datapoint type one of *raw*, *string*, *bool*, *int*, *uint*, *enum*, *bitmask* or *any*.
+- **datapoint_type** (**Required**, string): The datapoint type one of *raw*, *string*, *bool*, *int*, *uint*, *enum*,
+  *bitmask* or *any*.
 - See [Automation](#automation).
 
 ## See Also

--- a/content/components/update/_index.md
+++ b/content/components/update/_index.md
@@ -21,7 +21,8 @@ update:
 
 ## Configuration variables
 
-- **id** (*Optional*, [ID](#config-id)): Manually specify the ID used for code generation. At least one of **id** and **name** must be specified.
+- **id** (*Optional*, [ID](#config-id)): Manually specify the ID used for code generation. At least one of **id** and
+  **name** must be specified.
 - **name** (*Optional*, string): The name of the update entity. At least one of **id** and **name** must be specified.
 
 {{< note >}}

--- a/content/components/valve/_index.md
+++ b/content/components/valve/_index.md
@@ -53,7 +53,8 @@ Advanced options:
   (usually Home Assistant) without the user manually enabling it (via the Home Assistant UI). Defaults to `false`.
 
 - **entity_category** (*Optional*, string): The category of the entity. See
-  <https://developers.home-assistant.io/docs/core/entity/#generic-properties> for a list of available options. Set to `""` to remove the default entity category.
+  <https://developers.home-assistant.io/docs/core/entity/#generic-properties> for a list of available options. Set to
+  `""` to remove the default entity category.
 
 - If Webserver enabled and version 3 is selected, All other options from Webserver Component.. See [Webserver Version 3](#config-webserver-version-3-options).
 

--- a/content/guides/esp32_arduino_to_idf.md
+++ b/content/guides/esp32_arduino_to_idf.md
@@ -108,8 +108,8 @@ when available:
 | -------------------------------------------------------------- | ---------------------------------------------------------------------------- |
 | {{< docref "/components/sensor/bme680_bsec" "bme680_bsec" >}}  | {{< docref "/components/sensor/bme68x_bsec2" "bme68x_bsec2" >}}              |
 | {{< docref "/components/light/fastled" "fastled_clockless" >}} | {{< docref "/components/light/esp32_rmt_led_strip" "esp32_rmt_led_strip" >}} |
-| {{< docref "/components/light/fastled" "fastled_spi" >}} | {{< docref "/components/light/spi_led_strip" "spi_led_strip" >}} |
-| {{< docref "/components/light/neopixelbus" "neopixelbus" >}} | {{< docref "/components/light/esp32_rmt_led_strip" "esp32_rmt_led_strip" >}} |
+| {{< docref "/components/light/fastled" "fastled_spi" >}}       | {{< docref "/components/light/spi_led_strip" "spi_led_strip" >}}             |
+| {{< docref "/components/light/neopixelbus" "neopixelbus" >}}   | {{< docref "/components/light/esp32_rmt_led_strip" "esp32_rmt_led_strip" >}} |
 
 **Arduino-Only Components:**
 

--- a/content/guides/troubleshooting.md
+++ b/content/guides/troubleshooting.md
@@ -128,7 +128,9 @@ If you already have a stack trace but need to decode it, you can use the
 
 ## Adjusting Log Levels for Debugging
 
-When troubleshooting issues with your ESPHome device, increasing the log level can provide more detailed information about what's happening internally. This is particularly useful for diagnosing component-specific problems or understanding the data flow between components.
+When troubleshooting issues with your ESPHome device, increasing the log level can provide more detailed information
+about what's happening internally. This is particularly useful for diagnosing component-specific problems or
+understanding the data flow between components.
 
 ### Setting Global Log Level
 
@@ -150,12 +152,14 @@ Available log levels from least to most verbose:
 - `VERY_VERBOSE` - All internal messages including data bus traffic
 
 {{< warning >}}
-Using `VERY_VERBOSE` can significantly slow down your device and may cause connectivity issues due to the volume of log messages generated. Use it only for short debugging sessions.
+Using `VERY_VERBOSE` can significantly slow down your device and may cause connectivity issues due to the volume of
+log messages generated. Use it only for short debugging sessions.
 {{< /warning >}}
 
 ### ESP-IDF Framework Log Level
 
-When using the ESP-IDF framework on {{< docref "/components/esp32" >}}, you can also adjust the framework's internal log level to get more detailed information from the underlying system:
+When using the ESP-IDF framework on {{< docref "/components/esp32" >}}, you can also adjust the framework's internal
+log level to get more detailed information from the underlying system:
 
 ```yaml
 esp32:
@@ -168,10 +172,14 @@ Available ESP-IDF log levels: `NONE`, `ERROR` (default), `WARN`, `INFO`, `DEBUG`
 
 ### Component-Specific Log Levels
 
-You can also configure log levels for specific components to reduce noise or get more detail from individual components. See the {{< docref "/components/logger#manual-tag-specific-log-levels" "logger manual tag-specific log levels" >}} documentation for detailed information and examples.
+You can also configure log levels for specific components to reduce noise or get more detail from individual components.
+See the {{< docref "/components/logger#manual-tag-specific-log-levels" "logger manual tag-specific log levels" >}}
+documentation for detailed information and examples.
 
 {{< important >}}
-The global log level determines which messages are compiled into the binary. Component-specific log levels can only reduce verbosity, not increase it beyond the global level. For example, if the global level is `INFO`, setting a component to `DEBUG` will have no effect.
+The global log level determines which messages are compiled into the binary. Component-specific log levels can only
+reduce verbosity, not increase it beyond the global level. For example, if the global level is `INFO`, setting a
+component to `DEBUG` will have no effect.
 {{< /important >}}
 
 ## Performance Troubleshooting


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** related to #5406

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
