### PR TITLE
[psram] Document change in mode option

### DIFF
--- a/content/components/psram.md
+++ b/content/components/psram.md
@@ -21,7 +21,9 @@ psram:
 
 ## Configuration variables
 
-- **mode** (*Optional*): Defines the operating mode the PSRAM should utilize. One of `quad` (default) or `octal`.
+- **mode** (*Optional*): Defines the operating mode the PSRAM should utilize. One of `quad`, `octal` or `hex`.
+  Defaults to `quad` for ESP32 and `hex` for ESP32-P4. ESP32-S3 has no default and _requires_ this option to be set.
+  See notes below.
 - **speed** (*Optional*, int): The speed at which the PSRAM should operate. One of `40MHz` (default), `80MHz` or `120MHz`.
 - **enable_ecc** (*Optional*, bool): For octal mode, enable ECC (Error Correction Code) for the PSRAM (default is off.)
   ECC is a method of detecting and correcting single-bit errors in memory. It will reduce the available PSRAM size and speed by
@@ -30,15 +32,22 @@ psram:
 - **disabled** (*Optional*, bool): Don't try to initialize the PSRAM. This is needed if one of the configured components autoloads psram
   but the ESP32 module doesn't have PSRAM and you need to use one of the PSRAM control lines for something else. e.g. ethernet. Defaults to ``false``.
 
-## Restrictions
+## Modes
+
+The ESP32 PSRAM is only available in `quad` mode, and ESP32-P4 only supports `hex` mode. These are the defaults
+when using those variants. For ESP32-S3, the `mode` option is required and must be set to `quad` or `octal`.
+Typically on ESP32-S3 modules, a 2MB PSRAM will use quad mode, while 8 or 16MB will use octal mode, but check
+the datasheet for the module you are using to be sure.
+
+> [!WARNING]
+> If you choose the wrong mode for your board, the PSRAM will not work.
+
+## Notes
 
 - Not all ESP32 modules have PSRAM available. If you are unsure, consult the datasheet of your module.
 - Not all modules support all modes and speeds.
 - 120MHz is not available with octal mode, unless using ESP-IDF and the `enable_idf_experimental_features` is enabled
   in the ESP-IDF platform [Advanced Configuration](#esp32-advanced_configuration).
-
-- If you choose the wrong mode for your board, the PSRAM will not work.
 - Configuring an unsupported speed will usually result in the PSRAM running at the default speed.
-- Typically on ESP32-S3 modules, a 2MB PSRAM will use quad mode, while 8 or 16MB will use octal mode.
 
 ## See Also

--- a/content/components/psram.md
+++ b/content/components/psram.md
@@ -8,9 +8,10 @@ params:
 ---
 
 This component enables and configures PSRAM if/when available on ESP32 modules/boards.
-It is automatically loaded and enabled by components that require it.
+Some components require PSRAM, while others may use it for optional features. In any case
+it is required to explicitly configured - this is a change from previous versions of ESPHome.
 
-PSRAM is only available on the ESP32.
+PSRAM is not available with platforms other than ESP32.
 
 ```yaml
 # Example configuration entry

--- a/content/components/psram.md
+++ b/content/components/psram.md
@@ -23,7 +23,7 @@ psram:
 ## Configuration variables
 
 - **mode** (*Optional*): Defines the operating mode the PSRAM should utilize. One of `quad`, `octal` or `hex`.
-  Defaults to `quad` for ESP32 and `hex` for ESP32-P4. ESP32-S3 has no default and _requires_ this option to be set.
+  Defaults to `quad` for ESP32 and `hex` for ESP32-P4. ESP32-S3 has no default and *requires* this option to be set.
   See notes below.
 - **speed** (*Optional*, int): The speed at which the PSRAM should operate. One of `40MHz` (default), `80MHz` or `120MHz`.
 - **enable_ecc** (*Optional*, bool): For octal mode, enable ECC (Error Correction Code) for the PSRAM (default is off.)


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#11470

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
