### PR TITLE
Update installing_esphome guide for Py install manager

### DIFF
--- a/content/guides/installing_esphome.md
+++ b/content/guides/installing_esphome.md
@@ -13,13 +13,14 @@ Download Python from [the official site](https://www.python.org/downloads/).
 
 Make sure "Launch when ready" is checked and install.
 After the installation is completed, a terminal window will open asking to modify `App execution aliases`, enter `y`.
-It will open the app 
+It will open the app setting window. Make required adjustments as instructed and close the window.
+The python install manager should be ready.
+
+Proceed to install supported python runtime v3.13 using `py install 3.13`
 
 Log out and back in, or restart your computer. Whichever is easiest.
 
-Open the start menu and type `cmd`. Press the enter key.
-
-In the terminal that comes up, check that Python is installed:
+Open Windows terminal and check whether Python is installed:
 
 ```shell
 py install 3.13
@@ -33,9 +34,12 @@ It should show something like:
 Looks good? You can go ahead and install ESPHome:
 
 ```shell
-pip3 install wheel
-pip3 install esphome
+python3.13 -m pip install esphome
 ```
+
+If you spot pip complaining about PATH / `--no-warn-script-location`,
+add the scripts PATH to the user environment variable.
+`C:\Users\<username>\AppData\Local\Python\pythoncore-3.13-64\Scripts`
 
 And you should be good to go! You can test that things are properly installed
 with:

--- a/content/guides/installing_esphome.md
+++ b/content/guides/installing_esphome.md
@@ -8,11 +8,12 @@ title: "Installing ESPHome Manually"
 Download Python from [the official site](https://www.python.org/downloads/).
 
 {{< img src="python-win-installer.png"
-  alt="Python installer window with arrows pointing to \"Add Python to PATH\" and \"Install Now\""
+  alt="Python installer window with arrows pointing to \"Launch when ready\" and \"Install Python\""
   width="75.0%" class="align-center" >}}
 
-Make sure you check "Add Python to PATH", and go all the way through the
-installer.
+Make sure "Launch when ready" is checked and install.
+After the installation is completed, a terminal window will open asking to modify `App execution aliases`, enter `y`.
+It will open the app 
 
 Log out and back in, or restart your computer. Whichever is easiest.
 
@@ -21,14 +22,13 @@ Open the start menu and type `cmd`. Press the enter key.
 In the terminal that comes up, check that Python is installed:
 
 ```shell
-python --version
+py install 3.13
+python3.13 --version
 ```
 
 It should show something like:
 
-```shell
-Python 3.11.13
-```
+`Python 3.13.8`
 
 Looks good? You can go ahead and install ESPHome:
 
@@ -46,13 +46,11 @@ esphome version
 
 It should show something like:
 
-```shell
-Version: 2025.8.0
-```
+`Version: 2025.8.0`
 
 > [!NOTE]
 > You may additionally need to install git for the external components feature.
-> Download git from [the official link](https://git-scm.com/downloads)
+> Download git from [the official link](https://git-scm.com/downloads/win)
 
 ## Mac
 
@@ -78,9 +76,9 @@ esphome version
 
 It should show something like:
 
-```shell
+`
 Version: 2025.8.0
-```
+`
 
 > [!NOTE]
 >
@@ -129,9 +127,9 @@ python3 --version
 
 It should show something like:
 
-```shell
+`
 Python 3.11.13
-```
+`
 
 Looks good? Now create a virtual environment to contain ESPHome and it's dependencies.
 
@@ -168,9 +166,9 @@ esphome version
 
 It should show something like:
 
-```shell
+`
 Version: 2025.8.0
-```
+`
 
 If you get an error like "Command not found", you need to add the binary to
 your `PATH` using `export PATH=$PATH:$HOME/.local/bin`.


### PR DESCRIPTION
## Description:

update installiing ESPHome manually to account for newly released Python Install manager for Windows
**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
