### PR TITLE
Clarify how to use the `iteration` parameter for the repeat action

### DIFF
--- a/content/automations/actions.md
+++ b/content/automations/actions.md
@@ -253,8 +253,10 @@ on_...:
   - repeat:
       count: 5
       then:
+        - lambda: ESP_LOGI("main", "Turning lights on for iteration [%d]", iteration);
         - light.turn_on: some_light
         - delay: 1s
+        - lambda: ESP_LOGI("main", "Turning lights off for iteration [%d]", iteration);
         - light.turn_off: some_light
         - delay: 10s
 ```
@@ -262,7 +264,7 @@ on_...:
 #### Configuration variables
 
 - **count** (**Required**, int): The number of times the action should be repeated. The counter is available to
-  lambdas using the reserved word "iteration".
+  lambdas using the implicit script parameter `iteration`.
 
 - **then** (**Required**, [Action](#config-action)): The action to repeat.
 


### PR DESCRIPTION
## Description:

Clearer language for accessing the `iteration` parameter for the repeat action. Also update example to demonstrate how to use iteration.

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
