### PR TITLE
[nrf52] Document deep sleep feature for nRF52840

### DIFF
--- a/content/components/nrf52.md
+++ b/content/components/nrf52.md
@@ -97,7 +97,7 @@ nrf52:
 
 ## Deep sleep
 
-To put the nRF52840 (Nordic Semiconductor) into deep sleep — the lowest power consumption mode — you use `deep_sleep` componant.
+To put the nRF52840 (Nordic Semiconductor) into deep sleep — the lowest power consumption mode — you use `deep_sleep` component.
 
 ### Example Configuration
 

--- a/content/components/nrf52.md
+++ b/content/components/nrf52.md
@@ -114,7 +114,6 @@ deep_sleep:
   sleep_duration: 50s
 ```
 
-
 ## See Also
 
 - {{< docref "esphome/" >}}

--- a/content/components/nrf52.md
+++ b/content/components/nrf52.md
@@ -95,6 +95,26 @@ nrf52:
 
 - **reset_pin** (*Required*, [Pin](#config-pin)): The pin to use for trigger a hardware reset. This pin should be connected to the MCU's reset line or to a circuit that causes the bootloader to enter DFU mode after reset.
 
+## Deep sleep
+
+To put the nRF52840 (Nordic Semiconductor) into deep sleep — the lowest power consumption mode — you use `deep_sleep` componant.
+
+### Example Configuration
+
+```yaml
+esphome:
+  on_boot:
+    then:
+      - deep_sleep.prevent
+      - delay: 1s
+      - deep_sleep.allow
+
+deep_sleep:
+  run_duration: 10s
+  sleep_duration: 50s
+```
+
+
 ## See Also
 
 - {{< docref "esphome/" >}}


### PR DESCRIPTION
## Description:

Document deep sleep feature for nRF52840

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#11672

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
