### PR TITLE
Add warning to prevent flicker

### DIFF
--- a/content/components/light/esp32_rmt_led_strip.md
+++ b/content/components/light/esp32_rmt_led_strip.md
@@ -21,7 +21,7 @@ light:
 
 **Important note** In some specific cases, the RMT component might cause flicker of longer LED strips. The fix seem to be to disable the wifi power saving by setting 
   [power_save_mode](/components/wifi/#power-save-mode) to none in [wifi component](/components/wifi).
-  
+
 ## Configuration variables
 
 - **pin** (**Required**, [Pin](#config-pin)): The pin for the data line of the light.

--- a/content/components/light/esp32_rmt_led_strip.md
+++ b/content/components/light/esp32_rmt_led_strip.md
@@ -19,8 +19,8 @@ light:
     name: "My Light"
 ```
 
-**Important note** In some specific cases, the RMT component might cause flicker of longer LED strips. The fix seem to be to disable the wifi power saving by setting 
-  [power_save_mode](/components/wifi/#power-save-mode) to none in [wifi component](/components/wifi).
+**Important note** In some specific cases, the RMT component might cause flicker of longer LED strips. The fix seem to be to disable the wifi power saving by setting
+ [power_save_mode](/components/wifi/#power-save-mode) to  none in [wifi component](/components/wifi).
 
 ## Configuration variables
 

--- a/content/components/light/esp32_rmt_led_strip.md
+++ b/content/components/light/esp32_rmt_led_strip.md
@@ -18,7 +18,8 @@ light:
     chipset: ws2812
     name: "My Light"
 ```
-
+**Important note** In some specific cases, the RMT component might cause flicker of longer LED strips. The fix seem to be to disable the wifi power saving by setting 
+  [power_save_mode](/components/wifi/#power-save-mode) to none in [wifi component](/components/wifi).
 ## Configuration variables
 
 - **pin** (**Required**, [Pin](#config-pin)): The pin for the data line of the light.

--- a/content/components/light/esp32_rmt_led_strip.md
+++ b/content/components/light/esp32_rmt_led_strip.md
@@ -18,8 +18,10 @@ light:
     chipset: ws2812
     name: "My Light"
 ```
+
 **Important note** In some specific cases, the RMT component might cause flicker of longer LED strips. The fix seem to be to disable the wifi power saving by setting 
   [power_save_mode](/components/wifi/#power-save-mode) to none in [wifi component](/components/wifi).
+  
 ## Configuration variables
 
 - **pin** (**Required**, [Pin](#config-pin)): The pin for the data line of the light.


### PR DESCRIPTION
Due to combination of specific ESP32 boards, RMT component and wifi, it seems some ESPhome builds result in significant flicker on addressable LEDs. It has been tracked in defect https://github.com/esphome/esphome/issues/10335 and the solution seems to work OK for multiple people.

## Description:


**Related issue (if applicable):** fixes [<link to issue>](https://github.com/esphome/esphome/issues/10335)

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome# N/A

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.


