### PR TITLE
[lvgl] Document `if_nan` text format option

### DIFF
--- a/content/components/lvgl/widgets.md
+++ b/content/components/lvgl/widgets.md
@@ -165,6 +165,9 @@ The text value may also be a lambda returning a `std::string` or may be
 specified with a `format` property utilising `printf` style formatting. There is also a `time_format` option
 which allows use of [strftime](http://www.cplusplus.com/reference/ctime/strftime/) formats.
 
+When formatting a single floating point value, it is possible to provide a substitute string to be used when the
+value is `nan` or `inf`. The substitute string is specified with the `if_nan` option.
+
 **Examples:**
 
 ```yaml
@@ -199,6 +202,12 @@ on_...:
       text:
         time_format: "%c"
         time: !lambda return id(sntp_id).utcnow();
+  - lvgl.label.update:
+      id: value_id
+      text:
+        format: "%.1f"
+        args: [id(sensor_id).state]
+        if_nan: "N/A"
 ```
 
 {{< anchor "lvgl-widget-animimg" >}}


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#11712

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
