### PR TITLE
 Add sample code snippet for MEMS Microphone ICS-43434

### DIFF
--- a/content/components/microphone/i2s_audio.md
+++ b/content/components/microphone/i2s_audio.md
@@ -97,8 +97,6 @@ microphone:
 
 ### ICS-43434
 
-[Adafruit I2S MEMS Mic Breakout](https://www.adafruit.com/product/6049)
-
 ```yaml
 microphone:
   - platform: i2s_audio

--- a/content/components/microphone/i2s_audio.md
+++ b/content/components/microphone/i2s_audio.md
@@ -95,6 +95,23 @@ microphone:
     pdm: false
 ```
 
+### ICS-43434
+
+[Adafruit I2S MEMS Mic Breakout](https://www.adafruit.com/product/6049)
+
+```yaml
+microphone:
+  - platform: i2s_audio
+    i2s_din_pin: GPIOXX
+    adc_type: external
+    pdm: false
+    sample_rate: 48000
+    bits_per_sample: 32bit
+    channel: left
+    use_apll: true
+```
+
+
 ## See also
 
 - {{< docref "index/" >}}

--- a/content/components/microphone/i2s_audio.md
+++ b/content/components/microphone/i2s_audio.md
@@ -111,7 +111,6 @@ microphone:
     use_apll: true
 ```
 
-
 ## See also
 
 - {{< docref "index/" >}}


### PR DESCRIPTION
## Description:

Tested working with Adafruit MEMS i2s Breakout https://www.adafruit.com/product/6049
And vanilla ESP32 and XIAO ESP32-S3

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
