### PR TITLE
[wifi_info] Document a new wifi power mode text sensor

### DIFF
--- a/content/components/debug.md
+++ b/content/components/debug.md
@@ -93,10 +93,10 @@ sensor:
 The component enables debugging features for ESPHome devices running on the Zephyr RTOS.
 It helps with low-level firmware debugging using **SWD (Serial Wire Debug)**. It enables:
 
-- **Thread Awareness in GDB**
+- **Thread Awareness in GDB**  
 Injects Zephyr thread metadata so that all active threads can be inspected via GDB when connected over SWD.
 
-- **Real-Time Logging over RTT**
+- **Real-Time Logging over RTT**  
 Enables logging output over **SEGGER RTT** (Real Time Transfer), allowing non-intrusive debug logs through SWD.
 
 ## See Also

--- a/content/components/debug.md
+++ b/content/components/debug.md
@@ -72,10 +72,9 @@ sensor:
 
 - **reset_reason** (*Optional*): Reports the last reboot reason in a human-readable form. Accepts all options from [Text Sensor](/components/text_sensor#config-text_sensor).
 
-- **power_save_mode** (*Optional*): Reports the current WiFi power save mode. Only available on ESP32, ESP8266, RP2040, and LibreTiny platforms with WiFi enabled. Possible values:
+- **power_save_mode** (*Optional*): Reports the current WiFi power save mode. Only available on ESP32 and ESP8266 platforms with WiFi enabled. Possible values:
 
-  - ESP32, ESP8266, RP2040: `NONE`, `LIGHT`, `HIGH`, or `UNKNOWN`
-  - LibreTiny: `ON` or `OFF`
+  - ESP32, ESP8266: `NONE`, `LIGHT`, `HIGH`, or `UNKNOWN`
 
   Accepts all options from [Text Sensor](#config-text_sensor).
 

--- a/content/components/debug.md
+++ b/content/components/debug.md
@@ -72,9 +72,9 @@ sensor:
 
 - **reset_reason** (*Optional*): Reports the last reboot reason in a human-readable form. Accepts all options from [Text Sensor](/components/text_sensor#config-text_sensor).
 
-- **power_save_mode** (*Optional*): Reports the current WiFi power save mode. Only available on ESP32 and ESP8266 platforms with WiFi enabled. Possible values:
+- **power_save_mode** (*Optional*): Reports the current WiFi power save mode. Only available on ESP32 platforms with WiFi enabled. Possible values:
 
-  - ESP32, ESP8266: `NONE`, `LIGHT`, `HIGH`, or `UNKNOWN`
+  - `NONE`, `LIGHT`, `HIGH`, or `UNKNOWN`
 
   Accepts all options from [Text Sensor](#config-text_sensor).
 

--- a/content/components/debug.md
+++ b/content/components/debug.md
@@ -25,8 +25,6 @@ text_sensor:
       name: "Device Info"
     reset_reason:
       name: "Reset Reason"
-    power_save_mode:
-      name: "WiFi Power Save Mode"
 
 sensor:
   - platform: debug
@@ -101,10 +99,10 @@ sensor:
 The component enables debugging features for ESPHome devices running on the Zephyr RTOS.
 It helps with low-level firmware debugging using **SWD (Serial Wire Debug)**. It enables:
 
-- **Thread Awareness in GDB**  
+- **Thread Awareness in GDB**
 Injects Zephyr thread metadata so that all active threads can be inspected via GDB when connected over SWD.
 
-- **Real-Time Logging over RTT**  
+- **Real-Time Logging over RTT**
 Enables logging output over **SEGGER RTT** (Real Time Transfer), allowing non-intrusive debug logs through SWD.
 
 ## See Also

--- a/content/components/debug.md
+++ b/content/components/debug.md
@@ -25,6 +25,8 @@ text_sensor:
       name: "Device Info"
     reset_reason:
       name: "Reset Reason"
+    power_save_mode:
+      name: "WiFi Power Save Mode"
 
 sensor:
   - platform: debug
@@ -69,6 +71,13 @@ sensor:
   Accepts all options from [Text Sensor](/components/text_sensor#config-text_sensor).
 
 - **reset_reason** (*Optional*): Reports the last reboot reason in a human-readable form. Accepts all options from [Text Sensor](/components/text_sensor#config-text_sensor).
+
+- **power_save_mode** (*Optional*): Reports the current WiFi power save mode. Only available on ESP32, ESP8266, RP2040, and LibreTiny platforms with WiFi enabled. Possible values:
+
+  - ESP32, ESP8266, RP2040: `NONE`, `LIGHT`, `HIGH`, or `UNKNOWN`
+  - LibreTiny: `ON` or `OFF`
+
+  Accepts all options from [Text Sensor](#config-text_sensor).
 
 ## Sensor
 

--- a/content/components/debug.md
+++ b/content/components/debug.md
@@ -70,12 +70,6 @@ sensor:
 
 - **reset_reason** (*Optional*): Reports the last reboot reason in a human-readable form. Accepts all options from [Text Sensor](/components/text_sensor#config-text_sensor).
 
-- **power_save_mode** (*Optional*): Reports the current WiFi power save mode. Only available on ESP32 platforms with WiFi enabled. Possible values:
-
-  - `NONE`, `LIGHT`, `HIGH`, or `UNKNOWN`
-
-  Accepts all options from [Text Sensor](#config-text_sensor).
-
 ## Sensor
 
 ### Configuration variables

--- a/content/components/text_sensor/wifi_info.md
+++ b/content/components/text_sensor/wifi_info.md
@@ -36,6 +36,8 @@ text_sensor:
       name: ESP Latest Scan Results
     dns_address:
       name: ESP DNS Address
+    power_save_mode:
+      name: ESP Wifi Power Save Mode
 ```
 
 ## Configuration variables
@@ -61,6 +63,8 @@ text_sensor:
 
 - **dns_address** (*Optional*): Expose the DNS Address of the ESP as text sensor.
   [Text Sensor](/components/text_sensor#config-text_sensor).
+
+- **power_save_mode** (*Optional*) Expose the WiFi Power save mode of the ESP as a text sensor. Only available on ESP32.
 
 ## See Also
 

--- a/content/components/text_sensor/wifi_info.md
+++ b/content/components/text_sensor/wifi_info.md
@@ -15,34 +15,34 @@ via text sensors.
 text_sensor:
   - platform: wifi_info
     ip_address:
-      name: ESP IP Address
+      name: Device IP Address
       address_0:
-        name: ESP IP Address 0
+        name: Device IP Address 0
       address_1:
-        name: ESP IP Address 1
+        name: Device IP Address 1
       address_2:
-        name: ESP IP Address 2
+        name: Device IP Address 2
       address_3:
-        name: ESP IP Address 3
+        name: Device IP Address 3
       address_4:
-        name: ESP IP Address 4
+        name: Device IP Address 4
     ssid:
-      name: ESP Connected SSID
+      name: Device Connected SSID
     bssid:
-      name: ESP Connected BSSID
+      name: Device Connected BSSID
     mac_address:
-      name: ESP Mac Wifi Address
+      name: Device Mac Wifi Address
     scan_results:
-      name: ESP Latest Scan Results
+      name: Device Latest Scan Results
     dns_address:
-      name: ESP DNS Address
+      name: Device DNS Address
     power_save_mode:
-      name: ESP Wifi Power Save Mode
+      name: Device Wifi Power Save Mode
 ```
 
 ## Configuration variables
 
-- **ip_address** (*Optional*): Expose the IP Address of the ESP as a text sensor.
+- **ip_address** (*Optional*): Expose the IP Address of the device as a text sensor.
   All options from [Text Sensor](/components/text_sensor#config-text_sensor).
 
 - **address_0** (*Optional*): With dual stack (IPv4 and IPv6) the device will have at least two IP addresses, often more.
@@ -61,10 +61,10 @@ text_sensor:
 - **scan_results** (*Optional*): Expose the latest networks found during the latest scan. All options from
   [Text Sensor](/components/text_sensor#config-text_sensor).
 
-- **dns_address** (*Optional*): Expose the DNS Address of the ESP as text sensor.
+- **dns_address** (*Optional*): Expose the DNS Address of the device as text sensor.
   [Text Sensor](/components/text_sensor#config-text_sensor).
 
-- **power_save_mode** (*Optional*) Expose the WiFi Power save mode of the ESP as a text sensor.
+- **power_save_mode** (*Optional*) Expose the WiFi Power save mode of the device as a text sensor.
 
 ## See Also
 

--- a/content/components/text_sensor/wifi_info.md
+++ b/content/components/text_sensor/wifi_info.md
@@ -64,7 +64,7 @@ text_sensor:
 - **dns_address** (*Optional*): Expose the DNS Address of the ESP as text sensor.
   [Text Sensor](/components/text_sensor#config-text_sensor).
 
-- **power_save_mode** (*Optional*) Expose the WiFi Power save mode of the ESP as a text sensor. Only available on ESP32.
+- **power_save_mode** (*Optional*) Expose the WiFi Power save mode of the ESP as a text sensor.
 
 ## See Also
 


### PR DESCRIPTION
## Description:

Adds documentation for a new text sensor that gives the current WiFi power saving mode.

**Related issue (if applicable):** not applicable

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#11480

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
