### PR TITLE
2025.9.2

### DIFF
--- a/content/changelog/2025.9.0.md
+++ b/content/changelog/2025.9.0.md
@@ -160,13 +160,27 @@ and advanced setups may require updates.
 
 ## Release 2025.9.1 - September 19
 
-<details>
+<details open>
 <summary></summary>
 
 - [mqtt] Fix KeyError when MQTT logging configured without explicit level [esphome#10774](https://github.com/esphome/esphome/pull/10774) by [@bdraco](https://github.com/bdraco)
 - fix(packet_transport): Add initialization for sensor configuration in packet transport [esphome#10765](https://github.com/esphome/esphome/pull/10765) by [@TMaYaD](https://github.com/TMaYaD)
 - [core] Fix ESP8266 mDNS compilation failure caused by incorrect coroutine priorities [esphome#10773](https://github.com/esphome/esphome/pull/10773) by [@bdraco](https://github.com/bdraco)
 - [gpio] Fix unused function warnings when compiling with log level below DEBUG [esphome#10779](https://github.com/esphome/esphome/pull/10779) by [@bdraco](https://github.com/bdraco)
+
+</details>
+
+## Release 2025.9.2 - September 29
+
+<details open>
+<summary></summary>
+
+- [esp32_improv] Disable loop by default until provisioning needed [esphome#10764](https://github.com/esphome/esphome/pull/10764) by [@bdraco](https://github.com/bdraco)
+- [libretiny] Fix lib_ignore handling and ignore incompatible libraries [esphome#10846](https://github.com/esphome/esphome/pull/10846) by [@swoboda1337](https://github.com/swoboda1337)
+- Set color_order to RGB for the Waveshare ESP32-S3-TOUCH-LCD-4.3 and ESP32-S3-TOUCH-LCD-7-800X480 [esphome#10835](https://github.com/esphome/esphome/pull/10835) by [@stuartparmenter](https://github.com/stuartparmenter)
+- [esp32_improv] Fix crashes from uninitialized pointers and missing null checks [esphome#10902](https://github.com/esphome/esphome/pull/10902) by [@bdraco](https://github.com/bdraco)
+- [sx126x] Fix issues with variable length FSK packets [esphome#10911](https://github.com/esphome/esphome/pull/10911) by [@swoboda1337](https://github.com/swoboda1337)
+- [mipi_spi] Fix t-display-amoled [esphome#10922](https://github.com/esphome/esphome/pull/10922) by [@clydebarrow](https://github.com/clydebarrow)
 
 </details>
 

--- a/content/guides/supporters.md
+++ b/content/guides/supporters.md
@@ -459,6 +459,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Danilo Campos (@daniloc)](https://github.com/daniloc)
 - [Daniel Martin Gonzalez (@danimart1991)](https://github.com/danimart1991)
 - [danlimlu (@danlimlu)](https://github.com/danlimlu)
+- [DannyN2222 (@DannyN2222)](https://github.com/DannyN2222)
 - [Dan (@DanPlayz0)](https://github.com/DanPlayz0)
 - [Dariusz Dalecki (@darianndd)](https://github.com/darianndd)
 - [Jakub Darmach (@darmach)](https://github.com/darmach)
@@ -1412,6 +1413,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Matthew Pettitt (@mpettitt)](https://github.com/mpettitt)
 - [Michael P. Flaga (@mpflaga)](https://github.com/mpflaga)
 - [Matti Lattu (@mplattu)](https://github.com/mplattu)
+- [László Várady (@MrAnno)](https://github.com/MrAnno)
 - [Darren Griffin (@mrdarrengriffin)](https://github.com/mrdarrengriffin)
 - [Björn Ebbinghaus (@MrEbbinghaus)](https://github.com/MrEbbinghaus)
 - [Sam Hughes (@MrEditor97)](https://github.com/MrEditor97)
@@ -1627,6 +1629,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Piotr Kubiak (@piotr-kubiak)](https://github.com/piotr-kubiak)
 - [Tommy van der Vorst (@pixelspark)](https://github.com/pixelspark)
 - [pixiandreas (@pixiandreas)](https://github.com/pixiandreas)
+- [Paul Webster (@pjwebster)](https://github.com/pjwebster)
 - [Petr Kejval (@pkejval)](https://github.com/pkejval)
 - [Peter Kuehne (@pkuehne)](https://github.com/pkuehne)
 - [Plácido Revilla (@placidorevilla)](https://github.com/placidorevilla)
@@ -1696,6 +1699,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Benjamin G. (@Randomblock1)](https://github.com/Randomblock1)
 - [randomllama (@randomllama)](https://github.com/randomllama)
 - [Rodrigo Martín (@Rapsssito)](https://github.com/Rapsssito)
+- [Andrew Rankin (@RAR)](https://github.com/RAR)
 - [razorback16 (@razorback16)](https://github.com/razorback16)
 - [Marc Seeger (@rb2k)](https://github.com/rb2k)
 - [rbaron (@rbaron)](https://github.com/rbaron)
@@ -2189,6 +2193,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Péter Sárközi (@Xmister)](https://github.com/Xmister)
 - [xmos-jenkins (@xmos-jenkins)](https://github.com/xmos-jenkins)
 - [xmos-jmccarthy (@xmos-jmccarthy)](https://github.com/xmos-jmccarthy)
+- [Patrick Van Oosterwijck (@xorbit)](https://github.com/xorbit)
 - [Xose Pérez (@xoseperez)](https://github.com/xoseperez)
 - [Ross Owen (@xross)](https://github.com/xross)
 - [Mike (@xsnoopy)](https://github.com/xsnoopy)
@@ -2231,4 +2236,4 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Christian Zufferey (@zuzu59)](https://github.com/zuzu59)
 - [Zynth-dev (@Zynth-dev)](https://github.com/Zynth-dev)
 
-*This page was last updated September 19, 2025.*
+*This page was last updated September 29, 2025.*

--- a/data/version.yaml
+++ b/data/version.yaml
@@ -1,2 +1,2 @@
-release: 2025.9.1
+release: 2025.9.2
 version: '2025.9'


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- Update widgets.md [docs#5388](https://github.com/esphome/esphome-docs/pull/5388)
- Mapping: Fix typo [docs#5375](https://github.com/esphome/esphome-docs/pull/5375)
- [deep_sleep] removed extra spaces [docs#5366](https://github.com/esphome/esphome-docs/pull/5366)
- [binary_sensor] Remove deprecated config item `publish_initial_state` [docs#5356](https://github.com/esphome/esphome-docs/pull/5356)
- Update sx126x.md - Minor typo, heirachy of heading [docs#5364](https://github.com/esphome/esphome-docs/pull/5364)
- Update graph.md, fix graph_legend vs legend [docs#5354](https://github.com/esphome/esphome-docs/pull/5354)
- ld2420 max_gate_distance description [docs#5344](https://github.com/esphome/esphome-docs/pull/5344)
- Update to dsmr water metering documentation [docs#5321](https://github.com/esphome/esphome-docs/pull/5321)
- Update boot screen logo file path in LVGL cookbook [docs#5318](https://github.com/esphome/esphome-docs/pull/5318)
- Update tmp102.md [docs#5313](https://github.com/esphome/esphome-docs/pull/5313)
- Remove redundant newlines in documentation [docs#5295](https://github.com/esphome/esphome-docs/pull/5295)
- [deep_sleep] Update possible modes for esp32_ext1_wakeup [docs#5391](https://github.com/esphome/esphome-docs/pull/5391)
- Add Adaptive Lighting guide link to DIY section [docs#5367](https://github.com/esphome/esphome-docs/pull/5367)
- Update debug.md - remove logger level debug, add note about monitorin… [docs#5365](https://github.com/esphome/esphome-docs/pull/5365)
- Fix some HA "my" buttons [docs#5402](https://github.com/esphome/esphome-docs/pull/5402)
- Remove button shortcode [docs#5403](https://github.com/esphome/esphome-docs/pull/5403)
- Update pre-commit [docs#5404](https://github.com/esphome/esphome-docs/pull/5404)
- Lint script [docs#5405](https://github.com/esphome/esphome-docs/pull/5405)
- Allow vscode workspace settings to be checked into git [docs#5401](https://github.com/esphome/esphome-docs/pull/5401)
- Fix footer discord link [docs#5408](https://github.com/esphome/esphome-docs/pull/5408)
- Fix a bunch of line lengths [docs#5407](https://github.com/esphome/esphome-docs/pull/5407)
- Fix link to wake word yaml [docs#5409](https://github.com/esphome/esphome-docs/pull/5409)
- [number] Fix typos [docs#5411](https://github.com/esphome/esphome-docs/pull/5411)
- Go back to using port 8000 [docs#5413](https://github.com/esphome/esphome-docs/pull/5413)
- Update docker/devcontainers for hugo [docs#5414](https://github.com/esphome/esphome-docs/pull/5414)
- Pin SHA for github actions [docs#5410](https://github.com/esphome/esphome-docs/pull/5410)
- Fix formatting and wording in light component documentation [docs#5416](https://github.com/esphome/esphome-docs/pull/5416)
- offer a clearer explanation of the flicker effect and its parameters [docs#5392](https://github.com/esphome/esphome-docs/pull/5392)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
