### PR TITLE
Espnow packet transport

### DIFF
--- a/content/components/packet_transport/espnow.md
+++ b/content/components/packet_transport/espnow.md
@@ -1,0 +1,305 @@
+ESP-NOW Packet Transport Platform
+===================================
+
+The :doc:`Packet Transport Component </components/packet_transport>` platform allows ESPHome nodes to directly 
+communicate with each over a communication channel.
+
+The ESP-NOW implementation of the platform uses ESP-NOW as a communication medium. See the 
+:doc:`Packet Transport Component </components/packet_transport>` and :doc:`ESP-NOW Component </components/espnow>` 
+for more information.
+
+ESP-NOW provides low-latency, low-power wireless communication between ESP32 devices without requiring a WiFi 
+connection. This makes it ideal for battery-powered sensors or applications where WiFi overhead would impact 
+performance.
+
+.. note::
+
+    ESP-NOW communication occurs independently of WiFi. Devices can communicate via ESP-NOW even when WiFi is 
+    disabled, making it suitable for power-sensitive applications.
+
+Example Configuration
+---------------------
+
+.. code-block:: yaml
+
+    # Example configuration entry
+    espnow:
+      peers:
+        - mac_address: "AA:BB:CC:DD:EE:FF"
+          # Optional peer configuration
+
+    packet_transport:
+      - platform: espnow
+        peer_address: "AA:BB:CC:DD:EE:FF"
+        sensors:
+          - dht_temp
+
+    sensor:
+      - platform: dht
+        id: dht
+        pin: GPIO4
+        temperature:
+          name: "Temperature"
+          id: dht_temp
+
+Configuration Variables
+------------------------
+
+- **peer_address** (*Optional*, MAC Address): The MAC address to send packets to. This can be either a specific 
+  peer address for point-to-point communication, or the broadcast address ``FF:FF:FF:FF:FF:FF`` for broadcasting to 
+  all registered peers. Defaults to ``FF:FF:FF:FF:FF:FF``.
+
+- All other options from :doc:`Packet Transport Component </components/packet_transport>`.
+
+.. note::
+
+    Peers must be registered with the :doc:`ESP-NOW Component </components/espnow>` before they can receive packets. 
+    The ``peer_address`` only controls which peer(s) receive transmitted data; incoming packets are accepted from all 
+    registered peers.
+
+Broadcast vs Unicast
+--------------------
+
+The ``peer_address`` configuration determines the transmission mode:
+
+**Broadcast Mode** (default):
+
+.. code-block:: yaml
+
+    packet_transport:
+      - platform: espnow
+        # peer_address: "FF:FF:FF:FF:FF:FF"  # Default, can be omitted
+        sensors:
+          - sensor_id
+
+All devices with the broadcast address (``FF:FF:FF:FF:FF:FF``) registered as a peer will receive the packets. 
+This is useful for hub-and-spoke topologies where multiple devices monitor a single sensor source.
+
+**Unicast Mode**:
+
+.. code-block:: yaml
+
+    packet_transport:
+      - platform: espnow
+        peer_address: "AA:BB:CC:DD:EE:FF"
+        sensors:
+          - sensor_id
+
+Only the specified peer receives the packets. This is more efficient for point-to-point communication
+
+Complete Example
+----------------
+
+This example shows two devices exchanging sensor data over ESP-NOW with encryption enabled:
+
+.. code-block:: yaml
+
+    # Device 1 - Temperature Sensor Provider
+    esphome:
+      name: temp-sensor
+
+    espnow:
+      peers:
+        - mac_address: "AA:BB:CC:DD:EE:01"  # Device 2
+
+    packet_transport:
+      - platform: espnow
+        peer_address: "AA:BB:CC:DD:EE:01"  # Send to Device 2
+        encryption: "MySecretKey123"
+        sensors:
+          - outdoor_temp
+
+    sensor:
+      - platform: dht
+        pin: GPIO4
+        temperature:
+          name: "Outdoor Temperature"
+          id: outdoor_temp
+
+.. code-block:: yaml
+
+    # Device 2 - Temperature Display Consumer
+    esphome:
+      name: temp-display
+
+    espnow:
+      peers:
+        - mac_address: "AA:BB:CC:DD:EE:00"  # Device 1
+
+    packet_transport:
+      - platform: espnow
+        encryption: "MySecretKey123"
+        providers:
+          - name: temp-sensor
+
+    sensor:
+      - platform: packet_transport
+        provider: temp-sensor
+        id: remote_temp
+        remote_id: outdoor_temp
+        name: "Remote Outdoor Temperature"
+
+Multi-Device Hub Example
+------------------------
+
+This example shows a central hub receiving sensor data from multiple remote devices:
+
+.. code-block:: yaml
+
+    # Hub Device
+    esphome:
+      name: sensor-hub
+
+    espnow:
+      peers:
+        - mac_address: "FF:FF:FF:FF:FF:FF"  # Broadcast address
+
+    packet_transport:
+      - platform: espnow
+        encryption: "HubSecret123"
+        providers:
+          - name: room-sensor-1
+          - name: room-sensor-2
+          - name: outdoor-sensor
+
+    sensor:
+      - platform: packet_transport
+        provider: room-sensor-1
+        remote_id: temperature
+        name: "Room 1 Temperature"
+
+      - platform: packet_transport
+        provider: room-sensor-2
+        remote_id: temperature
+        name: "Room 2 Temperature"
+
+      - platform: packet_transport
+        provider: outdoor-sensor
+        remote_id: temperature
+        name: "Outdoor Temperature"
+
+.. code-block:: yaml
+
+    # Remote Sensor (repeat for each room)
+    esphome:
+      name: room-sensor-1
+
+    espnow:
+      peers:
+        - mac_address: "FF:FF:FF:FF:FF:FF"  # Broadcast
+
+    packet_transport:
+      - platform: espnow
+        peer_address: "FF:FF:FF:FF:FF:FF"  # Broadcast to hub
+        encryption: "HubSecret123"
+        sensors:
+          - temperature
+
+    sensor:
+      - platform: dht
+        pin: GPIO4
+        temperature:
+          id: temperature
+
+Power-Efficient OTA Updates
+----------------------------
+
+ESP-NOW can be used to remotely enable WiFi for OTA updates, keeping WiFi disabled during normal operation for 
+better performance:
+
+.. code-block:: yaml
+
+    # Remote device with WiFi normally disabled
+    esphome:
+      name: remote-device
+      on_boot:
+        priority: -100
+        then:
+          - wifi.disable:  # Disable WiFi on boot
+
+    wifi:
+      ssid: !secret wifi_ssid
+      password: !secret wifi_password
+
+    api:
+    ota:
+
+    espnow:
+      peers:
+        - mac_address: "AA:BB:CC:DD:EE:FF"  # Controller MAC
+
+    packet_transport:
+      - platform: espnow
+        id: espnow_transport
+        on_packet:
+          - lambda: |-
+              // Command protocol: 0x01 = enable WiFi, 0x02 = disable WiFi
+              if (data.size() >= 1) {
+                if (data[0] == 0x01) {
+                  ESP_LOGI("ota", "Enabling WiFi for OTA");
+                  wifi::global_wifi_component->set_enabled(true);
+                } else if (data[0] == 0x02) {
+                  ESP_LOGI("ota", "Disabling WiFi");
+                  wifi::global_wifi_component->set_enabled(false);
+                }
+              }
+
+.. code-block:: yaml
+
+    # Controller device
+    button:
+      - platform: template
+        name: "Enable OTA Mode"
+        on_press:
+          - lambda: |-
+              std::vector<uint8_t> cmd = {0x01};
+              id(espnow_transport)->send_packet(cmd);
+
+      - platform: template
+        name: "Disable OTA Mode"
+        on_press:
+          - lambda: |-
+              std::vector<uint8_t> cmd = {0x02};
+              id(espnow_transport)->send_packet(cmd);
+
+Performance Considerations
+--------------------------
+
+- **Maximum Packet Size**: ESP-NOW has a maximum packet size of 250 bytes. The packet transport component will 
+  automatically handle this limitation.
+
+- **Throughput**: ESP-NOW provides lower throughput than WiFi but has significantly lower latency (typically 
+  <10ms vs 50-100ms for WiFi).
+
+- **Range**: ESP-NOW typically provides similar range to WiFi (50-100 meters line-of-sight), but this varies 
+  based on environment and antenna configuration.
+
+- **Power Consumption**: ESP-NOW consumes significantly less power than maintaining a WiFi connection, making it 
+  ideal for battery-powered applications.
+
+- **Channel**: ESP-NOW operates on the same 2.4GHz channels as WiFi. When WiFi is enabled, ESP-NOW automatically 
+  uses the same channel. When WiFi is disabled, ESP-NOW uses channel 1 by default.
+
+Limitations
+-----------
+
+- **ESP32 Only**: ESP-NOW is only available on ESP32, ESP32-S2, ESP32-S3, and ESP32-C3 chips. ESP8266 support 
+  is not available.
+
+- **Peer Limit**: ESP32 devices can register a maximum of 20 peers (10 encrypted + 10 unencrypted, or various 
+  combinations).
+
+- **Packet Size**: Maximum 250 bytes per packet, which limits the amount of sensor data that can be transmitted 
+  in a single update.
+
+- **No Routing**: ESP-NOW is not a mesh protocol. Devices communicate directly and cannot route packets through 
+  intermediate nodes.
+
+See Also
+--------
+
+- :doc:`Packet Transport Component </components/packet_transport>`
+- :doc:`ESP-NOW Component </components/espnow>`
+- :doc:`UDP Packet Transport </components/packet_transport/udp>`
+- :apiref:`espnow/packet_transport/espnow_transport.h`
+- :ghedit:`Edit`

--- a/content/components/packet_transport/espnow.md
+++ b/content/components/packet_transport/espnow.md
@@ -1,9 +1,9 @@
 # ESP-NOW Packet Transport Platform
 
-The [Packet Transport Component](/components/packet_transport) platform allows ESPHome nodes to directly communicate with each other over a communication channel.
+The [Packet Transport Component](#packet_transport) platform allows ESPHome nodes to directly communicate with each other over a communication channel.
 
 The **ESP-NOW** implementation of this platform uses ESP-NOW as the communication medium. See the
-[Packet Transport Component](/components/packet_transport) and [ESP-NOW Component](/components/espnow) for more information.
+[Packet Transport Component](#acket_transport) and [ESP-NOW Component](#espnow) for more information.
 
 ESP-NOW provides low-latency, low-power wireless communication between ESP32 devices without requiring a Wi-Fi connection.
 This makes it ideal for battery-powered sensors or applications where Wi-Fi overhead would impact performance.
@@ -290,9 +290,9 @@ button:
 
 ## See Also
 
-* [Packet Transport Component](/components/packet_transport)
-* [ESP-NOW Component](/components/espnow)
-* [UDP Packet Transport](/components/packet_transport/udp)
+* [Packet Transport Component](#packet_transport)
+* [ESP-NOW Component](#espnow)
+* [UDP Packet Transport](#packet_transport/udp)
 * [espnow_transport.h (API Reference)](/api/espnow/packet_transport/espnow_transport.h)
 * [Edit on GitHub](https://github.com/esphome/esphome/edit/dev/esphome/components/packet_transport/espnow_transport.md)
 

--- a/content/components/packet_transport/espnow.md
+++ b/content/components/packet_transport/espnow.md
@@ -1,18 +1,20 @@
-# ESP-NOW Packet Transport Platform
-
-The [Packet Transport Component](#packet_transport) platform allows ESPHome nodes to directly communicate with each other over a communication channel.
-
-The **ESP-NOW** implementation of this platform uses ESP-NOW as the communication medium. See the
-[Packet Transport Component](#acket_transport) and [ESP-NOW Component](#espnow) for more information.
-
-ESP-NOW provides low-latency, low-power wireless communication between ESP32 devices without requiring a Wi-Fi connection.
-This makes it ideal for battery-powered sensors or applications where Wi-Fi overhead would impact performance.
-
-> **Note:**
-> ESP-NOW communication occurs independently of Wi-Fi.
-> Devices can communicate via ESP-NOW even when Wi-Fi is disabled, making it suitable for power-sensitive applications.
-
 ---
+description: "Instructions for setting up an ESP-NOW packet transport platform on ESPHome"
+title: "ESP-NOW Packet Transport Platform"
+params:
+  seo:
+    description: Instructions for setting up an ESP-NOW packet transport platform on ESPHome
+    image: espnow.svg
+---
+
+{{< anchor "espnow-packet-transport" >}}
+
+The [Packet Transport Component](#packet-transport) platform allows ESPHome nodes to directly communicate with each over a communication channel. The ESP-NOW implementation of the platform uses ESP-NOW as a communication medium. See the [Packet Transport Component](#packet-transport) and [ESP-NOW Component](#espnow) for more information.
+
+ESP-NOW provides low-latency, low-power wireless communication between ESP32 devices without requiring a Wi-Fi connection. This makes it ideal for battery-powered sensors or applications where Wi-Fi overhead would impact performance.
+
+> **Note:**  
+> ESP-NOW communication occurs independently of Wi-Fi. Devices can communicate via ESP-NOW even when Wi-Fi is disabled, making it suitable for power-sensitive applications.
 
 ## Example Configuration
 
@@ -38,20 +40,15 @@ sensor:
       id: dht_temp
 ```
 
----
-
 ## Configuration Variables
 
 | Name                | Type                     | Default             | Description                                                                                            |
 | ------------------- | ------------------------ | ------------------- | ------------------------------------------------------------------------------------------------------ |
-| `peer_address`      | MAC Address *(optional)* | `FF:FF:FF:FF:FF:FF` | MAC address to send packets to. May be a specific peer (unicast) or broadcast to all registered peers. |
-| *All other options* | —                        | —                   | From the [Packet Transport Component](/components/packet_transport).                                   |
+| `peer_address`      | MAC Address *(optional)* | `FF:FF:FF:FF:FF:FF` | MAC address to send packets to. This can be either a specific peer address for point-to-point communication, or the broadcast address `FF:FF:FF:FF:FF:FF` for broadcasting to all registered peers. |
+| *All other options* | —                        | —                   | From the [Packet Transport Component](#packet-transport).                                              |
 
-> **Note:**
-> Peers must be registered with the [ESP-NOW Component](/components/espnow) before they can receive packets.
-> The `peer_address` only controls which peer(s) receive transmitted data; incoming packets are accepted from all registered peers.
-
----
+> **Note:**  
+> Peers must be registered with the [ESP-NOW Component](#espnow) before they can receive packets. The `peer_address` only controls which peer(s) receive transmitted data; incoming packets are accepted from all registered peers.
 
 ## Broadcast vs Unicast
 
@@ -67,8 +64,10 @@ packet_transport:
       - sensor_id
 ```
 
-All devices with the broadcast address (`FF:FF:FF:FF:FF:FF`) registered as a peer will receive the packets.
-Useful for **hub-and-spoke** topologies where multiple devices monitor a single sensor source.
+All devices with the broadcast address (`FF:FF:FF:FF:FF:FF`) registered as a peer will receive the packets. This is useful for hub-and-spoke topologies where multiple devices monitor a single sensor source.
+
+> **Warning:**  
+> Using broadcast mode increases ESP-NOW traffic on the radio channel, which may impact performance of other ESP-NOW devices in range. Use specific peer addresses whenever possible to minimize interference.
 
 ### Unicast Mode
 
@@ -80,10 +79,7 @@ packet_transport:
       - sensor_id
 ```
 
-Only the specified peer receives the packets.
-This is more efficient for **point-to-point** communication.
-
----
+Only the specified peer receives the packets. This is more efficient for point-to-point communication and reduces radio channel congestion for neighboring ESP-NOW devices.
 
 ## Complete Example
 
@@ -137,8 +133,6 @@ sensor:
     remote_id: outdoor_temp
     name: "Remote Outdoor Temperature"
 ```
-
----
 
 ## Multi-Device Hub Example
 
@@ -203,11 +197,9 @@ sensor:
       id: temperature
 ```
 
----
-
 ## Power-Efficient OTA Updates
 
-ESP-NOW can be used to remotely enable Wi-Fi for OTA updates, keeping Wi-Fi disabled during normal operation for better power performance.
+One Potential application could be to use ESP-NOW to remotely enable Wi-Fi for OTA updates, keeping Wi-Fi disabled during normal operation for better performance.
 
 ### Remote Device (Wi-Fi normally disabled)
 
@@ -266,34 +258,27 @@ button:
           id(espnow_transport)->send_packet(cmd);
 ```
 
----
-
 ## Performance Considerations
 
-* **Maximum Packet Size:** ESP-NOW packets are limited to **250 bytes**. The packet transport component automatically handles this.
-* **Throughput:** ESP-NOW provides lower throughput than Wi-Fi but with significantly lower latency (<10 ms typical vs 50–100 ms).
-* **Range:** Typically **50–100 m line-of-sight**, similar to Wi-Fi.
-* **Power Consumption:** Far lower than maintaining a Wi-Fi connection — ideal for battery devices.
-* **Channel:** Uses the same 2.4 GHz channels as Wi-Fi. When Wi-Fi is disabled, defaults to channel 1.
-
----
+* **Maximum Packet Size:** ESP-NOW has a maximum packet size of 250 bytes. The packet transport component will automatically handle this limitation.
+* **Throughput:** ESP-NOW provides lower throughput than Wi-Fi but has significantly lower latency (typically <10ms vs 50-100ms for Wi-Fi).
+* **Range:** ESP-NOW typically provides similar range to Wi-Fi (50-100 meters line-of-sight), but this varies based on environment and antenna configuration.
+* **Power Consumption:** ESP-NOW consumes significantly less power than maintaining a Wi-Fi connection, making it ideal for battery-powered applications.
+* **Channel:** ESP-NOW operates on the same 2.4GHz channels as Wi-Fi. When Wi-Fi is enabled, ESP-NOW automatically uses the same channel. When Wi-Fi is disabled, ESP-NOW uses channel 1 by default.
 
 ## Limitations
 
-* **ESP32-only:** Available on ESP32, ESP32-S2, ESP32-S3, and ESP32-C3.
-  Not supported on ESP8266.
-* **Peer Limit:** Up to 20 peers total (10 encrypted + 10 unencrypted, or combinations).
-* **Packet Size:** Maximum 250 bytes per packet.
-* **No Routing:** ESP-NOW is not a mesh protocol; devices communicate directly only.
-
----
+* **ESP32 Only:** ESP-NOW is only available on ESP32, ESP32-S2, ESP32-S3, and ESP32-C3 chips. ESP8266 support is not available.
+* **Peer Limit:** ESP32 devices can register a maximum of 20 peers (10 encrypted + 10 unencrypted, or various combinations).
+* **Packet Size:** Maximum 250 bytes per packet, which limits the amount of sensor data that can be transmitted in a single update.
+* **No Routing:** ESP-NOW is not a mesh protocol. Devices communicate directly and cannot route packets through intermediate nodes.
 
 ## See Also
 
-* [Packet Transport Component](#packet_transport)
-* [ESP-NOW Component](#espnow)
-* [UDP Packet Transport](#packet_transport/udp)
-* [espnow_transport.h (API Reference)](/api/espnow/packet_transport/espnow_transport.h)
-* [Edit on GitHub](https://github.com/esphome/esphome/edit/dev/esphome/components/packet_transport/espnow_transport.md)
-
----
+- [Packet Transport Component](#packet-transport)
+- {{< docref "/components/espnow" >}}
+- {{< docref "/components/binary_sensor/packet_transport" >}}
+- {{< docref "/components/sensor/packet_transport" >}}
+- [UDP Packet Transport](#udp-packet-transport)
+- [Automation](#automation)
+- {{< apiref "packet_transport/espnow_transport.h" "packet_transport/espnow_transport.h" >}}

--- a/content/components/packet_transport/espnow.md
+++ b/content/components/packet_transport/espnow.md
@@ -1,305 +1,299 @@
-ESP-NOW Packet Transport Platform
-===================================
+# ESP-NOW Packet Transport Platform
 
-The :doc:`Packet Transport Component </components/packet_transport>` platform allows ESPHome nodes to directly 
-communicate with each over a communication channel.
+The [Packet Transport Component](/components/packet_transport) platform allows ESPHome nodes to directly communicate with each other over a communication channel.
 
-The ESP-NOW implementation of the platform uses ESP-NOW as a communication medium. See the 
-:doc:`Packet Transport Component </components/packet_transport>` and :doc:`ESP-NOW Component </components/espnow>` 
-for more information.
+The **ESP-NOW** implementation of this platform uses ESP-NOW as the communication medium. See the
+[Packet Transport Component](/components/packet_transport) and [ESP-NOW Component](/components/espnow) for more information.
 
-ESP-NOW provides low-latency, low-power wireless communication between ESP32 devices without requiring a WiFi 
-connection. This makes it ideal for battery-powered sensors or applications where WiFi overhead would impact 
-performance.
+ESP-NOW provides low-latency, low-power wireless communication between ESP32 devices without requiring a Wi-Fi connection.
+This makes it ideal for battery-powered sensors or applications where Wi-Fi overhead would impact performance.
 
-.. note::
+> **Note:**
+> ESP-NOW communication occurs independently of Wi-Fi.
+> Devices can communicate via ESP-NOW even when Wi-Fi is disabled, making it suitable for power-sensitive applications.
 
-    ESP-NOW communication occurs independently of WiFi. Devices can communicate via ESP-NOW even when WiFi is 
-    disabled, making it suitable for power-sensitive applications.
+---
 
-Example Configuration
----------------------
+## Example Configuration
 
-.. code-block:: yaml
+```yaml
+# Example configuration entry
+espnow:
+  peers:
+    - mac_address: "AA:BB:CC:DD:EE:FF"
+      # Optional peer configuration
 
-    # Example configuration entry
-    espnow:
-      peers:
-        - mac_address: "AA:BB:CC:DD:EE:FF"
-          # Optional peer configuration
+packet_transport:
+  - platform: espnow
+    peer_address: "AA:BB:CC:DD:EE:FF"
+    sensors:
+      - dht_temp
 
-    packet_transport:
-      - platform: espnow
-        peer_address: "AA:BB:CC:DD:EE:FF"
-        sensors:
-          - dht_temp
+sensor:
+  - platform: dht
+    id: dht
+    pin: GPIO4
+    temperature:
+      name: "Temperature"
+      id: dht_temp
+```
 
-    sensor:
-      - platform: dht
-        id: dht
-        pin: GPIO4
-        temperature:
-          name: "Temperature"
-          id: dht_temp
+---
 
-Configuration Variables
-------------------------
+## Configuration Variables
 
-- **peer_address** (*Optional*, MAC Address): The MAC address to send packets to. This can be either a specific 
-  peer address for point-to-point communication, or the broadcast address ``FF:FF:FF:FF:FF:FF`` for broadcasting to 
-  all registered peers. Defaults to ``FF:FF:FF:FF:FF:FF``.
+| Name                | Type                     | Default             | Description                                                                                            |
+| ------------------- | ------------------------ | ------------------- | ------------------------------------------------------------------------------------------------------ |
+| `peer_address`      | MAC Address *(optional)* | `FF:FF:FF:FF:FF:FF` | MAC address to send packets to. May be a specific peer (unicast) or broadcast to all registered peers. |
+| *All other options* | —                        | —                   | From the [Packet Transport Component](/components/packet_transport).                                   |
 
-- All other options from :doc:`Packet Transport Component </components/packet_transport>`.
+> **Note:**
+> Peers must be registered with the [ESP-NOW Component](/components/espnow) before they can receive packets.
+> The `peer_address` only controls which peer(s) receive transmitted data; incoming packets are accepted from all registered peers.
 
-.. note::
+---
 
-    Peers must be registered with the :doc:`ESP-NOW Component </components/espnow>` before they can receive packets. 
-    The ``peer_address`` only controls which peer(s) receive transmitted data; incoming packets are accepted from all 
-    registered peers.
+## Broadcast vs Unicast
 
-Broadcast vs Unicast
---------------------
+The `peer_address` configuration determines the transmission mode.
 
-The ``peer_address`` configuration determines the transmission mode:
+### Broadcast Mode (default)
 
-**Broadcast Mode** (default):
+```yaml
+packet_transport:
+  - platform: espnow
+    # peer_address: "FF:FF:FF:FF:FF:FF"  # Default, can be omitted
+    sensors:
+      - sensor_id
+```
 
-.. code-block:: yaml
+All devices with the broadcast address (`FF:FF:FF:FF:FF:FF`) registered as a peer will receive the packets.
+Useful for **hub-and-spoke** topologies where multiple devices monitor a single sensor source.
 
-    packet_transport:
-      - platform: espnow
-        # peer_address: "FF:FF:FF:FF:FF:FF"  # Default, can be omitted
-        sensors:
-          - sensor_id
+### Unicast Mode
 
-All devices with the broadcast address (``FF:FF:FF:FF:FF:FF``) registered as a peer will receive the packets. 
-This is useful for hub-and-spoke topologies where multiple devices monitor a single sensor source.
+```yaml
+packet_transport:
+  - platform: espnow
+    peer_address: "AA:BB:CC:DD:EE:FF"
+    sensors:
+      - sensor_id
+```
 
-**Unicast Mode**:
+Only the specified peer receives the packets.
+This is more efficient for **point-to-point** communication.
 
-.. code-block:: yaml
+---
 
-    packet_transport:
-      - platform: espnow
-        peer_address: "AA:BB:CC:DD:EE:FF"
-        sensors:
-          - sensor_id
+## Complete Example
 
-Only the specified peer receives the packets. This is more efficient for point-to-point communication
+This example shows two devices exchanging sensor data over ESP-NOW with encryption enabled.
 
-Complete Example
-----------------
+### Device 1 – Temperature Sensor Provider
 
-This example shows two devices exchanging sensor data over ESP-NOW with encryption enabled:
+```yaml
+esphome:
+  name: temp-sensor
 
-.. code-block:: yaml
+espnow:
+  peers:
+    - mac_address: "AA:BB:CC:DD:EE:01"  # Device 2
 
-    # Device 1 - Temperature Sensor Provider
-    esphome:
-      name: temp-sensor
-
-    espnow:
-      peers:
-        - mac_address: "AA:BB:CC:DD:EE:01"  # Device 2
-
-    packet_transport:
-      - platform: espnow
-        peer_address: "AA:BB:CC:DD:EE:01"  # Send to Device 2
-        encryption: "MySecretKey123"
-        sensors:
-          - outdoor_temp
-
-    sensor:
-      - platform: dht
-        pin: GPIO4
-        temperature:
-          name: "Outdoor Temperature"
-          id: outdoor_temp
-
-.. code-block:: yaml
-
-    # Device 2 - Temperature Display Consumer
-    esphome:
-      name: temp-display
-
-    espnow:
-      peers:
-        - mac_address: "AA:BB:CC:DD:EE:00"  # Device 1
-
-    packet_transport:
-      - platform: espnow
-        encryption: "MySecretKey123"
-        providers:
-          - name: temp-sensor
-
-    sensor:
-      - platform: packet_transport
-        provider: temp-sensor
-        id: remote_temp
-        remote_id: outdoor_temp
-        name: "Remote Outdoor Temperature"
-
-Multi-Device Hub Example
-------------------------
-
-This example shows a central hub receiving sensor data from multiple remote devices:
-
-.. code-block:: yaml
-
-    # Hub Device
-    esphome:
-      name: sensor-hub
-
-    espnow:
-      peers:
-        - mac_address: "FF:FF:FF:FF:FF:FF"  # Broadcast address
-
-    packet_transport:
-      - platform: espnow
-        encryption: "HubSecret123"
-        providers:
-          - name: room-sensor-1
-          - name: room-sensor-2
-          - name: outdoor-sensor
-
-    sensor:
-      - platform: packet_transport
-        provider: room-sensor-1
-        remote_id: temperature
-        name: "Room 1 Temperature"
-
-      - platform: packet_transport
-        provider: room-sensor-2
-        remote_id: temperature
-        name: "Room 2 Temperature"
-
-      - platform: packet_transport
-        provider: outdoor-sensor
-        remote_id: temperature
-        name: "Outdoor Temperature"
-
-.. code-block:: yaml
-
-    # Remote Sensor (repeat for each room)
-    esphome:
-      name: room-sensor-1
-
-    espnow:
-      peers:
-        - mac_address: "FF:FF:FF:FF:FF:FF"  # Broadcast
-
-    packet_transport:
-      - platform: espnow
-        peer_address: "FF:FF:FF:FF:FF:FF"  # Broadcast to hub
-        encryption: "HubSecret123"
-        sensors:
-          - temperature
-
-    sensor:
-      - platform: dht
-        pin: GPIO4
-        temperature:
-          id: temperature
-
-Power-Efficient OTA Updates
-----------------------------
-
-ESP-NOW can be used to remotely enable WiFi for OTA updates, keeping WiFi disabled during normal operation for 
-better performance:
-
-.. code-block:: yaml
-
-    # Remote device with WiFi normally disabled
-    esphome:
-      name: remote-device
-      on_boot:
-        priority: -100
-        then:
-          - wifi.disable:  # Disable WiFi on boot
-
-    wifi:
-      ssid: !secret wifi_ssid
-      password: !secret wifi_password
-
-    api:
-    ota:
-
-    espnow:
-      peers:
-        - mac_address: "AA:BB:CC:DD:EE:FF"  # Controller MAC
-
-    packet_transport:
-      - platform: espnow
-        id: espnow_transport
-        on_packet:
-          - lambda: |-
-              // Command protocol: 0x01 = enable WiFi, 0x02 = disable WiFi
-              if (data.size() >= 1) {
-                if (data[0] == 0x01) {
-                  ESP_LOGI("ota", "Enabling WiFi for OTA");
-                  wifi::global_wifi_component->set_enabled(true);
-                } else if (data[0] == 0x02) {
-                  ESP_LOGI("ota", "Disabling WiFi");
-                  wifi::global_wifi_component->set_enabled(false);
-                }
-              }
-
-.. code-block:: yaml
-
-    # Controller device
-    button:
-      - platform: template
-        name: "Enable OTA Mode"
-        on_press:
-          - lambda: |-
-              std::vector<uint8_t> cmd = {0x01};
-              id(espnow_transport)->send_packet(cmd);
-
-      - platform: template
-        name: "Disable OTA Mode"
-        on_press:
-          - lambda: |-
-              std::vector<uint8_t> cmd = {0x02};
-              id(espnow_transport)->send_packet(cmd);
-
-Performance Considerations
---------------------------
-
-- **Maximum Packet Size**: ESP-NOW has a maximum packet size of 250 bytes. The packet transport component will 
-  automatically handle this limitation.
-
-- **Throughput**: ESP-NOW provides lower throughput than WiFi but has significantly lower latency (typically 
-  <10ms vs 50-100ms for WiFi).
-
-- **Range**: ESP-NOW typically provides similar range to WiFi (50-100 meters line-of-sight), but this varies 
-  based on environment and antenna configuration.
-
-- **Power Consumption**: ESP-NOW consumes significantly less power than maintaining a WiFi connection, making it 
-  ideal for battery-powered applications.
-
-- **Channel**: ESP-NOW operates on the same 2.4GHz channels as WiFi. When WiFi is enabled, ESP-NOW automatically 
-  uses the same channel. When WiFi is disabled, ESP-NOW uses channel 1 by default.
-
-Limitations
------------
-
-- **ESP32 Only**: ESP-NOW is only available on ESP32, ESP32-S2, ESP32-S3, and ESP32-C3 chips. ESP8266 support 
-  is not available.
-
-- **Peer Limit**: ESP32 devices can register a maximum of 20 peers (10 encrypted + 10 unencrypted, or various 
-  combinations).
-
-- **Packet Size**: Maximum 250 bytes per packet, which limits the amount of sensor data that can be transmitted 
-  in a single update.
-
-- **No Routing**: ESP-NOW is not a mesh protocol. Devices communicate directly and cannot route packets through 
-  intermediate nodes.
-
-See Also
---------
-
-- :doc:`Packet Transport Component </components/packet_transport>`
-- :doc:`ESP-NOW Component </components/espnow>`
-- :doc:`UDP Packet Transport </components/packet_transport/udp>`
-- :apiref:`espnow/packet_transport/espnow_transport.h`
-- :ghedit:`Edit`
+packet_transport:
+  - platform: espnow
+    peer_address: "AA:BB:CC:DD:EE:01"  # Send to Device 2
+    encryption: "MySecretKey123"
+    sensors:
+      - outdoor_temp
+
+sensor:
+  - platform: dht
+    pin: GPIO4
+    temperature:
+      name: "Outdoor Temperature"
+      id: outdoor_temp
+```
+
+### Device 2 – Temperature Display Consumer
+
+```yaml
+esphome:
+  name: temp-display
+
+espnow:
+  peers:
+    - mac_address: "AA:BB:CC:DD:EE:00"  # Device 1
+
+packet_transport:
+  - platform: espnow
+    encryption: "MySecretKey123"
+    providers:
+      - name: temp-sensor
+
+sensor:
+  - platform: packet_transport
+    provider: temp-sensor
+    id: remote_temp
+    remote_id: outdoor_temp
+    name: "Remote Outdoor Temperature"
+```
+
+---
+
+## Multi-Device Hub Example
+
+This example shows a central hub receiving sensor data from multiple remote devices.
+
+### Hub Device
+
+```yaml
+esphome:
+  name: sensor-hub
+
+espnow:
+  peers:
+    - mac_address: "FF:FF:FF:FF:FF:FF"  # Broadcast address
+
+packet_transport:
+  - platform: espnow
+    encryption: "HubSecret123"
+    providers:
+      - name: room-sensor-1
+      - name: room-sensor-2
+      - name: outdoor-sensor
+
+sensor:
+  - platform: packet_transport
+    provider: room-sensor-1
+    remote_id: temperature
+    name: "Room 1 Temperature"
+
+  - platform: packet_transport
+    provider: room-sensor-2
+    remote_id: temperature
+    name: "Room 2 Temperature"
+
+  - platform: packet_transport
+    provider: outdoor-sensor
+    remote_id: temperature
+    name: "Outdoor Temperature"
+```
+
+### Remote Sensor (repeat for each room)
+
+```yaml
+esphome:
+  name: room-sensor-1
+
+espnow:
+  peers:
+    - mac_address: "FF:FF:FF:FF:FF:FF"  # Broadcast
+
+packet_transport:
+  - platform: espnow
+    peer_address: "FF:FF:FF:FF:FF:FF"  # Broadcast to hub
+    encryption: "HubSecret123"
+    sensors:
+      - temperature
+
+sensor:
+  - platform: dht
+    pin: GPIO4
+    temperature:
+      id: temperature
+```
+
+---
+
+## Power-Efficient OTA Updates
+
+ESP-NOW can be used to remotely enable Wi-Fi for OTA updates, keeping Wi-Fi disabled during normal operation for better power performance.
+
+### Remote Device (Wi-Fi normally disabled)
+
+```yaml
+esphome:
+  name: remote-device
+  on_boot:
+    priority: -100
+    then:
+      - wifi.disable:  # Disable WiFi on boot
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+
+api:
+ota:
+
+espnow:
+  peers:
+    - mac_address: "AA:BB:CC:DD:EE:FF"  # Controller MAC
+
+packet_transport:
+  - platform: espnow
+    id: espnow_transport
+    on_packet:
+      - lambda: |-
+          // Command protocol: 0x01 = enable WiFi, 0x02 = disable WiFi
+          if (data.size() >= 1) {
+            if (data[0] == 0x01) {
+              ESP_LOGI("ota", "Enabling WiFi for OTA");
+              wifi::global_wifi_component->set_enabled(true);
+            } else if (data[0] == 0x02) {
+              ESP_LOGI("ota", "Disabling WiFi");
+              wifi::global_wifi_component->set_enabled(false);
+            }
+          }
+```
+
+### Controller Device
+
+```yaml
+button:
+  - platform: template
+    name: "Enable OTA Mode"
+    on_press:
+      - lambda: |-
+          std::vector<uint8_t> cmd = {0x01};
+          id(espnow_transport)->send_packet(cmd);
+
+  - platform: template
+    name: "Disable OTA Mode"
+    on_press:
+      - lambda: |-
+          std::vector<uint8_t> cmd = {0x02};
+          id(espnow_transport)->send_packet(cmd);
+```
+
+---
+
+## Performance Considerations
+
+* **Maximum Packet Size:** ESP-NOW packets are limited to **250 bytes**. The packet transport component automatically handles this.
+* **Throughput:** ESP-NOW provides lower throughput than Wi-Fi but with significantly lower latency (<10 ms typical vs 50–100 ms).
+* **Range:** Typically **50–100 m line-of-sight**, similar to Wi-Fi.
+* **Power Consumption:** Far lower than maintaining a Wi-Fi connection — ideal for battery devices.
+* **Channel:** Uses the same 2.4 GHz channels as Wi-Fi. When Wi-Fi is disabled, defaults to channel 1.
+
+---
+
+## Limitations
+
+* **ESP32-only:** Available on ESP32, ESP32-S2, ESP32-S3, and ESP32-C3.
+  Not supported on ESP8266.
+* **Peer Limit:** Up to 20 peers total (10 encrypted + 10 unencrypted, or combinations).
+* **Packet Size:** Maximum 250 bytes per packet.
+* **No Routing:** ESP-NOW is not a mesh protocol; devices communicate directly only.
+
+---
+
+## See Also
+
+* [Packet Transport Component](/components/packet_transport)
+* [ESP-NOW Component](/components/espnow)
+* [UDP Packet Transport](/components/packet_transport/udp)
+* [espnow_transport.h (API Reference)](/api/espnow/packet_transport/espnow_transport.h)
+* [Edit on GitHub](https://github.com/esphome/esphome/edit/dev/esphome/components/packet_transport/espnow_transport.md)
+
+---

--- a/content/components/packet_transport/uart.md
+++ b/content/components/packet_transport/uart.md
@@ -1,45 +1,108 @@
 ---
-description: "Instructions for setting up a UART packet transport platform on ESPHome"
-title: "UART Packet Transport Platform"
+description: "Instructions for setting up an ESP-NOW packet transport platform on ESPHome"
+title: "ESP-NOW Packet Transport Platform"
 params:
   seo:
-    description: Instructions for setting up a UART packet transport platform on ESPHome
-    image: uart.svg
+    description: Instructions for setting up an ESP-NOW packet transport platform on ESPHome
+    image: espnow.svg
 ---
 
-{{< anchor "uart-packet-transport" >}}
+{{< anchor "espnow-packet-transport" >}}
 
-The [Packet Transport Component](#packet-transport) platform allows ESPHome nodes to directly communicate with each over a communication channel.
-The UART implementation of the platform uses a serial port as a communication medium. See the [Packet Transport Component](#packet-transport) and [UART Bus](#uart) for more information.
+The **ESP-NOW Packet Transport** platform allows ESPHome nodes to communicate directly using the [ESP-NOW protocol](https://www.espressif.com/en/solutions/low-power-solutions/esp-now).  
+This enables lightweight, peer-to-peer communication between nodes without Wi-Fi association or IP transport.  
+It is ideal for fast, low-power message delivery across multiple ESP32 devices.
+
+This implementation integrates with the core [Packet Transport Component](#packet-transport) interface, allowing data exchange between nodes via standardized packet APIs.
 
 ## Example Configuration
 
 ```yaml
 # Example configuration entry
 packet_transport:
-  platform: uart
+  platform: espnow
+  peers:
+    - mac_address: "24:6F:28:AB:CD:EF"
+    - mac_address: "24:6F:28:12:34:56"
   sensors:
-    - dht_temp
+    - battery_voltage
 
-uart:
-  tx_pin: GPIOXX
-  rx_pin: GPIOXX
-  baud_rate: 9600
+espnow:
+  wifi_channel: 6
+  encryption_key: "0123456789ABCDEF0123456789ABCDEF"
+  max_queue_size: 20
+  resend_retries: 3
+  resend_interval: 200ms
+  verbose: false
 
 sensor:
-  - platform: dht
-      id: dht
-      pin: GPIOXX
-      temperature:
-        name: "Temperature"
-        id: dht_temp
+  - platform: adc
+    pin: GPIO32
+    name: "Battery Voltage"
+    id: battery_voltage
 ```
+
+## Configuration Options
+
+### `peers`
+A list of peer devices (by MAC address) that the ESP32 will communicate with.
+
+| Name | Type | Description |
+|------|------|--------------|
+| **mac_address** | string | MAC address of the remote peer device. |
+| **channel** | int (optional) | Wi-Fi channel to use (default matches local `espnow` config). |
+| **encryption_key** | string (optional) | Optional per-peer key to override the global key. |
+
+### `espnow`
+Defines the ESP-NOW radio transport configuration.
+
+| Name | Type | Description |
+|------|------|--------------|
+| **wifi_channel** | int | Wi-Fi channel used for all peer communications. Must match across nodes. |
+| **encryption_key** | string (optional) | 128-bit key used for encrypted ESP-NOW messages. |
+| **max_queue_size** | int (optional) | Number of packets that can be queued for sending (default: 10). |
+| **resend_retries** | int (optional) | Number of automatic retransmission attempts (default: 3). |
+| **resend_interval** | time (optional) | Delay between retries (default: 100 ms). |
+| **verbose** | bool (optional) | Enables detailed debug logs (default: false). |
+
+### `packet_transport`
+Links the ESP-NOW transport to the core packet transport framework.
+
+| Name | Type | Description |
+|------|------|--------------|
+| **platform** | string | Must be set to `"espnow"`. |
+| **sensors** | list | List of sensors whose data should be shared between nodes. |
+
+## Advanced Usage
+
+### Peer Management
+Peers are automatically registered when defined in the configuration.  
+Dynamic registration or removal may also be handled through API calls if runtime discovery is required.
+
+### Reliability
+ESP-NOW is a connectionless protocol; reliability is implemented in this component via automatic retries, ACK tracking, and packet sequencing.  
+The retry mechanism ensures consistent delivery across noisy RF environments.
+
+### Debugging
+Enable `verbose: true` in the `espnow` section to trace peer registration, packet send/receive events, and transmission statistics.
+
+Log example:
+```
+[V][espnow:284]: <<< [E4:B3:23:C2:76:D8 -> FF:FF:FF:FF:FF:FF] Packet TX (len=42)
+[V][espnow:301]: >>> [E4:B3:23:C2:76:D8] Packet RX OK (len=42)
+```
+
+### Performance Considerations
+- ESP-NOW packets are limited to **250 bytes**.
+- Broadcasting consumes more airtime; unicast to peers for reliability.
+- Encryption adds latency and reduces maximum packet size slightly.
+- Keep the number of peers below 20 for best results.
 
 ## See Also
 
 - [Packet Transport Component](#packet-transport)
-- {{< docref "/components/uart" >}}
+- {{< docref "/components/wifi" >}}
 - {{< docref "/components/binary_sensor/packet_transport" >}}
 - {{< docref "/components/sensor/packet_transport" >}}
 - [Automation](#automation)
-- {{< apiref "packet_transport/packet_transport.h" "packet_transport/packet_transport.h" >}}
+- {{< apiref "packet_transport/espnow_packet_transport.h" "packet_transport/espnow_packet_transport.h" >}}

--- a/content/components/packet_transport/uart.md
+++ b/content/components/packet_transport/uart.md
@@ -1,108 +1,45 @@
 ---
-description: "Instructions for setting up an ESP-NOW packet transport platform on ESPHome"
-title: "ESP-NOW Packet Transport Platform"
+description: "Instructions for setting up a UART packet transport platform on ESPHome"
+title: "UART Packet Transport Platform"
 params:
   seo:
-    description: Instructions for setting up an ESP-NOW packet transport platform on ESPHome
-    image: espnow.svg
+    description: Instructions for setting up a UART packet transport platform on ESPHome
+    image: uart.svg
 ---
 
-{{< anchor "espnow-packet-transport" >}}
+{{< anchor "uart-packet-transport" >}}
 
-The **ESP-NOW Packet Transport** platform allows ESPHome nodes to communicate directly using the [ESP-NOW protocol](https://www.espressif.com/en/solutions/low-power-solutions/esp-now).  
-This enables lightweight, peer-to-peer communication between nodes without Wi-Fi association or IP transport.  
-It is ideal for fast, low-power message delivery across multiple ESP32 devices.
-
-This implementation integrates with the core [Packet Transport Component](#packet-transport) interface, allowing data exchange between nodes via standardized packet APIs.
+The [Packet Transport Component](#packet-transport) platform allows ESPHome nodes to directly communicate with each over a communication channel.
+The UART implementation of the platform uses a serial port as a communication medium. See the [Packet Transport Component](#packet-transport) and [UART Bus](#uart) for more information.
 
 ## Example Configuration
 
 ```yaml
 # Example configuration entry
 packet_transport:
-  platform: espnow
-  peers:
-    - mac_address: "24:6F:28:AB:CD:EF"
-    - mac_address: "24:6F:28:12:34:56"
+  platform: uart
   sensors:
-    - battery_voltage
+    - dht_temp
 
-espnow:
-  wifi_channel: 6
-  encryption_key: "0123456789ABCDEF0123456789ABCDEF"
-  max_queue_size: 20
-  resend_retries: 3
-  resend_interval: 200ms
-  verbose: false
+uart:
+  tx_pin: GPIOXX
+  rx_pin: GPIOXX
+  baud_rate: 9600
 
 sensor:
-  - platform: adc
-    pin: GPIO32
-    name: "Battery Voltage"
-    id: battery_voltage
+  - platform: dht
+      id: dht
+      pin: GPIOXX
+      temperature:
+        name: "Temperature"
+        id: dht_temp
 ```
-
-## Configuration Options
-
-### `peers`
-A list of peer devices (by MAC address) that the ESP32 will communicate with.
-
-| Name | Type | Description |
-|------|------|--------------|
-| **mac_address** | string | MAC address of the remote peer device. |
-| **channel** | int (optional) | Wi-Fi channel to use (default matches local `espnow` config). |
-| **encryption_key** | string (optional) | Optional per-peer key to override the global key. |
-
-### `espnow`
-Defines the ESP-NOW radio transport configuration.
-
-| Name | Type | Description |
-|------|------|--------------|
-| **wifi_channel** | int | Wi-Fi channel used for all peer communications. Must match across nodes. |
-| **encryption_key** | string (optional) | 128-bit key used for encrypted ESP-NOW messages. |
-| **max_queue_size** | int (optional) | Number of packets that can be queued for sending (default: 10). |
-| **resend_retries** | int (optional) | Number of automatic retransmission attempts (default: 3). |
-| **resend_interval** | time (optional) | Delay between retries (default: 100 ms). |
-| **verbose** | bool (optional) | Enables detailed debug logs (default: false). |
-
-### `packet_transport`
-Links the ESP-NOW transport to the core packet transport framework.
-
-| Name | Type | Description |
-|------|------|--------------|
-| **platform** | string | Must be set to `"espnow"`. |
-| **sensors** | list | List of sensors whose data should be shared between nodes. |
-
-## Advanced Usage
-
-### Peer Management
-Peers are automatically registered when defined in the configuration.  
-Dynamic registration or removal may also be handled through API calls if runtime discovery is required.
-
-### Reliability
-ESP-NOW is a connectionless protocol; reliability is implemented in this component via automatic retries, ACK tracking, and packet sequencing.  
-The retry mechanism ensures consistent delivery across noisy RF environments.
-
-### Debugging
-Enable `verbose: true` in the `espnow` section to trace peer registration, packet send/receive events, and transmission statistics.
-
-Log example:
-```
-[V][espnow:284]: <<< [E4:B3:23:C2:76:D8 -> FF:FF:FF:FF:FF:FF] Packet TX (len=42)
-[V][espnow:301]: >>> [E4:B3:23:C2:76:D8] Packet RX OK (len=42)
-```
-
-### Performance Considerations
-- ESP-NOW packets are limited to **250 bytes**.
-- Broadcasting consumes more airtime; unicast to peers for reliability.
-- Encryption adds latency and reduces maximum packet size slightly.
-- Keep the number of peers below 20 for best results.
 
 ## See Also
 
 - [Packet Transport Component](#packet-transport)
-- {{< docref "/components/wifi" >}}
+- {{< docref "/components/uart" >}}
 - {{< docref "/components/binary_sensor/packet_transport" >}}
 - {{< docref "/components/sensor/packet_transport" >}}
 - [Automation](#automation)
-- {{< apiref "packet_transport/espnow_packet_transport.h" "packet_transport/espnow_packet_transport.h" >}}
+- {{< apiref "packet_transport/packet_transport.h" "packet_transport/packet_transport.h" >}}


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#11025

## Checklist:

  - [X ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
