### PR TITLE
[esp32] Add ignore_pin_validation_error docs

### DIFF
--- a/content/guides/configuration-types.md
+++ b/content/guides/configuration-types.md
@@ -128,8 +128,8 @@ Advanced options:
   you can suppress the warning by setting this option to `true` in the pin configuration.
 
 - **ignore_pin_validation_error** (*Optional*, boolean): Certain pins on ESP32 chips are reserved
-  for internal functions like flash memory interface (e.g., GPIO 6-11 on most ESP32 variants). ESPHome will
-  raise an error if you try to use these reserved pins.
+  for internal functions like flash memory interface (for example, GPIO 6-11 on most ESP32 variants). ESPHome
+  will raise an error if you try to use these reserved pins.
 
   However, some ESP32 board designs wire specific flash configurations that free up certain pins for general use.
   If you are *absolutely* certain that your specific board design allows a normally-reserved pin to be used,

--- a/content/guides/configuration-types.md
+++ b/content/guides/configuration-types.md
@@ -127,6 +127,14 @@ Advanced options:
   If you are *absolutely* sure that you are using a strapping pin for I/O in a way that will not cause problems,
   you can suppress the warning by setting this option to `true` in the pin configuration.
 
+- **ignore_pin_validation_error** (*Optional*, boolean): Certain pins on ESP32 chips are reserved
+  for internal functions like flash memory interface (e.g., GPIO 6-11 on most ESP32 variants). ESPHome will
+  raise an error if you try to use these reserved pins.
+
+  However, some ESP32 board designs wire specific flash configurations that free up certain pins for general use.
+  If you are *absolutely* certain that your specific board design allows a normally-reserved pin to be used,
+  you can suppress the error by setting this option to `true`. Defaults to `false`.
+
 {{< anchor "config-time" >}}
 
 ## Time


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
