### PR TITLE
[usb_host] Fix transfer slot exhaustion at high data rates and add configurable max_transfer_requests

### DIFF
--- a/content/components/usb_host.md
+++ b/content/components/usb_host.md
@@ -18,6 +18,7 @@ possible to configure devices directly in this component, but this has no applic
 # Example configuration entry
 usb_host:
   enable_hubs: true
+  max_transfer_requests: 32  # For high-throughput devices like USB UART at 115200+ baud
   devices:
     - id: device_0
       vid: 0x1725
@@ -28,6 +29,7 @@ usb_host:
 
 - **id** (*Optional*, [ID](#config-id)): The id to use for this component.
 - **enable_hubs** (*Optional*, boolean): Whether to include support for hubs. Defaults to `false`.
+- **max_transfer_requests** (*Optional*, int): Maximum number of concurrent USB transfer requests. Range: 1-32. Defaults to `16`. Increase this value for high-throughput devices (e.g., USB UART at 115200+ baud) if you see "All X transfer slots in use" errors.
 - **devices** (*Optional*, list): A list of devices to configure.
 
 ## Device configuration options


### PR DESCRIPTION
## Description:

Documents the new `max_transfer_requests` configuration option for the `usb_host` component. This option allows users to increase the number of concurrent USB transfer request slots from the default 16 up to 32 for high-throughput devices like USB UART at 115200+ baud.

This documentation accompanies the fix for USB transfer slot exhaustion at high data rates.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#11174

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
