### PR TITLE
software_coexistence is sibling to scan_parameters, rather than child

### DIFF
--- a/content/components/esp32_ble_tracker.md
+++ b/content/components/esp32_ble_tracker.md
@@ -87,10 +87,10 @@ sensor:
   - **continuous** (*Optional*, boolean): Whether to scan continuously (forever) or to only scan when
     asked to start a scan (with start_scan action). Defaults to `true`.
 
-  - **software_coexistence** (*Optional*, boolean): When enabled, software coexistence will
-    briefly prioritize Bluetooth over Wi-Fi during the initial establishment of BLE connections,
-    which can improve reliability. Only available if `wifi` component is configured.
-    Defaults to `true`.
+- **software_coexistence** (*Optional*, boolean): When enabled, software coexistence will
+  briefly prioritize Bluetooth over Wi-Fi during the initial establishment of BLE connections,
+  which can improve reliability. Only available if `wifi` component is configured.
+  Defaults to `true`.
 
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID for this ESP32 BLE Hub.
 - **max_connections** (*Optional*, int): **DEPRECATED** - This option has been moved to the {{< docref "esp32_ble/" >}} component.


### PR DESCRIPTION
## Description:
software_coexistence in the docs is a child of scan_parameters, but in the latest deployed version it is a sibling


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
