### PR TITLE
[wifi] Document priority type change to integer

### DIFF
--- a/content/components/wifi.md
+++ b/content/components/wifi.md
@@ -248,8 +248,8 @@ wifi:
 - **hidden** (*Optional*, boolean): Whether this network is hidden. Defaults to false.
   If you add this option you also have to specify ssid.
 
-- **priority** (*Optional*, int): The priority of this network (range: -128 to 127). After each time, the network with
-  the highest priority is chosen. If the connection fails, the priority is decreased by one.
+- **priority** (*Optional*, int): The priority of this network (range: -128 to 127). The network with
+  the highest priority is chosen. After each connection failure, the priority is decreased by one.
   If all tracked BSSIDs have identical priorities, they are automatically reset to 0 to start fresh.
   Defaults to `0`.
 

--- a/content/components/wifi.md
+++ b/content/components/wifi.md
@@ -248,8 +248,9 @@ wifi:
 - **hidden** (*Optional*, boolean): Whether this network is hidden. Defaults to false.
   If you add this option you also have to specify ssid.
 
-- **priority** (*Optional*, float): The priority of this network. After each time, the network with
+- **priority** (*Optional*, int): The priority of this network (range: -128 to 127). After each time, the network with
   the highest priority is chosen. If the connection fails, the priority is decreased by one.
+  If all tracked BSSIDs have identical priorities, they are automatically reset to 0 to start fresh.
   Defaults to `0`.
 
 {{< anchor "eap" >}}


### PR DESCRIPTION
## Description:

Updates WiFi component documentation for the priority type change from `float` to `int8_t`.

### Changes

- Updated `priority` configuration option to specify integer type (range: -128 to 127)
- Documented auto-reset behavior when all BSSIDs have identical priorities
- Clarified that priority is decreased by one on each connection failure

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#11830

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
