### PR TITLE
Fix automation links

### DIFF
--- a/content/changelog/v1.7.0.md
+++ b/content/changelog/v1.7.0.md
@@ -53,7 +53,7 @@ be travelling a lot (and enjoying my vacation 😎), so don't expect too many aw
 
 ## New Features
 
-- While all [automations](#automation) were previously already performed on the ESP itself, they only
+- While all [automations](/automations) were previously already performed on the ESP itself, they only
   triggered when an active WiFi and MQTT connection existed. Large parts of the WiFi and MQTT clients has now
   been rewritten to allow for automations to be executed asynchronously, while the device is still connecting to WiFi.
 
@@ -64,7 +64,7 @@ be travelling a lot (and enjoying my vacation 😎), so don't expect too many aw
   complicated actions using lambdas. See [Binary Sensor Filters](#binary_sensor-filters). ⛹️‍
 
 - All components can now be flagged `internal`. Doing so will prevent them from being represented in the front-end
-  (like MQTT). Useful for [on-device automations](#automation). See 😎
+  (like MQTT). Useful for [on-device automations](/automations). See 😎
 
 - The {{< docref "/components/deep_sleep" >}} now has a `wakeup_pin_mode` option for the ESP32. This option
   can be used to tell esphomelib what to do if the wakeup pin is already in the wakeup level when attempting

--- a/content/components/api.md
+++ b/content/components/api.md
@@ -142,7 +142,7 @@ Then:
 > your device to perform actions.
 
 When using the native API with Home Assistant, you can create events in the Home Assistant event bus
-straight from ESPHome [Automations](#automation).
+straight from ESPHome [Automations](/automations).
 
 ```yaml
 # In some trigger
@@ -172,7 +172,7 @@ on_...:
 > Be sure to [follow the instructions above](#api-actions) to tell Home Assistant to allow
 > your device to perform actions.
 
-When using the native API with Home Assistant, you can perform Home Assistant actions straight from ESPHome [Automations](#automation).
+When using the native API with Home Assistant, you can perform Home Assistant actions straight from ESPHome [Automations](/automations).
 
 ```yaml
 # In some trigger
@@ -213,11 +213,11 @@ on_...:
   the action response data. This template is evaluated on the Home Assistant side with Home Assistant's templating engine.
   Requires `capture_response: true`.
 
-- **on_success** (*Optional*, [Automation](#automation)): Optional automation to execute when the Home Assistant action
+- **on_success** (*Optional*, [Automation](/automations)): Optional automation to execute when the Home Assistant action
   call succeeds. When `capture_response: true`, the response data is available as a `response` variable of type `JsonObjectConst`.
   See [Action Response Handling](#action-response-handling).
 
-- **on_error** (*Optional*, [Automation](#automation)): Optional automation to execute when the Home Assistant action
+- **on_error** (*Optional*, [Automation](/automations)): Optional automation to execute when the Home Assistant action
   call fails. See [Action Response Handling](#action-response-handling).
 
 Data structures are not possible, but you can create a script in Home Assistant and call with all
@@ -330,7 +330,7 @@ When `response_template` is used, the processed result is available in `response
 > your device to make action calls.
 
 When using the native API with Home Assistant, you can push tag_scanned to Home Assistant
-straight from ESPHome [Automations](#automation).
+straight from ESPHome [Automations](/automations).
 
 ```yaml
 # In some trigger

--- a/content/components/binary_sensor/_index.md
+++ b/content/components/binary_sensor/_index.md
@@ -44,24 +44,24 @@ Configuration variables:
 
 Automations:
 
-- **on_press** (*Optional*, [Automation](#automation)): An automation to perform
+- **on_press** (*Optional*, [Automation](/automations)): An automation to perform
   when the button is pressed. See [`on_press`](#binary_sensor-on_press).
 
-- **on_release** (*Optional*, [Automation](#automation)): An automation to perform
+- **on_release** (*Optional*, [Automation](/automations)): An automation to perform
   when the button is released. See [`on_release`](#binary_sensor-on_release).
 
-- **on_state** (*Optional*, [Automation](#automation)): An automation to perform
+- **on_state** (*Optional*, [Automation](/automations)): An automation to perform
   when a state change is published. See [`on_state`](#binary_sensor-on_state).
 
-- **on_click** (*Optional*, [Automation](#automation)): An automation to perform
+- **on_click** (*Optional*, [Automation](/automations)): An automation to perform
   when the button is held down for a specified period of time.
   See [`on_click`](#binary_sensor-on_click).
 
-- **on_double_click** (*Optional*, [Automation](#automation)): An automation to perform
+- **on_double_click** (*Optional*, [Automation](/automations)): An automation to perform
   when the button is pressed twice for specified periods of time.
   See [`on_double_click`](#binary_sensor-on_double_click).
 
-- **on_multi_click** (*Optional*, [Automation](#automation)): An automation to perform
+- **on_multi_click** (*Optional*, [Automation](/automations)): An automation to perform
   when the button is pressed in a specific sequence.
   See [`on_multi_click`](#binary_sensor-on_multi_click).
 
@@ -266,7 +266,7 @@ binary_sensor:
         - switch.turn_on: relay_1
 ```
 
-Configuration variables: See [Automation](#automation).
+Configuration variables: See [Automation](/automations).
 
 {{< anchor "binary_sensor-on_release" >}}
 
@@ -284,7 +284,7 @@ binary_sensor:
         - switch.turn_off: relay_1
 ```
 
-Configuration variables: See [Automation](#automation).
+Configuration variables: See [Automation](/automations).
 
 {{< anchor "binary_sensor-on_state" >}}
 
@@ -304,7 +304,7 @@ binary_sensor:
         - switch.turn_off: relay_1
 ```
 
-Configuration variables: See [Automation](#automation).
+Configuration variables: See [Automation](/automations).
 
 {{< anchor "binary_sensor-on_state_change" >}}
 
@@ -328,7 +328,7 @@ binary_sensor:
           args: ['x.has_value() ? ONOFF(x) : "Unknown"']
 ```
 
-Configuration variables: See [Automation](#automation).
+Configuration variables: See [Automation](/automations).
 
 {{< anchor "binary_sensor-on_click" >}}
 
@@ -353,7 +353,7 @@ Configuration variables:
 
 - **min_length** (*Optional*, [Time](#config-time)): The minimum duration the click should last. Defaults to `50ms`.
 - **max_length** (*Optional*, [Time](#config-time)): The maximum duration the click should last. Defaults to `350ms`.
-- See [Automation](#automation).
+- See [Automation](/automations).
 
 > [!NOTE]
 > Multiple `on_click` entries can be defined like this (see also [`on_multi_click`](#binary_sensor-on_multi_click)
@@ -397,7 +397,7 @@ Configuration variables:
 
 - **min_length** (*Optional*, [Time](#config-time)): The minimum duration the click should last. Defaults to `50ms`.
 - **max_length** (*Optional*, [Time](#config-time)): The maximum duration the click should last. Defaults to `350ms`.
-- See [Automation](#automation).
+- See [Automation](/automations).
 
 {{< anchor "binary_sensor-on_multi_click" >}}
 
@@ -432,7 +432,7 @@ Configuration variables:
   set in `timing` does not match, a "cool down" period will be activated during which no timing
   will be matched. Defaults to `1s`.
 
-- See [Automation](#automation).
+- See [Automation](/automations).
 
 > [!NOTE]
 > Getting the timing right for your use-case can sometimes be a bit difficult. If you set the

--- a/content/components/binary_sensor/analog_threshold.md
+++ b/content/components/binary_sensor/analog_threshold.md
@@ -49,5 +49,5 @@ binary_sensor:
 
 - {{< docref "/components/binary_sensor" >}}
 - {{< docref "/components/sensor" >}}
-- [Automation](#automation)
+- [Automation](/automations)
 - {{< apiref "analog_threshold/analog_threshold_binary_sensor.h" "analog_threshold/analog_threshold_binary_sensor.h" >}}

--- a/content/components/binary_sensor/homeassistant.md
+++ b/content/components/binary_sensor/homeassistant.md
@@ -44,5 +44,5 @@ binary_sensor:
 
 ## See Also
 
-- [Automation](#automation)
+- [Automation](/automations)
 - {{< apiref "homeassistant/binary_sensor/homeassistant_binary_sensor.h" "homeassistant/binary_sensor/homeassistant_binary_sensor.h" >}}

--- a/content/components/binary_sensor/packet_transport.md
+++ b/content/components/binary_sensor/packet_transport.md
@@ -54,4 +54,4 @@ configured.
 
 - {{< docref "/components/packet_transport" >}}
 - {{< docref "/components/sensor" >}}
-- [Automation](#automation)
+- [Automation](/automations)

--- a/content/components/binary_sensor/pn532.md
+++ b/content/components/binary_sensor/pn532.md
@@ -54,10 +54,10 @@ binary_sensor:
   duration that the individual binary sensors stay active when they're found.
   If a device is not found within this time window, it will be marked as not present. Defaults to 1s.
 
-- **on_tag** (*Optional*, [Automation](#automation)): An automation to perform
+- **on_tag** (*Optional*, [Automation](/automations)): An automation to perform
   when a tag is read. See [pn532-on_tag](#pn532-on_tag).
 
-- **on_tag_removed** (*Optional*, [Automation](#automation)): An automation to perform
+- **on_tag_removed** (*Optional*, [Automation](/automations)): An automation to perform
   when a tag is removed. See [`on_tag_removed`](#pn532-on_tag_removed).
 
 - **spi_id** (*Optional*, [ID](#config-id)): Manually specify the ID of the [SPI Component](#spi) if you want
@@ -93,7 +93,7 @@ binary_sensor:
   duration that the individual binary sensors stay active when they're found.
   If a device is not found within this time window, it will be marked as not present. Defaults to 1s.
 
-- **on_tag** (*Optional*, [Automation](#automation)): An automation to perform
+- **on_tag** (*Optional*, [Automation](/automations)): An automation to perform
   when a tag is read. See [pn532-on_tag](#pn532-on_tag).
 
 - **i2c_id** (*Optional*, [ID](#config-id)): Manually specify the ID of the [I²C Component](#i2c) if you want

--- a/content/components/binary_sensor/rc522.md
+++ b/content/components/binary_sensor/rc522.md
@@ -62,10 +62,10 @@ binary_sensor:
   to use multiple SPI buses.
 
 - **id** (*Optional*, [ID](#config-id)): Manually specify the ID for this component.
-- **on_tag** (*Optional*, [Automation](#automation)): An automation to perform when a tag is read. See
+- **on_tag** (*Optional*, [Automation](/automations)): An automation to perform when a tag is read. See
   [`on_tag` Trigger](#rc522-on_tag).
 
-- **on_tag_removed** (*Optional*, [Automation](#automation)): An automation to perform after a tag is removed. See
+- **on_tag_removed** (*Optional*, [Automation](/automations)): An automation to perform after a tag is removed. See
   [`on_tag_removed` Trigger](#rc522-on_tag_removed).
 
 ## Over I²C
@@ -100,10 +100,10 @@ binary_sensor:
   to use multiple I²C buses.
 
 - **id** (*Optional*, [ID](#config-id)): Manually specify the ID for this component.
-- **on_tag** (*Optional*, [Automation](#automation)): An automation to perform when a tag is read. See
+- **on_tag** (*Optional*, [Automation](/automations)): An automation to perform when a tag is read. See
   [`on_tag` Trigger](#rc522-on_tag).
 
-- **on_tag_removed** (*Optional*, [Automation](#automation)): An automation to perform after a tag is removed. See
+- **on_tag_removed** (*Optional*, [Automation](/automations)): An automation to perform after a tag is removed. See
   [`on_tag_removed` Trigger](#rc522-on_tag_removed).
 
 ## Triggers

--- a/content/components/binary_sensor/rdm6300.md
+++ b/content/components/binary_sensor/rdm6300.md
@@ -44,7 +44,7 @@ binary_sensor:
 - **uart_id** (*Optional*, [ID](#config-id)): Manually specify the ID of the [UART Component](#uart) if you want
   to use multiple UART buses.
 
-- **on_tag** (*Optional*, [Automation](#automation)): An automation to perform
+- **on_tag** (*Optional*, [Automation](/automations)): An automation to perform
   when a tag is read. See [`on_tag`](#rdm6300-on_tag).
 
 - **id** (*Optional*, [ID](#config-id)): Manually specify the ID for this component.

--- a/content/components/binary_sensor/template.md
+++ b/content/components/binary_sensor/template.md
@@ -98,5 +98,5 @@ Configuration options:
 
 - {{< docref "/components/binary_sensor" >}}
 - {{< docref "/components/sensor/template" >}}
-- [Automation](#automation)
+- [Automation](/automations)
 - {{< apiref "template/binary_sensor/template_binary_sensor.h" "template/binary_sensor/template_binary_sensor.h" >}}

--- a/content/components/ble_client.md
+++ b/content/components/ble_client.md
@@ -48,19 +48,19 @@ ble_client:
 
 Automations:
 
-- **on_connect** (*Optional*, [Automation](#automation)): An automation to perform
+- **on_connect** (*Optional*, [Automation](/automations)): An automation to perform
   when the client connects to a device. See [`on_connect`](#ble_client-on_connect).
 
-- **on_disconnect** (*Optional*, [Automation](#automation)): An automation to perform
+- **on_disconnect** (*Optional*, [Automation](/automations)): An automation to perform
   when the client disconnects from a device. See [`on_disconnect`](#ble_client-on_disconnect).
 
-- **on_passkey_request** (*Optional*, [Automation](#automation)): An automation to enter
+- **on_passkey_request** (*Optional*, [Automation](/automations)): An automation to enter
   the passkey required by the other BLE device. See [`on_passkey_request`](#ble_client-on_passkey_request).
 
-- **on_passkey_notification** (*Optional*, [Automation](#automation)): An automation to
+- **on_passkey_notification** (*Optional*, [Automation](/automations)): An automation to
   display the passkey to the user. See [`on_passkey_notification`](#ble_client-on_passkey_notification).
 
-- **on_numeric_comparison_request** (*Optional*, [Automation](#automation)): An automation to
+- **on_numeric_comparison_request** (*Optional*, [Automation](/automations)): An automation to
   compare the passkeys shown on the two BLE devices. See [`on_numeric_comparison_request`](#ble_client-on_numeric_comparison_request).
 
 ## BLE Client Automation
@@ -494,5 +494,5 @@ ble_client:
 ## See Also
 
 - {{< docref "/components/sensor/ble_client" >}}
-- [Automation](#automation)
+- [Automation](/automations)
 - {{< apiref "ble_client/ble_client.h" "ble_client/ble_client.h" >}}

--- a/content/components/button/_index.md
+++ b/content/components/button/_index.md
@@ -66,7 +66,7 @@ Configuration variables:
 
 Automations:
 
-- **on_press** (*Optional*, [Automation](#automation)): An automation to perform
+- **on_press** (*Optional*, [Automation](/automations)): An automation to perform
   when the button is pressed. See [`on_press`](#button-on_press).
 
 MQTT options:
@@ -90,7 +90,7 @@ button:
         - logger.log: Button Pressed
 ```
 
-Configuration variables: see [Automation](#automation).
+Configuration variables: see [Automation](/automations).
 
 {{< anchor "button-press_action" >}}
 

--- a/content/components/canbus/_index.md
+++ b/content/components/canbus/_index.md
@@ -87,7 +87,7 @@ canbus:
   - `500KBPS`
   - `1000KBPS`
 
-- **on_frame** (*Optional*, [Automation](#automation)): An automation to perform when a
+- **on_frame** (*Optional*, [Automation](/automations)): An automation to perform when a
   CAN frame is received. See [`on_frame` Trigger](#canbus-on-frame).
 
 {{< anchor "platforms-canbus" >}}

--- a/content/components/climate/bedjet.md
+++ b/content/components/climate/bedjet.md
@@ -191,7 +191,7 @@ sensor:
 > and toggle those off while performing the installation. This will free up resources
 > on the ESP and allow the installation to complete.
 >
-> Additionally, you may use an [ota.on_begin](#ota-on_begin) [Automation](#automation)
+> Additionally, you may use an [ota.on_begin](#ota-on_begin) [Automation](/automations)
 > to do this automatically:
 >
 > ```yaml

--- a/content/components/climate/haier.md
+++ b/content/components/climate/haier.md
@@ -100,9 +100,9 @@ climate:
 - **supported_modes** (*Optional*, list): Can be used to disable some of AC modes. Possible values: `'OFF'`, `HEAT_COOL`, `COOL`, `HEAT`, `DRY`, `FAN_ONLY`.
 - **supported_swing_modes** (*Optional*, list): Can be used to disable some swing modes if your AC does not support it. Possible values: `'OFF'`, `VERTICAL`, `HORIZONTAL`, `BOTH`.
 - **supported_presets** (*Optional*, list): Can be used to disable some presets. Possible values for smartair2 are: `AWAY`, `BOOST`, `COMFORT`. Possible values for hOn are: `AWAY`, `BOOST`, `SLEEP`. `AWAY` preset can be enabled only in `HEAT` mode, it is disabled by default.
-- **on_alarm_start** (*Optional*, [Automation](#automation)): (supported only by hOn) Automation to perform when AC activates a new alarm. See [`on_alarm_start` Trigger](#haier-on_alarm_start).
-- **on_alarm_end** (*Optional*, [Automation](#automation)): (supported only by hOn) Automation to perform when AC deactivates a new alarm. See [`on_alarm_end` Trigger](#haier-on_alarm_end).
-- **on_status_message** (*Optional*, [Automation](#automation)): Automation to perform when status message received from AC. See [`on_status_message` Trigger](#haier-on_status_message).
+- **on_alarm_start** (*Optional*, [Automation](/automations)): (supported only by hOn) Automation to perform when AC activates a new alarm. See [`on_alarm_start` Trigger](#haier-on_alarm_start).
+- **on_alarm_end** (*Optional*, [Automation](/automations)): (supported only by hOn) Automation to perform when AC deactivates a new alarm. See [`on_alarm_end` Trigger](#haier-on_alarm_end).
+- **on_status_message** (*Optional*, [Automation](/automations)): Automation to perform when status message received from AC. See [`on_status_message` Trigger](#haier-on_status_message).
 - All other options from [Climate](#config-climate).
 
 ## Automations

--- a/content/components/cover/am43.md
+++ b/content/components/cover/am43.md
@@ -65,5 +65,5 @@ To make use of the battery and light level sensors, see the
 ## See Also
 
 - {{< docref "index/" >}}
-- [Automation](#automation)
+- [Automation](/automations)
 - {{< apiref "am43/am43_cover.h" "am43/am43_cover.h" >}}

--- a/content/components/cover/current_based.md
+++ b/content/components/cover/current_based.md
@@ -255,5 +255,5 @@ status_led:
 - {{< docref "index/" >}}
 - {{< docref "/components/cover/template" >}}
 - {{< docref "/components/sensor/ade7953" >}}
-- [Automation](#automation)
+- [Automation](/automations)
 - {{< apiref "current_based/current_based_cover.h" "current_based/current_based_cover.h" >}}

--- a/content/components/cover/endstop.md
+++ b/content/components/cover/endstop.md
@@ -74,5 +74,5 @@ cover:
 ## See Also
 
 - {{< docref "index/" >}}
-- [Automation](#automation)
+- [Automation](/automations)
 - {{< apiref "endstop/endstop_cover.h" "endstop/endstop_cover.h" >}}

--- a/content/components/cover/feedback.md
+++ b/content/components/cover/feedback.md
@@ -261,5 +261,5 @@ Most options can be left untouched, but some modifications are needed:
 ## See Also
 
 - {{< docref "index/" >}}
-- [Automation](#automation)
+- [Automation](/automations)
 - {{< apiref "feedback/feedback_cover.h" "feedback/feedback_cover.h" >}}

--- a/content/components/cover/he60r.md
+++ b/content/components/cover/he60r.md
@@ -96,5 +96,5 @@ binary_sensor:
 ## See Also
 
 - {{< docref "index/" >}}
-- [Automation](#automation)
+- [Automation](/automations)
 - [GPIO Binary Sensor](#gpio-binary-sensor)

--- a/content/components/cover/template.md
+++ b/content/components/cover/template.md
@@ -135,6 +135,6 @@ Configuration options:
 ## See Also
 
 - {{< docref "/components/cover" >}}
-- [Automation](#automation)
+- [Automation](/automations)
 - {{< docref "/cookbook/garage-door" >}}
 - {{< apiref "template/cover/template_cover.h" "template/cover/template_cover.h" >}}

--- a/content/components/cover/time_based.md
+++ b/content/components/cover/time_based.md
@@ -94,5 +94,5 @@ stop_action:
 ## See Also
 
 - {{< docref "index/" >}}
-- [Automation](#automation)
+- [Automation](/automations)
 - {{< apiref "time_based/time_based_cover.h" "time_based/time_based_cover.h" >}}

--- a/content/components/cover/tormatic.md
+++ b/content/components/cover/tormatic.md
@@ -96,5 +96,5 @@ can be bent 90 degrees to sit parallel to the PCB, keeping a low profile.
 ## See Also
 
 * {{< docref "index/" >}}
-* [Automation](#automation)
+* [Automation](/automations)
 * {{< apiref "tormatic/tormatic_cover.h" "tormatic/tormatic_cover.h" >}}

--- a/content/components/datetime/_index.md
+++ b/content/components/datetime/_index.md
@@ -61,7 +61,7 @@ MQTT Options:
 
 Time and DateTime Options:
 
-- **on_time** (*Optional*, [Automation](#automation)): Automation to run when the current datetime or time matches the current state.
+- **on_time** (*Optional*, [Automation](/automations)): Automation to run when the current datetime or time matches the current state.
   Only valid on `time` or `datetime` types. Use of `on_time` causes `time_id` to be required, `time_id` will be automatically assigned if a time source exists in the config, and will cause an invalid configuration if there is no {{< docref "/components/time" >}} configured.
 
 ## Automation
@@ -89,7 +89,7 @@ datetime:
             }
 ```
 
-Configuration variables: See [Automation](#automation).
+Configuration variables: See [Automation](/automations).
 
 ## Date Automation
 

--- a/content/components/datetime/template.md
+++ b/content/components/datetime/template.md
@@ -106,5 +106,5 @@ datetime:
 
 ## See Also
 
-- [Automation](#automation)
+- [Automation](/automations)
 - {{< apiref "template/datetime/template_date.h" "template/datetime/template_date.h" >}}

--- a/content/components/deep_sleep.md
+++ b/content/components/deep_sleep.md
@@ -215,5 +215,5 @@ on_...:
 ## See Also
 
 - {{< docref "switch/shutdown" >}}
-- [Automation](#automation)
+- [Automation](/automations)
 - {{< apiref "deep_sleep/deep_sleep_component.h" "deep_sleep/deep_sleep_component.h" >}}

--- a/content/components/dfplayer.md
+++ b/content/components/dfplayer.md
@@ -33,7 +33,7 @@ dfplayer:
 
 - **uart_id** (*Optional*, [ID](#config-id)): Manually specify the ID of the UART hub.
 - **id** (*Optional*, [ID](#config-id)): Manually specify the ID used for code generation.
-- **on_finished_playback** (*Optional*, [Automation](#automation)): An action to be
+- **on_finished_playback** (*Optional*, [Automation](/automations)): An action to be
   performed when playback is finished.
 
 ## `dfplayer.is_playing` Condition

--- a/content/components/display_menu/_index.md
+++ b/content/components/display_menu/_index.md
@@ -97,10 +97,10 @@ Configuration variables:
 
 Automations:
 
-- **on_enter** (*Optional*, [Automation](#automation)): An automation to perform
+- **on_enter** (*Optional*, [Automation](/automations)): An automation to perform
   when the menu level (here the root one) is entered. See [`on_enter`](#display_menu-on_enter).
 
-- **on_leave** (*Optional*, [Automation](#automation)): An automation to perform
+- **on_leave** (*Optional*, [Automation](/automations)): An automation to perform
   when the menu level is not displayed anymore.
   See [`on_leave`](#display_menu-on_leave).
 
@@ -178,10 +178,10 @@ Configuration variables:
 
 Automations:
 
-- **on_enter** (*Optional*, [Automation](#automation)): An automation to perform
+- **on_enter** (*Optional*, [Automation](/automations)): An automation to perform
   when the menu level is entered. See [`on_enter`](#display_menu-on_enter).
 
-- **on_leave** (*Optional*, [Automation](#automation)): An automation to perform
+- **on_leave** (*Optional*, [Automation](/automations)): An automation to perform
   when the menu level is not displayed anymore.
   See [`on_leave`](#display_menu-on_leave).
 
@@ -244,14 +244,14 @@ Configuration variables:
 
 Automations:
 
-- **on_enter** (*Optional*, [Automation](#automation)): An automation to perform
+- **on_enter** (*Optional*, [Automation](/automations)): An automation to perform
   when the editing mode is activated. See [`on_enter`](#display_menu-on_enter).
 
-- **on_leave** (*Optional*, [Automation](#automation)): An automation to perform
+- **on_leave** (*Optional*, [Automation](/automations)): An automation to perform
   when the editing mode is exited.
   See [`on_leave`](#display_menu-on_leave).
 
-- **on_value** (*Optional*, [Automation](#automation)): An automation to perform
+- **on_value** (*Optional*, [Automation](/automations)): An automation to perform
   when the value is changed.
   See [`on_value`](#display_menu-on_value).
 
@@ -318,14 +318,14 @@ Configuration variables:
 
 Automations:
 
-- **on_enter** (*Optional*, [Automation](#automation)): An automation to perform
+- **on_enter** (*Optional*, [Automation](/automations)): An automation to perform
   when the editing mode is activated. See [`on_enter`](#display_menu-on_enter).
 
-- **on_leave** (*Optional*, [Automation](#automation)): An automation to perform
+- **on_leave** (*Optional*, [Automation](/automations)): An automation to perform
   when the editing mode is exited.
   See [`on_leave`](#display_menu-on_leave).
 
-- **on_value** (*Optional*, [Automation](#automation)): An automation to perform
+- **on_value** (*Optional*, [Automation](/automations)): An automation to perform
   when the value is changed.
   See [`on_value`](#display_menu-on_value).
 
@@ -374,14 +374,14 @@ Configuration variables:
 
 Automations:
 
-- **on_enter** (*Optional*, [Automation](#automation)): An automation to perform
+- **on_enter** (*Optional*, [Automation](/automations)): An automation to perform
   when the editing mode is activated. See [`on_enter`](#display_menu-on_enter).
 
-- **on_leave** (*Optional*, [Automation](#automation)): An automation to perform
+- **on_leave** (*Optional*, [Automation](/automations)): An automation to perform
   when the editing mode is exited.
   See [`on_leave`](#display_menu-on_leave).
 
-- **on_value** (*Optional*, [Automation](#automation)): An automation to perform
+- **on_value** (*Optional*, [Automation](/automations)): An automation to perform
   when the value is changed.
   See [`on_value`](#display_menu-on_value).
 
@@ -401,7 +401,7 @@ additional configuration.
 
 Automations:
 
-- **on_value** (*Optional*, [Automation](#automation)): An automation to perform
+- **on_value** (*Optional*, [Automation](/automations)): An automation to perform
   when the menu item is clicked.
   See [`on_value`](#display_menu-on_value).
 
@@ -436,22 +436,22 @@ Configuration variables:
 
 Automations:
 
-- **on_enter** (*Optional*, [Automation](#automation)): An automation to perform
+- **on_enter** (*Optional*, [Automation](/automations)): An automation to perform
   when the editing mode is activated. See [`on_enter`](#display_menu-on_enter).
 
-- **on_leave** (*Optional*, [Automation](#automation)): An automation to perform
+- **on_leave** (*Optional*, [Automation](/automations)): An automation to perform
   when the editing mode is exited.
   See [`on_leave`](#display_menu-on_leave).
 
-- **on_value** (*Optional*, [Automation](#automation)): An automation to perform
+- **on_value** (*Optional*, [Automation](/automations)): An automation to perform
   when the value is changed.
   See [`on_value`](#display_menu-on_value).
 
-- **on_next** (*Optional*, [Automation](#automation)): An automation to perform
+- **on_next** (*Optional*, [Automation](/automations)): An automation to perform
   when the user navigates to the next value.
   See [`on_next`](#display_menu-on_next).
 
-- **on_prev** (*Optional*, [Automation](#automation)): An automation to perform
+- **on_prev** (*Optional*, [Automation](/automations)): An automation to perform
   when the user navigates to the previous value.
   See [`on_prev`](#display_menu-on_prev).
 

--- a/content/components/display_menu/graphical_display_menu.md
+++ b/content/components/display_menu/graphical_display_menu.md
@@ -54,7 +54,7 @@ Configuration variables:
 
 Automations:
 
-- **on_redraw** (*Optional*, [Automation](#automation)): An automation to perform
+- **on_redraw** (*Optional*, [Automation](/automations)): An automation to perform
   when the menu needs to be redrawn. This can be useful if your display has slow refresh rates.
   For example E-Ink displays that are used with `display_interval: never`.
 

--- a/content/components/esp32_ble_server.md
+++ b/content/components/esp32_ble_server.md
@@ -41,8 +41,8 @@ esp32_ble_server:
   packet. Should be a list of bytes, where the first two are the little-endian representation of the 16-bit
   manufacturer ID as assigned by the Bluetooth SIG.
 
-- **on_connect** (*Optional*, [Automation](#automation)): An action to be performed when a client connects to the BLE server. It provides the `id` variable which contains the ID of the client that connected.
-- **on_disconnect** (*Optional*, [Automation](#automation)): An action to be performed when a client disconnects from the BLE server. It provides the `id` variable which contains the ID of the client that disconnected.
+- **on_connect** (*Optional*, [Automation](/automations)): An action to be performed when a client connects to the BLE server. It provides the `id` variable which contains the ID of the client that connected.
+- **on_disconnect** (*Optional*, [Automation](/automations)): An action to be performed when a client disconnects from the BLE server. It provides the `id` variable which contains the ID of the client that disconnected.
 - **services** (*Optional*, list of [Service Configuration](#esp32_ble_server-service)): A list of services to expose on the BLE GATT server.
 
 {{< anchor "esp32_ble_server-service" >}}
@@ -108,7 +108,7 @@ esp32_ble_server:
 - **write_no_response** (*Optional*, boolean): If the characteristic should be writable without a response. Defaults to `false`.
 - **value** (*Optional*, [Value Configuration](#esp32_ble_server-value)): The value of the characteristic.
 - **descriptors** (*Optional*, list of [Descriptor Configuration](#esp32_ble_server-descriptor)): A list of descriptors to expose in this characteristic.
-- **on_write** (*Optional*, [Automation](#automation)): An action to be performed when the characteristic is written to. The characteristic must have the `write` property. See [`on_write` Trigger](#esp32_ble_server-characteristic-on_write).
+- **on_write** (*Optional*, [Automation](/automations)): An action to be performed when the characteristic is written to. The characteristic must have the `write` property. See [`on_write` Trigger](#esp32_ble_server-characteristic-on_write).
 
 {{< anchor "esp32_ble_server-descriptor" >}}
 

--- a/content/components/esp32_ble_tracker.md
+++ b/content/components/esp32_ble_tracker.md
@@ -98,18 +98,18 @@ sensor:
 
 Automations:
 
-- **on_ble_advertise** (*Optional*, [Automation](#automation)): An automation to perform
+- **on_ble_advertise** (*Optional*, [Automation](/automations)): An automation to perform
   when a Bluetooth advertising is received. See [`on_ble_advertise` Trigger](#esp32_ble_tracker-on_ble_advertise).
 
-- **on_ble_manufacturer_data_advertise** (*Optional*, [Automation](#automation)): An automation to
+- **on_ble_manufacturer_data_advertise** (*Optional*, [Automation](/automations)): An automation to
   perform when a Bluetooth advertising with manufacturer data is received. See
   [`on_ble_manufacturer_data_advertise` Trigger](#esp32_ble_tracker-on_ble_manufacturer_data_advertise).
 
-- **on_ble_service_data_advertise** (*Optional*, [Automation](#automation)): An automation to
+- **on_ble_service_data_advertise** (*Optional*, [Automation](/automations)): An automation to
   perform when a Bluetooth advertising with service data is received. See
   [`on_ble_service_data_advertise` Trigger](#esp32_ble_tracker-on_ble_service_data_advertise).
 
-- **on_scan_end** (*Optional*, [Automation](#automation)): An automation to perform when
+- **on_scan_end** (*Optional*, [Automation](/automations)): An automation to perform when
   a BLE scan has completed (the duration of the scan). This works with continuous set to true or false.
 
 ## ESP32 Bluetooth Low Energy Tracker Automation
@@ -149,7 +149,7 @@ esp32_ble_tracker:
 #### Configuration variables
 
 - **mac_address** (*Optional*, list of MAC Address): The MAC address to filter for this automation.
-- See [Automation](#automation).
+- See [Automation](/automations).
 
 {{< anchor "esp32_ble_tracker-on_ble_manufacturer_data_advertise" >}}
 
@@ -179,7 +179,7 @@ esp32_ble_tracker:
 
 - **mac_address** (*Optional*, MAC Address): The MAC address to filter for this automation.
 - **manufacturer_id** (**Required**, string): 16 bit, 32 bit, or 128 bit BLE Manufacturer ID.
-- See [Automation](#automation).
+- See [Automation](/automations).
 
 {{< anchor "esp32_ble_tracker-on_ble_service_data_advertise" >}}
 
@@ -206,7 +206,7 @@ esp32_ble_tracker:
 
 - **mac_address** (*Optional*, MAC Address): The MAC address to filter for this automation.
 - **service_uuid** (**Required**, string): 16 bit, 32 bit, or 128 bit BLE Service UUID.
-- See [Automation](#automation).
+- See [Automation](/automations).
 
 ### `on_scan_end` Trigger
 
@@ -226,7 +226,7 @@ esp32_ble_tracker:
 
 - None
 
-- See [Automation](#automation).
+- See [Automation](/automations).
 
 ### `esp32_ble_tracker.start_scan` Action
 

--- a/content/components/esp32_camera.md
+++ b/content/components/esp32_camera.md
@@ -168,13 +168,13 @@ White Balance Setting:
 
 Automations:
 
-- **on_stream_start** (*Optional*, [Automation](#automation)): An automation to perform
+- **on_stream_start** (*Optional*, [Automation](/automations)): An automation to perform
   when a stream starts.
 
-- **on_stream_stop** (*Optional*, [Automation](#automation)): An automation to perform
+- **on_stream_stop** (*Optional*, [Automation](/automations)): An automation to perform
   when a stream stops.
 
-- **on_image** (*Optional*, [Automation](#automation)): An automation called when image taken. Image is available as `image` variable of type {{< apistruct "esp32_camera::CameraImageData" "esp32_camera::CameraImageData" >}}.
+- **on_image** (*Optional*, [Automation](/automations)): An automation called when image taken. Image is available as `image` variable of type {{< apistruct "esp32_camera::CameraImageData" "esp32_camera::CameraImageData" >}}.
 
 Test Setting:
 

--- a/content/components/esp32_improv.md
+++ b/content/components/esp32_improv.md
@@ -41,26 +41,26 @@ esp32_improv:
 - **wifi_timeout** (*Optional*, [Time](#config-time)): The amount of time to wait before starting the Improv service
   after Wi-Fi is no longer connected. Defaults to `1min`.
 
-- **on_start** (*Optional*, [Automation](#automation)): An action to be performed when Improv is waiting for
+- **on_start** (*Optional*, [Automation](/automations)): An action to be performed when Improv is waiting for
   authorization and/or upon authorization. See [`on_start`](#improv-on_start).
 
-- **on_provisioned** (*Optional*, [Automation](#automation)): An action to be performed when provisioning has
+- **on_provisioned** (*Optional*, [Automation](/automations)): An action to be performed when provisioning has
   completed. See [`on_provisioned`](#improv-on_provisioned).
 
-- **on_provisioning** (*Optional*, [Automation](#automation)): An action to be performed when the device begins the
+- **on_provisioning** (*Optional*, [Automation](/automations)): An action to be performed when the device begins the
   provisioning process. See [`on_provisioning`](#improv-on_provisioning).
 
-- **on_stop** (*Optional*, [Automation](#automation)): An action to be performed when Improv has stopped.
+- **on_stop** (*Optional*, [Automation](/automations)): An action to be performed when Improv has stopped.
   See [`on_stop`](#improv-on_stop).
 
-- **on_state** (*Optional*, [Automation](#automation)): An action to be performed when an Improv state change
+- **on_state** (*Optional*, [Automation](/automations)): An action to be performed when an Improv state change
   happens. See [`on_state`](#improv-on_state).
 
 {{< anchor "improv-automations" >}}
 
 ## Improv Automations
 
-The ESP32 Improv component provides various [automations](#automation) that can be used to provide feedback during
+The ESP32 Improv component provides various [automations](/automations) that can be used to provide feedback during
 the Improv provisioning process.
 
 {{< anchor "improv-on_start" >}}

--- a/content/components/esphome.md
+++ b/content/components/esphome.md
@@ -71,7 +71,7 @@ Advanced options:
 
   - **name** (**Required**, string): Name of the project
   - **version** (**Required**, string): Version of the project
-  - **on_update** (*Optional*, [Automation](#automation)): An automation to perform when the device firmware is updated.
+  - **on_update** (*Optional*, [Automation](/automations)): An automation to perform when the device firmware is updated.
     This compares the above `version` field with the `version` that was in the previous firmware
     as long as the `name` matches.
     The `version` is stored in flash memory when the firmware is first run for future comparisons.
@@ -88,13 +88,13 @@ Advanced options:
 
 Automations:
 
-- **on_boot** (*Optional*, [Automation](#automation)): An automation to perform
+- **on_boot** (*Optional*, [Automation](/automations)): An automation to perform
   when the node starts. See [`on_boot`](#esphome-on_boot).
 
-- **on_shutdown** (*Optional*, [Automation](#automation)): An automation to perform
+- **on_shutdown** (*Optional*, [Automation](/automations)): An automation to perform
   right before the node shuts down. See [`on_shutdown`](#esphome-on_shutdown).
 
-- **on_loop** (*Optional*, [Automation](#automation)): An automation to perform
+- **on_loop** (*Optional*, [Automation](/automations)): An automation to perform
   on each `loop()` iteration. See [`on_loop`](#esphome-on_loop).
 
 {{< anchor "esphome-on_boot" >}}
@@ -127,7 +127,7 @@ esphome:
   - `200.0`  : Network connections like MQTT/native API are set up at this priority.
   - `-100.0`  : At this priority, pretty much everything should already be initialized.
 
-- See [Automation](#automation).
+- See [Automation](/automations).
 
 {{< anchor "esphome-on_shutdown" >}}
 
@@ -157,7 +157,7 @@ esphome:
   Please note this is an ESPHome-internal value and any change will not be marked as a breaking change.
   Defaults to `600`. For priority values refer to the list in the [`on_boot`](#esphome-on_boot) section.
 
-- See [Automation](#automation).
+- See [Automation](/automations).
 
 {{< anchor "esphome-on_loop" >}}
 

--- a/content/components/espnow.md
+++ b/content/components/espnow.md
@@ -34,9 +34,9 @@ espnow:
 
 Automations:
 
-- **on_receive** (*Optional*, [Automation](#automation)): An automation to perform when data is received. See [`on_receive`](#espnow-on_receive).
-- **on_unknown_peer** (*Optional*, [Automation](#automation)): An automation to perform when data is received from an unknown peer. See [`on_unknown_peer`](#espnow-on_unknown_peer).
-- **on_broadcast** (*Optional*, [Automation](#automation)): An automation to perform when a broadcast packet is received.
+- **on_receive** (*Optional*, [Automation](/automations)): An automation to perform when data is received. See [`on_receive`](#espnow-on_receive).
+- **on_unknown_peer** (*Optional*, [Automation](/automations)): An automation to perform when data is received from an unknown peer. See [`on_unknown_peer`](#espnow-on_unknown_peer).
+- **on_broadcast** (*Optional*, [Automation](/automations)): An automation to perform when a broadcast packet is received.
   See [`on_broadcast`](#espnow-on_broadcast).
 
 ## Automations
@@ -121,8 +121,8 @@ on_...:
 
 Automations:
 
-- **on_sent** (*Optional*, [Automation](#automation)): An automation to perform when the data is sent successfully.
-- **on_error** (*Optional*, [Automation](#automation)): An automation to perform when the data could not be sent.
+- **on_sent** (*Optional*, [Automation](/automations)): An automation to perform when the data is sent successfully.
+- **on_error** (*Optional*, [Automation](/automations)): An automation to perform when the data could not be sent.
 
 {{< anchor "espnow-broadcast-action" >}}
 

--- a/content/components/event/_index.md
+++ b/content/components/event/_index.md
@@ -79,7 +79,7 @@ One of `id` or `name` is required.
 
 Automations:
 
-- **on_event** (*Optional*, [Automation](#automation)): An automation to perform when an event is triggered.
+- **on_event** (*Optional*, [Automation](/automations)): An automation to perform when an event is triggered.
 
 MQTT options:
 
@@ -104,7 +104,7 @@ event:
             ESP_LOGD("main", "Event %s triggered.", event_type.c_str());
 ```
 
-Configuration variables: see [Automation](#automation).
+Configuration variables: see [Automation](/automations).
 
 ### `event.trigger` Action
 

--- a/content/components/exposure_notifications.md
+++ b/content/components/exposure_notifications.md
@@ -26,7 +26,7 @@ exposure_notifications:
 
 ## Configuration variables
 
-- **on_exposure_notification** (*Optional*, [Automation](#automation)): An automation
+- **on_exposure_notification** (*Optional*, [Automation](/automations)): An automation
   to run when an exposure notification bluetooth message is received.
 
   A variable `x` of type {{< apistruct "exposure_notifications::ExposureNotification" "exposure_notifications::ExposureNotification" >}} is passed to the automation.

--- a/content/components/ezo_pmp.md
+++ b/content/components/ezo_pmp.md
@@ -240,7 +240,7 @@ text_sensor:
 
 ### `ezo_pmp.dose_continuously` Action
 
-Use this action in an [automations](#automation) to have the peristaltic pump dose continuously
+Use this action in an [automations](/automations) to have the peristaltic pump dose continuously
 at the [Maximum Flow Rate](#ezo_pmp-max_flow_rate_sensor). The pump will automatically stop after 20 days
 of running in continuous mode.
 
@@ -259,7 +259,7 @@ on_...:
 
 ### `ezo_pmp.dose_volume` Action
 
-Use this action in an [automations](#automation) to have the peristaltic pump dose an specific volume (in milliliters)
+Use this action in an [automations](/automations) to have the peristaltic pump dose an specific volume (in milliliters)
 at the [Maximum Flow Rate](#ezo_pmp-max_flow_rate_sensor). If the volume is negative the pump will run backwards.
 
 ```yaml
@@ -285,7 +285,7 @@ on_...:
 
 ### `ezo_pmp.dose_volume_over_time` Action
 
-Use this action in an [automations](#automation) to have the peristaltic pump dose an specific `volume` (in milliliters)
+Use this action in an [automations](/automations) to have the peristaltic pump dose an specific `volume` (in milliliters)
 over the provided `duration` (in minutes). At the end of the time period the pump will have dosed the specified `volume`.
 If the volume is negative the pump will run backwards.
 
@@ -316,7 +316,7 @@ on_...:
 
 ### `ezo_pmp.dose_with_constant_flow_rate` Action
 
-Use this action in an [automations](#automation) to have the peristaltic pump dose an specific `volume` (in milliliters) every minute
+Use this action in an [automations](/automations) to have the peristaltic pump dose an specific `volume` (in milliliters) every minute
 for the provided `duration` (in minutes). At the end of the time period the pump will have dosed the specified `volume` times the `duration`.
 If the volume is negative the pump will run backwards.
 

--- a/content/components/fingerprint_grow.md
+++ b/content/components/fingerprint_grow.md
@@ -59,14 +59,14 @@ Base Configuration:
 - **password** (*Optional*, int): Password to use for authentication. Defaults to `0x00`.
 - **new_password** (*Optional*, int): Sets a new password to use for authentication. See [Setting a New Password](#fingerprint_grow-set_new_password) for more information.
 - **idle_period_to_sleep** (*Optional*, [Time](#config-time)): The sensor idle period to wait before powering it off (sleep). Defaults to `5s`. See [Sleep Mode](#fingerprint_grow-sleep_mode) for more information.
-- **on_finger_scan_start** (*Optional*, [Automation](#automation)): An action to be performed when the finger touches the sensor. See [`on_finger_scan_start` Trigger](#fingerprint_grow-on_finger_scan_start).
-- **on_finger_scan_matched** (*Optional*, [Automation](#automation)): An action to be performed when an enrolled fingerprint is scanned. See [`on_finger_scan_matched` Trigger](#fingerprint_grow-on_finger_scan_matched).
-- **on_finger_scan_unmatched** (*Optional*, [Automation](#automation)): An action to be performed when an unknown fingerprint is scanned. See [`on_finger_scan_unmatched` Trigger](#fingerprint_grow-on_finger_scan_unmatched).
-- **on_finger_scan_misplaced** (*Optional*, [Automation](#automation)): An action to be performed when the finger is not entirely touching the sensor. See [`on_finger_scan_misplaced` Trigger](#fingerprint_grow-on_finger_scan_misplaced).
-- **on_finger_scan_invalid** (*Optional*, [Automation](#automation)): An action to be performed when the scan of a fingerprint failed. See [`on_finger_scan_invalid` Trigger](#fingerprint_grow-on_finger_scan_invalid).
-- **on_enrollment_scan** (*Optional*, [Automation](#automation)): An action to be performed when a fingerprint is scanned during enrollment. See [`on_enrollment_scan` Trigger](#fingerprint_grow-on_enrollment_scan).
-- **on_enrollment_done** (*Optional*, [Automation](#automation)): An action to be performed when a fingerprint is enrolled. See [`on_enrollment_done` Trigger](#fingerprint_grow-on_enrollment_done).
-- **on_enrollment_failed** (*Optional*, [Automation](#automation)): An action to be performed when a fingerprint enrollment failed. See [`on_enrollment_failed` Trigger](#fingerprint_grow-on_enrollment_failed).
+- **on_finger_scan_start** (*Optional*, [Automation](/automations)): An action to be performed when the finger touches the sensor. See [`on_finger_scan_start` Trigger](#fingerprint_grow-on_finger_scan_start).
+- **on_finger_scan_matched** (*Optional*, [Automation](/automations)): An action to be performed when an enrolled fingerprint is scanned. See [`on_finger_scan_matched` Trigger](#fingerprint_grow-on_finger_scan_matched).
+- **on_finger_scan_unmatched** (*Optional*, [Automation](/automations)): An action to be performed when an unknown fingerprint is scanned. See [`on_finger_scan_unmatched` Trigger](#fingerprint_grow-on_finger_scan_unmatched).
+- **on_finger_scan_misplaced** (*Optional*, [Automation](/automations)): An action to be performed when the finger is not entirely touching the sensor. See [`on_finger_scan_misplaced` Trigger](#fingerprint_grow-on_finger_scan_misplaced).
+- **on_finger_scan_invalid** (*Optional*, [Automation](/automations)): An action to be performed when the scan of a fingerprint failed. See [`on_finger_scan_invalid` Trigger](#fingerprint_grow-on_finger_scan_invalid).
+- **on_enrollment_scan** (*Optional*, [Automation](/automations)): An action to be performed when a fingerprint is scanned during enrollment. See [`on_enrollment_scan` Trigger](#fingerprint_grow-on_enrollment_scan).
+- **on_enrollment_done** (*Optional*, [Automation](/automations)): An action to be performed when a fingerprint is enrolled. See [`on_enrollment_done` Trigger](#fingerprint_grow-on_enrollment_done).
+- **on_enrollment_failed** (*Optional*, [Automation](/automations)): An action to be performed when a fingerprint enrollment failed. See [`on_enrollment_failed` Trigger](#fingerprint_grow-on_enrollment_failed).
 
 ## Binary Sensor
 

--- a/content/components/http_request.md
+++ b/content/components/http_request.md
@@ -114,8 +114,8 @@ on_...:
 - **max_response_buffer_size** (*Optional*, integer): The maximum buffer size to be used to store the response.
   Defaults to `1 kB`.
 
-- **on_response** (*Optional*, [Automation](#automation)): An automation to perform after the request is received.
-- **on_error** (*Optional*, [Automation](#automation)): An automation to perform if the request cannot be completed.
+- **on_response** (*Optional*, [Automation](/automations)): An automation to perform after the request is received.
+- **on_error** (*Optional*, [Automation](/automations)): An automation to perform if the request cannot be completed.
 
 {{< anchor "http_request-post_action" >}}
 

--- a/content/components/key_collector.md
+++ b/content/components/key_collector.md
@@ -72,19 +72,19 @@ accepted until an end key is pressed.
 
 ## Triggers
 
-- **on_progress** (*Optional*, [Automation](#automation)): An automation to perform
+- **on_progress** (*Optional*, [Automation](/automations)): An automation to perform
   when keys are pressed. The current sequence of pressed keys is placed in a `vector<uint8_t>` variable `x`
   and `start` holds the start key that activated this sequence or else `0`.
   Useful if you want to have a display showing the current value or number of key presses,
   or a speaker beeping when keys are being pressed.
 
-- **on_result** (*Optional*, [Automation](#automation)): An automation to perform
+- **on_result** (*Optional*, [Automation](/automations)): An automation to perform
   when the sequence has been finished (eg. `max_length` has been reached or one of
   the `end_keys` was pressed). The finalized key sequence is placed in a `vector<uint8_t>` variable `x`,
   `start` holds the start key that activated this sequence or else `0`, and
   `end` holds the end key that terminated this sequence or else `0`.
 
-- **on_timeout** (*Optional*, [Automation](#automation)): An automation to perform
+- **on_timeout** (*Optional*, [Automation](/automations)): An automation to perform
   if the timeout happens. The current sequence of pressed keys is placed in a `vector<uint8_t>` variable `x`
   and `start` holds the start key that activated this sequence or else `0`.
 

--- a/content/components/light/_index.md
+++ b/content/components/light/_index.md
@@ -970,7 +970,7 @@ in [the source code](https://github.com/esphome/esphome/blob/dev/esphome/compone
 ### Automation Light Effect
 
 In addition to the `lambda` and `addressable_lambda` light effects, effects can also be created with ESPHome's
-[Automation](#automation) system with the `automation` effect type.
+[Automation](/automations) system with the `automation` effect type.
 
 The automation given in the `sequence` block will be repeatedly executed until the effect is stopped by the user.
 

--- a/content/components/logger.md
+++ b/content/components/logger.md
@@ -57,7 +57,7 @@ Advanced settings:
 - **esp8266_store_log_strings_in_flash** (*Optional*, boolean): If set to false, disables storing
    log strings in the flash section of the device (uses more memory). Defaults to true.
 
-- **on_message** (*Optional*, [Automation](#automation)): An action to be
+- **on_message** (*Optional*, [Automation](/automations)): An action to be
    performed when a message is to be logged. The variables `int level`, `const char* tag` and
    `const char* message` are available for lambda processing.
 

--- a/content/components/lvgl/_index.md
+++ b/content/components/lvgl/_index.md
@@ -59,7 +59,7 @@ Every widget has a parent object where it is created. For example, if a label is
 
 Pages in ESPHome are implemented as LVGL screens, which are special objects which have no parent. There is always one active page on a display.
 
-Widgets can be assigned with an [ID](#config-id) so that they can be referenced in [automations](#automation).
+Widgets can be assigned with an [ID](#config-id) so that they can be referenced in [automations](/automations).
 
 Some widgets integrate also as native ESPHome components:
 
@@ -948,7 +948,7 @@ Widget level [interaction triggers](#lvgl-automation-triggers) are available, pl
 
 LVGL has a notion of screen inactivity -- i.e. the time since the last user interaction with the screen is tracked. This can, for example, be used to dim the display backlight or turn it off after a moment of inactivity (like a screen saver). Every use of an input device (touchscreen, rotary encoder) counts as an activity and resets the inactivity counter.
 
-The `on_idle` [triggers](#automation) are activated when inactivity time becomes longer than the specified `timeout`. You can configure any desired number of timeouts with different actions.
+The `on_idle` [triggers](/automations) are activated when inactivity time becomes longer than the specified `timeout`. You can configure any desired number of timeouts with different actions.
 
 - **timeout** (**Required**, [templatable](#config-templatable), int): [Time](#config-time) that has elapsed since the last touch event, after which the trigger will be invoked.
 

--- a/content/components/matrix_keypad.md
+++ b/content/components/matrix_keypad.md
@@ -84,7 +84,7 @@ Either the `row` and `col` parameters, or the `key` parameter has to be provided
 
 ## Automations
 
-- **on_key** (*Optional*, [Automation](#automation)): An automation to perform
+- **on_key** (*Optional*, [Automation](/automations)): An automation to perform
   when a key has been pressed. The key is in a variable called `x`.
 
   > [!NOTE]

--- a/content/components/media_player/speaker.md
+++ b/content/components/media_player/speaker.md
@@ -54,9 +54,9 @@ media_player:
 - **files** (*Optional*, list): A list of media files to build into the firmware for on-device playback.
   - **id** (**Required**, [ID](#config-id)): Unique ID for the file.
   - **file** (**Required**, string): Path to audio file. Can be a local file path or a URL.
-- **on_mute** (*Optional*, [Automation](#automation)): An automation to perform when muted.
-- **on_unmute** (*Optional*, [Automation](#automation)): An automation to perform when unmuted.
-- **on_volume** (*Optional*, [Automation](#automation)): An automation to perform when the volume is changed.
+- **on_mute** (*Optional*, [Automation](/automations)): An automation to perform when muted.
+- **on_unmute** (*Optional*, [Automation](/automations)): An automation to perform when unmuted.
+- **on_volume** (*Optional*, [Automation](/automations)): An automation to perform when the volume is changed.
 - All other options from [Media Player](#config-media_player)
 
 {{< anchor "media_player-speaker-examples" >}}

--- a/content/components/microphone/_index.md
+++ b/content/components/microphone/_index.md
@@ -16,7 +16,7 @@ microphone platforms.
 
 Configuration variables:
 
-- **on_data** (*Optional*, [Automation](#automation)): An automation to
+- **on_data** (*Optional*, [Automation](/automations)): An automation to
   perform when new data is received.
 
 {{< anchor "config-microphone-source" >}}

--- a/content/components/modbus_controller.md
+++ b/content/components/modbus_controller.md
@@ -108,9 +108,9 @@ On the bus side, you need 120 Ohm termination resistors at the ends of the bus c
 
 Automations:
 
-- **on_command_sent** (*Optional*, [Automation](#automation)): An automation to perform when a modbus command has been sent. See [`on_command_sent`](#modbus_controller-on_command_sent)
-- **on_online** (*Optional*, [Automation](#automation)): An automation to perform when a modbus controller goes online. See [`on_online`](#modbus_controller-on_online)
-- **on_offline** (*Optional*, [Automation](#automation)): An automation to perform when a modbus controller goes offline. See [`on_offline`](#modbus_controller-on_offline)
+- **on_command_sent** (*Optional*, [Automation](/automations)): An automation to perform when a modbus command has been sent. See [`on_command_sent`](#modbus_controller-on_command_sent)
+- **on_online** (*Optional*, [Automation](/automations)): An automation to perform when a modbus controller goes online. See [`on_online`](#modbus_controller-on_online)
+- **on_offline** (*Optional*, [Automation](/automations)): An automation to perform when a modbus controller goes offline. See [`on_offline`](#modbus_controller-on_offline)
 
 ## Example Client
 

--- a/content/components/mqtt.md
+++ b/content/components/mqtt.md
@@ -118,16 +118,16 @@ mqtt:
   to keep the MQTT socket alive, decreasing this can help with overall stability due to more
   WiFi traffic with more pings. Defaults to 15 seconds.
 
-- **on_connect** (*Optional*, [Automation](#automation)): An action to be performed when a connection
+- **on_connect** (*Optional*, [Automation](/automations)): An action to be performed when a connection
   to the broker is established.
 
-- **on_disconnect** (*Optional*, [Automation](#automation)): An action to be performed when the connection
+- **on_disconnect** (*Optional*, [Automation](/automations)): An action to be performed when the connection
   to the broker is dropped.
 
-- **on_message** (*Optional*, [Automation](#automation)): An action to be
+- **on_message** (*Optional*, [Automation](/automations)): An action to be
   performed when a message on a specific MQTT topic is received. See [`on_message` Trigger](#mqtt-on_message).
 
-- **on_json_message** (*Optional*, [Automation](#automation)): An action to be
+- **on_json_message** (*Optional*, [Automation](/automations)): An action to be
   performed when a JSON message on a specific MQTT topic is received. See [`on_json_message` Trigger](#mqtt-on_json_message).
 
 - **id** (*Optional*, [ID](#config-id)): Manually specify the ID used for code generation.

--- a/content/components/number/_index.md
+++ b/content/components/number/_index.md
@@ -67,10 +67,10 @@ Configuration variables:
 
 Automations:
 
-- **on_value** (*Optional*, [Automation](#automation)): An automation to perform
+- **on_value** (*Optional*, [Automation](/automations)): An automation to perform
   when a new value is published. See [`on_value`](#number-on_value).
 
-- **on_value_range** (*Optional*, [Automation](#automation)): An automation to perform
+- **on_value_range** (*Optional*, [Automation](/automations)): An automation to perform
   when a published value transition from outside to a range to inside. See [`on_value_range`](#number-on_value_range).
 
 MQTT Options:
@@ -100,7 +100,7 @@ number:
             red: !lambda "return x/255;"
 ```
 
-Configuration variables: See [Automation](#automation).
+Configuration variables: See [Automation](/automations).
 
 {{< anchor "number-on_value_range" >}}
 
@@ -130,7 +130,7 @@ Configuration variables:
 
 - **above** (*Optional*, float): The minimum for the trigger.
 - **below** (*Optional*, float): The maximum for the trigger.
-- See [Automation](#automation).
+- See [Automation](/automations).
 
 {{< anchor "number-in_range_condition" >}}
 

--- a/content/components/number/homeassistant.md
+++ b/content/components/number/homeassistant.md
@@ -35,5 +35,5 @@ with the [`number.set` Action](#number-set_action).
 
 ## See Also
 
-- [Automation](#automation)
+- [Automation](/automations)
 - {{< apiref "homeassistant/number/homeassistant_number.h" "homeassistant/number/homeassistant_number.h" >}}

--- a/content/components/number/template.md
+++ b/content/components/number/template.md
@@ -56,5 +56,5 @@ with the [`number.set` Action](#number-set_action).
 
 ## See Also
 
-- [Automation](#automation)
+- [Automation](/automations)
 - {{< apiref "template/number/template_number.h" "template/number/template_number.h" >}}

--- a/content/components/online_image.md
+++ b/content/components/online_image.md
@@ -74,7 +74,7 @@ Advanced options:
 
 ## Automations
 
-- **on_download_finished** (*Optional*, [Automation](#automation)): An automation to perform when the image has been successfully downloaded.
+- **on_download_finished** (*Optional*, [Automation](/automations)): An automation to perform when the image has been successfully downloaded.
 
 The variable `cached` is a boolean available in [lambdas](#config-lambda) that indicates cache status:
 
@@ -101,7 +101,7 @@ online_image:
 
 A good example for that is to update the display component after the download succeeded.
 
-- **on_error** (*Optional*, [Automation](#automation)): An automation to perform when an error happened during download or decode.
+- **on_error** (*Optional*, [Automation](/automations)): An automation to perform when an error happened during download or decode.
 
 ## Actions
 

--- a/content/components/ota/_index.md
+++ b/content/components/ota/_index.md
@@ -31,26 +31,26 @@ ota:
 
 ## Configuration variables
 
-- **on_begin** (*Optional*, [Automation](#automation)): An action to be performed when an OTA update is started.
+- **on_begin** (*Optional*, [Automation](/automations)): An action to be performed when an OTA update is started.
    See [`on_begin`](#ota-on_begin).
 
-- **on_progress** (*Optional*, [Automation](#automation)): An action to be performed (approximately each second)
+- **on_progress** (*Optional*, [Automation](/automations)): An action to be performed (approximately each second)
    while an OTA update is in progress. See [`on_progress`](#ota-on_progress).
 
-- **on_end** (*Optional*, [Automation](#automation)): An action to be performed after a successful OTA update.
+- **on_end** (*Optional*, [Automation](/automations)): An action to be performed after a successful OTA update.
    See [`on_end`](#ota-on_end).
 
-- **on_error** (*Optional*, [Automation](#automation)): An action to be performed after a failed OTA update.
+- **on_error** (*Optional*, [Automation](/automations)): An action to be performed after a failed OTA update.
    See [`on_error`](#ota-on_error).
 
-- **on_state_change** (*Optional*, [Automation](#automation)): An action to be performed when an OTA update state
+- **on_state_change** (*Optional*, [Automation](/automations)): An action to be performed when an OTA update state
    change happens. See [`on_state_change`](#ota-on_state_change).
 
 {{< anchor "ota-automations" >}}
 
 ## OTA Automations
 
-The OTA component provides various [automations](#automation) that can be used to provide feedback during the OTA
+The OTA component provides various [automations](/automations) that can be used to provide feedback during the OTA
 update process. When using these automation triggers, note that:
 
 - OTA updates block the main application loop while in progress. You won't be able to represent state changes using

--- a/content/components/ota/esphome.md
+++ b/content/components/ota/esphome.md
@@ -39,7 +39,7 @@ ota:
 - **version** (*Optional*, int): Version of OTA protocol to use. Version 2 is more stable. To downgrade to legacy
    ESPHome, the device should be updated with OTA version 1 first. Defaults to `2`.
 
-- All [automations](#automation) supported by {{< docref "/components/ota" >}}.
+- All [automations](/automations) supported by {{< docref "/components/ota" >}}.
 
 > [!NOTE]
 > After a serial upload, ESP8266 modules must be reset before OTA updates will work. If you attempt to perform an OTA

--- a/content/components/ota/http_request.md
+++ b/content/components/ota/http_request.md
@@ -25,14 +25,14 @@ ota:
 
 ## Configuration variables
 
-- All [automations](#automation) supported by {{< docref "/components/ota" >}}.
+- All [automations](/automations) supported by {{< docref "/components/ota" >}}.
 
 {{< anchor "ota_http_request-flash_action" >}}
 
 ## `ota.http_request.flash` Action
 
 This action triggers the download and installation of the updated firmware from the configured URL. As it's an
-ESPHome [action](#config-action), it may be used in any ESPHome [automation(s)](#automation).
+ESPHome [action](#config-action), it may be used in any ESPHome [automation(s)](/automations).
 
 ```yaml
 on_...:

--- a/content/components/ota/web_server.md
+++ b/content/components/ota/web_server.md
@@ -37,7 +37,7 @@ ota:
 ## Configuration variables
 
 - **id** (*Optional*, [ID](#config-id)): Manually specify the ID used for code generation.
-- All [automations](#automation) supported by {{< docref "/components/ota" >}}.
+- All [automations](/automations) supported by {{< docref "/components/ota" >}}.
 
 > [!NOTE]
 > This platform requires the {{< docref "/components/web_server" >}} component to be configured in your device.

--- a/content/components/output/sigma_delta_output.md
+++ b/content/components/output/sigma_delta_output.md
@@ -51,9 +51,9 @@ Configuration variables:
 
 - **update_interval** (**Required**, [Time](#config-time)): The cycle interval at which the output is recalculated.
 - **pin** (*Optional*, [Pin Schema](#config-pin_schema)): The pin to pulse.
-- **state_change_action** (*Optional*, [Automation](#automation)): An automation to perform when the load is switched. If a lambda is used the boolean `state` parameter holds the new status.
-- **turn_on_action** (*Optional*, [Automation](#automation)): An automation to perform when the load is turned on. Can be used to control for example a switch or output component.
-- **turn_off_action** (*Optional*, [Automation](#automation)): An automation to perform when the load is turned off. `turn_on_action` and `turn_off_action` must be configured together.
+- **state_change_action** (*Optional*, [Automation](/automations)): An automation to perform when the load is switched. If a lambda is used the boolean `state` parameter holds the new status.
+- **turn_on_action** (*Optional*, [Automation](/automations)): An automation to perform when the load is turned on. Can be used to control for example a switch or output component.
+- **turn_off_action** (*Optional*, [Automation](/automations)): An automation to perform when the load is turned off. `turn_on_action` and `turn_off_action` must be configured together.
 - All options from [Output](#config-output).
 
 > [!NOTE]

--- a/content/components/output/slow_pwm.md
+++ b/content/components/output/slow_pwm.md
@@ -34,9 +34,9 @@ output:
   period at 50% duty would result in the pin being turned on for 5s, then off for 5s)
 
 - **pin** (*Optional*, [Pin Schema](#config-pin_schema)): The pin to pulse.
-- **state_change_action** (*Optional*, [Automation](#automation)): An automation to perform when the load is switched. If a lambda is used the boolean `state` parameter holds the new status.
-- **turn_on_action** (*Optional*, [Automation](#automation)): An automation to perform when the load is turned on. Can be used to control for example a switch or output component.
-- **turn_off_action** (*Optional*, [Automation](#automation)): An automation to perform when the load is turned off. `turn_on_action` and `turn_off_action` must be configured together.
+- **state_change_action** (*Optional*, [Automation](/automations)): An automation to perform when the load is switched. If a lambda is used the boolean `state` parameter holds the new status.
+- **turn_on_action** (*Optional*, [Automation](/automations)): An automation to perform when the load is turned on. Can be used to control for example a switch or output component.
+- **turn_off_action** (*Optional*, [Automation](/automations)): An automation to perform when the load is turned off. `turn_on_action` and `turn_off_action` must be configured together.
 - **restart_cycle_on_state_change** (*Optional*, boolean): Restart a timer of a cycle
   when new state is set. Defaults to `false`.
 

--- a/content/components/output/template.md
+++ b/content/components/output/template.md
@@ -33,7 +33,7 @@ output:
 
 - **id** (**Required**, [ID](#config-id)): The id to use for this output component.
 - **type** (**Required**, string): The type of output. One of `binary` and `float`.
-- **write_action** (**Required**, [Automation](#automation)): An automation to perform
+- **write_action** (**Required**, [Automation](/automations)): An automation to perform
   when the state of the output is updated.
 
 - All other options from [Output](#config-output).
@@ -70,4 +70,4 @@ Complete example: [Sonoff Dual Light Switch](https://devices.esphome.io/devices/
 ## See Also
 
 - {{< docref "/components/output" >}}
-- [Automation](#automation)
+- [Automation](/automations)

--- a/content/components/packet_transport/_index.md
+++ b/content/components/packet_transport/_index.md
@@ -282,7 +282,7 @@ binary_sensor:
 
 - {{< docref "/components/binary_sensor/packet_transport" >}}
 - {{< docref "/components/sensor/packet_transport" >}}
-- [Automation](#automation)
+- [Automation](/automations)
 - {{< apiref "packet_transport/packet_transport.h" "packet_transport/packet_transport.h" >}}
 
 [^f1]: As known in 2025.02.

--- a/content/components/packet_transport/sx126x.md
+++ b/content/components/packet_transport/sx126x.md
@@ -56,5 +56,5 @@ sensor:
 - {{< docref "/components/sx126x" >}}
 - {{< docref "/components/binary_sensor/packet_transport" >}}
 - {{< docref "/components/sensor/packet_transport" >}}
-- [Automation](#automation)
+- [Automation](/automations)
 - {{< apiref "packet_transport/packet_transport.h" "packet_transport/packet_transport.h" >}}

--- a/content/components/packet_transport/sx127x.md
+++ b/content/components/packet_transport/sx127x.md
@@ -52,5 +52,5 @@ sensor:
 - {{< docref "/components/sx127x" >}}
 - {{< docref "/components/binary_sensor/packet_transport" >}}
 - {{< docref "/components/sensor/packet_transport" >}}
-- [Automation](#automation)
+- [Automation](/automations)
 - {{< apiref "packet_transport/packet_transport.h" "packet_transport/packet_transport.h" >}}

--- a/content/components/packet_transport/uart.md
+++ b/content/components/packet_transport/uart.md
@@ -41,5 +41,5 @@ sensor:
 - {{< docref "/components/uart" >}}
 - {{< docref "/components/binary_sensor/packet_transport" >}}
 - {{< docref "/components/sensor/packet_transport" >}}
-- [Automation](#automation)
+- [Automation](/automations)
 - {{< apiref "packet_transport/packet_transport.h" "packet_transport/packet_transport.h" >}}

--- a/content/components/packet_transport/udp.md
+++ b/content/components/packet_transport/udp.md
@@ -38,5 +38,5 @@ sensor:
 - {{< docref "/components/udp" >}}
 - {{< docref "/components/binary_sensor/packet_transport" >}}
 - {{< docref "/components/sensor/packet_transport" >}}
-- [Automation](#automation)
+- [Automation](/automations)
 - {{< apiref "packet_transport/packet_transport.h" "packet_transport/packet_transport.h" >}}

--- a/content/components/pipsolar.md
+++ b/content/components/pipsolar.md
@@ -301,7 +301,7 @@ All sensors are normal text sensors... so all text sensor variables are working 
 
 ## `output.pipsolar.set_level` Action
 
-To use your outputs in [automations](#automation) or templates, you can use this action to set the
+To use your outputs in [automations](/automations) or templates, you can use this action to set the
 target level of the output.
 
 ```yaml

--- a/content/components/pn7150.md
+++ b/content/components/pn7150.md
@@ -52,13 +52,13 @@ pn7150_i2c:
 - **tag_ttl** (*Optional*, [Time](#config-time)): The duration that must elapse after the PN7150 is no longer able to
   "see" a tag before it is considered to have been removed from the reader.
 
-- **on_tag** (*Optional*, [Automation](#automation)): An automation to perform when a tag is first read. See
+- **on_tag** (*Optional*, [Automation](/automations)): An automation to perform when a tag is first read. See
   [`on_tag` Trigger](#pn7150-on_tag).
 
-- **on_tag_removed** (*Optional*, [Automation](#automation)): An automation to perform after a tag is removed. See
+- **on_tag_removed** (*Optional*, [Automation](/automations)): An automation to perform after a tag is removed. See
   [`on_tag_removed` Trigger](#pn7150-on_tag_removed).
 
-- **on_emulated_tag_scan** (*Optional*, [Automation](#automation)): An automation to perform when the PN7150 is
+- **on_emulated_tag_scan** (*Optional*, [Automation](/automations)): An automation to perform when the PN7150 is
   scanned by another tag reader (such as a smartphone). See [`on_emulated_tag_scan` Trigger](#pn7150-on_emulated_tag_scan).
 
 - **i2c_id** (*Optional*, [ID](#config-id)): Manually specify the ID of the [I²C Component](#i2c) if you need

--- a/content/components/pn7160.md
+++ b/content/components/pn7160.md
@@ -67,13 +67,13 @@ pn7160_spi:
 - **tag_ttl** (*Optional*, [Time](#config-time)): The duration that must elapse after the PN7160 is no longer able to
   "see" a tag before it is considered to have been removed from the reader.
 
-- **on_tag** (*Optional*, [Automation](#automation)): An automation to perform when a tag is first read. See
+- **on_tag** (*Optional*, [Automation](/automations)): An automation to perform when a tag is first read. See
   [`on_tag` Trigger](#pn7160-on_tag).
 
-- **on_tag_removed** (*Optional*, [Automation](#automation)): An automation to perform after a tag is removed. See
+- **on_tag_removed** (*Optional*, [Automation](/automations)): An automation to perform after a tag is removed. See
   [`on_tag_removed` Trigger](#pn7160-on_tag_removed).
 
-- **on_emulated_tag_scan** (*Optional*, [Automation](#automation)): An automation to perform when the PN7160 is
+- **on_emulated_tag_scan** (*Optional*, [Automation](/automations)): An automation to perform when the PN7160 is
   scanned by another tag reader (such as a smartphone). See [`on_emulated_tag_scan` Trigger](#pn7160-on_emulated_tag_scan).
 
 - **spi_id** (*Optional*, [ID](#config-id)): Manually specify the ID of the [SPI Component](#spi) if you want
@@ -114,13 +114,13 @@ pn7160_i2c:
 - **tag_ttl** (*Optional*, [Time](#config-time)): The duration that must elapse after the PN7160 is no longer able to
   "see" a tag before it is considered to have been removed from the reader.
 
-- **on_tag** (*Optional*, [Automation](#automation)): An automation to perform when a tag is first read. See
+- **on_tag** (*Optional*, [Automation](/automations)): An automation to perform when a tag is first read. See
   [`on_tag` Trigger](#pn7160-on_tag).
 
-- **on_tag_removed** (*Optional*, [Automation](#automation)): An automation to perform after a tag is removed. See
+- **on_tag_removed** (*Optional*, [Automation](/automations)): An automation to perform after a tag is removed. See
   [`on_tag_removed` Trigger](#pn7160-on_tag_removed).
 
-- **on_emulated_tag_scan** (*Optional*, [Automation](#automation)): An automation to perform when the PN7160 is
+- **on_emulated_tag_scan** (*Optional*, [Automation](/automations)): An automation to perform when the PN7160 is
   scanned by another tag reader (such as a smartphone). See [`on_emulated_tag_scan` Trigger](#pn7160-on_emulated_tag_scan).
 
 - **i2c_id** (*Optional*, [ID](#config-id)): Manually specify the ID of the [I²C Component](#i2c) if you need

--- a/content/components/remote_receiver.md
+++ b/content/components/remote_receiver.md
@@ -146,136 +146,136 @@ To enable signal demodulation, configure the signal carrier frequency and duty c
 
 ## Automations
 
-- **on_abbwelcome** (*Optional*, [Automation](#automation)): An automation to perform when a
+- **on_abbwelcome** (*Optional*, [Automation](/automations)): An automation to perform when a
   ABB-Welcome code has been decoded. A variable `x` of type {{< apiclass "remote_base::ABBWelcomeData" "remote_base::ABBWelcomeData" >}}
   is passed to the automation for use in lambdas.
 
-- **on_aeha** (*Optional*, [Automation](#automation)): An automation to perform when a
+- **on_aeha** (*Optional*, [Automation](/automations)): An automation to perform when a
   AEHA remote code has been decoded. A variable `x` of type {{< apistruct "remote_base::AEHAData" "remote_base::AEHAData" >}}
   is passed to the automation for use in lambdas.
 
-- **on_beo4** (*Optional*, [Automation](#automation)): An automation to perform when a
+- **on_beo4** (*Optional*, [Automation](/automations)): An automation to perform when a
   B&O Beo4 infrared remote code has been decoded. A variable `x` of type {{< apistruct "remote_base::Beo4Data" "remote_base::Beo4Data" >}}
   is passed to the automation for use in lambdas.
 
-- **on_byronsx** (*Optional*, [Automation](#automation)): An automation to perform when a
+- **on_byronsx** (*Optional*, [Automation](/automations)): An automation to perform when a
   Byron SX doorbell RF code has been decoded. A variable `x` of type {{< apistruct "remote_base::ByronSXData" "remote_base::ByronSXData" >}}
   is passed to the automation for use in lambdas.
 
-- **on_canalsat** (*Optional*, [Automation](#automation)): An automation to perform when a
+- **on_canalsat** (*Optional*, [Automation](/automations)): An automation to perform when a
   CanalSat remote code has been decoded. A variable `x` of type {{< apistruct "remote_base::CanalSatData" "remote_base::CanalSatData" >}}
   is passed to the automation for use in lambdas.
 
-- **on_canalsatld** (*Optional*, [Automation](#automation)): An automation to perform when a
+- **on_canalsatld** (*Optional*, [Automation](/automations)): An automation to perform when a
   CanalSatLD remote code has been decoded. A variable `x` of type {{< apistruct "remote_base::CanalSatLDData" "remote_base::CanalSatLDData" >}}
   is passed to the automation for use in lambdas.
 
-- **on_coolix** (*Optional*, [Automation](#automation)): An automation to perform when a
+- **on_coolix** (*Optional*, [Automation](/automations)): An automation to perform when a
   Coolix remote code has been decoded. A variable `x` of type {{< apistruct "remote_base::CoolixData" "remote_base::CoolixData" >}}
   is passed to the automation for use in lambdas.
 
-- **on_dish** (*Optional*, [Automation](#automation)): An automation to perform when a
+- **on_dish** (*Optional*, [Automation](/automations)): An automation to perform when a
   dish network remote code has been decoded. A variable `x` of type {{< apistruct "remote_base::DishData" "remote_base::DishData" >}}
   is passed to the automation for use in lambdas.
   Beware that Dish remotes use a different carrier frequency (57.6kHz) that many receiver hardware don't decode.
 
-- **on_dooya** (*Optional*, [Automation](#automation)): An automation to perform when a
+- **on_dooya** (*Optional*, [Automation](/automations)): An automation to perform when a
   Dooya RF remote code has been decoded. A variable `x` of type {{< apistruct "remote_base::DooyaData" "remote_base::DooyaData" >}}
   is passed to the automation for use in lambdas.
 
-- **on_drayton** (*Optional*, [Automation](#automation)): An automation to perform when a
+- **on_drayton** (*Optional*, [Automation](/automations)): An automation to perform when a
   Drayton Digistat RF code has been decoded. A variable `x` of type {{< apistruct "remote_base::DraytonData" "remote_base::DraytonData" >}}
   is passed to the automation for use in lambdas.
 
-- **on_gobox** (*Optional*, [Automation](#automation)): An automation to perform when a
+- **on_gobox** (*Optional*, [Automation](/automations)): An automation to perform when a
   Go-Box remote code has been decoded. A variable `x` of type {{< apistruct "remote_base::GoboxData" "remote_base::GoboxData" >}}
   is passed to the automation for use in lambdas.
 
-- **on_jvc** (*Optional*, [Automation](#automation)): An automation to perform when a
+- **on_jvc** (*Optional*, [Automation](/automations)): An automation to perform when a
   JVC remote code has been decoded. A variable `x` of type {{< apistruct "remote_base::JVCData" "remote_base::JVCData" >}}
   is passed to the automation for use in lambdas.
 
-- **on_keeloq** (*Optional*, [Automation](#automation)): An automation to perform when a
+- **on_keeloq** (*Optional*, [Automation](/automations)): An automation to perform when a
   KeeLoq RF code has been decoded. A variable `x` of type {{< apistruct "remote_base::KeeloqData" "remote_base::KeeloqData" >}}
   is passed to the automation for use in lambdas.
 
-- **on_haier** (*Optional*, [Automation](#automation)): An automation to perform when a
+- **on_haier** (*Optional*, [Automation](/automations)): An automation to perform when a
   Haier remote code has been decoded. A variable `x` of type {{< apistruct "remote_base::HaierData" "remote_base::HaierData" >}}
   is passed to the automation for use in lambdas.
 
-- **on_lg** (*Optional*, [Automation](#automation)): An automation to perform when a
+- **on_lg** (*Optional*, [Automation](/automations)): An automation to perform when a
   LG remote code has been decoded. A variable `x` of type {{< apistruct "remote_base::LGData" "remote_base::LGData" >}}
   is passed to the automation for use in lambdas.
 
-- **on_magiquest** (*Optional*, [Automation](#automation)): An automation to perform when a
+- **on_magiquest** (*Optional*, [Automation](/automations)): An automation to perform when a
   MagiQuest wand remote code has been decoded. A variable `x` of type {{< apistruct "remote_base::MagiQuestData" "remote_base::MagiQuestData" >}}
   is passed to the automation for use in lambdas.
 
-- **on_midea** (*Optional*, [Automation](#automation)): An automation to perform when a
+- **on_midea** (*Optional*, [Automation](/automations)): An automation to perform when a
   Midea remote code has been decoded. A variable `x` of type {{< apiclass "remote_base::MideaData" "remote_base::MideaData" >}}
   is passed to the automation for use in lambdas.
 
-- **on_nec** (*Optional*, [Automation](#automation)): An automation to perform when a
+- **on_nec** (*Optional*, [Automation](/automations)): An automation to perform when a
   NEC remote code has been decoded. A variable `x` of type {{< apistruct "remote_base::NECData" "remote_base::NECData" >}}
   is passed to the automation for use in lambdas.
 
-- **on_nexa** (*Optional*, [Automation](#automation)): An automation to perform when a
+- **on_nexa** (*Optional*, [Automation](/automations)): An automation to perform when a
   Nexa RF code has been decoded. A variable `x` of type {{< apistruct "remote_base::NexaData" "remote_base::NexaData" >}}
   is passed to the automation for use in lambdas.
 
-- **on_panasonic** (*Optional*, [Automation](#automation)): An automation to perform when a
+- **on_panasonic** (*Optional*, [Automation](/automations)): An automation to perform when a
   Panasonic remote code has been decoded. A variable `x` of type {{< apistruct "remote_base::PanasonicData" "remote_base::PanasonicData" >}}
   is passed to the automation for use in lambdas.
 
-- **on_pioneer** (*Optional*, [Automation](#automation)): An automation to perform when a
+- **on_pioneer** (*Optional*, [Automation](/automations)): An automation to perform when a
   pioneer remote code has been decoded. A variable `x` of type {{< apistruct "remote_base::PioneerData" "remote_base::PioneerData" >}}
   is passed to the automation for use in lambdas.
 
-- **on_pronto** (*Optional*, [Automation](#automation)): An automation to perform when a
+- **on_pronto** (*Optional*, [Automation](/automations)): An automation to perform when a
   Pronto remote code has been decoded. A variable `x` of type `std::string`
   is passed to the automation for use in lambdas.
 
-- **on_raw** (*Optional*, [Automation](#automation)): An automation to perform when a
+- **on_raw** (*Optional*, [Automation](/automations)): An automation to perform when a
   raw remote code has been decoded. A variable `x` of type `std::vector<int>`
   is passed to the automation for use in lambdas.
 
-- **on_rc5** (*Optional*, [Automation](#automation)): An automation to perform when a
+- **on_rc5** (*Optional*, [Automation](/automations)): An automation to perform when a
   RC5 remote code has been decoded. A variable `x` of type {{< apistruct "remote_base::RC5Data" "remote_base::RC5Data" >}}
   is passed to the automation for use in lambdas.
 
-- **on_rc6** (*Optional*, [Automation](#automation)): An automation to perform when a
+- **on_rc6** (*Optional*, [Automation](/automations)): An automation to perform when a
   RC6 remote code has been decoded. A variable `x` of type {{< apistruct "remote_base::RC6Data" "remote_base::RC6Data" >}}
   is passed to the automation for use in lambdas.
 
-- **on_rc_switch** (*Optional*, [Automation](#automation)): An automation to perform when a
+- **on_rc_switch** (*Optional*, [Automation](/automations)): An automation to perform when a
   RCSwitch RF code has been decoded. A variable `x` of type {{< apistruct "remote_base::RCSwitchData" "remote_base::RCSwitchData" >}}
   is passed to the automation for use in lambdas.
 
-- **on_roomba** (*Optional*, [Automation](#automation)): An automation to perform when a
+- **on_roomba** (*Optional*, [Automation](/automations)): An automation to perform when a
   Roomba remote code has been decoded. A variable `x` of type {{< apistruct "remote_base::RoombaData" "remote_base::RoombaData" >}}
   is passed to the automation for use in lambdas.
 
-- **on_samsung** (*Optional*, [Automation](#automation)): An automation to perform when a
+- **on_samsung** (*Optional*, [Automation](/automations)): An automation to perform when a
   Samsung remote code has been decoded. A variable `x` of type {{< apistruct "remote_base::SamsungData" "remote_base::SamsungData" >}}
   is passed to the automation for use in lambdas.
 
-- **on_samsung36** (*Optional*, [Automation](#automation)): An automation to perform when a
+- **on_samsung36** (*Optional*, [Automation](/automations)): An automation to perform when a
   Samsung36 remote code has been decoded. A variable `x` of type {{< apistruct "remote_base::Samsung36Data" "remote_base::Samsung36Data" >}}
   is passed to the automation for use in lambdas.
 
-- **on_sony** (*Optional*, [Automation](#automation)): An automation to perform when a
+- **on_sony** (*Optional*, [Automation](/automations)): An automation to perform when a
   Sony remote code has been decoded. A variable `x` of type {{< apistruct "remote_base::SonyData" "remote_base::SonyData" >}}
   is passed to the automation for use in lambdas.
 
-- **on_toshiba_ac** (*Optional*, [Automation](#automation)): An automation to perform when a
+- **on_toshiba_ac** (*Optional*, [Automation](/automations)): An automation to perform when a
   Toshiba AC remote code has been decoded. A variable `x` of type {{< apistruct "remote_base::ToshibaAcData" "remote_base::ToshibaAcData" >}}
   is passed to the automation for use in lambdas.
 
-- **on_mirage** (*Optional*, [Automation](#automation)): An automation to perform when a
+- **on_mirage** (*Optional*, [Automation](/automations)): An automation to perform when a
   Mirage remote code has been decoded. A variable `x` of type {{< apistruct "remote_base::MirageData" "remote_base::MirageData" >}}
   is passed to the automation for use in lambdas.
 
-- **on_toto** (*Optional*, [Automation](#automation)): An automation to perform when a
+- **on_toto** (*Optional*, [Automation](/automations)): An automation to perform when a
   Toto remote code has been decoded. A variable `x` of type {{< apistruct "remote_base::TotoData" "remote_base::TotoData" >}}
   is passed to the automation for use in lambdas.
 

--- a/content/components/remote_transmitter.md
+++ b/content/components/remote_transmitter.md
@@ -65,10 +65,10 @@ remote_transmitter:
 
 ## Automations
 
-- **on_transmit** (*Optional*, [Automation](#automation)): An automation to perform before
+- **on_transmit** (*Optional*, [Automation](/automations)): An automation to perform before
   data is sent. Useful if the radio / IR hardware needs to change state or power on.
 
-- **on_complete** (*Optional*, [Automation](#automation)): An automation to perform after
+- **on_complete** (*Optional*, [Automation](/automations)): An automation to perform after
   data has been sent. Useful if the radio / IR hardware needs to change state or power off.
 
 ```yaml

--- a/content/components/rf_bridge.md
+++ b/content/components/rf_bridge.md
@@ -40,7 +40,7 @@ rf_bridge:
 
 * **id** (*Optional*, [ID](#config-id)): Manually specify the ID of the RF bridge.
 * **uart_id** (*Optional*, [ID](#config-id)): Manually specify the ID of the UART hub that the bridge component uses.
-* **on_code_received** (*Optional*, [Automation](#automation)): An action to be
+* **on_code_received** (*Optional*, [Automation](/automations)): An action to be
   performed when a code is received. See [`on_code_received` Trigger](#rf_bridge-on_code_received).
 
 {{< anchor "rf_bridge-on_code_received" >}}

--- a/content/components/rtttl.md
+++ b/content/components/rtttl.md
@@ -60,7 +60,7 @@ rtttl:
 - **speaker** (**Exclusive**, [ID](#config-id)): The id of the [speaker](#i2s_audio) to play the song on.
 - **id** (*Optional*, [ID](#config-id)): Manually specify the ID used for code generation.
 - **gain** (*Optional*, Percentage): With this value you can set the volume of the sound.
-- **on_finished_playback** (*Optional*, [Automation](#automation)): An action to be
+- **on_finished_playback** (*Optional*, [Automation](/automations)): An action to be
   performed when playback is finished.
 
 Note: You can only use the **output** or **speaker** variable, not both at the same time.

--- a/content/components/runtime_stats.md
+++ b/content/components/runtime_stats.md
@@ -101,5 +101,5 @@ Components are sorted by total execution time (descending) to highlight the most
 
 - {{< docref "debug/" >}}
 - {{< docref "logger/" >}}
-- [Automation](#automation)
+- [Automation](/automations)
 - {{< apiref "runtime_stats/runtime_stats.h" "runtime_stats/runtime_stats.h" >}}

--- a/content/components/safe_mode.md
+++ b/content/components/safe_mode.md
@@ -38,10 +38,10 @@ safe_mode:
 - **reboot_timeout** (*Optional*, [Time](#config-time)): The amount of time to wait before rebooting when in safe mode.
    Defaults to `5min`.
 
-- **on_safe_mode** (*Optional*, [Automation](#automation)): An action to be performed once when safe mode is invoked.
+- **on_safe_mode** (*Optional*, [Automation](/automations)): An action to be performed once when safe mode is invoked.
 
 > [!WARNING]
-> The `on_safe_mode` [automation](#automation) is intended for use by recovery actions **only**.
+> The `on_safe_mode` [automation](/automations) is intended for use by recovery actions **only**.
 >
 > As mentioned above, in safe mode, all components are disabled except serial logging, network (Wi-Fi or Ethernet)
 > and OTA component(s).

--- a/content/components/select/_index.md
+++ b/content/components/select/_index.md
@@ -55,7 +55,7 @@ Configuration variables:
 
 Automations:
 
-- **on_value** (*Optional*, [Automation](#automation)): An automation to perform
+- **on_value** (*Optional*, [Automation](/automations)): An automation to perform
   when a new value is published. See [`on_value`](#select-on_value).
 
 MQTT Options:
@@ -86,7 +86,7 @@ select:
             args: ["x.c_str()", "i"]
 ```
 
-Configuration variables: See [Automation](#automation).
+Configuration variables: See [Automation](/automations).
 
 {{< anchor "select-set_action" >}}
 

--- a/content/components/select/logger.md
+++ b/content/components/select/logger.md
@@ -21,5 +21,5 @@ select:
 
 ## See Also
 
-- [Automation](#automation)
+- [Automation](/automations)
 - {{< docref "/components/logger" >}}

--- a/content/components/select/modbus_controller.md
+++ b/content/components/select/modbus_controller.md
@@ -146,5 +146,5 @@ select:
 - {{< docref "/components/switch/modbus_controller" >}}
 - {{< docref "/components/number/modbus_controller" >}}
 - {{< docref "/components/text_sensor/modbus_controller" >}}
-- [Automation](#automation)
+- [Automation](/automations)
 - <https://www.modbustools.com/modbus.html>

--- a/content/components/select/template.md
+++ b/content/components/select/template.md
@@ -59,5 +59,5 @@ with the [`select.set` Action](#select-set_action).
 
 ## See Also
 
-- [Automation](#automation)
+- [Automation](/automations)
 - {{< apiref "template/select/template_select.h" "template/select/template_select.h" >}}

--- a/content/components/sensor/_index.md
+++ b/content/components/sensor/_index.md
@@ -94,13 +94,13 @@ Configuration variables:
 
 Automations:
 
-- **on_value** (*Optional*, [Automation](#automation)): An automation to perform
+- **on_value** (*Optional*, [Automation](/automations)): An automation to perform
   when a new value is published. See [`on_value`](#sensor-on_value).
 
-- **on_value_range** (*Optional*, [Automation](#automation)): An automation to perform
+- **on_value_range** (*Optional*, [Automation](/automations)): An automation to perform
   when a published value transition from outside to a range to inside. See [`on_value_range`](#sensor-on_value_range).
 
-- **on_raw_value** (*Optional*, [Automation](#automation)): An automation to perform
+- **on_raw_value** (*Optional*, [Automation](/automations)): An automation to perform
   when a raw value is received that hasn't passed through any filters. See [`on_raw_value`](#sensor-on_raw_value).
 
 MQTT Options:
@@ -325,7 +325,7 @@ sensor:
             red: !lambda "return x/255;"
 ```
 
-Configuration variables: See [Automation](#automation).
+Configuration variables: See [Automation](/automations).
 
 {{< anchor "sensor-on_value_range" >}}
 
@@ -362,7 +362,7 @@ Configuration variables:
 
 - **above** (*Optional*, float): The minimum for the trigger.
 - **below** (*Optional*, float): The maximum for the trigger.
-- See [Automation](#automation).
+- See [Automation](/automations).
 
 {{< anchor "sensor-on_raw_value" >}}
 
@@ -383,7 +383,7 @@ sensor:
             red: !lambda "return x/255;"
 ```
 
-Configuration variables: See [Automation](#automation).
+Configuration variables: See [Automation](/automations).
 
 {{< anchor "sensor-in_range_condition" >}}
 

--- a/content/components/sensor/am43.md
+++ b/content/components/sensor/am43.md
@@ -60,5 +60,5 @@ For more details on setting up this device, see the
 
 - {{< docref "index/" >}}
 - {{< docref "/components/cover/am43" >}}
-- [Automation](#automation)
+- [Automation](/automations)
 - {{< apiref "sensor/am43/am43.h" "sensor/am43/am43.h" >}}

--- a/content/components/sensor/ble_client.md
+++ b/content/components/sensor/ble_client.md
@@ -71,7 +71,7 @@ characteristic options:
 
 Automations:
 
-- **on_notify** (*Optional*, [Automation](#automation)): An automation to
+- **on_notify** (*Optional*, [Automation](/automations)): An automation to
   perform when a notify message is received from the device. See [`on_notify`](#ble_sensor-on_notify).
 
 {{< anchor "ble-sensor-lambda" >}}

--- a/content/components/sensor/duty_time.md
+++ b/content/components/sensor/duty_time.md
@@ -109,6 +109,6 @@ on_...:
 
 - [Base Sensor Configuration](#config-sensor)
 - [Templates](#config-lambda)
-- [Automation](#automation)
+- [Automation](/automations)
 - {{< docref "/components/binary_sensor" >}}
 - {{< apiref "duty_time/duty_time_sensor.h" "duty_time/duty_time_sensor.h" >}}

--- a/content/components/sensor/homeassistant.md
+++ b/content/components/sensor/homeassistant.md
@@ -55,5 +55,5 @@ sensor:
 ## See Also
 
 - [Sensor Filters](#sensor-filters)
-- [Automation](#automation)
+- [Automation](/automations)
 - {{< apiref "homeassistant/sensor/homeassistant_sensor.h" "homeassistant/sensor/homeassistant_sensor.h" >}}

--- a/content/components/sensor/packet_transport.md
+++ b/content/components/sensor/packet_transport.md
@@ -48,4 +48,4 @@ configured.
 - {{< docref "/components/packet_transport" >}}
 - {{< docref "/components/binary_sensor" >}}
 - {{< docref "/components/udp" >}}
-- [Automation](#automation)
+- [Automation](/automations)

--- a/content/components/sensor/rotary_encoder.md
+++ b/content/components/sensor/rotary_encoder.md
@@ -78,10 +78,10 @@ pin_a:
   - `RESTORE_DEFAULT_ZERO` - (Default) Attempt to restore state and default to zero (0) if not possible to restore.
   - `ALWAYS_ZERO` - Always initialize the counter with value zero (0).
 
-- **on_clockwise** (*Optional*, [Automation](#automation)): Actions to be performed when
+- **on_clockwise** (*Optional*, [Automation](/automations)): Actions to be performed when
   the knob is turned clockwise. See [`on_clockwise` and `on_anticlockwise` Triggers](#sensor-rotary_encoder-triggers).
 
-- **on_anticlockwise** (*Optional*, [Automation](#automation)): Actions to be performed when
+- **on_anticlockwise** (*Optional*, [Automation](/automations)): Actions to be performed when
   the knob is turned anticlockwise. See [`on_clockwise` and `on_anticlockwise` Triggers](#sensor-rotary_encoder-triggers).
 
 - All other options from [Sensor](#config-sensor).

--- a/content/components/sensor/template.md
+++ b/content/components/sensor/template.md
@@ -112,5 +112,5 @@ sensor:
 ## See Also
 
 - [Sensor Filters](#sensor-filters)
-- [Automation](#automation)
+- [Automation](/automations)
 - {{< apiref "template/sensor/template_sensor.h" "template/sensor/template_sensor.h" >}}

--- a/content/components/servo.md
+++ b/content/components/servo.md
@@ -74,7 +74,7 @@ Advanced Options:
 
 ## `servo.write` Action
 
-To use your servo motor in [automations](#automation) or templates, you can use this action to set the
+To use your servo motor in [automations](/automations) or templates, you can use this action to set the
 target level of the servo from -100% to 100%.
 
 - -100% (= -1.0) is the minimum value of the servo. For continuous-rotation servos this will

--- a/content/components/sim800l.md
+++ b/content/components/sim800l.md
@@ -39,17 +39,17 @@ sim800l:
 
 - **uart_id** (*Optional*, [ID](#config-id)): Manually specify the ID of the UART hub.
 - **id** (*Optional*, [ID](#config-id)): Manually specify the ID used for code generation.
-- **on_sms_received** (*Optional*, [Automation](#automation)): An action to be
+- **on_sms_received** (*Optional*, [Automation](/automations)): An action to be
   performed when an SMS is received. See [`on_sms_received` Trigger](#sim800l-on_sms_received).
 
-- **on_incoming_call** (*Optional*, [Automation](#automation)): An action to be
+- **on_incoming_call** (*Optional*, [Automation](/automations)): An action to be
   performed when a call is received. See [`on_incoming_call` Trigger](#sim800l-on_incoming_call).
 
-- **on_call_connected** (*Optional*, [Automation](#automation)): An action to be
+- **on_call_connected** (*Optional*, [Automation](/automations)): An action to be
   performed when a call is connected, either because an outgoing call accepted is
   accepted or an incoming call answered.
 
-- **on_call_disconnected** (*Optional*, [Automation](#automation)): An action to be
+- **on_call_disconnected** (*Optional*, [Automation](/automations)): An action to be
   performed when a call is disconnected.
 
 ## Sensor

--- a/content/components/sml.md
+++ b/content/components/sml.md
@@ -103,7 +103,7 @@ text_sensor:
 
 ## Automations
 
-- **on_data** (*Optional*, [Automation](#automation)): An automation to perform when a
+- **on_data** (*Optional*, [Automation](/automations)): An automation to perform when a
   SML message is received. See [`on_data` Trigger](#sml-on-data).
 
 {{< anchor "sml-on-data" >}}

--- a/content/components/stepper/_index.md
+++ b/content/components/stepper/_index.md
@@ -136,7 +136,7 @@ Configuration variables:
 
 ## `stepper.set_target` Action
 
-To use your stepper motor in [automations](#automation) or templates, you can use this action to set the target
+To use your stepper motor in [automations](/automations) or templates, you can use this action to set the target
 position (in steps). The stepper will always run towards the target position and stop once it has reached the target.
 
 ```yaml

--- a/content/components/sun.md
+++ b/content/components/sun.md
@@ -49,13 +49,13 @@ sun:
         - logger.log: Good evening!
 ```
 
-- **on_sunrise** (*Optional*, [Automation](#automation)): An automation to perform at sunrise
+- **on_sunrise** (*Optional*, [Automation](/automations)): An automation to perform at sunrise
   when the sun crosses a specified angle.
 
   - **elevation** (*Optional*, float): The elevation to cross. Defaults to -0.833° (the horizon, slightly less than 0°
     to compensate for atmospheric refraction).
 
-- **on_sunset** (*Optional*, [Automation](#automation)): An automation to perform at sunset
+- **on_sunset** (*Optional*, [Automation](/automations)): An automation to perform at sunset
   when the sun crosses a specified angle.
 
   - **elevation** (*Optional*, float): The elevation to cross. Defaults to -0.833° (the horizon, slightly less than 0°

--- a/content/components/switch/homeassistant.md
+++ b/content/components/switch/homeassistant.md
@@ -43,5 +43,5 @@ The following entity domains from Home Assistant are supported by this platform.
 
 ## See Also
 
-- [Automation](#automation)
+- [Automation](/automations)
 - {{< apiref "homeassistant/switch/homeassistant_switch.h" "homeassistant/switch/homeassistant_switch.h" >}}

--- a/content/components/sx126x.md
+++ b/content/components/sx126x.md
@@ -118,7 +118,7 @@ sx126x:
 
 ### Triggers
 
-- **on_packet** (*Optional*, [Automation](#automation)): An automation to perform when a packet has
+- **on_packet** (*Optional*, [Automation](/automations)): An automation to perform when a packet has
   been decoded. Variable x of type `std::vector<uint8_t>` and rssi of type `float` are passed to the
   automation for use in lambdas. In LoRa mode the variable snr is also available.
 

--- a/content/components/sx127x.md
+++ b/content/components/sx127x.md
@@ -119,7 +119,7 @@ sx127x:
 
 ### Triggers
 
-- **on_packet** (*Optional*, [Automation](#automation)): An automation to perform in packet mode
+- **on_packet** (*Optional*, [Automation](/automations)): An automation to perform in packet mode
   when a packet has been decoded. A variable x of type std::vector<uint8_t> is passed to the automation
   for use in lambdas. In LoRa mode the variables snr and rssi are also available.
 

--- a/content/components/sx1509.md
+++ b/content/components/sx1509.md
@@ -62,7 +62,7 @@ up to 8x8 matrix (i.e. 64 keys).
   - **keys** (*Optional*, string): The keys present on the matrix, from top left to bottom right,
     row by row. Required for `key_collector`.
 
-  - **on_key** (*Optional*, [Automation](#automation)): An automation to perform
+  - **on_key** (*Optional*, [Automation](/automations)): An automation to perform
     when a key has been pressed. The key is in a variable called `x`.
 
 {{< img src="sx1509-keypad.jpg" alt="Image" caption="SX1509 pins for keypad setup (image from the datasheet)." width="80.0%" class="align-center" >}}

--- a/content/components/text/_index.md
+++ b/content/components/text/_index.md
@@ -57,7 +57,7 @@ Configuration variables:
 
 Automations:
 
-- **on_value** (*Optional*, [Automation](#automation)): An automation to perform
+- **on_value** (*Optional*, [Automation](/automations)): An automation to perform
   when a new value is published. See [`on_value`](#text-on_value).
 
 MQTT Options:
@@ -87,7 +87,7 @@ text:
             args: ["x.c_str()"]
 ```
 
-Configuration variables: See [Automation](#automation).
+Configuration variables: See [Automation](/automations).
 
 {{< anchor "text-set_action" >}}
 

--- a/content/components/text/template.md
+++ b/content/components/text/template.md
@@ -51,5 +51,5 @@ text:
 
 ## See Also
 
-- [Automation](#automation)
+- [Automation](/automations)
 - {{< apiref "template/text/template_text.h" "template/text/template_text.h" >}}

--- a/content/components/text_sensor/_index.md
+++ b/content/components/text_sensor/_index.md
@@ -56,10 +56,10 @@ Configuration variables:
 
 Automations:
 
-- **on_value** (*Optional*, [Automation](#automation)): An automation to perform
+- **on_value** (*Optional*, [Automation](/automations)): An automation to perform
   when a new value is published. See [`on_value`](#text_sensor-on_value).
 
-- **on_raw_value** (*Optional*, [Automation](#automation)): An automation to perform
+- **on_raw_value** (*Optional*, [Automation](/automations)): An automation to perform
   when a new value is received that hasn't passed through any filters. See [`on_raw_value`](#text_sensor-on_raw_value).
 
 {{< anchor "text_sensor-filters" >}}
@@ -207,7 +207,7 @@ text_sensor:
             ESP_LOGD("main", "The current version is %s", x.c_str());
 ```
 
-Configuration variables: See [Automation](#automation).
+Configuration variables: See [Automation](/automations).
 
 {{< anchor "text_sensor-on_raw_value" >}}
 
@@ -226,7 +226,7 @@ text_sensor:
             ESP_LOGD("main", "The current version is %s", x.c_str());
 ```
 
-Configuration variables: See [Automation](#automation).
+Configuration variables: See [Automation](/automations).
 
 {{< anchor "text_sensor-state_condition" >}}
 

--- a/content/components/text_sensor/ble_client.md
+++ b/content/components/text_sensor/ble_client.md
@@ -42,7 +42,7 @@ text_sensor:
 
 Automations:
 
-- **on_notify** (*Optional*, [Automation](#automation)): An automation to
+- **on_notify** (*Optional*, [Automation](/automations)): An automation to
   perform when a notify message is received from the device. See [`on_notify`](#ble_text_sensor-on_notify).
 
 ## BLE Sensor Automation

--- a/content/components/text_sensor/homeassistant.md
+++ b/content/components/text_sensor/homeassistant.md
@@ -45,5 +45,5 @@ text_sensor:
 ## See Also
 
 - [Sensor Filters](#sensor-filters)
-- [Automation](#automation)
+- [Automation](/automations)
 - {{< apiref "homeassistant/text_sensor/homeassistant_text_sensor.h" "homeassistant/text_sensor/homeassistant_text_sensor.h" >}}

--- a/content/components/text_sensor/template.md
+++ b/content/components/text_sensor/template.md
@@ -114,5 +114,5 @@ text_sensor:
 ## See Also
 
 - {{< docref "/components/text_sensor" >}}
-- [Automation](#automation)
+- [Automation](/automations)
 - {{< apiref "template/text_sensor/template_text_sensor.h" "template/text_sensor/template_text_sensor.h" >}}

--- a/content/components/time/_index.md
+++ b/content/components/time/_index.md
@@ -25,10 +25,10 @@ All time configuration schemas inherit these options.
   `<Region>/<City>`. ESPHome tries to automatically infer the time zone string based on the time zone of the computer
   that is running ESPHome, but this might not always be accurate.
 
-- **on_time** (*Optional*, [Automation](#automation)): Automation to run at specific intervals using
+- **on_time** (*Optional*, [Automation](/automations)): Automation to run at specific intervals using
   a cron-like syntax. See [`on_time` Trigger](#time-on_time).
 
-- **on_time_sync** (*Optional*, [Automation](#automation)): Automation to run when the time source
+- **on_time_sync** (*Optional*, [Automation](/automations)): Automation to run when the time source
   could be (re-)synchronized.. See [`on_time_sync` Trigger](#time-on_time_sync).
 
 - **update_interval** (*Optional*, [Time](#config-time)): How often to synchronize the device time from the source.
@@ -124,7 +124,7 @@ Configuration variables:
   the day of week field is interpreted like the **days_of_week** variable (range from 1 (Sunday) to 7 (Saturday)) and
   not like other cron implementations would do it (range from 0 (Sunday) to 7 (Sunday)).
 
-- See [Automation](#automation).
+- See [Automation](/automations).
 
 In the `seconds:`, `minutes:`, ... fields you can use the following operators:
 

--- a/content/components/touchscreen/_index.md
+++ b/content/components/touchscreen/_index.md
@@ -66,13 +66,13 @@ touchscreen:
 
       (or right if `swap_xy` is specified) edge of the touchscreen.
 
-- **on_touch** (*Optional*, [Automation](#automation)): An automation to perform
+- **on_touch** (*Optional*, [Automation](/automations)): An automation to perform
   when the touchscreen is touched. See [`on_touch` Trigger](#touchscreen-on_touch).
 
-- **on_update** (*Optional*, [Automation](#automation)): An automation to perform
+- **on_update** (*Optional*, [Automation](/automations)): An automation to perform
   when the touchscreen is touched. See [`on_update` Trigger](#touchscreen-on_update).
 
-- **on_release** (*Optional*, [Automation](#automation)): An automation to perform
+- **on_release** (*Optional*, [Automation](/automations)): An automation to perform
   when the touchscreen is no longer touched. See [`on_release` Trigger](#touchscreen-on_release).
 
 {{< anchor "touchscreen-touchpoint" >}}

--- a/content/components/tuya.md
+++ b/content/components/tuya.md
@@ -126,7 +126,7 @@ tuya:
 - **sensor_datapoint** (**Required**, int): The datapoint id number of the sensor.
 - **datapoint_type** (**Required**, string): The datapoint type one of *raw*, *string*, *bool*, *int*, *uint*, *enum*,
   *bitmask* or *any*.
-- See [Automation](#automation).
+- See [Automation](/automations).
 
 ## See Also
 

--- a/content/components/udp.md
+++ b/content/components/udp.md
@@ -119,5 +119,5 @@ binary_sensor:
 - {{< docref "/components/packet_transport/udp" >}}
 - {{< docref "/components/binary_sensor/packet_transport" >}}
 - {{< docref "/components/sensor/packet_transport" >}}
-- [Automation](#automation)
+- [Automation](/automations)
 - {{< apiref "udp/udp_component.h" "udp/udp_component.h" >}}

--- a/content/components/valve/template.md
+++ b/content/components/valve/template.md
@@ -122,6 +122,6 @@ Configuration options:
 ## See Also
 
 - {{< docref "/components/valve" >}}
-- [Automation](#automation)
+- [Automation](/automations)
 - {{< docref "/cookbook/garage-door" >}}
 - {{< apiref "template/valve/template_valve.h" "template/valve/template_valve.h" >}}

--- a/content/components/voice_assistant.md
+++ b/content/components/voice_assistant.md
@@ -45,58 +45,58 @@ voice_assistant:
 - **conversation_timeout** (*Optional*, [Time](#config-time)): How long to wait before resetting the `conversation_id`
   sent to the voice assist pipeline, which contains the context of the current assist pipeline. Defaults to `300s`.
 
-- **on_intent_start** (*Optional*, [Automation](#automation)): An automation to perform when intent processing starts.
-- **on_intent_progress** (*Optional*, [Automation](#automation)): An automation to perform when intent progress happens.
+- **on_intent_start** (*Optional*, [Automation](/automations)): An automation to perform when intent processing starts.
+- **on_intent_progress** (*Optional*, [Automation](/automations)): An automation to perform when intent progress happens.
   The variable `x` is a non-empty string containing the streaming TTS response URL only if it is sent to the media player.
 
-- **on_intent_end** (*Optional*, [Automation](#automation)): An automation to perform when intent processing ends.
-- **on_listening** (*Optional*, [Automation](#automation)): An automation to
+- **on_intent_end** (*Optional*, [Automation](/automations)): An automation to perform when intent processing ends.
+- **on_listening** (*Optional*, [Automation](/automations)): An automation to
   perform when the voice assistant microphone starts listening.
 
-- **on_start** (*Optional*, [Automation](#automation)): An automation to
+- **on_start** (*Optional*, [Automation](/automations)): An automation to
   perform when the assist pipeline is started.
 
-- **on_wake_word_detected** (*Optional*, [Automation](#automation)): An automation
+- **on_wake_word_detected** (*Optional*, [Automation](/automations)): An automation
   to perform when the assist pipeline has detected a wake word.
 
-- **on_end** (*Optional*, [Automation](#automation)): An automation to perform
+- **on_end** (*Optional*, [Automation](/automations)): An automation to perform
   when the voice assistant is finished all tasks.
 
-- **on_stt_end** (*Optional*, [Automation](#automation)): An automation to perform
+- **on_stt_end** (*Optional*, [Automation](/automations)): An automation to perform
   when the voice assistant has finished speech-to-text. The resulting text is
   available to automations as the variable `x`.
 
-- **on_stt_vad_start** (*Optional*, [Automation](#automation)): An automation to perform when voice activity
+- **on_stt_vad_start** (*Optional*, [Automation](/automations)): An automation to perform when voice activity
   detection starts speech-to-text processing.
 
-- **on_stt_vad_end** (*Optional*, [Automation](#automation)): An automation to perform when voice activity
+- **on_stt_vad_end** (*Optional*, [Automation](/automations)): An automation to perform when voice activity
   detection ends speech-to-text processing.
 
-- **on_tts_start** (*Optional*, [Automation](#automation)): An automation to perform
+- **on_tts_start** (*Optional*, [Automation](/automations)): An automation to perform
   when the voice assistant has started text-to-speech. The text to be spoken is
   available to automations as the variable `x`.
 
-- **on_tts_end** (*Optional*, [Automation](#automation)): An automation to perform
+- **on_tts_end** (*Optional*, [Automation](/automations)): An automation to perform
   when the voice assistant has finished text-to-speech. A URL containing the audio response
   is available to automations as the variable `x`.
 
-- **on_tts_stream_start** (*Optional*, [Automation](#automation)): An automation to perform when audio stream
+- **on_tts_stream_start** (*Optional*, [Automation](/automations)): An automation to perform when audio stream
   (voice response) playback starts. Requires `speaker` to be configured.
 
-- **on_tts_stream_end** (*Optional*, [Automation](#automation)): An automation to perform when audio stream
+- **on_tts_stream_end** (*Optional*, [Automation](/automations)): An automation to perform when audio stream
   (voice response) playback ends. Requires `speaker` to be configured.
 
-- **on_idle** (*Optional*, [Automation](#automation)): An automation to perform
+- **on_idle** (*Optional*, [Automation](/automations)): An automation to perform
   when the voice assistant is idle (no other actions/states are in progress).
 
-- **on_error** (*Optional*, [Automation](#automation)): An automation to perform
+- **on_error** (*Optional*, [Automation](/automations)): An automation to perform
   when the voice assistant has encountered an error. The error code and message are available to
   automations as the variables `code` and `message`.
 
-- **on_client_connected** (*Optional*, [Automation](#automation)): An automation to perform
+- **on_client_connected** (*Optional*, [Automation](/automations)): An automation to perform
   when Home Assistant has connected and is waiting for Voice Assistant commands.
 
-- **on_client_disconnected** (*Optional*, [Automation](#automation)): An automation to perform
+- **on_client_disconnected** (*Optional*, [Automation](/automations)): An automation to perform
   when Home Assistant disconnects from the Voice Assistant.
 
 - **noise_suppression_level** (*Optional*, integer): The noise suppression level to apply to the assist pipeline.
@@ -108,23 +108,23 @@ voice_assistant:
 - **volume_multiplier** (*Optional*, float): Volume multiplier to apply to the assist pipeline.
   Must be larger than 0. Defaults to 1 (disabled).
 
-- **on_timer_started** (*Optional*, [Automation](#automation)): An automation to perform when a voice assistant
+- **on_timer_started** (*Optional*, [Automation](/automations)): An automation to perform when a voice assistant
   timer has started. The timer is available as `timer` of type
   {{< apistruct "voice_assistant::Timer" "voice_assistant::Timer" >}}.
 
-- **on_timer_finished** (*Optional*, [Automation](#automation)): An automation to perform when a voice assistant
+- **on_timer_finished** (*Optional*, [Automation](/automations)): An automation to perform when a voice assistant
   timer has finished. The timer is available as `timer` of type
   {{< apistruct "voice_assistant::Timer" "voice_assistant::Timer" >}}.
 
-- **on_timer_cancelled** (*Optional*, [Automation](#automation)): An automation to perform when a voice assistant
+- **on_timer_cancelled** (*Optional*, [Automation](/automations)): An automation to perform when a voice assistant
   timer has been cancelled. The timer is available as `timer` of type
   {{< apistruct "voice_assistant::Timer" "voice_assistant::Timer" >}}.
 
-- **on_timer_updated** (*Optional*, [Automation](#automation)): An automation to perform when a voice assistant
+- **on_timer_updated** (*Optional*, [Automation](/automations)): An automation to perform when a voice assistant
   timer has been updated (paused/resumed/duration changed). The timer is available as `timer` of type
   {{< apistruct "voice_assistant::Timer" "voice_assistant::Timer" >}}.
 
-- **on_timer_tick** (*Optional*, [Automation](#automation)): An automation to perform when the voice assistant timers
+- **on_timer_tick** (*Optional*, [Automation](/automations)): An automation to perform when the voice assistant timers
   tick is triggered.
   This is called every **1 second** while there are timers on this device.
   The timers are available as `timers` which is a `std::vector` (array) of type

--- a/content/components/wiegand.md
+++ b/content/components/wiegand.md
@@ -43,14 +43,14 @@ wiegand:
 
 ### Triggers
 
-- **on_key** (*Optional*, [Automation](#automation)): An automation to perform
+- **on_key** (*Optional*, [Automation](/automations)): An automation to perform
   when a key has been pressed on the pad. The key is in a variable called `x`.
 
-- **on_tag** (*Optional*, [Automation](#automation)): An automation to perform
+- **on_tag** (*Optional*, [Automation](/automations)): An automation to perform
   when a Wiegand-compatible card or a tag has been read by the device. The tag code is
   in a variable called `x`.
 
-- **on_raw** (*Optional*, [Automation](#automation)): An automation to perform
+- **on_raw** (*Optional*, [Automation](/automations)): An automation to perform
   for any data sent by the device. The value is in a variable called `value`, the number of
   bits is in a variable called `bits`. Note that this will include parity bits as well and
   no parity checking is done.

--- a/content/components/wifi.md
+++ b/content/components/wifi.md
@@ -107,8 +107,8 @@ wifi:
 - **enable_btm** (*Optional*, bool): Only on `esp32`. Enable 802.11v BSS Transition Management support.
 - **enable_rrm** (*Optional*, bool): Only on `esp32`. Enable 802.11k Radio Resource Management support.
 
-- **on_connect** (*Optional*, [Automation](#automation)): An action to be performed when a connection is established.
-- **on_disconnect** (*Optional*, [Automation](#automation)): An action to be performed when the connection is dropped.
+- **on_connect** (*Optional*, [Automation](/automations)): An action to be performed when a connection is established.
+- **on_disconnect** (*Optional*, [Automation](/automations)): An action to be performed when the connection is dropped.
 - **enable_on_boot** (*Optional*, boolean): If enabled, the WiFi interface will be enabled on boot. Defaults to `true`.
 - **use_psram** (*Optional*, boolean): For ESP32 only, requests that the WiFi libraries try to allocate memory from PSRAM.
   Defaults to `false`. Requires PSRAM to be configured.
@@ -377,8 +377,8 @@ on_...:
 - **timeout** (*Optional*, [Time](#config-time), [templatable](#config-templatable)): The time to wait for the connection
   to be established. Defaults to 30 seconds.
 
-- **on_connect** (*Optional*, [Automation](#automation)): An action to be performed when a connection is established.
-- **on_error** (*Optional*, [Automation](#automation)): An action to be performed when the connection fails.
+- **on_connect** (*Optional*, [Automation](/automations)): An action to be performed when a connection is established.
+- **on_error** (*Optional*, [Automation](/automations)): An action to be performed when the connection fails.
 
 ## Conditions
 

--- a/content/components/wireguard.md
+++ b/content/components/wireguard.md
@@ -353,7 +353,7 @@ The device should now be linked to your remote Home Assistant.
 
 - {{< docref "time/" >}}
 - {{< docref "time/sntp" >}}
-- [Automation](#automation)
+- [Automation](/automations)
 - [WireGuard®](https://www.wireguard.org/) official website
 - [Home Assistant Community Add-on: WireGuard](https://community.home-assistant.io/t/home-assistant-community-add-on-wireguard/134662)
   (also on [GitHub](https://github.com/hassio-addons/addon-wireguard))

--- a/content/cookbook/infostrip.md
+++ b/content/cookbook/infostrip.md
@@ -92,7 +92,7 @@ light:
 ## Home Assistant configuration
 
 The automation to show the CO2 warning light (e.g. red if CO2 > 1000 ppm) is done in Home Assistant, but could also be
-implemented using ESPHome [Automations](#automation).
+implemented using ESPHome [Automations](/automations).
 
 ```yaml
 # Turn on a light with the related color

--- a/content/cookbook/lambda_magic.md
+++ b/content/cookbook/lambda_magic.md
@@ -282,4 +282,4 @@ sensor:
 ## See Also
 
 - [Templates](#config-lambda)
-- [Automation](#automation)
+- [Automation](/automations)

--- a/content/cookbook/lvgl.md
+++ b/content/cookbook/lvgl.md
@@ -29,7 +29,7 @@ Here are a couple recipes for various interesting things you can do with {{< doc
 {{< img src="lvgl_switch.png" alt="Image" class="align-left" >}}
 
 The easiest way to integrate an LVGL [`switch`](#lvgl-widget-switch) widget and a switch or light is with
-[automations](#automation):
+[automations](/automations):
 
 ```yaml
 light:
@@ -2307,7 +2307,7 @@ You can combine it with the previous example to turn off the backlight, so the u
 
 - {{< docref "/components/lvgl" >}}
 - [Templates](#config-lambda)
-- [Automation](#automation)
+- [Automation](/automations)
 - [Key collector component](#key_collector)
 - [What is Image Sticking, Image Burn-in, an After Image, or a Ghost Image on an LCD?](https://www.philips.ca/c-f/XC000007486/what-is-image-sticking,-image-burn-in,-an-after-image,-or-a-ghost-image-on-an-lcd)
 - [Image persistence](https://en.wikipedia.org/wiki/Image_persistence)


### PR DESCRIPTION
## Description:
Fix all automation links.
Currently all links are pointing to the modubus controller. I assume this bug was introduced with the restructure of the docs

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
