### PR TITLE
Add lambda examples for deep sleep actions

### DIFF
--- a/content/components/deep_sleep.md
+++ b/content/components/deep_sleep.md
@@ -148,6 +148,10 @@ on_...:
         id: deep_sleep_1
         until: "16:00:00"
         time_id: sntp_id
+
+# in a lambda
+  - lambda: |-
+      id(deep_sleep_1).begin(true);
 ```
 
 Configuration options:
@@ -167,6 +171,10 @@ Useful for keeping the ESP active during data transfer or OTA updating (See note
 on_...:
   then:
     - deep_sleep.prevent: deep_sleep_1
+
+# in a lambda
+  - lambda: |-
+      id(deep_sleep_1).prevent_deep_sleep();
 ```
 
 > [!NOTE]
@@ -199,7 +207,7 @@ on_...:
 >       then:
 >         - deep_sleep.enter: deep_sleep_1
 > ```
-
+  
 {{< anchor "deep_sleep-allow_action" >}}
 
 ## `deep_sleep.allow` Action
@@ -210,6 +218,10 @@ This action allows the given deep sleep component to enter deep sleep, after pre
 on_...:
   then:
     - deep_sleep.allow: deep_sleep_1
+
+# in a lambda
+    - lambda: |-
+        id(deep_sleep_1).enable();
 ```
 
 ## See Also

--- a/content/components/deep_sleep.md
+++ b/content/components/deep_sleep.md
@@ -218,9 +218,11 @@ This action allows the given deep sleep component to enter deep sleep, after pre
 on_...:
   then:
     - deep_sleep.allow: deep_sleep_1
+
 # in a lambda
   - lambda: |-
       id(deep_sleep_1).enable();
+```
 
 ## See Also
 

--- a/content/components/deep_sleep.md
+++ b/content/components/deep_sleep.md
@@ -218,11 +218,9 @@ This action allows the given deep sleep component to enter deep sleep, after pre
 on_...:
   then:
     - deep_sleep.allow: deep_sleep_1
-
 # in a lambda
-    - lambda: |-
-        id(deep_sleep_1).enable();
-```
+  - lambda: |-
+      id(deep_sleep_1).enable();
 
 ## See Also
 

--- a/content/components/deep_sleep.md
+++ b/content/components/deep_sleep.md
@@ -221,7 +221,7 @@ on_...:
 
 # in a lambda
   - lambda: |-
-      id(deep_sleep_1).enable();
+      id(deep_sleep_1).allow_deep_sleep();
 ```
 
 ## See Also


### PR DESCRIPTION
The C++ function names for the deep_sleep actions are not immediately obvious.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
