### PR TITLE
Fix broken external links

### DIFF
--- a/content/components/climate/haier.md
+++ b/content/components/climate/haier.md
@@ -211,7 +211,7 @@ on_...:
 
 ### `climate.haier.health_on` Action
 
-Turn on health mode ([UV light sterilization](https://www.haierhvac.eu/en/node/1809)).
+Turn on health mode (UV light sterilization).
 
 ```yaml
 on_...:

--- a/content/components/climate/midea.md
+++ b/content/components/climate/midea.md
@@ -12,7 +12,7 @@ The `midea` component creates a Midea air conditioner climate device.
 > [!NOTE]
 > This protocol also used by some vendors:
 >
-> - [Electrolux](https://www.electrolux.ru/)
+> - [Electrolux](https://www.electrolux.com/en/)
 > - [Qlima](https://www.qlima.com/)
 > - [Artel](https://www.artelgroup.com/)
 > - [Carrier](https://www.carrier.com/)

--- a/content/components/climate/midea.md
+++ b/content/components/climate/midea.md
@@ -16,7 +16,7 @@ The `midea` component creates a Midea air conditioner climate device.
 > - [Qlima](https://www.qlima.com/)
 > - [Artel](https://www.artelgroup.com/)
 > - [Carrier](https://www.carrier.com/)
-> - [Comfee](http://www.comfee-russia.ru/)
+> - [Comfee](https://www.feelcomfee.com/global/)
 > - [Inventor](https://www.inventorairconditioner.com/)
 > - [Senville](https://senville.com/)
 > - and maybe others

--- a/content/components/climate/pid.md
+++ b/content/components/climate/pid.md
@@ -27,9 +27,6 @@ temperature to a user-specified setpoint.
 > keep the temperature as constant as possible, and smooth out oscillations otherwise produced by
 > classic thermostats.
 
-Explaining how PID controllers work in detail is out of scope of this documentation entry,
-but there's a nice article explaining the function principle at <https://blog.opticontrols.com/archives/344>.
-
 ```yaml
 # Example configuration entry
 climate:

--- a/content/components/climate/pid.md
+++ b/content/components/climate/pid.md
@@ -440,6 +440,5 @@ Advanced options:
 - {{< docref "/components/climate" >}}
 - {{< docref "/components/output/sigma_delta_output" >}}
 - {{< docref "/components/output/slow_pwm" >}}
-- [Principles of PID](https://blog.opticontrols.com/archives/344)
 - {{< apiref "pid/pid_climate.h" "pid/pid_climate.h" >}}
 - {{< apiref "PID Autotuner" "pid/pid_autotuner.h" >}}

--- a/content/components/display/ssd1327.md
+++ b/content/components/display/ssd1327.md
@@ -12,7 +12,7 @@ params:
 ## Over I²C
 
 The `ssd1327_i2c` display platform allows you to use
-SSD1327 ([datasheet](https://www.waveshare.com/w/upload/a/ac/SSD1327-datasheet.pdf),
+SSD1327 ([datasheet](https://cdn.sparkfun.com/assets/1/a/5/d/4/DS-15890-Zio_OLED.pdf),
 [Waveshare](https://www.waveshare.com/1.5inch-oled-module.htm)) displays with ESPHome. Note that this component is for
 displays that are connected via the [I²C Bus](#i2c). If your SSD1327 is connected via the 4-Wire
 [SPI bus](#spi), see [Over SPI](#ssd1327-spi).
@@ -65,7 +65,7 @@ display:
 ## Over SPI
 
 The `ssd1327_spi` display platform allows you to use
-SSD1327 ([datasheet](https://cdn-shop.adafruit.com/datasheets/SSD1327.pdf), [Adafruit](https://www.adafruit.com/product/326))
+SSD1327 ([datasheet](https://cdn.sparkfun.com/assets/1/a/5/d/4/DS-15890-Zio_OLED.pdf), [Adafruit](https://www.adafruit.com/product/326))
 displays with ESPHome. Note that this component is for displays that are connected via the 4-Wire [SPI bus](#spi).
 If your SSD1327 is connected via the [I²C Bus](#i2c), see [Over I²C](#ssd1327-i2c).
 

--- a/content/components/display/ssd1351.md
+++ b/content/components/display/ssd1351.md
@@ -15,7 +15,7 @@ The `ssd1351_spi` display platform allows you to use
 SSD1351 ([datasheet](https://cdn-shop.adafruit.com/datasheets/SSD1351-Revision+1.3.pdf),
 [Adafruit 128x128](https://www.adafruit.com/product/1431),
 [Adafruit 128x96](https://www.adafruit.com/product/1673),
-[Waveshare 128x128](https://www.waveshare.com/product/displays/lcd-oled/lcd-oled-3/1.5inch-rgb-oled-module.htm))
+[Waveshare 128x128](https://www.waveshare.com/1.5inch-rgb-oled-module.htm))
 displays with ESPHome. This component is for displays that are connected via the 4-Wire [SPI bus](#spi).
 
 {{< img src="ssd1351-full.jpg" alt="Image" caption="SSD1351 OLED Display" width="75.0%" class="align-center" >}}

--- a/content/components/gps.md
+++ b/content/components/gps.md
@@ -76,5 +76,5 @@ See {{< docref "time/gps" >}} for config options for the GPS time source.
 ## See Also
 
 - [Sensor Filters](#sensor-filters)
-- [TinyGPS++ library](https://github.com/mikalhart/TinyGPSPlus)
+- [TinyGPS++ library](https://github.com/esphome/TinyGPSPlus)
 - {{< apiref "gps/gps.h" "gps/gps.h" >}}

--- a/content/components/gps.md
+++ b/content/components/gps.md
@@ -76,5 +76,5 @@ See {{< docref "time/gps" >}} for config options for the GPS time source.
 ## See Also
 
 - [Sensor Filters](#sensor-filters)
-- [TinyGPS++ library](http://arduiniana.org/libraries/tinygpsplus/)
+- [TinyGPS++ library](https://github.com/mikalhart/TinyGPSPlus)
 - {{< apiref "gps/gps.h" "gps/gps.h" >}}

--- a/content/components/lvgl/widgets.md
+++ b/content/components/lvgl/widgets.md
@@ -2027,7 +2027,7 @@ ESPHome implements as universal triggers the following interaction events genera
 
 These triggers can be applied directly to any widget in the LVGL configuration, *given that the widget itself supports generating such events*. For the widgets having a value, the triggers return the current value in variable `x`  ; this variable may be used in lambdas defined within those triggers.
 
-Each trigger also deliver an `event` parameter, which is a pointer to the LVGL C type `lv_event_t`. This may be used in lambdas defined within those triggers. Refer to the [LVGL documentation](https://docs.lvgl.io/8.4/overview/event.html/) for more information.
+Each trigger also deliver an `event` parameter, which is a pointer to the LVGL C type `lv_event_t`. This may be used in lambdas defined within those triggers. Refer to the [LVGL documentation](https://docs.lvgl.io/8.4/overview/event.html) for more information.
 
 There are additional triggers for pages - each page may have an `on_load` and `on_unload` trigger. These will be called
 when the page becomes active or inactive respectively.

--- a/content/components/rf_bridge.md
+++ b/content/components/rf_bridge.md
@@ -284,7 +284,8 @@ The raw data will be available in the log and can later be used with [`rf_bridge
 
 > [!NOTE]
 > A conversion from *B1* (received) raw format to *B0* (send) raw command format should be applied.
-> For this, you can use the tool [BitBucket Converter](https://bbconv.hrbl.pl/) or [B1 Converter](https://jonajona.nl/convertB1.html/)
+> For this, you can use the tool [B1 Converter](https://jonajona.nl/convertB1.html)
+
 > [!NOTE]
 > There seems to be an overflow problem in Portisch firmware and after a short while, the bucket sniffing stops.
 > You should re-call the action to reset and start sniffing again. This issue is fixed in Mightymos firmware.

--- a/content/components/sensor/bme680_bsec.md
+++ b/content/components/sensor/bme680_bsec.md
@@ -400,6 +400,5 @@ so that the process does not have to start from zero on device restart.
 - {{< docref "bme680/" >}}
 - {{< apiref "bme680_bsec/bme680_bsec.h" "bme680_bsec/bme680_bsec.h" >}}
 - [BME680 Datasheet](https://www.bosch-sensortec.com/media/boschsensortec/downloads/datasheets/bst-bme680-ds001.pdf)
-- [BME680 VOC classification](https://community.bosch-sensortec.com/t5/MEMS-sensors-forum/BME680-VOC-classification/td-p/26154)
 - [BSEC Arduino Library](https://github.com/BoschSensortec/BSEC-Arduino-library) by [Bosch Sensortec](https://www.bosch-sensortec.com/)
 - [Bosch Sensortec Community](https://community.bosch-sensortec.com/)

--- a/content/components/sensor/bme68x_bsec2.md
+++ b/content/components/sensor/bme68x_bsec2.md
@@ -247,6 +247,5 @@ saved to flash so that the process does not have to start from scratch on device
 - {{< apiref "bme68x_bsec2_i2c/bme68x_bsec2_i2c.h" "bme68x_bsec2_i2c/bme68x_bsec2_i2c.h" >}}
 - [BME680 datasheet](https://www.bosch-sensortec.com/media/boschsensortec/downloads/datasheets/bst-bme680-ds001.pdf)
 - [BME688 datasheet](https://www.bosch-sensortec.com/media/boschsensortec/downloads/datasheets/bst-bme688-ds000.pdf)
-- [BME680 VOC classification](https://community.bosch-sensortec.com/t5/MEMS-sensors-forum/BME680-VOC-classification/td-p/26154)
 - [Bosch BSEC2 Library](https://github.com/boschsensortec/Bosch-BSEC2-Library) by [Bosch Sensortec](https://www.bosch-sensortec.com/)
 - [Bosch Sensortec Community](https://community.bosch-sensortec.com/)

--- a/content/components/sensor/dht.md
+++ b/content/components/sensor/dht.md
@@ -9,7 +9,7 @@ params:
 
 The DHT Temperature+Humidity sensor allows you to use your
 
-- DHT11 ([datasheet](https://akizukidenshi.com/download/ds/aosong/DHT11.pdf), [Adafruit](https://www.adafruit.com/product/386)),
+- DHT11 ([datasheet](https://www.makerhero.com/img/files/download/DHT11-Datasheet.pdf), [Adafruit](https://www.adafruit.com/product/386)),
 - DHT21/DHT22 ([datasheet](https://www.sparkfun.com/datasheets/Sensors/Temperature/DHT22.pdf), [Adafruit](https://www.adafruit.com/product/385)),
 - AMS2301/AM2302 ([datasheet](https://cdn-shop.adafruit.com/datasheets/Digital+humidity+and+temperature+sensor+AM2302.pdf), [Adafruit](https://www.adafruit.com/product/393)),
 - AM2120 ([datasheet](https://www.micros.com.pl/mediaserver/UPAM2120_0004.pdf)),

--- a/content/components/sensor/dsmr.md
+++ b/content/components/sensor/dsmr.md
@@ -19,7 +19,7 @@ This component is passive, it does not transmit any data to your equipment, the 
 data which this component decodes and updates the configured sensors at the pace the data is received.
 
 - For official information about DSMR refer to: [DSMR Document](https://www.netbeheernederland.nl/dossiers/slimme-meter-15)
-- For official information about the P1 port refer to: [P1 Companion Standard](https://www.netbeheernederland.nl/_upload/Files/Slimme_meter_15_a727fce1f1.pdf)
+- For official information about the P1 port refer to: [P1 Companion Standard](https://www.netbeheernederland.nl/sites/default/files/2024-02/dsmr_5.0.2_p1_companion_standard.pdf)
 
 ```yaml
 # Example configuration entry

--- a/content/components/sensor/ens160.md
+++ b/content/components/sensor/ens160.md
@@ -82,7 +82,7 @@ Advanced:
 ## Example Text Sensor configuration
 
 The Air Quality Index(AQI) from this sensor is a number between 1 and 5. The ENS160
-([datasheet](https://www.sciosense.com/wp-content/uploads/documents/SC-001224-DS-7-ENS160-Datasheet.pdf)) states that
+([datasheet](https://www.sciosense.com/wp-content/uploads/2023/12/ENS160-Datasheet.pdf)) states that
 "The AQI-UBA air quality index is derived from a guideline by the German Federal Environmental
 Agency based on a TVOC sum signal". The following is an example configuration to convert the numeric ENS160 AQI to the rating text.
 

--- a/content/components/sensor/gcja5.md
+++ b/content/components/sensor/gcja5.md
@@ -8,7 +8,7 @@ params:
 ---
 
 The `gcja5` sensor platform allows you to use your Panasonic SN-GCJA5 laser based particulate matter sensor
-([datasheet](https://na.industrial.panasonic.com/products/sensors/air-quality-gas-flow-sensors/lineup/laser-type-pm-sensor/series/123557/model/123559))
+([datasheet](https://industrial.panasonic.com/ww/products/pt/dust-sensor/pm_laser))
 sensors with ESPHome.
 
 As the communication with the GCJA5 is done using UART, you need

--- a/content/components/sensor/havells_solar.md
+++ b/content/components/sensor/havells_solar.md
@@ -8,7 +8,7 @@ params:
 ---
 
 The `Havells Inverter` sensor platform allows you to use Havells inverter data reading on modbus
-([website](https://www.havells.com/en/consumer/solar/solar-on-grid-inverter-and-solutions/solar-on-grid-inverter.html))
+([website](https://havells.com/business/discover-solar-solutions))
 with ESPHome.
 
 {{< img src="havellsgti5000d.jpg" alt="Image" caption="Havells On Grid Solar Inverter." width="50.0%" class="align-center" >}}

--- a/content/components/sensor/honeywell_hih_i2c.md
+++ b/content/components/sensor/honeywell_hih_i2c.md
@@ -7,8 +7,8 @@ params:
     image: honeywellhih.jpg
 ---
 
-Honeywell HumidIcon (I2C HIH series) Temperature & Humidity sensors with ESPHome ([website](https://sps.honeywell.com/us/en/products/advanced-sensing-technologies/healthcare-sensing/humidity-with-temperature-sensors),
-[datasheet](https://prod-edam.honeywell.com/content/dam/honeywell-edam/sps/siot/en-us/products/sensors/humidity-with-temperature-sensors/common/documents/sps-siot-humidity-sensors-line-guide-009034-7-en-ciid-54931.pdf?download=false)).
+Honeywell HumidIcon (I2C HIH series) Temperature & Humidity sensors with ESPHome
+([datasheet](https://prod-edam.honeywell.com/content/dam/honeywell-edam/sps/siot/en-us/products/sensors/humidity-with-temperature-sensors/common/documents/sps-siot-humidity-sensors-line-guide-009034-7-en-ciid-54931.pdf?download=false)).
 The [I²C Bus](#i2c) is required to be set up in your configuration for this sensor to work.
 
 Example sensors:

--- a/content/components/sensor/honeywellabp.md
+++ b/content/components/sensor/honeywellabp.md
@@ -8,9 +8,9 @@ params:
 ---
 
 The `honeywellabp` sensor platform allows you to use your Honeywell ABP
-([website](https://sps.honeywell.com/us/en/products/sensing-and-iot/sensors/pressure-sensors/board-mount-pressure-sensors/basic-abp-series),
-[datasheet](https://prod-edam.honeywell.com/content/dam/honeywell-edam/sps/siot/en-us/products/sensors/pressure-sensors/board-mount-pressure-sensors/basic-abp-series/documents/sps-siot-basic-board-mount-pressure-abp-series-datasheet-32305128-ciid-155789.pdf?download=false),
-[Mouser](https://www.mouser.ca/new/honeywell/honeywell-abp-pressure-sensors/)) pressure and temperature sensors with ESPHome. The [SPI](#spi) is
+([datasheet](https://prod-edam.honeywell.com/content/dam/honeywell-edam/sps/siot/en-us/products/sensors/pressure-sensors/board-mount-pressure-sensors/basic-abp-series/documents/sps-siot-basic-board-mount-pressure-abp-series-datasheet-32305128-ciid-155789.pdf?download=false),
+[Mouser](https://www.mouser.ca/new/honeywell/honeywell-abp-pressure-sensors/))
+pressure and temperature sensors with ESPHome. The [SPI](#spi) is
 required to be set up in your configuration for this sensor to work
 
 {{< img src="honeywellabp.jpg" alt="Image" caption="Honeywell ABP Pressure and Temperature Sensor." width="50.0%" class="align-center" >}}

--- a/content/components/sensor/honeywellabp2_i2c.md
+++ b/content/components/sensor/honeywellabp2_i2c.md
@@ -7,9 +7,8 @@ params:
     image: honeywellabp.jpg
 ---
 
-The `honeywellabp2_i2c` sensor platform allows you to use your Honeywell ABP
-([website](https://sps.honeywell.com/us/en/products/advanced-sensing-technologies/healthcare-sensing/board-mount-pressure-sensors/basic-abp2-series),
-[datasheet](https://prod-edam.honeywell.com/content/dam/honeywell-edam/sps/siot/en-us/products/sensors/pressure-sensors/board-mount-pressure-sensors/basic-abp2-series/documents/sps-siot-abp2-series-datasheet-32350268-en.pdf?download=false))
+The `honeywellabp2_i2c` sensor platform allows you to use your Honeywell ABP2
+([datasheet](https://prod-edam.honeywell.com/content/dam/honeywell-edam/sps/siot/en-us/products/sensors/pressure-sensors/board-mount-pressure-sensors/basic-abp2-series/documents/sps-siot-abp2-series-datasheet-32350268-en.pdf?download=false))
 pressure and temperature sensors with ESPHome. The [I2C](#i2c) is
 required to be set up in your configuration for this sensor to work
 

--- a/content/components/sensor/iaqcore.md
+++ b/content/components/sensor/iaqcore.md
@@ -8,7 +8,7 @@ params:
 ---
 
 The AMS iAQ-Core sensor allows you to use your
-([datasheet](https://www.sciosense.com/wp-content/uploads/documents/iaQ-Core-Datasheet.pdf))
+([datasheet](https://www.digikey.com/en/htmldatasheets/production/1723318/0/0/1/iaq-core))
 sensors with ESPHome.
 
 {{< img src="iaqcore.jpg" alt="Image" caption="AMS iAQ-Core Indoor Air Quality Sensor." width="30.0%" class="align-center" >}}

--- a/content/components/sensor/sen21231.md
+++ b/content/components/sensor/sen21231.md
@@ -7,7 +7,7 @@ params:
     image: description.svg
 ---
 
-[Person Sensor (SEN21231) from Useful Sensors](https://usefulsensors.com/person-sensor) has built in facial recognition that can detect how many people are facing the sensor and relative positions of the faces.
+[Person Sensor (SEN21231) from Useful Sensors](https://www.sparkfun.com/person-sensor-by-useful-sensors.html) has built in facial recognition that can detect how many people are facing the sensor and relative positions of the faces.
 
 {{< img src="sen21231.png" alt="Image" caption="Person Sensor" width="70.0%" class="align-center" >}}
 

--- a/content/components/sensor/sht4x.md
+++ b/content/components/sensor/sht4x.md
@@ -8,7 +8,7 @@ params:
 ---
 
 The `sht4x` sensor platform allows you to use your SHT4X temperature and humidity sensor
-([datasheet](https://sensirion.com/media/documents/33FD6951/63E1087C/Datasheet_SHT4x_1.pdf), `Adafruit`_) with ESPHome.
+([datasheet](https://sensirion.com/media/documents/33FD6951/661CD142/HT_DS_Datasheet_SHT4x.pdf), `Adafruit`_) with ESPHome.
 
 The [I²C Bus](#i2c) is required to be set up in your configuration for this sensor to work.
 
@@ -50,7 +50,7 @@ The heater can be enabled by setting `heater_max_duty` up to a maximum duty cycl
 of `5%` (`0.05`  ). This runs the heater on a regular interval. While the heater
 is in operation the sensor disables measurements so no updates will be published.
 
-See the ([datasheet](https://sensirion.com/media/documents/33FD6951/63E1087C/Datasheet_SHT4x_1.pdf))
+See the ([datasheet](https://sensirion.com/media/documents/33FD6951/661CD142/HT_DS_Datasheet_SHT4x.pdf))
 for more information about heater operation.
 
 ## See Also

--- a/content/components/sensor/shtcx.md
+++ b/content/components/sensor/shtcx.md
@@ -9,7 +9,7 @@ params:
 
 The `shtcx` sensor platform Temperature+Humidity sensor allows you to use your Sensirion SHTC1
 ([datasheet](https://sensirion.com/media/documents/21BF77EA/63A5A411/Datasheet_SHTC1.pdf),
-[Sensirion STHC1](https://sensirion.com/products/catalog/SHTC1/)) and
+[Sensirion SHTC1](https://sensirion.com/products/catalog/SHTC1/)) and
 the newer SHTC3
 ([datasheet](https://sensirion.com/media/documents/643F9C8E/63A5A436/Datasheet_SHTC3.pdf),
 `SparkFun`_ ) sensors with

--- a/content/components/sensor/shtcx.md
+++ b/content/components/sensor/shtcx.md
@@ -9,7 +9,7 @@ params:
 
 The `shtcx` sensor platform Temperature+Humidity sensor allows you to use your Sensirion SHTC1
 ([datasheet](https://sensirion.com/media/documents/21BF77EA/63A5A411/Datasheet_SHTC1.pdf),
-[Sensirion STHC1](https://www.sensirion.com/en/environmental-sensors/humidity-sensors/digital-humidity-sensor-for-consumer-electronics-and-iot/)) and
+[Sensirion STHC1](https://sensirion.com/products/catalog/SHTC1/)) and
 the newer SHTC3
 ([datasheet](https://sensirion.com/media/documents/643F9C8E/63A5A436/Datasheet_SHTC3.pdf),
 `SparkFun`_ ) sensors with

--- a/content/components/sensor/sts3x.md
+++ b/content/components/sensor/sts3x.md
@@ -8,7 +8,7 @@ params:
 ---
 
 The `sts3x` sensor platform Temperature sensor allows you to use your Sensirion STS30-DIS, STS31-DIS or STS35-DIS
-([datasheet](https://sensirion.com/media/documents/1DA31AFD/61641F76/Sensirion_Temperature_Sensors_STS3x_Datasheet.pdf),
+([datasheet](https://sensirion.com/media/documents/1DA31AFD/65D613A8/Datasheet_STS3x_DIS.pdf),
 [Sensirion STS3x](https://www.sensirion.com/sts3x/)) sensors with
 ESPHome. The [I²C Bus](#i2c) is
 required to be set up in your configuration for this sensor to work.

--- a/content/components/sensor/t6615.md
+++ b/content/components/sensor/t6615.md
@@ -47,5 +47,5 @@ sensor:
 ## See Also
 
 - [Sensor Filters](#sensor-filters)
-- [UART Protocol Documentation](https://amphenol-sensors.com/en/component/edocman/561-telaire-co2-sensors-uart-communications-protocol/download?Itemid=8486%20%27)
+- [UART Protocol Documentation](https://www.amphenol-sensors.com/hubfs/Documents/T63182-004-091614-web.pdf)
 - {{< apiref "t6615/t6615.h" "t6615/t6615.h" >}}

--- a/content/components/sensor/zyaura.md
+++ b/content/components/sensor/zyaura.md
@@ -9,7 +9,7 @@ params:
 
 The ZyAura CO2 & Temperature & Humidity sensor allows you to use your
 [ZGm05(3)(U)](http://www.zyaura.com/products/ZGm05.asp)
-([MT8057](https://masterkit.ru/shop/1266110), [MT8057S](https://medgadgets.ru/shop/kit-mt8057.html)),
+[MT8057](https://masterkit.ru/shop/1266110),
 [ZG1683R(U)](http://www.zyaura.com/products/ZG1683R.asp) ([MT8060](https://masterkit.ru/shop/1921398)),
 [ZG1583RUD](http://www.zyaura.com/products/ZG1583RUD.asp)
 monitors with ESPHome.

--- a/content/components/switch/haier.md
+++ b/content/components/switch/haier.md
@@ -29,7 +29,7 @@ switch:
 - **beeper** (*Optional*): (supported only by hOn) A switch that enables or disables Haier climate sound feedback.
   All options from [Switch](#config-switch).
 
-- **health_mode** (*Optional*): A switch that enables or disables Haier climate health mode ([UV light sterilization](https://www.haierhvac.eu/en/node/1809)).
+- **health_mode** (*Optional*): A switch that enables or disables Haier climate health mode (UV light sterilization).
   All options from [Switch](#config-switch).
 
 - **display** (*Optional*): A switch that enables or disables Haier climate led display.

--- a/content/components/touchscreen/xpt2046.md
+++ b/content/components/touchscreen/xpt2046.md
@@ -11,7 +11,7 @@ params:
 
 The `xpt2046` touchscreen platform allows using the resistive touch screen controllers
 based on the XPT2046 chip
-([datasheet](https://datasheetspdf.com/pdf-file/746665/XPTEK/XPT2046/1),
+([datasheet](https://grobotronics.com/images/datasheets/xpt2046-datasheet.pdf),
 `AZ-Delivery`_) with ESPHome. Many cheap LCD displays contain this controller.
 The [SPI](#spi) is required to be set up in your configuration for this sensor to work.
 

--- a/content/guides/configuration-types.md
+++ b/content/guides/configuration-types.md
@@ -23,8 +23,7 @@ ID twice.
 
 Because ESPHome converts your configuration into C++ code and the
 IDs are in reality just C++ variable names, they must also adhere to
-C++'s naming conventions. [C++ Variablenames](https://venus.cs.qc.cuny.edu/~krishna/cs111/lectures/D3_C++_Variables.pdf)
-…
+[C++'s naming conventions](https://en.cppreference.com/w/cpp/language/identifiers)…
 
 - … must start with a letter and can end with numbers.
 - … must not have a space in the name.

--- a/content/guides/diy.md
+++ b/content/guides/diy.md
@@ -39,7 +39,6 @@ unless it's truly exceptional, etc.
 - [ESPHome 12v Fan Controller with PID Climate](https://github.com/patrickcollins12/esphome-fan-controller) by {{< ghuser name="patrickcollins12" >}}
 - [Sonoff 4CH Irrigation Controller with Nextion Display](https://github.com/bruxy70/Irrigation-with-display) by {{< ghuser name="bruxy70" >}}
 - [Automated Bathroom Ventilation](https://www.youtube.com/watch?v=weBDnmrQYOs) by [Intermittent Technology](https://intermit.tech)
-- [ESPHome MP3 Sound Machine](https://selfhostedhome.com/esp8266-mp3-sound-machine/) by [Self Hosted Home](https://selfhostedhome.com)
 - [Detecting Sound with ESP8266](https://thibmaek.com/posts/detecting-sound-level-using-esp8266-and-esphome) by [Thibault Maekelbergh](https://thibmaek.com)
 - [SW420 Vibration Sensor with Remote Notifications](https://github.com/rmooreID/Home-Assistant-Appliance-Monitor/) by {{< ghuser name="rmooreID" >}}
 - [DIY Irrigation Controller (with Internal Scheduler + Lovelace UI)](https://brianhanifin.com/posts/diy-irrigation-controller-esphome-home-assistant/) by {{< ghuser name="BrianHanifin" >}}

--- a/content/guides/physical_device_connection.md
+++ b/content/guides/physical_device_connection.md
@@ -52,7 +52,7 @@ On Windows these interfaces are named `COM1`, `COM2`, etc. and on Linux they are
 >
 > * CH34x: [driver](https://github.com/nodemcu/nodemcu-devkit/tree/master/Drivers)
 > * CP2102: [driver](https://www.silabs.com/products/development-tools/software/usb-to-uart-bridge-vcp-drivers)
-> * PL2303: [driver](https://www.prolific.com.tw/US/ShowProduct.aspx?p_id=225&pcid=41)
+> * PL2303: [driver](https://cdn-shop.adafruit.com/datasheets/PL2303HX.pdf)
 
 With the exception of the situation where you have a USB port, you need to make
 five electrical connections to program an ESP-based board:


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
