### PR TITLE
[api] Add configurable connection limits

### DIFF
--- a/content/components/api.md
+++ b/content/components/api.md
@@ -54,7 +54,7 @@ api:
   Defaults to `4` for ESP8266/RP2040, `8` for ESP32 and other platforms. Each connection uses approximately 500-1000 bytes of RAM.
 
   > [!NOTE]
-  > Each API connection consumes approximately 500-1000 bytes of RAM. ESP8266 and RP2040 devices have limited
+  > Each API connection consumes approximately 500–1000 bytes of RAM while connected. ESP8266 and RP2040 devices have limited
   > RAM available (ESP8266 typically has around 40KB of free RAM after boot, but this can drop to under 20KB once sensors and other components are configured; RP2040 uses LWIP raw sockets with similar constraints), so be careful not to set this value too high or it may cause out-of-memory crashes.
   > The defaults are set to balance memory usage with allowing multiple simultaneous connections.
 

--- a/content/components/api.md
+++ b/content/components/api.md
@@ -53,11 +53,11 @@ api:
 - **max_connections** (*Optional*, int): The maximum number of simultaneous API connections allowed. Must be between 1 and 20.
   Defaults to `4` for ESP8266/RP2040, `8` for ESP32 and other platforms. Each connection uses approximately 500-1000 bytes of RAM.
 
-  {{< note >}}
-  Each API connection consumes approximately 500-1000 bytes of RAM. ESP8266 and RP2040 devices have limited
-  RAM available (ESP8266 typically has around 40KB of free RAM after boot, but this can drop to under 20KB once sensors and other components are configured; RP2040 uses LWIP raw sockets with similar constraints), so be careful not to set this value too high or it may cause out-of-memory crashes.
-  The defaults are set to balance memory usage with allowing multiple simultaneous connections.
-  {{< /note >}}
+  > [!NOTE]
+  > Each API connection consumes approximately 500-1000 bytes of RAM. ESP8266 and RP2040 devices have limited
+  > RAM available (ESP8266 typically has around 40KB of free RAM after boot, but this can drop to under 20KB once sensors and other components are configured; RP2040 uses LWIP raw sockets with similar constraints), so be careful not to set this value too high or it may cause out-of-memory crashes.
+  > The defaults are set to balance memory usage with allowing multiple simultaneous connections.
+
 
 - **encryption** (*Optional*): If present, encryption will be enabled for the API. Using encryption helps to secure the
   communication between the device running ESPHome and the connected client(s).

--- a/content/components/api.md
+++ b/content/components/api.md
@@ -58,7 +58,6 @@ api:
   > RAM available (ESP8266 typically has around 40KB of free RAM after boot, but this can drop to under 20KB once sensors and other components are configured; RP2040 uses LWIP raw sockets with similar constraints), so be careful not to set this value too high or it may cause out-of-memory crashes.
   > The defaults are set to balance memory usage with allowing multiple simultaneous connections.
 
-
 - **encryption** (*Optional*): If present, encryption will be enabled for the API. Using encryption helps to secure the
   communication between the device running ESPHome and the connected client(s).
 

--- a/content/components/api.md
+++ b/content/components/api.md
@@ -49,15 +49,15 @@ api:
 
 - **port** (*Optional*, int): The port to run the API server on. Defaults to `6053`.
 - **listen_backlog** (*Optional*, int): The maximum number of pending connections in the listen queue. Must be between 1 and 10.
-  Defaults to `1` for ESP8266, `4` for other platforms. Lower values use less memory but may reject connections during bursts.
+  Defaults to `1` for ESP8266/RP2040, `4` for ESP32 and other platforms. Lower values use less memory but may reject connections during bursts.
 - **max_connections** (*Optional*, int): The maximum number of simultaneous API connections allowed. Must be between 1 and 20.
-  Defaults to `4` for ESP8266, `8` for other platforms. Each connection uses approximately 500-1000 bytes of RAM.
+  Defaults to `4` for ESP8266/RP2040, `8` for ESP32 and other platforms. Each connection uses approximately 500-1000 bytes of RAM.
 
   {{< note >}}
-  Each API connection consumes approximately 500-1000 bytes of RAM. ESP8266 devices typically have much less
-  free RAM available (often under 20KB with sensors configured), so be careful not to set this value too high
-  or it may cause out-of-memory crashes. The defaults are set to balance memory usage with allowing multiple
-  simultaneous connections.
+  Each API connection consumes approximately 500-1000 bytes of RAM. ESP8266 and RP2040 devices have limited
+  RAM available (ESP8266 often has under 20KB free with sensors configured, RP2040 uses LWIP raw sockets with
+  similar constraints), so be careful not to set this value too high or it may cause out-of-memory crashes.
+  The defaults are set to balance memory usage with allowing multiple simultaneous connections.
   {{< /note >}}
 
 - **encryption** (*Optional*): If present, encryption will be enabled for the API. Using encryption helps to secure the

--- a/content/components/api.md
+++ b/content/components/api.md
@@ -38,6 +38,8 @@ api:
 api:
   port: 6053
   batch_delay: 50ms  # Reduce latency for real-time applications
+  listen_backlog: 2  # Allow 2 pending connections in queue
+  max_connections: 6  # Allow up to 6 simultaneous connections
   encryption:
     key: "YOUR_ENCRYPTION_KEY_HERE"
   reboot_timeout: 30min
@@ -46,6 +48,18 @@ api:
 ## Configuration variables
 
 - **port** (*Optional*, int): The port to run the API server on. Defaults to `6053`.
+- **listen_backlog** (*Optional*, int): The maximum number of pending connections in the listen queue. Must be between 1 and 10.
+  Defaults to `1` for ESP8266, `4` for other platforms. Lower values use less memory but may reject connections during bursts.
+- **max_connections** (*Optional*, int): The maximum number of simultaneous API connections allowed. Must be between 1 and 20.
+  Defaults to `4` for ESP8266, `8` for other platforms. Each connection uses approximately 500-1000 bytes of RAM.
+
+  {{< note >}}
+  Each API connection consumes approximately 500-1000 bytes of RAM. ESP8266 devices typically have much less
+  free RAM available (often under 20KB with sensors configured), so be careful not to set this value too high
+  or it may cause out-of-memory crashes. The defaults are set to balance memory usage with allowing multiple
+  simultaneous connections.
+  {{< /note >}}
+
 - **encryption** (*Optional*): If present, encryption will be enabled for the API. Using encryption helps to secure the
   communication between the device running ESPHome and the connected client(s).
 

--- a/content/components/api.md
+++ b/content/components/api.md
@@ -55,8 +55,7 @@ api:
 
   {{< note >}}
   Each API connection consumes approximately 500-1000 bytes of RAM. ESP8266 and RP2040 devices have limited
-  RAM available (ESP8266 often has under 20KB free with sensors configured, RP2040 uses LWIP raw sockets with
-  similar constraints), so be careful not to set this value too high or it may cause out-of-memory crashes.
+  RAM available (ESP8266 typically has around 40KB of free RAM after boot, but this can drop to under 20KB once sensors and other components are configured; RP2040 uses LWIP raw sockets with similar constraints), so be careful not to set this value too high or it may cause out-of-memory crashes.
   The defaults are set to balance memory usage with allowing multiple simultaneous connections.
   {{< /note >}}
 


### PR DESCRIPTION
## Description:

This PR documents the new `listen_backlog` and `max_connections` configuration options for the API component. These options allow users to configure connection limits to prevent memory exhaustion on constrained devices.

The documentation explains:
- The purpose of each option and their valid ranges
- Platform-specific default values (ESP8266/RP2040 vs ESP32 and other platforms)
- Memory usage considerations for connection limits
- Example configuration

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#10939

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

## Changes Made

### Updated `/content/components/api.md`:

1. **Added new configuration variables:**
   - `listen_backlog`: Configures the maximum pending connections queue
   - `max_connections`: Configures the maximum simultaneous API connections

2. **Added platform-specific defaults documentation:**
   - ESP8266/RP2040: 1 backlog, 4 max connections (limited RAM, LWIP raw sockets)
   - ESP32 and other platforms: 4 backlog, 8 max connections (more generous limits)

3. **Added memory usage note:**
   - Explains that each connection uses 500-1000 bytes of RAM
   - Warns ESP8266 and RP2040 users about RAM limitations and LWIP constraints
   - Helps users understand the trade-offs when adjusting limits

4. **Updated example configuration:**
   - Shows how to configure the new options
   - Includes helpful comments explaining each option

## Context

These connection limits are being added to prevent out-of-memory crashes on devices with limited RAM. Without limits, multiple simultaneous connections could exhaust available memory, especially on ESP8266 which has only ~40KB of free RAM and RP2040 which uses LWIP raw sockets with similar constraints. The defaults are set high enough for typical usage (Home Assistant uses 1 connection, dashboard adds 1 when viewing logs) while preventing memory exhaustion from too many connections.