### PR TITLE
Tuya Low Energy docs

### DIFF
--- a/content/components/_index.md
+++ b/content/components/_index.md
@@ -1052,6 +1052,7 @@ ESPHome to cellular networks. **Does not encompass Wi-Fi.**
 "Status LED","components/status_led","led-on.svg","dark-invert"
 "Sun","components/sun","weather-sunny.svg","dark-invert"
 "Tuya MCU","components/tuya","tuya.png",""
+"Tuya Low Energy MCU","components/tuya_low_energy","tuya.png",""
 "Z-Wave Proxy","components/zwave_proxy","z-wave.svg",""
 {{< /imgtable >}}
 

--- a/content/components/tuya_low_energy.md
+++ b/content/components/tuya_low_energy.md
@@ -1,0 +1,31 @@
+---
+description: "Instructions for setting up the Tuya Low Energy component."
+title: "Tuya Low Energy"
+params:
+  seo:
+    description: Instructions for setting up the Tuya Low Energy component.
+    image: tuya.png
+---
+
+The `tuya_low_energy` component creates a serial connection to the Tuya MCU for low energy platforms to use. This component inherits from the [tuya component](/components/tuya) and is specifically designed for Tuya devices that use the low energy protocol, which differs from the standard Tuya MCU protocol.
+
+{{< img src="tuya.png" alt="Image" width="40%" class="align-center" >}}
+
+The `tuya_low_energy` serial component requires a [UART bus](#uart) to be configured. Put the `tuya_low_energy` component in the config and it will list the possible devices for you in the config log.
+
+```yaml
+# Register the Tuya Low Energy MCU connection
+tuya_low_energy:
+```
+
+For configuration variables, datapoint handling, and automation, refer to the [tuya component](/components/tuya) documentation, as `tuya_low_energy` supports the same options including `time_id`, `status_pin`, `ignore_mcu_update_on_datapoints`, and `on_datapoint_update`.
+
+## See Also
+
+- {{< docref "/components/tuya" >}}
+- {{< docref "/components/switch/tuya" >}}
+- {{< docref "/components/binary_sensor/tuya" >}}
+- {{< docref "/components/sensor/tuya" >}}
+- {{< docref "/components/text_sensor/tuya" >}}
+- {{< docref "/components/number/tuya" >}}
+- {{< apiref "tuya_low_energy/tuya_low_energy.h" "tuya_low_energy/tuya_low_energy.h" >}}


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#11168

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [x] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
