### PR TITLE
[ESP32_CAN] Add documentation for advanced bit rate settings on ESP32_CAN component

### DIFF
--- a/content/components/canbus/esp32_can.md
+++ b/content/components/canbus/esp32_can.md
@@ -67,12 +67,14 @@ The following table lists the bit rates supported by the component for ESP32 var
 | 1000KBPS | x | x | x | x | x | x |
 
 ## Advanced bit rate option
+
 - **prescaler** (**Required**, int): Prescaler to compute the time quanta.
 - **tseg_1** (**Required**, int): An integer between 1 and 16.
 - **tseg_2** (**Required**, int): An integer between 1 and 8.
 
 The bit rate is computed as:
-$$bit_rate = {{80 MHz} \over prescaler * (1 + tseg_1 + tseg_2)}$$
+
+$$bit\\_rate = {{80 MHz} \over prescaler * (1 + tseg\\_1 + tseg\\_2)}$$
 
 **tseg_1** and **tseg_2** control the moment the signal is being sampled.
 

--- a/content/components/canbus/esp32_can.md
+++ b/content/components/canbus/esp32_can.md
@@ -72,7 +72,7 @@ The following table lists the bit rates supported by the component for ESP32 var
 - **tseg_2** (**Required**, int): An integer between 1 and 8.
 
 The bit rate is computed as:
-$$bit\_rate = {{80 MHz} \over prescaler * (1 + tseg\_1 + tseg\_2)}$$
+$$bit_rate = {{80 MHz} \over prescaler * (1 + tseg_1 + tseg_2)}$$
 
 **tseg_1** and **tseg_2** control the moment the signal is being sampled.
 

--- a/content/components/canbus/esp32_can.md
+++ b/content/components/canbus/esp32_can.md
@@ -20,6 +20,10 @@ canbus:
     rx_pin: GPIOXX
     can_id: 4
     bit_rate: 50kbps
+    advanced_bit_rate:
+        prescaler: 80
+        tseg_1: 15
+        tseg_2: 4
     on_frame:
       ...
 ```
@@ -32,7 +36,7 @@ canbus:
 - **tx_queue_len** (*Optional*, int): Length of TX queue, 0 to disable.
 - **tx_enqueue_timeout** (*Optional*, [Time](#config-time)): Maximum time to wait when the TX queue is full before
   dropping the message (by default, this is set to the time it takes to send 10 CAN messages at the given bit rate).
-
+- **advanced_bit_rate** (*Optional*): When present, overrides the bit_rate setting and allows fine tunning of the bit rate.
 - All other options from [Canbus](#config-canbus).
 
 {{< anchor "esp32-can-bit-rate" >}}
@@ -61,6 +65,16 @@ The following table lists the bit rates supported by the component for ESP32 var
 | 500KBPS | x | x | x | x | x | x |
 | 800KBPS | x | x | x | x | x | x |
 | 1000KBPS | x | x | x | x | x | x |
+
+## Advanced bit rate option
+- **prescaler** (**Required**, int): Prescaler to compute the time quanta.
+- **tseg_1** (**Required**, int): An integer between 1 and 16.
+- **tseg_2** (**Required**, int): An integer between 1 and 8.
+
+The bit rate is computed as:
+$$bit\_rate = {{80 MHz} \over prescaler * (1 + tseg\_1 + tseg\_2)}$$
+
+**tseg_1** and **tseg_2** control the moment the signal is being sampled.
 
 ## Wiring options
 


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** none

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#11413

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
