### PR TITLE
[logger] Document runtime_tag_levels configuration option

### DIFF
--- a/content/components/logger.md
+++ b/content/components/logger.md
@@ -35,6 +35,10 @@ logger:
 - **logs** (*Optional*, mapping): Manually set the log level for a
    specific component or tag. See [Manual Log Levels for more information](#logger-manual_tag_specific_levels).
 
+- **runtime_tag_levels** (*Optional*, boolean): Enable runtime per-tag log level changes. This is automatically enabled
+   when `logs` is configured or when `logger.set_level` is used with a `tag` parameter. Only needs to be manually
+   enabled if calling `set_log_level()` from a lambda or external component. Defaults to `false` (auto-enabled as needed).
+
 - **id** (*Optional*, [ID](#config-id)): Manually specify the ID used for code generation.
 
 Advanced settings:
@@ -174,6 +178,10 @@ logger:
     mqtt.client: ERROR
 ```
 
+> [!NOTE]
+> When using `logs`, runtime per-tag log level support is automatically enabled. When this feature is disabled
+> (the default when `logs` is not configured), the logger is optimized for better performance and reduced memory usage.
+
 The `level` option controls which log statements are included in the
 firmware. You cannot set a tag to a more detailed level than
 the global one, because log statements with lower severity than that level are not compiled in.
@@ -237,6 +245,11 @@ on_...:
         level: DEBUG
         tag: mqtt.client
 ```
+
+> [!NOTE]
+> When using `logger.set_level` with a `tag` parameter, runtime per-tag log level support is automatically enabled.
+> If you need to call `set_log_level()` directly from a lambda or external component, you must manually enable
+> `runtime_tag_levels: true` in the logger configuration.
 
 ## Logger Automation
 


### PR DESCRIPTION
## Description:

Document the new `runtime_tag_levels` configuration option for the logger component and explain the performance optimization for runtime tag-specific log levels.

**Changes:**
- Added `runtime_tag_levels` configuration option documentation
- Explained auto-enable behavior when `logs:` is configured or `logger.set_level` uses `tag:` parameter
- Added performance/memory optimization notes
- Provided migration guidance for C++ lambda usage with examples

**Related issue (if applicable):** N/A - Performance optimization

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#11004

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
