### PR TITLE
[nextion] Add configurable startup and queue timeout constants

### DIFF
--- a/content/components/display/nextion.md
+++ b/content/components/display/nextion.md
@@ -80,13 +80,13 @@ display:
 - **auto_wake_on_touch** (*Optional*, boolean): If set to `true`, the Nextion will be configured to wake from sleep
   when touched.
 
-- **max_queue_age** (*Optional*, int): Maximum age in milliseconds for queued commands before they are automatically
+- **max_queue_age** (*Optional*, [Time](/guides/configuration-types#time)): Maximum age in milliseconds for queued commands before they are automatically
   removed. This helps prevent stale commands from being executed after delays. Set to ``0`` to disable age-based
   removal (commands are only limited by queue size). **Note:** Very low values (e.g., <50ms) may cause commands
   to be dropped before transmission due to ESPHome's loop timing (~16ms). Recommended minimum is 100ms when enabled.
   Range: 0-65535. Defaults to ``8000`` (8 seconds).
 
-- **startup_override_ms** (*Optional*, int): Time in milliseconds to wait before forcing the display to be marked as ready
+- **startup_override_ms** (*Optional*, [Time](/guides/configuration-types#time)): Time in milliseconds to wait before forcing the display to be marked as ready
   if it hasn't responded to the connection handshake. Set to ``0`` to disable the override and wait indefinitely
   for the handshake. This is useful for displays with slower startup sequences or to enforce strict handshake requirements.
   Range: 0-65535. Defaults to ``8000`` (8 seconds).

--- a/content/components/display/nextion.md
+++ b/content/components/display/nextion.md
@@ -81,13 +81,16 @@ display:
   when touched.
 
 - **max_queue_age** (*Optional*, int): Maximum age in milliseconds for queued commands before they are automatically
-  removed. This helps prevent stale commands from being executed after delays.
-  Range: 0-65535. Defaults to `8000` (8 seconds).
+  removed. This helps prevent stale commands from being executed after delays. Set to ``0`` to disable age-based
+  removal (commands are only limited by queue size). **Note:** Very low values (e.g., <50ms) may cause commands
+  to be dropped before transmission due to ESPHome's loop timing (~16ms). Recommended minimum is 100ms when enabled.
+  Range: 0-65535. Defaults to ``8000`` (8 seconds).
 
 - **startup_override_ms** (*Optional*, int): Time in milliseconds to wait before forcing the display to be marked as ready
-  if it hasn't responded to the connection handshake. This is useful for displays with slower startup sequences.
-  Range: 0-65535. Defaults to `8000` (8 seconds).
-
+  if it hasn't responded to the connection handshake. Set to ``0`` to disable the override and wait indefinitely
+  for the handshake. This is useful for displays with slower startup sequences or to enforce strict handshake requirements.
+  Range: 0-65535. Defaults to ``8000`` (8 seconds).
+  
 - **skip_connection_handshake** (*Optional*, boolean): Sets whether the initial display connection handshake process is
   skipped. When set to `true`, the connection will be established without performing the handshake. This can be
   useful when using Nextion Simulator. Defaults to `false`.

--- a/content/components/display/nextion.md
+++ b/content/components/display/nextion.md
@@ -80,6 +80,14 @@ display:
 - **auto_wake_on_touch** (*Optional*, boolean): If set to `true`, the Nextion will be configured to wake from sleep
   when touched.
 
+- **max_queue_age** (*Optional*, int): Maximum age in milliseconds for queued commands before they are automatically
+  removed. This helps prevent stale commands from being executed after delays.
+  Range: 0-65535. Defaults to `8000` (8 seconds).
+
+- **startup_override_ms** (*Optional*, int): Time in milliseconds to wait before forcing the display to be marked as ready
+  if it hasn't responded to the connection handshake. This is useful for displays with slower startup sequences.
+  Range: 0-65535. Defaults to `8000` (8 seconds).
+
 - **skip_connection_handshake** (*Optional*, boolean): Sets whether the initial display connection handshake process is
   skipped. When set to `true`, the connection will be established without performing the handshake. This can be
   useful when using Nextion Simulator. Defaults to `false`.


### PR DESCRIPTION
## Description:

Makes the Nextion startup override and max queue age constants configurable via YAML, allowing users to tune timing parameters for their specific displays without modifying the code.

Previously, these were hardcoded as `const uint16_t` member variables with 8000ms defaults. Now they are configurable via YAML while maintaining the same memory efficiency through member variable initialization.

**This documentation supports esphome/esphome#11098**, which supersedes and closes #3657, providing a cleaner, user-friendly solution that allows configuration without requiring code modifications or custom builds.

### Changes
- Added `startup_override_ms` configuration option (default: 8000ms)
- Added `max_queue_age` configuration option (default: 8000ms)
- Added documentation for new configuration parameters
- Added usage examples

### Why?
Different Nextion displays (especially larger ones or those with complex startup sequences) may need longer timeouts. This allows users to optimize these values for their specific hardware without recompiling ESPHome or maintaining custom forks.

### Memory Impact
- **Flash**: Minimal increase (~100-200 bytes for setter methods and validation)
- **RAM**: 4 bytes total (two `uint16_t` member variables, same as before)
- **Performance**: Setters called once at initialization, no runtime overhead

**Related issue (if applicable):**

- fixes esphome/issues#3225
- fixes esphome/issues#3335

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#11098

## Checklist:

  - [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
