### PR TITLE
[epaper_spi] Update docs for code revisions

### DIFF
--- a/content/components/display/epaper_spi.md
+++ b/content/components/display/epaper_spi.md
@@ -18,7 +18,6 @@ configuration.
 The driver supports a number of displays and there are also specific configurations for ESP32 boards with integrated displays.
 For tbose boards the predefined configuration will set the correct pins and dimensions for the display.
 
-
 ```yaml
 display:
   - platform: epaper_spi
@@ -29,15 +28,14 @@ display:
 
 ## Supported displays
 
-| Model name             | Manufacturer | Product Description                                        | 
+| Model name             | Manufacturer | Product Description                                        |
 |------------------------|--------------|------------------------------------------------------------|
 | Spectra-E6             | Eink         | <https://www.eink.com/brand/detail/Spectra6>               |
 | Seeed-reTerminal-E1002 | Seeed Studio | <https://www.seeedstudio.com/reTerminal-E1002-p-6533.html> |
 
-
 ## Configuration variables
 
-When using an model defining an integrated ESP32 display board most of the configuration such as the pins and dimensions will be set by default,
+When using a model defining an integrated ESP32 display board most of the configuration such as the pins and dimensions will be set by default,
 but can be overridden if needed.
 
 - **model** (**Required**): The model of the ePaper display. See the table above for options.

--- a/content/components/display/epaper_spi.md
+++ b/content/components/display/epaper_spi.md
@@ -15,28 +15,36 @@ better integration with ESPHome's async architecture.
 The communication method uses 4-wire [SPI](#spi), so you need to have an `spi:` section in your
 configuration.
 
+The driver supports a number of displays and there are also specific configurations for ESP32 boards with integrated displays.
+For tbose boards the predefined configuration will set the correct pins and dimensions for the display.
+
+
 ```yaml
 display:
   - platform: epaper_spi
-    cs_pin: GPIOXX
-    dc_pin: GPIOXX
-    busy_pin: GPIOXX
-    reset_pin: GPIOXX
-    model: 7.3in-spectra-e6
+    model: Seeed-reTerminal-E1002
     lambda: |-
       it.filled_circle(it.get_width() / 2, it.get_height() / 2, 50, Color::BLACK);
 ```
 
+## Supported displays
+
+| Model name             | Manufacturer | Product Description                                        | 
+|------------------------|--------------|------------------------------------------------------------|
+| Spectra-E6             | Eink         | <https://www.eink.com/brand/detail/Spectra6>               |
+| Seeed-reTerminal-E1002 | Seeed Studio | <https://www.seeedstudio.com/reTerminal-E1002-p-6533.html> |
+
+
 ## Configuration variables
 
-- **cs_pin** (**Required**, [Pin Schema](#config-pin_schema)): The CS pin.
-- **dc_pin** (**Required**, [Pin Schema](#config-pin_schema)): The DC pin.
-- **model** (**Required**): The model of the ePaper display. Currently supported:
+When using an model defining an integrated ESP32 display board most of the configuration such as the pins and dimensions will be set by default,
+but can be overridden if needed.
 
-  - `7.3in-spectra-e6` - 7.3" Spectra E6 6-color display (800×480 pixels)
-
-- **busy_pin** (*Optional*, [Pin Schema](#config-pin_schema)): The BUSY pin. Defaults to not connected.
-- **reset_pin** (*Optional*, [Pin Schema](#config-pin_schema)): The RESET pin. Defaults to not connected.
+- **model** (**Required**): The model of the ePaper display. See the table above for options.
+- **cs_pin** (**Required**, [Pin Schema](#config-pin_schema)): The CS pin. Predefined for integrated boards.
+- **dc_pin** (**Required**, [Pin Schema](#config-pin_schema)): The DC pin. Predefined for integrated boards.
+- **busy_pin** (*Optional*, [Pin Schema](#config-pin_schema)): The BUSY pin, if used.
+- **reset_pin** (*Optional*, [Pin Schema](#config-pin_schema)): The RESET pin, if used.
   Make sure you pull this pin high (by connecting it to 3.3V with a resistor) if not connected to a GPIO pin.
 
 - **rotation** (*Optional*): Set the rotation of the display. Everything you draw in `lambda:` will be rotated

--- a/content/components/display/epaper_spi.md
+++ b/content/components/display/epaper_spi.md
@@ -16,7 +16,7 @@ The communication method uses 4-wire [SPI](#spi), so you need to have an `spi:` 
 configuration.
 
 The driver supports a number of displays and there are also specific configurations for ESP32 boards with integrated displays.
-For tbose boards the predefined configuration will set the correct pins and dimensions for the display.
+For those boards the predefined configuration will set the correct pins and dimensions for the display.
 
 ```yaml
 display:

--- a/content/components/display/mipi_spi.md
+++ b/content/components/display/mipi_spi.md
@@ -29,7 +29,7 @@ boards and chips, but the driver is also designed to be customisable in YAML for
 ## Supported boards and driver chips
 
 The driver supports a number of display driver chips, and can be configured for custom displays. As well as support for
-driver chips, there are also specific configurations for several ESP32 boards with integrated displays. For tbose boards
+driver chips, there are also specific configurations for several ESP32 boards with integrated displays. For those boards
 the predefined configuration will set the correct pins and dimensions for the display.
 
 For custom displays, the driver can be configured with the correct pins and dimensions, and the driver chip can be


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#11540
## Checklist:

  - [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
