### PR TITLE
[nrf52] Document Nordic UART Service (NUS) configuration

### DIFF
--- a/content/automations/_index.md
+++ b/content/automations/_index.md
@@ -7,6 +7,8 @@ params:
     image: auto-fix.svg
 ---
 
+{{< anchor "automation" >}}
+
 Automations are a very powerful aspect of ESPHome; they allow you to easily perform actions given some condition(s).
 
 When you want your ESPHome device to respond to its environment, you use an automation. Here are some examples:

--- a/content/automations/actions.md
+++ b/content/automations/actions.md
@@ -253,8 +253,10 @@ on_...:
   - repeat:
       count: 5
       then:
+        - lambda: ESP_LOGI("main", "Turning lights on for iteration [%d]", iteration);
         - light.turn_on: some_light
         - delay: 1s
+        - lambda: ESP_LOGI("main", "Turning lights off for iteration [%d]", iteration);
         - light.turn_off: some_light
         - delay: 10s
 ```
@@ -262,7 +264,7 @@ on_...:
 #### Configuration variables
 
 - **count** (**Required**, int): The number of times the action should be repeated. The counter is available to
-  lambdas using the reserved word "iteration".
+  lambdas using the implicit script parameter `iteration`.
 
 - **then** (**Required**, [Action](#config-action)): The action to repeat.
 

--- a/content/components/display/max7219digit.md
+++ b/content/components/display/max7219digit.md
@@ -75,13 +75,9 @@ display:
 - **chip_lines_style** (*Optional*): How are the lines in Multiline Mode connected? Possible values are `zigzag` and `snake`. Defaults to `snake`
 - **flip_x** (*Optional*, boolean): Flip the horizontal axis on the screen. Defaults to `false`.
 
-{{< anchor "display-max7219digit_actions" >}}
-
 ## Actions
 
 The following actions are replicas of the LAMBDA functions shown in the next section.
-
-{{< anchor "display-max7219digit_actions_invert_on_off>" >}}
 
 ### `MAX7219.invert_on` & `MAX7219.invert_off` Action
 
@@ -89,19 +85,13 @@ This action `MAX7219.invert_on` will invert the display. So background pixels ar
 off. `MAX7219.invert_off` sets the display back to normal. The background pixels are only set at the next update, the pixels drawn in
 the various function like print, line, etc. are directly influenced by the invert command.
 
-{{< anchor "display-max7219digit_actions_turn_on_off" >}}
-
 ### `MAX7219.turn_on` & `MAX7219.turn_off` Action
 
 The display can be switched on and off "dynamically" with the actions `MAX7219.turn_on` & `MAX7219.turn_off`.
 
-{{< anchor "display-max7219digit_actions_reverse_off" >}}
-
 ## `MAX7219.reverse_on` & `MAX7219.reverse_off` Action
 
 With this actions you can reverse the display direction from left to right to right to left.
-
-{{< anchor "display-max7219digit_actions_intensity" >}}
 
 ## `MAX7219.intensity` Action
 

--- a/content/components/display/mipi_spi.md
+++ b/content/components/display/mipi_spi.md
@@ -73,7 +73,7 @@ using an octal SPI bus, so references here to parallel and octal SPI are equival
 | JC3636W518                           | Guition | <https://www.aliexpress.com/item/1005007890666293.html> |
 | JC3636W518V2                         | Guition | <https://www.aliexpress.com/item/1005007890666293.html> |
 | LANBON-L8                            | Lanbon | <https://www.lanbon.cn/product/lanbon-l8> |
-| T4-S3-AMOLED                         | Lilygo | <https://www.lilygo.cc/products/t4-s3> |
+| T4-S3                                | Lilygo | <https://www.lilygo.cc/products/t4-s3> |
 | T-EMBED                              | Lilygo | <https://www.lilygo.cc/products/t-embed> |
 | T-DISPLAY                            | Lilygo | <https://www.lilygo.cc/products/t-display> |
 | T-DISPLAY-S3                         | Lilygo | <https://www.lilygo.cc/products/t-display-s3> |

--- a/content/components/nrf52.md
+++ b/content/components/nrf52.md
@@ -95,6 +95,18 @@ nrf52:
 
 - **reset_pin** (*Required*, [Pin](#config-pin)): The pin to use for trigger a hardware reset. This pin should be connected to the MCU's reset line or to a circuit that causes the bootloader to enter DFU mode after reset.
 
+
+## Nordic UART Service (NUS)
+
+The Bluetooth® Low Energy (LE) GATT Nordic UART Service is a custom service that receives and writes data and serves as a bridge to the UART interface.
+
+### Example Configuration
+
+```yaml
+ble_nus:
+  type: logs
+```
+
 ## See Also
 
 - {{< docref "esphome/" >}}

--- a/content/components/nrf52.md
+++ b/content/components/nrf52.md
@@ -95,7 +95,6 @@ nrf52:
 
 - **reset_pin** (*Required*, [Pin](#config-pin)): The pin to use for trigger a hardware reset. This pin should be connected to the MCU's reset line or to a circuit that causes the bootloader to enter DFU mode after reset.
 
-
 ## Nordic UART Service (NUS)
 
 The Bluetooth® Low Energy (LE) GATT Nordic UART Service is a custom service that receives and writes data and serves as a bridge to the UART interface.

--- a/script/md_anchors.py
+++ b/script/md_anchors.py
@@ -32,7 +32,7 @@ def process_markdown_file(file_path):
             continue
 
         # Shortcodes
-        shortcode_match = re.search(r'{{<\s*anchor\s*"([^"]+)"\s*>}}', line)
+        shortcode_match = re.search(r'\{\{<\s*anchor\s+"([^\s>]+)"\s*>}}', line)
         if shortcode_match:
             anchor_id = shortcode_match.group(1)
             # Look ahead for heading


### PR DESCRIPTION
## Description:

Added section for Nordic UART Service (NUS) with example configuration.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#9846

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
