### PR TITLE
[nRF52] Put the most common case first (Adafruit bootloader)

### DIFF
--- a/content/components/nrf52.md
+++ b/content/components/nrf52.md
@@ -31,7 +31,7 @@ Examples of low power [nRF52840 boards](https://github.com/joric/nrfmicro/wiki).
 
 ## Flashing with Adafruit nRF52 Bootloader
 
-For Adafruit, Promicro nRF52840, Seeed Studio XIAO BLE boards via a flash drive.
+For Adafruit, ProMicro nRF52840, Seeed Studio XIAO BLE boards via a flash drive.
 
 1. Connect the board to the PC via USB.
 1. Quickly short the reset pin to ground twice.

--- a/content/components/nrf52.md
+++ b/content/components/nrf52.md
@@ -31,9 +31,7 @@ Examples of low power [nRF52840 boards](https://github.com/joric/nrfmicro/wiki).
 
 ## Flashing with Adafruit nRF52 Bootloader
 
-For Adafruit, Promicro nRF52840n Seeed Studio XIAO BLE, etc.
-
-For flashing via a flash drive.
+For Adafruit, Promicro nRF52840, Seeed Studio XIAO BLE boards via a flash drive.
 
 1. Connect the board to the PC via USB.
 1. Quickly short the reset pin to ground twice.

--- a/content/components/nrf52.md
+++ b/content/components/nrf52.md
@@ -29,20 +29,9 @@ The nRF52840 requires a bootloader, with two supported options: `MCUboot` and `A
 
 Examples of low power [nRF52840 boards](https://github.com/joric/nrfmicro/wiki).
 
-## Flashing with MCUboot
-
-Flashing this bootloader requires an SWD connection, for which a programmer is necessary. A cheap ST-Link V2 can be utilized.
-
-1. Connect the board to the PC via SWD.
-1. Run `esphome upload yourfile.yaml --device PYOCD`.
-
-```yaml
-# Example configuration entry
-nrf52:
-  board: adafruit_feather_nrf52840
-```
-
 ## Flashing with Adafruit nRF52 Bootloader
+
+For Adafruit, Promicro nRF52840n Seeed Studio XIAO BLE, etc.
 
 For flashing via a flash drive.
 
@@ -60,6 +49,19 @@ This bootloader supports updates over USB CDC.
 # Example configuration entry
 nrf52:
   board: adafruit_itsybitsy_nrf52840
+```
+
+## Flashing with MCUboot
+
+Flashing this bootloader requires an SWD connection, for which a programmer is necessary. A cheap ST-Link V2 can be utilized.
+
+1. Connect the board to the PC via SWD.
+1. Run `esphome upload yourfile.yaml --device PYOCD`.
+
+```yaml
+# Example configuration entry
+nrf52:
+  board: adafruit_feather_nrf52840
 ```
 
 ## GPIO Pin Numbering


### PR DESCRIPTION
## Description:
This PR reorganizes the flashing instructions for nRF52 boards by reordering sections and improving documentation clarity.
- Moved Adafruit nRF52 Bootloader section before MCUboot section
- Enhanced board compatibility information for Adafruit bootloader method

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
