### PR TITLE
Update docker/devcontainers for hugo

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,15 +1,19 @@
 {
   "name": "ESPHome - docs",
-  "image": "mcr.microsoft.com/devcontainers/python:3.12",
+  "image": "mcr.microsoft.com/devcontainers/python:3.13",
   "postCreateCommand": ".devcontainer/postCreate.sh",
   "postAttachCommand": "make live-html",
-  "forwardPorts": [8000],
+  "forwardPorts": [
+    8000
+  ],
   "features": {
     "ghcr.io/devcontainers/features/github-cli:1": {}
   },
   "customizations": {
     "vscode": {
-      "extensions": ["ms-python.python"]
+      "extensions": [
+        "ms-python.python"
+      ]
     }
   }
 }

--- a/.devcontainer/postCreate.sh
+++ b/.devcontainer/postCreate.sh
@@ -7,4 +7,15 @@ pip3 install -r requirements_test.txt
 pre-commit install
 
 mkdir -p ~/.local/bin
-curl -L https://github.com/CloudCannon/pagefind/releases/download/v1.3.0/pagefind-v1.3.0-x86_64-unknown-linux-musl.tar.gz | tar -xz -C ~/.local/bin
+
+ARCH="$(uname -m)"
+case "$ARCH" in
+  x86_64) PAGEFIND_ARCH="x86_64" ;;
+  arm64|aarch64) PAGEFIND_ARCH="aarch64" ;;
+  *)
+    echo "Unsupported architecture: $ARCH" >&2
+    exit 1
+    ;;
+esac
+curl -L "https://github.com/CloudCannon/pagefind/releases/download/v1.3.0/pagefind-v1.3.0-${PAGEFIND_ARCH}-unknown-linux-musl.tar.gz" \
+  | tar -xz -C ~/.local/bin

--- a/.devcontainer/postCreate.sh
+++ b/.devcontainer/postCreate.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
+set -euo pipefail
 
+sudo apt update && sudo apt install -y hugo
 
-pip3 install -r requirements.txt -r requirements_test.txt
-curl -L https://github.com/CloudCannon/pagefind/releases/download/v1.1.0/pagefind-v1.1.0-x86_64-unknown-linux-musl.tar.gz | tar -xz -C ~/.local/bin
+pip3 install -r requirements_test.txt
+pre-commit install
+
+mkdir -p ~/.local/bin
+curl -L https://github.com/CloudCannon/pagefind/releases/download/v1.3.0/pagefind-v1.3.0-x86_64-unknown-linux-musl.tar.gz | tar -xz -C ~/.local/bin

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,12 +6,10 @@ on:
     branches:
       - current
     paths:
-      - requirements.txt
       - Dockerfile
       - .github/workflows/docker.yml
   pull_request:
     paths:
-      - requirements.txt
       - Dockerfile
       - .github/workflows/docker.yml
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,7 +29,7 @@ jobs:
       with:
         python-version: 3.12
     - name: Install dependencies
-      run: pip install -r requirements.txt -r requirements_test.txt
+      run: pip install -r requirements_test.txt
     - name: Register problem matchers
       run: |
         echo "::add-matcher::.github/workflows/matchers/ci-custom.json"

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -3,5 +3,4 @@ ports:
   onOpen: open-preview
 
 tasks:
-- before: pip3 install -r requirements.txt
-  command: make live-html
+- command: make live-html

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
-FROM python:3.12-slim
+FROM python:3.13-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         curl \
         git \
         make \
         openssh-client \
-        software-properties-common \
+        hugo \
         && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/*
 
-ENV PAGEFIND_VERSION="1.1.0"
+ENV PAGEFIND_VERSION="1.3.0"
 ARG TARGETARCH
 SHELL ["/bin/bash", "-c"]
 RUN <<EOF
@@ -28,9 +28,6 @@ USER esphome
 
 WORKDIR /workspaces/esphome-docs
 ENV PATH="${PATH}:/home/esphome/.local/bin"
-
-COPY requirements.txt ./
-RUN pip3 install --no-cache-dir -r requirements.txt
 
 EXPOSE 8000
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ SHELL := bash
 .SHELLFLAGS := -euo pipefail -c
 
 
-PAGEFIND=npx --yes pagefind@1.3.0
+PAGEFIND=$(shell command -v pagefind >/dev/null 2>&1 && echo "pagefind" || echo "npx --yes pagefind@1.3.0")
 
 export HUGO_PARAMS_COMMIT_HASH=$(shell git rev-parse --short HEAD)
 export HUGO_PARAMS_COMMIT_TITLE=$(shell git log -1 --pretty=%s)

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,3 +1,4 @@
 # for lint.py checking of images
 pillow
 colorama
+pre-commit


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
