### PR TITLE
Fix note re: drawing legend

### DIFF
--- a/content/components/graph.md
+++ b/content/components/graph.md
@@ -169,5 +169,5 @@ color:
 > - Setting `y_grid` will expand any specified range to the nearest multiple of grid spacings.
 > - Axis labels are currently not possible without manually placing them.
 > - The grid and border color is set with `it.graph()`, while the traces are defined separately.
-> - Legends are drawn separately using `it.graph_legend()` and can be positioned independently of the graph.
+> - Legends are drawn separately using `it.legend()` and can be positioned independently of the graph.
 > - Legend dimensions are automatically calculated if not specified, based on font sizes and trace count.


### PR DESCRIPTION
Fixes the note to include the correct member to call to draw the graph legend.

## Description:

Fixes #5449 

Change the note to specify the correct Display member to call when trying to draw a graph legend.
It should be `legend()`, not `graph_legend()`. 
See https://github.com/esphome/esphome/blob/93e18e850e9e949b39d82c6d691257f2bb8dc094/esphome/components/display/display.cpp#L533