### PR TITLE
[rx8130] Fix documentation build error with note shortcode

### DIFF
--- a/content/components/time/rx8130.md
+++ b/content/components/time/rx8130.md
@@ -23,10 +23,8 @@ time:
 
 This [Action](#config-action) triggers a synchronization of the current system time to the RTC hardware.
 
-{{< note >}}
-The RX8130 component will *not* write to the RTC clock if not triggered *explicitly* by this action.
-
-{{< /note >}}
+> [!NOTE]
+> The RX8130 component will *not* write to the RTC clock if not triggered *explicitly* by this action.
 
 ```yaml
 on_...:
@@ -43,12 +41,10 @@ on_...:
 
 This [Action](#config-action) triggers a synchronization of the current system time from the RTC hardware.
 
-{{< note >}}
-The RX8130 component will automatically read the RTC clock every 15 minutes by default and synchronize the
-system clock when a valid timestamp is read from the RTC. (The `update_interval` can be changed.)
-This action can be used to trigger *additional* synchronizations.
-
-{{< /note >}}
+> [!NOTE]
+> The RX8130 component will automatically read the RTC clock every 15 minutes by default and synchronize the
+> system clock when a valid timestamp is read from the RTC. (The `update_interval` can be changed.)
+> This action can be used to trigger *additional* synchronizations.
 
 ```yaml
 on_...:


### PR DESCRIPTION
## Description:

Fix documentation build error in RX8130 component documentation introduced in PR #5315.

The RX8130 documentation was using Hugo shortcode syntax `{{< note >}}` which does not exist in the ESPHome documentation theme. This caused build failures with the error:

```
failed to extract shortcode: template for shortcode "note" not found
```

This PR converts the non-existent `{{< note >}}` shortcodes to the standard markdown alert syntax `> [!NOTE]` that is used throughout the rest of the ESPHome documentation (e.g., in `ds1307.md` and other time component docs).

**Related issue (if applicable):** N/A - fixes build error

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

N/A - documentation-only fix

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
