### PR TITLE
Document `analyze-memory` CLI command

### DIFF
--- a/content/guides/cli.md
+++ b/content/guides/cli.md
@@ -245,6 +245,23 @@ If set, opens the dashboard UI in a browser once the server is up and running. D
 `--socket`.
 {{< /option >}}
 
+### `analyze-memory` Command
+
+> [!NOTE]
+> This is an advanced command primarily intended for developers and debugging memory issues.
+
+The `esphome analyze-memory <CONFIG>` command compiles the configuration and analyzes memory usage by component.
+
+This command is useful for:
+
+* Understanding which components are consuming the most memory
+* Identifying optimization opportunities to reduce flash or RAM usage
+* Analyzing memory usage before adding more components to a tight build
+* Debugging builds that are approaching memory limits (especially on ESP8266)
+* Contributing to ESPHome development and optimization efforts
+
+The command automatically compiles the configuration if needed (or quickly relinks if sources haven't changed), then analyzes the resulting firmware to show a detailed breakdown of memory usage by component, including flash memory (code and data) and RAM usage (data and BSS).
+
 ### `logs` Command
 
 The `esphome logs <CONFIG>` command validates the configuration and shows all logs.


### PR DESCRIPTION
## Description:

This PR adds documentation for the new `esphome analyze-memory` command introduced in esphome/esphome#11395.

The `analyze-memory` command is an advanced developer tool that compiles a configuration and analyzes memory usage by component. This is particularly useful for:
- Understanding which components consume the most memory
- Identifying optimization opportunities to reduce flash or RAM usage
- Analyzing memory usage before adding more components to a tight build
- Debugging builds that are approaching memory limits (especially on ESP8266)

### Changes Made:

- Added new `analyze-memory` command section in `content/guides/cli.md`
- Positioned after `dashboard` command, before `logs` command
- Includes a NOTE callout indicating this is an advanced command for developers
- Documents the command's purpose, use cases, and behavior

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#11395

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
