### PR TITLE
Update esp_ldo.md

### DIFF
--- a/content/components/esp_ldo.md
+++ b/content/components/esp_ldo.md
@@ -14,12 +14,14 @@ component allows those regulators to be configured and enabled.
 esp_ldo:
   - channel: 3
     voltage: 2.5V
+  - channel: 4      // example for sd activation on Guition JC-ESP32-P4-M3 dev board
+    voltage: 3.3V   // GPIO45 on these boards can then do PWM on that power supply line on runtime (ledc)
 ```
 
 ## Configuration variables
 
 - **channel** (**Required**, int): The channel number of the LDO regulator to configure. Only channels 3 and 4 are supported (1 and 2 are used internally by the chip.)
-- **voltage** (**Required**, voltage): The desired output voltage - must be in the range 0.5V to 2.7V.
+- **voltage** (**Required**, voltage): The desired output voltage - must be in the range 0.5V to 3.3V. Default is 2.7V. 3.3V in case LDO is used for SD-card slot power.
 - **adjustable** (*Optional*, bool): If true, the output voltage can be adjusted at run-time. Defaults to false.
 
 ## `esp_ldo.voltage.adjust` Action
@@ -37,7 +39,7 @@ on_...:
 ### Configuration variables
 
 - **id** (**Required**, [ID](#config-id)) The ID of the LDO to adjust.
-- **voltage** (**Required**, voltage): The desired output voltage - must be in the range 0.5V to 2.7V.
+- **voltage** (**Required**, voltage): The desired output voltage - must be in the range 0.5V to 3.3V. Defaults to 2.7V
 
 ## See Also
 


### PR DESCRIPTION
## Description:
Document 3.3V LDO channel usage as sd-slot power supply line on some boards.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#10981

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
