### PR TITLE
[st7701s] [mipi_rgb] Document deprecation of st7701s in favor of mipi_rgb

### DIFF
--- a/content/components/display/st7701s.md
+++ b/content/components/display/st7701s.md
@@ -14,6 +14,10 @@ params:
 This display driver supports displays with 16 bit parallel interfaces, often referred to as "RGB". It currently
 supports the ST7701S chip.
 
+> [!WARNING]
+> This component has been made redundant since the ST7701S is now supported by the {{< docref "mipi_rgb" >}}.
+> This component will be removed in a future release.
+
 This driver has been tested with the following displays:
 
 - Seeed Sensecap Indicator


### PR DESCRIPTION
## Description:

Based on https://github.com/esphome/esphome/pull/9892 stating that the mipi_rgb driver replaces the st7701s driver, I am under the impression that @clydebarrow likely intended https://github.com/esphome/esphome-docs/pull/5260 to include this change.

(Discovered while helping @smakolski in #homeassistant on irc.libera.chat.)

@clydebarrow Can you confirm that this change reflects your intention?

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.