### PR TITLE
fix: missing underscore in pcd_8544.h link

### DIFF
--- a/content/components/display/pcd8544.md
+++ b/content/components/display/pcd8544.md
@@ -60,6 +60,6 @@ To use a backlight LIGHT pin needs to be connected to ground. If connected to GP
 ## See Also
 
 - {{< docref "index/" >}}
-- {{< apiref "pcd8544/pcd8544.h" "pcd8544/pcd8544.h" >}}
+- {{< apiref "pcd8544/pcd_8544.h" "pcd8544/pcd_8544.h" >}}
 - [Tutorial from Adafruit](https://learn.adafruit.com/nokia-5110-3310-monochrome-lcd)
 - [PCD8544 Library](https://github.com/adafruit/Adafruit-PCD8544-Nokia-5110-LCD-library) by [Adafruit](https://www.adafruit.com/)


### PR DESCRIPTION
## Description:

The doxygen URL didn't work, fixed.

## Checklist:

  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.
