### PR TITLE
Dockerfile - add missing `jq` package to fix broken Docker documentation build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM python:3.13-slim
 RUN apt-get update && apt-get install -y --no-install-recommends \
         curl \
         git \
+        jq \
         make \
         openssh-client \
         hugo \


### PR DESCRIPTION
## Description:

Attempting to build and preview documentation using the Docker method described in <https://developers.esphome.io/contributing/docs/> is failing as follows:

```
$ docker image ls ghcr.io/esphome/esphome-docs:latest
REPOSITORY                     TAG       IMAGE ID       CREATED       SIZE
ghcr.io/esphome/esphome-docs   latest    7aec82903c85   5 weeks ago   328MB

$ docker run --rm -v "${PWD}/":/workspaces/esphome-docs -p 8000:8000 -it ghcr.io/esphome/esphome-docs
mkdir -p data public pagefind content static
mkdir -p data/automations
curl -s -S https://data.esphome.io/release/automations.json | script/collate_automations.sh > data/automations/current.json
script/collate_automations.sh: 2: jq: not found
curl: (23) Failure writing output to destination, passed 1369 returned 1367
make: *** [Makefile:34: repo-data] Error 127
```

This PR adds `jq` to the package install list in the Dockerfile - testing with a locally built Docker image now works as expected.

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
