### PR TITLE
Add WeAct-Studio epaper support reference

### DIFF
--- a/content/components/display/waveshare_epaper.md
+++ b/content/components/display/waveshare_epaper.md
@@ -164,3 +164,4 @@ lambda: |-
 - {{< docref "index/" >}}
 - {{< apiref "waveshare_epaper/waveshare_epaper.h" "waveshare_epaper/waveshare_epaper.h" >}}
 - [Arduino Waveshare E-Paper library](https://github.com/soonuse/epd-library-arduino) by [Yehui (@soonuse)](https://github.com/soonuse)
+- [Support for some WeAct-Studio epapers](https://github.com/Ottes42/WeAct-Studio_ePaper) (and 3-Color-Support for some Waveshare ones) by [Ottes (@Ottes)](https://github.com/Ottes)


### PR DESCRIPTION
This pull request adds a new reference to the documentation for Waveshare e-paper displays, highlighting additional library support for WeAct-Studio e-paper modules and enhanced 3-color support for certain Waveshare models.

----

WeAct Studio ePaper Component for ESPHome
ESPHome external component for WeAct Studio ePaper screens, including support for select Waveshare ePaper displays.

Supported Displays

WeAct Studio 2.9" BWR screen (296x128) - Based on ESPHome pull request #6226 by jbergler
WeAct Studio 4.2" BW screen (400x300) - Based on ESPHome pull request #6209 by MrMDavidson
WeAct Studio 4.2" BWR screen (400x300) - Custom implementation based on jbergler's work
Various Waveshare ePaper displays - Latest ESPHome waveshare_epaper component code