### PR TITLE
[remote_transmitter] Add non-blocking mode

### DIFF
--- a/content/components/remote_transmitter.md
+++ b/content/components/remote_transmitter.md
@@ -57,6 +57,8 @@ remote_transmitter:
 | ESP32-S3 | 192 symbols | 48 symbols |
 
 - **clock_resolution** (*Optional*, int): The clock resolution used by the RMT peripheral in Hz. Defaults to `1000000`.
+- **non_blocking** (*Optional*, boolean): If enabled, any transmit will return immediately and the RMT will run in the
+  background. The `on_complete` [Automation](#automation) will trigger after the transmit completes. Defaults to `false`.
 - **use_dma** (*Optional*, boolean): Enable DMA on variants that support it. If enabled `rmt_symbols` controls
   the DMA buffer size and can be set to a large value.
 

--- a/content/components/remote_transmitter.md
+++ b/content/components/remote_transmitter.md
@@ -58,7 +58,7 @@ remote_transmitter:
 
 - **clock_resolution** (*Optional*, int): The clock resolution used by the RMT peripheral in Hz. Defaults to `1000000`.
 - **non_blocking** (*Optional*, boolean): If enabled, any transmit will return immediately and the RMT will run in the
-  background. The `on_complete` [Automation](#automation) will trigger after the transmit completes. Defaults to `false`.
+  background. The `on_complete` automation will trigger after the transmit completes. Defaults to `false`.
 - **use_dma** (*Optional*, boolean): Enable DMA on variants that support it. If enabled `rmt_symbols` controls
   the DMA buffer size and can be set to a large value.
 

--- a/content/components/remote_transmitter.md
+++ b/content/components/remote_transmitter.md
@@ -58,7 +58,7 @@ remote_transmitter:
 
 - **clock_resolution** (*Optional*, int): The clock resolution used by the RMT peripheral in Hz. Defaults to `1000000`.
 - **non_blocking** (*Optional*, boolean): If enabled, any transmit will return immediately and the RMT will run in the
-  background. The `on_complete` automation will trigger after the transmit completes. Defaults to `false`.
+  background. The `on_complete` automation will trigger after the transmit completes. Defaults to `true`.
 - **use_dma** (*Optional*, boolean): Enable DMA on variants that support it. If enabled `rmt_symbols` controls
   the DMA buffer size and can be set to a large value.
 


### PR DESCRIPTION
## Description:

Remote transmitter can block for a long time:
```
[16:58:18.971][W][component:453]: api took a long time for an operation (146 ms)
[16:58:18.980][W][component:456]: Components should block for at most 30 ms
```

Add a non-blocking mode as followup to https://github.com/esphome/esphome/pull/11505

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#11524

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
