### PR TITLE
[wifi] Document min_auth_mode configuration option

### DIFF
--- a/content/components/wifi.md
+++ b/content/components/wifi.md
@@ -101,6 +101,22 @@ wifi:
   In case it fails, all networks are then tested one after the other in their declared order, starting with the first
   one in the list.
 
+- **min_auth_mode** (*Optional*, string): Only on `esp32` and `esp8266`. Sets the minimum WiFi authentication mode
+  that the device will accept when connecting to access points. This controls the weakest encryption your device will
+  allow. Possible values are:
+
+  - `WPA` - Allows WPA, WPA2, and WPA3 networks (least secure, uses TKIP encryption with known vulnerabilities)
+  - `WPA2` - Allows WPA2 and WPA3 networks (recommended, uses AES encryption)
+  - `WPA3` - Only allows WPA3 networks (most secure, ESP32 only)
+
+  Defaults to `WPA2` on ESP32 and `WPA` on ESP8266 (will change to `WPA2` in 2026.6.0).
+
+  {{% notice warning %}}
+  **Security Warning:** Setting `min_auth_mode: WPA` allows connection to networks using deprecated WPA/TKIP encryption,
+  which has known security vulnerabilities. Only use this setting for legacy routers that cannot be upgraded to WPA2 or WPA3.
+  If your router supports WPA2 or newer, use the default `WPA2` setting for better security.
+  {{% /notice %}}
+
 - **passive_scan** (*Optional*, boolean): If enabled, then the device will perform WiFi scans in a passive fashion.
   Defaults to `false`.
 
@@ -200,6 +216,41 @@ power saving mode.
 wifi:
   # ...
   power_save_mode: none
+```
+
+{{< anchor "wifi-min_auth_mode" >}}
+
+## WiFi Authentication Mode
+
+The `min_auth_mode` option allows you to control the minimum WiFi security standard your device will accept.
+This is useful for ensuring your device only connects to secure networks, or for maintaining compatibility with
+legacy routers that only support older encryption standards.
+
+### Example: Maximum Security (WPA2 or newer)
+
+```yaml
+wifi:
+  ssid: MyHomeNetwork
+  password: VerySafePassword
+  min_auth_mode: WPA2  # Reject WPA-only networks
+```
+
+### Example: Legacy Router Support (WPA allowed)
+
+```yaml
+wifi:
+  ssid: OldRouter
+  password: VerySafePassword
+  min_auth_mode: WPA  # Allow connection to WPA-only routers (less secure)
+```
+
+### Example: Modern Security (WPA3 only, ESP32 only)
+
+```yaml
+wifi:
+  ssid: ModernRouter
+  password: VerySafePassword
+  min_auth_mode: WPA3  # Only connect to WPA3 networks (most secure)
 ```
 
 {{< anchor "wifi-networks" >}}

--- a/content/components/wifi.md
+++ b/content/components/wifi.md
@@ -111,11 +111,9 @@ wifi:
 
   Defaults to `WPA2` on ESP32 and `WPA` on ESP8266 (will change to `WPA2` in 2026.6.0).
 
-  {{% notice warning %}}
   **Security Warning:** Setting `min_auth_mode: WPA` allows connection to networks using deprecated WPA/TKIP encryption,
   which has known security vulnerabilities. Only use this setting for legacy routers that cannot be upgraded to WPA2 or WPA3.
   If your router supports WPA2 or newer, use the default `WPA2` setting for better security.
-  {{% /notice %}}
 
 - **passive_scan** (*Optional*, boolean): If enabled, then the device will perform WiFi scans in a passive fashion.
   Defaults to `false`.


### PR DESCRIPTION
## Description:

Adds documentation for the new `min_auth_mode` WiFi configuration option that allows users to control the minimum WiFi authentication/encryption standard their device will accept.

**Changes made:**

1. **Configuration Variables Section**: Added `min_auth_mode` documentation with:
   - Description of what it controls (minimum authentication mode)
   - Available options: WPA, WPA2, WPA3
   - Platform support: ESP32 and ESP8266 only
   - Default values: WPA2 (ESP32), WPA (ESP8266, changing to WPA2 in 2026.6.0)
   - Security warning box about WPA/TKIP vulnerabilities

2. **New Section**: "WiFi Authentication Mode" with practical examples:
   - Maximum security configuration (WPA2)
   - Legacy router support (WPA)
   - Modern security configuration (WPA3, ESP32 only)

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#11814

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
