### PR TITLE
[nrf52] Enhance OpenThread documentation with nrf52 example

### DIFF
--- a/content/components/openthread.md
+++ b/content/components/openthread.md
@@ -56,7 +56,7 @@ openthread:
 
 ### Nordic nRF52
 
-This component allow an nRF52840 board to use Thread as a transport layer.
+This component allow a nRF52840 board to use Thread as a transport layer.
 This example show how to configure Thread Dataset for a node.
 
 ```yaml
@@ -75,7 +75,6 @@ openthread:
   mesh_local_prefix: fd53:145f:ed22:ad81::/64
   force_dataset: true
 ```
-
 
 ### Configuration variables
 

--- a/content/components/openthread.md
+++ b/content/components/openthread.md
@@ -18,6 +18,8 @@ This component allows ESPHome nodes to communicate with Home Assistant over a Th
 
 ## Usage
 
+### ESP32
+
 This component requires an ESP32 (ESP32-C6 or ESP32-H2 because they have Thread radio chip) and the use of
 ESP-IDF.
 
@@ -31,7 +33,7 @@ esp32:
 
 {{< anchor "config-openthread" >}}
 
-## Full Configuration
+#### Full Configuration
 
 This example show how to configure Thread Dataset for a node.
 
@@ -51,6 +53,29 @@ openthread:
   mesh_local_prefix: fd53:145f:ed22:ad81::/64
   force_dataset: true
 ```
+
+### Nordic nRF52
+
+This component allow an nRF52840 board to use Thread as a transport layer.
+This example show how to configure Thread Dataset for a node.
+
+```yaml
+# Example OpenThread component configuration
+network:
+  enable_ipv6: true
+
+openthread:
+  device_type: FTD
+  channel: 13
+  network_name: OpenThread-8f28
+  network_key: 0xdfd34f0f05cad978ec4e32b0413038ff
+  pan_id: 0x8f28
+  ext_pan_id: 0xd63e8e3e495ebbc3
+  pskc: 0xc23a76e98f1a6483639b1ac1271e2e27
+  mesh_local_prefix: fd53:145f:ed22:ad81::/64
+  force_dataset: true
+```
+
 
 ### Configuration variables
 


### PR DESCRIPTION
## Description:

Enhance OpenThread documentation with nrf52 example

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#11671

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
