### PR TITLE
Added docs for power limit

### DIFF
--- a/content/components/light/_index.md
+++ b/content/components/light/_index.md
@@ -79,6 +79,33 @@ light:
 - **power_supply** (*Optional*, [ID](#config-id)): The {{< docref "/components/power_supply" >}} to connect to this light. When
   the light is turned on, the power supply will automatically be switched on too.
 
+- **power_limits** (_Optional_): Power management for addressable LED strips to prevent overloading power supplies.
+
+  > [!NOTE] **This is a software-based power management feature, not a hardware guarantee.**
+  > 
+  > Other components (sensors, WiFi, etc.) also consume power and are not included in this calculation. 
+  > **Always ensure your power supply can handle the maximum possible load with safety margins.**
+  > 
+  > Power calculations are based on LED brightness values and may not account for all real-world factors.
+
+  **How it works:** When the total calculated power consumption exceeds `max_watts`, the brightness of all LEDs is automatically scaled down proportionally to stay within the power limit. This helps prevent power supply overload and potential damage.
+
+  Below is an example, please refer to the specification of your hardware. 
+  ```yaml
+  light:
+    - platform: esp32_rmt_led_strip
+      # ... other configuration ...
+      power_limits:
+        max_watts: 5.0 # Maximum total power consumption in watts
+        voltage: 5.0 # Supply voltage of the LEDs
+        led_power_consumption: # Power consumption per LED channel in watts
+          red: 0.16
+          green: 0.16
+          blue: 0.16
+          white: 0.26
+  ```
+
+
 **Advanced options:**
 
 - **internal** (*Optional*, boolean): Mark this component as internal. Internal components will not be exposed to the


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
