### PR TITLE
Update AM2320 documentation with frequency note

### DIFF
--- a/content/components/sensor/am2320.md
+++ b/content/components/sensor/am2320.md
@@ -8,7 +8,7 @@ params:
 ---
 
 The `am2320` Temperature+Humidity sensor allows you to use your AM2320
-([datasheet](https://cdn-shop.adafruit.com/product-files/3721/AM2320.pdf)) [I²C](#i2c)-based sensor with
+([datasheet](https://cdn-shop.adafruit.com/product-files/3721/AM2320.pdf)) I²C-based sensor with
 ESPHome.
 
 {{< img src="am2320-full.jpg" alt="Image" caption="AM2320 Temperature & Humidity Sensor." width="50.0%"

--- a/content/components/sensor/am2320.md
+++ b/content/components/sensor/am2320.md
@@ -47,7 +47,7 @@ sensor:
 
 If you experience communication or reliability issues with the AM2320 sensor, the
 [I²C Bus](#i2c) frequency may be too high. The AM2320 supports I²C standard-mode with a maximum
-clock frequency of 100 kHz. Some platforms may use higher default frequencies.
+clock frequency of 100 kHz.
 
 ## See Also
 

--- a/content/components/sensor/am2320.md
+++ b/content/components/sensor/am2320.md
@@ -8,35 +8,26 @@ params:
 ---
 
 The `am2320` Temperature+Humidity sensor allows you to use your AM2320
-([datasheet](https://akizukidenshi.com/download/ds/aosong/AM2320.pdf)) I²C-based sensor with ESPHome.
+([datasheet](https://cdn-shop.adafruit.com/product-files/3721/AM2320.pdf)) I²C-based sensor with ESPHome.
 
-{{< img src="am2320-full.jpg" alt="Image" caption="AM2320 Temperature & Humidity Sensor." width="50.0%" class="align-center" >}}
+{{< img src="am2320-full.jpg" alt="Image" caption="AM2320 Temperature & Humidity Sensor." width="50.0%"
+class="align-center" >}}
 
 {{< img src="temperature-humidity.png" alt="Image" width="80.0%" class="align-center" >}}
 
 > [!NOTE]
 > Logs might include some warnings about receiving a NACK from the sensor.
 > This is due to a wake call to the sensor which the sensor never acknowledges by design.
-> Sensor works on BUS frequency up to 100kHz, but by default is 200kHz in use. So decrease will help with sensor reliability.
 
 ```yaml
 # Example configuration entry
-i2c:
-  - id: bus_a
-    sda: GPIO4
-    scl: GPIO5
-    scan: true
-    frequency: 50000
-
 sensor:
   - platform: am2320
-    i2c_id: bus_a
     temperature:
       name: "Living Room Temperature"
     humidity:
       name: "Living Room Humidity"
     update_interval: 60s
-    address: 0x5C
 ```
 
 ## Configuration variables
@@ -49,7 +40,14 @@ sensor:
 
   - All options from [Sensor](#config-sensor).
 
-- **update_interval** (*Optional*, [Time](#config-time)): The interval to check the sensor. Defaults to `60s`.
+- **update_interval** (*Optional*, [Time](#config-time)): The interval to check the sensor. Defaults to
+  `60s`.
+
+## Troubleshooting
+
+If you experience communication or reliability issues with the AM2320 sensor, the
+[I²C Bus](#i2c) frequency may be too high. The AM2320 supports I²C standard-mode with a maximum
+clock frequency of 100 kHz. Some platforms may use higher default frequencies.
 
 ## See Also
 

--- a/content/components/sensor/am2320.md
+++ b/content/components/sensor/am2320.md
@@ -8,7 +8,8 @@ params:
 ---
 
 The `am2320` Temperature+Humidity sensor allows you to use your AM2320
-([datasheet](https://cdn-shop.adafruit.com/product-files/3721/AM2320.pdf)) I²C-based sensor with ESPHome.
+([datasheet](https://cdn-shop.adafruit.com/product-files/3721/AM2320.pdf)) [I²C](#i2c)-based sensor with
+ESPHome.
 
 {{< img src="am2320-full.jpg" alt="Image" caption="AM2320 Temperature & Humidity Sensor." width="50.0%"
 class="align-center" >}}
@@ -52,6 +53,7 @@ clock frequency of 100 kHz.
 ## See Also
 
 - [Sensor Filters](#sensor-filters)
+- {{< docref "/components/i2c" >}}
 - {{< docref "absolute_humidity/" >}}
 - {{< docref "dht/" >}}
 - {{< docref "dht12/" >}}

--- a/content/components/sensor/am2320.md
+++ b/content/components/sensor/am2320.md
@@ -17,16 +17,26 @@ The `am2320` Temperature+Humidity sensor allows you to use your AM2320
 > [!NOTE]
 > Logs might include some warnings about receiving a NACK from the sensor.
 > This is due to a wake call to the sensor which the sensor never acknowledges by design.
+> Sensor works on BUS frequency up to 100kHz, but by default is 200kHz in use. So decrease will help with sensor reliability.
 
 ```yaml
 # Example configuration entry
+i2c:
+  - id: bus_a
+    sda: GPIO4
+    scl: GPIO5
+    scan: true
+    frequency: 50000
+
 sensor:
   - platform: am2320
+    i2c_id: bus_a
     temperature:
       name: "Living Room Temperature"
     humidity:
       name: "Living Room Humidity"
     update_interval: 60s
+    address: 0x5C
 ```
 
 ## Configuration variables

--- a/content/components/sensor/am2320.md
+++ b/content/components/sensor/am2320.md
@@ -47,13 +47,13 @@ sensor:
 ## Troubleshooting
 
 If you experience communication or reliability issues with the AM2320 sensor, the
-[I²C Bus](#i2c) frequency may be too high. The AM2320 supports I²C standard-mode with a maximum
+{{< docref "i2c" >}} frequency may be too high. The AM2320 supports I²C standard-mode with a maximum
 clock frequency of 100 kHz.
 
 ## See Also
 
 - [Sensor Filters](#sensor-filters)
-- {{< docref "/components/i2c" >}}
+- {{< docref "i2c" >}}
 - {{< docref "absolute_humidity/" >}}
 - {{< docref "dht/" >}}
 - {{< docref "dht12/" >}}


### PR DESCRIPTION
Added note about sensor frequency for improved reliability, and allow it to work.

## Description:
I spend a lot of time with searching for why the sensor AM2320 doesn't work with ESPhome, but with arduino code yes. I tried many solutions, like add there setup prio -100, or pull up the SCL right after the boot, but nothing of that work correctly and reliably. After that I found a documentation for AM2320 where is that maximal BUS frequency is 100kHZ, and thats it. Just decrease the frequency from default 200kHz to 50kHz make the magic. 
So would be perfect add this info to official FAQ to help others.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
