### PR TITLE
[switch] Add `control()` method to API

### DIFF
--- a/content/components/switch/_index.md
+++ b/content/components/switch/_index.md
@@ -182,7 +182,7 @@ advanced stuff (see the full API Reference for more info).
 >
 > For example, if you are using a {{< docref "/components/switch/gpio" >}}, calling `publish_state()` will
 > not change the GPIO pin level. To do that, you need to call `turn_on()`,
-> `turn_off()` or `toggle()`. The same applies to other switch platforms.
+> `turn_off()`, `toggle()` or `control()`. The same applies to other switch platforms.
 
 - `state`  : Retrieve the current state of the switch.
 
@@ -204,6 +204,16 @@ advanced stuff (see the full API Reference for more info).
     id(my_switch).turn_on();
     // Toggle the switch
     id(my_switch).toggle();
+```
+
+- `control()`  : Control the switch state using a boolean parameter.
+  This provides a unified interface for setting switch state dynamically.
+
+```yaml
+    // Within lambda, control switch based on a condition
+    id(my_switch).control(true);   // Turn ON
+    id(my_switch).control(false);  // Turn OFF
+    id(my_switch).control(some_condition);  // Set based on condition
 ```
 
 {{< anchor "switch-on_turn_on_off_trigger" >}}


### PR DESCRIPTION
## Description:

This is a copy of #5214, but in the new format.
That one should have been merged when esphome/esphome#10118 was merged, but for some reason it was missed.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#10118 (already merged)

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
