### PR TITLE
Minor corrections to LVGL examples

### DIFF
--- a/content/cookbook/lvgl.md
+++ b/content/cookbook/lvgl.md
@@ -939,28 +939,28 @@ lvgl:
     pages:
       - id: room_page
         widgets:
-          - obj: # a properly placed coontainer object for all these controls
+          - obj: # a properly placed container object for all these controls
               align: CENTER
               width: 240
               height: 256
               x: 4
               y: 4
               pad_all: 3
-              pad_row: 6
-              pad_column: 8
               bg_opa: TRANSP
               border_opa: TRANSP
               layout: # enable the FLEX layout for the children widgets
                 type: FLEX
                 flex_flow: COLUMN_WRAP # the order of the widgets starts top left
                 flex_align_cross: CENTER # they sould be centered
+                pad_row: 6
+                pad_column: 8
               widgets:
                 - label:
                     text: "East"
                 - button:
                     id: but_cov_up_east
                     width: 70 # choose the button dimensions so
-                    height: 68 # they fill the columns nincely as they flow
+                    height: 68 # they fill the columns nicely as they flow
                     widgets:
                       - label:
                           id: cov_up_east
@@ -1065,19 +1065,19 @@ lvgl:
     pages:
       - id: room_page
         widgets:
-          - obj: # a properly placed coontainer object for all these controls
+          - obj: # a properly placed container object for all these controls
               align: CENTER
               width: 240
               height: 256
               pad_all: 6
-              pad_row: 6
-              pad_column: 8
               bg_opa: TRANSP
               border_opa: TRANSP
               layout: # enable the GRID layout for the children widgets
                 type: GRID # split the rows and the columns proportionally
                 grid_columns: [FR(1), FR(1), FR(1)] # equal
                 grid_rows: [FR(10), FR(30), FR(30), FR(30)] # like percents
+                pad_row: 6
+                pad_column: 8
               widgets:
                 - label:
                     text: "East"


### PR DESCRIPTION
## Description:

I noticed some typos in the examples, and that `pad_row` and `pad_column` at some point have changed so they must now be under `layout`

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
