### PR TITLE
Add documentation for Sonoff SPM

### DIFF
--- a/content/components/sensor/sonoff_spm.md
+++ b/content/components/sensor/sonoff_spm.md
@@ -1,0 +1,126 @@
+---
+description: "Instructions for setting up Sonoff SPM sensors in ESPHome."
+title: "Sonoff SPM Sensor"
+params:
+  seo:
+    description: Instructions for setting up Sonoff SPM sensors in ESPHome.
+---
+
+The `sonoff_spm` sensor platform allows you to monitor energy consumption from the Sonoff SPM (Smart Power Manager) system and requires {{< docref "/components/sonoff_spm" >}} to be configured.
+
+Each relay on the SPM-4Relay modules includes a CSE7761 energy monitoring chip that provides comprehensive power measurements.
+
+## Configuration Variables
+
+- **sonoff_spm_id** (*Optional*, {{< apiref "sonoff_spm/sonoff_spm.h" "ID" >}}): Manually specify the ID of the {{< docref "/components/sonoff_spm" "Sonoff SPM Component" >}}.
+- **relay_id** (**Required**, int): The relay number (0-127) to monitor. See {{< docref "/components/sonoff_spm#relay-id-mapping" "Relay ID Mapping" >}}.
+
+- **voltage** (*Optional*): Voltage measurement in Volts (V).
+  - All options from [Sensor](#config-sensor).
+
+- **current** (*Optional*): Current measurement in Amperes (A).
+  - All options from [Sensor](#config-sensor).
+
+- **power** (*Optional*): Active power measurement in Watts (W).
+  - All options from [Sensor](#config-sensor).
+
+- **apparent_power** (*Optional*): Apparent power measurement in Volt-Amperes (VA).
+  - All options from [Sensor](#config-sensor).
+
+- **reactive_power** (*Optional*): Reactive power measurement in Volt-Amperes Reactive (var).
+  - All options from [Sensor](#config-sensor).
+
+- **power_factor** (*Optional*): Power factor (dimensionless, 0-1).
+  - All options from [Sensor](#config-sensor).
+
+- **energy** (*Optional*): Total energy consumption in kilowatt-hours (kWh).
+  - All options from [Sensor](#config-sensor).
+
+## Example
+
+```yaml
+# Example configuration entry
+uart:
+  id: uart_bus
+  tx_pin: GPIO4
+  rx_pin: GPIO16
+  baud_rate: 115200
+
+sonoff_spm:
+  id: spm_main
+  uart_id: uart_bus
+
+# Basic monitoring for Relay 0
+sensor:
+  - platform: sonoff_spm
+    sonoff_spm_id: spm_main
+    relay_id: 0
+    voltage:
+      name: "Kitchen Voltage"
+    current:
+      name: "Kitchen Current"
+    power:
+      name: "Kitchen Power"
+    energy:
+      name: "Kitchen Energy"
+
+  # Detailed monitoring for Relay 5 (Pool Pump)
+  - platform: sonoff_spm
+    sonoff_spm_id: spm_main
+    relay_id: 5
+    voltage:
+      name: "Pool Pump Voltage"
+    current:
+      name: "Pool Pump Current"
+    power:
+      name: "Pool Pump Power"
+    apparent_power:
+      name: "Pool Pump Apparent Power"
+    reactive_power:
+      name: "Pool Pump Reactive Power"
+    power_factor:
+      name: "Pool Pump Power Factor"
+    energy:
+      name: "Pool Pump Energy Total"
+```
+
+## Automatic Entity Creation
+
+Instead of manually defining sensors, you can use the automatic entity creation feature:
+
+```yaml
+uart:
+  id: uart_bus
+  tx_pin: GPIO4
+  rx_pin: GPIO16
+  baud_rate: 115200
+
+sonoff_spm:
+  id: spm_main
+  uart_id: uart_bus
+  module_count: 2                # Number of SPM-4Relay modules
+  auto_create_sensors: true      # Automatically create sensors
+  name_prefix: "SPM"             # Prefix for sensor names
+  sensor_types:                  # Which sensor types to create
+    - voltage
+    - current
+    - power
+    - energy
+```
+
+This will automatically create voltage, current, power, and energy sensors for all relays on the connected modules.
+
+## Important Notes
+
+- Energy measurements are only updated when relays are powered ON
+- Wait a few seconds after turning on a relay for energy data to appear
+- The relay_id is calculated as: `(module_number * 4) + channel_number`
+- All sensors for a given relay_id should be defined in a single sensor block
+
+## See Also
+
+- {{< docref "/components/sonoff_spm" >}}
+- {{< docref "/components/switch/sonoff_spm" >}}
+- {{< docref "/components/uart" >}}
+- {{< docref "/components/sensor" >}}
+- {{< apiref "sonoff_spm/sonoff_spm.h" "sonoff_spm/sonoff_spm.h" >}}

--- a/content/components/sonoff_spm.md
+++ b/content/components/sonoff_spm.md
@@ -1,0 +1,211 @@
+---
+description: "Instructions for setting up the Sonoff SPM (Smart Power Manager) in ESPHome."
+title: "Sonoff SPM"
+params:
+  seo:
+    description: Instructions for setting up the Sonoff SPM (Smart Power Manager) in ESPHome.
+---
+
+{{< anchor "sonoff_spm" >}}
+
+The Sonoff SPM (Smart Power Manager) component provides support for the Sonoff SPM system, which consists of:
+
+- **SPM Main** unit: ESP32-based controller with UART interface to ARM processors
+- **SPM-4Relay** modules: Up to 32 modules, each with 4 relays and CSE7761 energy monitoring per relay (128 relays total)
+
+The Sonoff SPM uses a proprietary serial protocol at 115200 baud to communicate between the ESP32 and ARM processors on the relay modules. Each SPM-4Relay module provides:
+
+- 4 bistable relays
+- Per-relay energy monitoring (voltage, current, power, energy)
+- Overload protection
+- Power state logging
+
+## Hardware Setup
+
+1. Connect ESP32 UART pins to SPM Main unit:
+   - TX: GPIO4
+   - RX: GPIO16
+   - Baud: 115200
+
+1. Connect SPM-4Relay modules to the SPM Main unit via RS-485
+
+1. Power on the system and the ESP32 will automatically discover connected modules
+
+The SPM component requires a {{< docref "/components/uart" "UART bus" >}} to be configured.
+
+```yaml
+# Example configuration entry
+uart:
+  id: uart_bus
+  tx_pin: GPIO4
+  rx_pin: GPIO16
+  baud_rate: 115200
+
+sonoff_spm:
+  id: spm_main
+  uart_id: uart_bus
+  module_count: 2
+  auto_create_switches: true
+  auto_create_sensors: true
+  name_prefix: "SPM Relay"
+```
+
+## Configuration Variables
+
+- **uart_id** (*Optional*, {{< apiref "uart/uart_component.h" "ID" >}}): Manually specify the ID of the {{< docref "/components/uart" "UART Component" >}} if you want to use multiple UART buses.
+- **module_count** (*Optional*, int): Maximum number of SPM-4Relay modules to scan for (1-32). Default: `32`
+- **auto_create_switches** (*Optional*, boolean): Automatically create switch entities for all relays. Default: `false`
+- **auto_create_sensors** (*Optional*, boolean): Automatically create sensor entities for all relays. Default: `false`
+- **name_prefix** (*Optional*, string): Prefix for auto-generated entity names. Default: `"SPM Relay"`
+- **sensor_types** (*Optional*, list): Which sensors to auto-create when `auto_create_sensors` is enabled. Options: `voltage`, `current`, `power`, `energy`. Default: all four types
+- **id** (*Optional*, {{< apiref "sonoff_spm/sonoff_spm.h" "ID" >}}): Manually specify the ID used for code generation.
+
+## Automatic Entity Creation (Recommended)
+
+The easiest way to use this component is with automatic entity creation - no need to manually specify each relay!
+
+```yaml
+uart:
+  id: uart_bus
+  tx_pin: GPIO4
+  rx_pin: GPIO16
+  baud_rate: 115200
+
+sonoff_spm:
+  id: spm_main
+  uart_id: uart_bus
+  module_count: 4                # Number of SPM-4Relay modules you have
+  auto_create_switches: true     # Automatically create switches for all relays
+  auto_create_sensors: true      # Automatically create sensors for all relays
+  name_prefix: "Power"           # Optional: customize entity names
+  sensor_types:                  # Optional: choose which sensors to create
+    - voltage
+    - current
+    - power
+    - energy
+```
+
+This will automatically create:
+
+- **Switches**: `Power 0`, `Power 1`, ..., `Power 15` (for 4 modules)
+- **Sensors**: Voltage, Current, Power, and Energy for each relay
+
+## Manual Configuration
+
+For more control over entity names and which relays to expose:
+
+```yaml
+uart:
+  id: uart_bus
+  tx_pin: GPIO4
+  rx_pin: GPIO16
+  baud_rate: 115200
+
+sonoff_spm:
+  id: spm_main
+  uart_id: uart_bus
+  module_count: 32  # Maximum modules to scan for
+
+# Manually define switches
+switch:
+  - platform: sonoff_spm
+    name: "Kitchen Light"
+    sonoff_spm_id: spm_main
+    relay_id: 0
+
+  - platform: sonoff_spm
+    name: "Living Room Light"
+    sonoff_spm_id: spm_main
+    relay_id: 1
+
+# Manually define sensors
+sensor:
+  - platform: sonoff_spm
+    sonoff_spm_id: spm_main
+    relay_id: 0
+    voltage:
+      name: "Kitchen Voltage"
+    current:
+      name: "Kitchen Current"
+    power:
+      name: "Kitchen Power"
+    energy:
+      name: "Kitchen Energy"
+```
+
+## Relay ID Mapping
+
+Relay IDs are calculated as: `relay_id = (module_number * 4) + channel_number`
+
+Where:
+
+- `module_number`: 0-31 (for up to 32 SPM-4Relay modules)
+- `channel_number`: 0-3 (4 channels per module)
+
+Examples:
+
+- Module 0, Channel 0: relay_id = 0
+- Module 0, Channel 3: relay_id = 3
+- Module 1, Channel 0: relay_id = 4
+- Module 1, Channel 3: relay_id = 7
+- Module 2, Channel 0: relay_id = 8
+- Module 31, Channel 0: relay_id = 124
+- Module 31, Channel 3: relay_id = 127
+
+## Features
+
+- **Automatic module discovery**: The component automatically scans for connected SPM-4Relay modules
+- **Real-time energy monitoring**: Voltage, current, power, power factor, and energy consumption
+- **Relay control**: Switch relays on/off via ESPHome
+- **State synchronization**: Automatically syncs relay states from device button presses
+- **Energy data types**:
+  - Voltage (V)
+  - Current (A)
+  - Active Power (W)
+  - Apparent Power (VA)
+  - Reactive Power (var)
+  - Power Factor
+  - Total Energy (kWh)
+
+## Protocol Details
+
+The component implements the Sonoff SPM serial protocol:
+
+- **Baud Rate**: 115200 bps, 8N1
+- **Message Format**: `AA 55 01 [Module ID] [Command] [Data] [CRC]`
+- **CRC**: CRC-16/ARC (polynomial 0xA001)
+
+## Troubleshooting
+
+### No modules detected
+
+- Check UART wiring (TX/RX not swapped)
+- Verify baud rate is 115200
+- Ensure SPM-4Relay modules are powered
+- Check RS-485 connections between Main and relay modules
+
+### Energy readings not updating
+
+- Relays must be powered ON to report energy data
+- Wait a few seconds after turning on relay for data to appear
+
+### Relay state not syncing
+
+- Component automatically syncs state changes from physical buttons
+- Check logs for communication errors
+
+## Notes
+
+- Energy measurements are only updated when relays are powered on
+- The component handles module scanning and state synchronization automatically
+- Up to 32 SPM-4Relay modules (128 relays) are supported
+- Each relay can be independently monitored and controlled
+- Module scanning may take up to 30 seconds for systems with many modules
+
+## See Also
+
+- {{< docref "/components/uart" >}}
+- {{< docref "/components/switch/sonoff_spm" >}}
+- {{< docref "/components/sensor/sonoff_spm" >}}
+- {{< apiref "sonoff_spm/sonoff_spm.h" "sonoff_spm/sonoff_spm.h" >}}
+- [Tasmota Sonoff SPM driver](https://github.com/arendst/Tasmota/blob/development/tasmota/tasmota_xdrv_driver/xdrv_86_esp32_sonoff_spm.ino)

--- a/content/components/switch/sonoff_spm.md
+++ b/content/components/switch/sonoff_spm.md
@@ -1,0 +1,131 @@
+---
+description: "Instructions for setting up Sonoff SPM switches in ESPHome."
+title: "Sonoff SPM Switch"
+params:
+  seo:
+    description: Instructions for setting up Sonoff SPM switches in ESPHome.
+---
+
+The `sonoff_spm` switch platform allows you to control relays on the Sonoff SPM (Smart Power Manager) system and requires {{< docref "/components/sonoff_spm" >}} to be configured.
+
+Each SPM-4Relay module provides 4 bistable relays that can be independently controlled.
+
+## Configuration Variables
+
+- **sonoff_spm_id** (*Optional*, {{< apiref "sonoff_spm/sonoff_spm.h" "ID" >}}): Manually specify the ID of the {{< docref "/components/sonoff_spm" "Sonoff SPM Component" >}}.
+- **relay_id** (**Required**, int): The relay number (0-127) to control. See {{< docref "/components/sonoff_spm#relay-id-mapping" "Relay ID Mapping" >}}.
+- **name** (**Required**, string): The name of the switch.
+- All other options from [Switch](#config-switch).
+
+## Example
+
+```yaml
+# Example configuration entry
+uart:
+  id: uart_bus
+  tx_pin: GPIO4
+  rx_pin: GPIO16
+  baud_rate: 115200
+
+sonoff_spm:
+  id: spm_main
+  uart_id: uart_bus
+
+# Manual switch definitions
+switch:
+  # Module 0, Channel 0
+  - platform: sonoff_spm
+    name: "Kitchen Light"
+    sonoff_spm_id: spm_main
+    relay_id: 0
+
+  # Module 0, Channel 1
+  - platform: sonoff_spm
+    name: "Living Room Light"
+    sonoff_spm_id: spm_main
+    relay_id: 1
+
+  # Module 0, Channel 2
+  - platform: sonoff_spm
+    name: "Bedroom Light"
+    sonoff_spm_id: spm_main
+    relay_id: 2
+
+  # Module 0, Channel 3
+  - platform: sonoff_spm
+    name: "Bathroom Light"
+    sonoff_spm_id: spm_main
+    relay_id: 3
+
+  # Module 1, Channel 0
+  - platform: sonoff_spm
+    name: "Garage Door"
+    sonoff_spm_id: spm_main
+    relay_id: 4
+
+  # Module 1, Channel 1
+  - platform: sonoff_spm
+    name: "Pool Pump"
+    sonoff_spm_id: spm_main
+    relay_id: 5
+```
+
+## Automatic Entity Creation
+
+Instead of manually defining switches, you can use the automatic entity creation feature:
+
+```yaml
+uart:
+  id: uart_bus
+  tx_pin: GPIO4
+  rx_pin: GPIO16
+  baud_rate: 115200
+
+sonoff_spm:
+  id: spm_main
+  uart_id: uart_bus
+  module_count: 2                # Number of SPM-4Relay modules
+  auto_create_switches: true     # Automatically create switches
+  name_prefix: "Relay"           # Prefix for switch names
+```
+
+This will automatically create switches for all relays on the connected modules:
+
+- `Relay 0`, `Relay 1`, ..., `Relay 7` (for 2 modules)
+
+## Relay ID Mapping
+
+Relay IDs are calculated as: `relay_id = (module_number * 4) + channel_number`
+
+Where:
+
+- `module_number`: 0-31 (for up to 32 SPM-4Relay modules)
+- `channel_number`: 0-3 (4 channels per module)
+
+Examples:
+
+- Module 0, Channel 0: relay_id = 0
+- Module 0, Channel 1: relay_id = 1
+- Module 0, Channel 2: relay_id = 2
+- Module 0, Channel 3: relay_id = 3
+- Module 1, Channel 0: relay_id = 4
+- Module 2, Channel 0: relay_id = 8
+
+## State Synchronization
+
+The component automatically synchronizes relay states when physical buttons on the SPM modules are pressed. This ensures that ESPHome always reflects the current state of the relays.
+
+## Important Notes
+
+- Each SPM-4Relay module has 4 bistable relays
+- Up to 32 modules can be connected (128 relays total)
+- Relay states persist across power cycles (bistable relays)
+- The component automatically discovers connected modules at startup
+
+## See Also
+
+- {{< docref "/components/sonoff_spm" >}}
+- {{< docref "/components/sensor/sonoff_spm" >}}
+- {{< docref "/components/uart" >}}
+- {{< docref "/components/switch" >}}
+- {{< apiref "sonoff_spm/sonoff_spm.h" "sonoff_spm/sonoff_spm.h" >}}


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#11838

## Checklist:

  - [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
