### PR TITLE
Fix footer discord link

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -116,7 +116,7 @@ menu:
 
     - name: Community
       weight: 2
-    - { parent: Community, url: "https://discord.gg/KhAMKrd/", post: "discord", name: Discord}
+    - { parent: Community, url: "https://discord.gg/KhAMKrd", post: "discord", name: Discord}
     - { parent: Community, url: "https://github.com/esphome/esphome", post: "github", name: Github}
     - { parent: Community, url: "https://community.home-assistant.io/c/esphome/", post: "comments", name: Forum}
 


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes #5338

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
