### PR TITLE
[mipi_rgb] [mipi_spi] Document `transform: disabled`

### DIFF
--- a/content/components/display/mipi_rgb.md
+++ b/content/components/display/mipi_rgb.md
@@ -66,7 +66,7 @@ display:
     id: my_display
 ```
 
-## Configuration variables
+## Configuration options
 
 - **rotation** (*Optional*): Rotate the display presentation in software. Choose one of `0°`, `90°`, `180°`, or `270°`.
   This option cannot be used with `transform`.
@@ -135,7 +135,8 @@ Displays needing a custom init sequence require an SPI bus to be configured, plu
 - **invert_colors** (*Optional*): Inverts the display colors, (white becomes black.) Defaults to false.
 - **color_order** (*Optional*): Should be one of `bgr` (default) or `rgb`.
 - **transform** (*Optional*): Transform the display presentation using hardware. All defaults are `false`.
-  This option cannot be used with `rotation`.
+  This option should not be used with `rotation`. For the `CUSTOM` model, use `transform: disabled`
+  if the display does not support it, which will prevent a `rotation` being translated to a hardware transform.
 
   - **mirror_x** (*Optional*, boolean): If true, mirror the x-axis.
   - **mirror_y** (*Optional*, boolean): If true, mirror the y-axis.

--- a/content/components/display/mipi_spi.md
+++ b/content/components/display/mipi_spi.md
@@ -127,6 +127,8 @@ most of the configuration will be set by default, but can be overridden if neede
 - **invert_colors** (*Optional*, boolean): Specifies whether the display colors should be inverted. Options are `true` or `false`. Defaults to `false`.
 - **rotation** (*Optional*): Rotate the display presentation in software. Choose one of `0°`, `90°`, `180°`, or `270°`. If the driver chip supports hardware rotation for the given orientation this will be translated to the appropriate hardware command. If hardware rotation is not supported, the display will be rotated in software.
 - **transform** (*Optional*): If `rotation` is not sufficient, use this to transform the display. If this option is specified, then the `dimensions` option must also be provided. The value can either be the string `disabled` to disable hardware transform, or a dictionary. Options are:
+  This option should not be used with `rotation`. For the `CUSTOM` model, use `transform: disabled`
+  if the display does not support it, which will prevent a `rotation` being translated to a hardware transform.
 
   - **swap_xy** (**Required**, boolean): If true, exchange the x and y axes.
   - **mirror_x** (**Required**, boolean): If true, mirror the x axis.


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#11585

## Checklist:

  - [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
