### PR TITLE
Document extend/remove with substitutions and Jinja

### DIFF
--- a/content/components/packages.md
+++ b/content/components/packages.md
@@ -182,7 +182,7 @@ captive_portal:
 sensor:
   - platform: uptime
     id: uptime_sensor
-    update_interval: 1min
+    update_interval: 5min
 ```
 
 ```yaml
@@ -192,6 +192,31 @@ packages: !include common.yaml
 sensor:
   - id: !extend uptime_sensor
     update_interval: 10s
+```
+
+`!extend` also works with substitutions and jinja:
+
+```yaml
+substitutions:
+  switches:
+    - left_switch
+    - right_switch
+    - center_switch
+  
+  mains_switch: 1
+
+switch:
+  - platform: gpio
+    id: left_switch
+    pin: 1
+  - platform: gpio
+    id: right_switch
+    pin: 2
+  - platform: gpio
+    id: center_switch
+    pin: 3
+  - id: !extend ${ switches[mains_switch] }
+    name: "Mains switch"
 ```
 
 {{< anchor "config-packages_remove" >}}
@@ -227,6 +252,19 @@ packages:
 sensor:
   - id: !extend uptime_sensor
     update_interval: !remove
+```
+
+`!remove` also works with substitutions:
+
+```yaml
+substitutions:
+  disable_reboot: true
+
+switch:
+  - platform: restart
+    id: restart_switch
+    name: "Living Room Restart"
+  - id: !remove ${disable_reboot and "restart_switch"}
 ```
 
 ## See Also


### PR DESCRIPTION
## Description:

Documents the possibility of using `!extend` and `!remove` in substitutions and with Jinja.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#11203

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
