### PR TITLE
[nrf52,i2c] update doc

### DIFF
--- a/content/components/i2c.md
+++ b/content/components/i2c.md
@@ -39,7 +39,8 @@ i2c:
   Defaults to `true`.
 
 - **frequency** (*Optional*, float): Set the frequency the I²C bus should operate on.
-  Defaults to `50kHz`. Default for NRF52 is `100kHz`. Values are `10kHz`, `50kHz`, `100kHz`, `200kHz`, ... `800kHz`. NRF52 support only `100kHz` and `400kHz`.
+  Defaults to `50kHz`. Default for NRF52 is `100kHz`. Values are `10kHz`, `50kHz`, `100kHz`, `200kHz`, ... `800kHz`.
+  NRF52 support only `100kHz` and `400kHz`.
 
 - **timeout** (*Optional*, [Time](#config-time)): Set the I²C bus timeout.
   Defaults to the framework defaults (`100us` on `esp32` with `esp-idf`, `50ms` on `esp32` with `Arduino`,

--- a/content/components/i2c.md
+++ b/content/components/i2c.md
@@ -39,7 +39,7 @@ i2c:
   Defaults to `true`.
 
 - **frequency** (*Optional*, float): Set the frequency the I²C bus should operate on.
-  Defaults to `50kHz`. Default for NRF52 is `100kHz`. Values are `10kHz`, `50kHz`, `100kHz`, `200kHz`, ... `800kHz`. NRF52 support only `100kHz` and `800kHz`.
+  Defaults to `50kHz`. Default for NRF52 is `100kHz`. Values are `10kHz`, `50kHz`, `100kHz`, `200kHz`, ... `800kHz`. NRF52 support only `100kHz` and `400kHz`.
 
 - **timeout** (*Optional*, [Time](#config-time)): Set the I²C bus timeout.
   Defaults to the framework defaults (`100us` on `esp32` with `esp-idf`, `50ms` on `esp32` with `Arduino`,

--- a/content/components/i2c.md
+++ b/content/components/i2c.md
@@ -39,7 +39,7 @@ i2c:
   Defaults to `true`.
 
 - **frequency** (*Optional*, float): Set the frequency the I²C bus should operate on.
-  Defaults to `50kHz`. Default for NRF52 is `100kHz`. Values are `10kHz`, `50kHz`, `100kHz`, `200kHz`, ... `800kHz`
+  Defaults to `50kHz`. Default for NRF52 is `100kHz`. Values are `10kHz`, `50kHz`, `100kHz`, `200kHz`, ... `800kHz`. NRF52 support only `100kHz` and `800kHz`.
 
 - **timeout** (*Optional*, [Time](#config-time)): Set the I²C bus timeout.
   Defaults to the framework defaults (`100us` on `esp32` with `esp-idf`, `50ms` on `esp32` with `Arduino`,

--- a/content/components/i2c.md
+++ b/content/components/i2c.md
@@ -9,7 +9,7 @@ params:
 
 {{< anchor "i2c" >}}
 
-This component sets up the I²C bus for your ESP32 or ESP8266. In order for these components
+This component sets up the I²C bus for your ESP32, ESP8266, RP2040 or NRF52. In order for these components
 to work correctly, you need to define the I²C bus in your configuration. Please note the ESP
 will enable its internal 10kΩ pullup resistors for these pins, so you usually don't need to
 put on external ones. You can use multiple devices on one I²C bus as each device is given a
@@ -39,7 +39,7 @@ i2c:
   Defaults to `true`.
 
 - **frequency** (*Optional*, float): Set the frequency the I²C bus should operate on.
-  Defaults to `50kHz`. Values are `10kHz`, `50kHz`, `100kHz`, `200kHz`, ... `800kHz`
+  Defaults to `50kHz`. Default for NRF52 is `100kHz`. Values are `10kHz`, `50kHz`, `100kHz`, `200kHz`, ... `800kHz`
 
 - **timeout** (*Optional*, [Time](#config-time)): Set the I²C bus timeout.
   Defaults to the framework defaults (`100us` on `esp32` with `esp-idf`, `50ms` on `esp32` with `Arduino`,

--- a/content/components/i2c.md
+++ b/content/components/i2c.md
@@ -40,7 +40,7 @@ i2c:
 
 - **frequency** (*Optional*, float): Set the frequency the I²C bus should operate on.
   Defaults to `50kHz`. Default for NRF52 is `100kHz`. Values are `10kHz`, `50kHz`, `100kHz`, `200kHz`, ... `800kHz`.
-  NRF52 support only `100kHz` and `400kHz`.
+  NRF52 supports only `100kHz` and `400kHz`.
 
 - **timeout** (*Optional*, [Time](#config-time)): Set the I²C bus timeout.
   Defaults to the framework defaults (`100us` on `esp32` with `esp-idf`, `50ms` on `esp32` with `Arduino`,


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 


https://github.com/esphome/esphome/pull/8150

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
