### PR TITLE
2025.10.5

### DIFF
--- a/content/changelog/2025.10.0.md
+++ b/content/changelog/2025.10.0.md
@@ -463,16 +463,6 @@ continue working, but custom components and advanced setups may require updates.
 - [audio] Update esp-audio-libs 2.0.1 to use new FLAC decoder [esphome#10974](https://github.com/esphome/esphome/pull/10974) by [@kahrendt](https://github.com/kahrendt) (breaking-change)
 - [api] Add message size limits to prevent memory exhaustion [esphome#10936](https://github.com/esphome/esphome/pull/10936) by [@bdraco](https://github.com/bdraco) (breaking-change)
 
-## Release 2025.10.5 - November 11
-
-<details>
-<summary></summary>
-
-- [core] Don't allow python 3.14 [esphome#11527](https://github.com/esphome/esphome/pull/11527) by [@swoboda1337](https://github.com/swoboda1337)
-- [usb_uart] Fixes for transfer queue allocation [esphome#11548](https://github.com/esphome/esphome/pull/11548) by [@clydebarrow](https://github.com/clydebarrow)
-- [lvgl] Fix rotation with unusual width [esphome#11680](https://github.com/esphome/esphome/pull/11680) by [@clydebarrow](https://github.com/clydebarrow)
-
-</details>
 ### All changes
 
 <details>
@@ -509,16 +499,7 @@ continue working, but custom components and advanced setups may require updates.
 - [zephyr] Fix compilation after Path migration [esphome#10811](https://github.com/esphome/esphome/pull/10811) by [@bdraco](https://github.com/bdraco)
 - [http_request] Fix Path object passed to C++ codegen [esphome#10812](https://github.com/esphome/esphome/pull/10812) by [@bdraco](https://github.com/bdraco)
 - Synchronise Device Classes from Home Assistant [esphome#10803](https://github.com/esphome/esphome/pull/10803) by [@esphomebot](https://github.com/esphomebot)
-- [sensirion] Fix warning [esphome#10813](https:/## Release 2025.10.5 - November 11
-
-<details>
-<summary></summary>
-
-- [core] Don't allow python 3.14 [esphome#11527](https://github.com/esphome/esphome/pull/11527) by [@swoboda1337](https://github.com/swoboda1337)
-- [usb_uart] Fixes for transfer queue allocation [esphome#11548](https://github.com/esphome/esphome/pull/11548) by [@clydebarrow](https://github.com/clydebarrow)
-- [lvgl] Fix rotation with unusual width [esphome#11680](https://github.com/esphome/esphome/pull/11680) by [@clydebarrow](https://github.com/clydebarrow)
-
-</details>/github.com/esphome/esphome/pull/10813) by [@swoboda1337](https://github.com/swoboda1337)
+- [sensirion] Fix warning [esphome#10813](https://github.com/esphome/esphome/pull/10813) by [@swoboda1337](https://github.com/swoboda1337)
 - [core] Fix TypeError in update-all command after Path migration [esphome#10821](https://github.com/esphome/esphome/pull/10821) by [@bdraco](https://github.com/bdraco)
 - Add coverage for Path to str fix in #10807 [esphome#10808](https://github.com/esphome/esphome/pull/10808) by [@bdraco](https://github.com/bdraco)
 - [web_server] Reduce flash usage by eliminating lambda overhead in JSON generation [esphome#10749](https://github.com/esphome/esphome/pull/10749) by [@bdraco](https://github.com/bdraco)

--- a/content/changelog/2025.10.0.md
+++ b/content/changelog/2025.10.0.md
@@ -462,6 +462,7 @@ continue working, but custom components and advanced setups may require updates.
 - [esp32_ble] Fix max_connections architecture (shared client+server limit) [esphome#11006](https://github.com/esphome/esphome/pull/11006) by [@bdraco](https://github.com/bdraco) (breaking-change)
 - [audio] Update esp-audio-libs 2.0.1 to use new FLAC decoder [esphome#10974](https://github.com/esphome/esphome/pull/10974) by [@kahrendt](https://github.com/kahrendt) (breaking-change)
 - [api] Add message size limits to prevent memory exhaustion [esphome#10936](https://github.com/esphome/esphome/pull/10936) by [@bdraco](https://github.com/bdraco) (breaking-change)
+
 ## Release 2025.10.5 - November 11
 
 <details>

--- a/content/changelog/2025.10.0.md
+++ b/content/changelog/2025.10.0.md
@@ -396,6 +396,17 @@ continue working, but custom components and advanced setups may require updates.
 
 </details>
 
+## Release 2025.10.5 - November 11
+
+<details>
+<summary></summary>
+
+- [core] Don't allow python 3.14 [esphome#11527](https://github.com/esphome/esphome/pull/11527) by [@swoboda1337](https://github.com/swoboda1337)
+- [usb_uart] Fixes for transfer queue allocation [esphome#11548](https://github.com/esphome/esphome/pull/11548) by [@clydebarrow](https://github.com/clydebarrow)
+- [lvgl] Fix rotation with unusual width [esphome#11680](https://github.com/esphome/esphome/pull/11680) by [@clydebarrow](https://github.com/clydebarrow)
+
+</details>
+
 ## Full list of changes
 
 ### New Features
@@ -451,7 +462,16 @@ continue working, but custom components and advanced setups may require updates.
 - [esp32_ble] Fix max_connections architecture (shared client+server limit) [esphome#11006](https://github.com/esphome/esphome/pull/11006) by [@bdraco](https://github.com/bdraco) (breaking-change)
 - [audio] Update esp-audio-libs 2.0.1 to use new FLAC decoder [esphome#10974](https://github.com/esphome/esphome/pull/10974) by [@kahrendt](https://github.com/kahrendt) (breaking-change)
 - [api] Add message size limits to prevent memory exhaustion [esphome#10936](https://github.com/esphome/esphome/pull/10936) by [@bdraco](https://github.com/bdraco) (breaking-change)
+## Release 2025.10.5 - November 11
 
+<details>
+<summary></summary>
+
+- [core] Don't allow python 3.14 [esphome#11527](https://github.com/esphome/esphome/pull/11527) by [@swoboda1337](https://github.com/swoboda1337)
+- [usb_uart] Fixes for transfer queue allocation [esphome#11548](https://github.com/esphome/esphome/pull/11548) by [@clydebarrow](https://github.com/clydebarrow)
+- [lvgl] Fix rotation with unusual width [esphome#11680](https://github.com/esphome/esphome/pull/11680) by [@clydebarrow](https://github.com/clydebarrow)
+
+</details>
 ### All changes
 
 <details>
@@ -488,7 +508,16 @@ continue working, but custom components and advanced setups may require updates.
 - [zephyr] Fix compilation after Path migration [esphome#10811](https://github.com/esphome/esphome/pull/10811) by [@bdraco](https://github.com/bdraco)
 - [http_request] Fix Path object passed to C++ codegen [esphome#10812](https://github.com/esphome/esphome/pull/10812) by [@bdraco](https://github.com/bdraco)
 - Synchronise Device Classes from Home Assistant [esphome#10803](https://github.com/esphome/esphome/pull/10803) by [@esphomebot](https://github.com/esphomebot)
-- [sensirion] Fix warning [esphome#10813](https://github.com/esphome/esphome/pull/10813) by [@swoboda1337](https://github.com/swoboda1337)
+- [sensirion] Fix warning [esphome#10813](https:/## Release 2025.10.5 - November 11
+
+<details>
+<summary></summary>
+
+- [core] Don't allow python 3.14 [esphome#11527](https://github.com/esphome/esphome/pull/11527) by [@swoboda1337](https://github.com/swoboda1337)
+- [usb_uart] Fixes for transfer queue allocation [esphome#11548](https://github.com/esphome/esphome/pull/11548) by [@clydebarrow](https://github.com/clydebarrow)
+- [lvgl] Fix rotation with unusual width [esphome#11680](https://github.com/esphome/esphome/pull/11680) by [@clydebarrow](https://github.com/clydebarrow)
+
+</details>/github.com/esphome/esphome/pull/10813) by [@swoboda1337](https://github.com/swoboda1337)
 - [core] Fix TypeError in update-all command after Path migration [esphome#10821](https://github.com/esphome/esphome/pull/10821) by [@bdraco](https://github.com/bdraco)
 - Add coverage for Path to str fix in #10807 [esphome#10808](https://github.com/esphome/esphome/pull/10808) by [@bdraco](https://github.com/bdraco)
 - [web_server] Reduce flash usage by eliminating lambda overhead in JSON generation [esphome#10749](https://github.com/esphome/esphome/pull/10749) by [@bdraco](https://github.com/bdraco)

--- a/content/guides/supporters.md
+++ b/content/guides/supporters.md
@@ -65,6 +65,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Ian Blais (@aeonsablaze)](https://github.com/aeonsablaze)
 - [Johan Bloemberg (@aequitas)](https://github.com/aequitas)
 - [Andrew Erickson (@aerickson)](https://github.com/aerickson)
+- [Ben (@af3556)](https://github.com/af3556)
 - [Attila Farago (@afarago)](https://github.com/afarago)
 - [Kjell Braden (@afflux)](https://github.com/afflux)
 - [Alejandro Galfrascoli (@AGalfra)](https://github.com/AGalfra)
@@ -952,6 +953,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Jake Crosby (@jake-nz)](https://github.com/jake-nz)
 - [jakehdk (@jakehdk)](https://github.com/jakehdk)
 - [Jake Shirley (@JakeShirley)](https://github.com/JakeShirley)
+- [Jakob S. (@jakicoll)](https://github.com/jakicoll)
 - [Jonathan Kollasch (@jakllsch)](https://github.com/jakllsch)
 - [Jakob Reiter (@jakommo)](https://github.com/jakommo)
 - [jakub-medrzak (@jakub-medrzak)](https://github.com/jakub-medrzak)
@@ -1279,6 +1281,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Piotr Majkrzak (@majkrzak)](https://github.com/majkrzak)
 - [Major Péter (@majorpeter)](https://github.com/majorpeter)
 - [Dmitry (@mak-42)](https://github.com/mak-42)
+- [Makerfabs (@Makerfabs)](https://github.com/Makerfabs)
 - [Max Slotov (@makstech)](https://github.com/makstech)
 - [Kasper Malfroid (@malfroid)](https://github.com/malfroid)
 - [Malle355 (@Malle355)](https://github.com/Malle355)
@@ -2268,4 +2271,4 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Christian Zufferey (@zuzu59)](https://github.com/zuzu59)
 - [Zynth-dev (@Zynth-dev)](https://github.com/Zynth-dev)
 
-*This page was last updated November 4, 2025.*
+*This page was last updated November 11, 2025.*

--- a/data/version.yaml
+++ b/data/version.yaml
@@ -1,2 +1,2 @@
-release: 2025.10.4
+release: 2025.10.5
 version: '2025.10'


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- Changelog 2025.10.0.md - Change WTS01 sensor interface from I2C to UART [docs#5559](https://github.com/esphome/esphome-docs/pull/5559)
- [nrf52,logger] add doc [docs#5544](https://github.com/esphome/esphome-docs/pull/5544)
- Minor corrections to LVGL examples [docs#5558](https://github.com/esphome/esphome-docs/pull/5558)
- [htu21d] Add note about hardware version [docs#5390](https://github.com/esphome/esphome-docs/pull/5390)
- [packet_transport] Fix rst conversion issues [docs#5509](https://github.com/esphome/esphome-docs/pull/5509)
- [esp32] Add ignore_pin_validation_error docs [docs#5563](https://github.com/esphome/esphome-docs/pull/5563)
- [sensors] Make filters consistent [docs#5508](https://github.com/esphome/esphome-docs/pull/5508)
- Fix search key [docs#5565](https://github.com/esphome/esphome-docs/pull/5565)
- Update AM2320 documentation with frequency note [docs#5522](https://github.com/esphome/esphome-docs/pull/5522)
- Dockerfile - add missing `jq` package to fix broken Docker documentation build [docs#5567](https://github.com/esphome/esphome-docs/pull/5567)
- Fix broken external links [docs#5568](https://github.com/esphome/esphome-docs/pull/5568)
- Fix RST conversion issues [docs#5570](https://github.com/esphome/esphome-docs/pull/5570)
- Update remaining bad links [docs#5575](https://github.com/esphome/esphome-docs/pull/5575)
- fix: missing underscore in pcd_8544.h link [docs#5580](https://github.com/esphome/esphome-docs/pull/5580)
- Replace global links #1 [docs#5577](https://github.com/esphome/esphome-docs/pull/5577)
- [workflows] Handle whitespace in component names correctly [docs#5587](https://github.com/esphome/esphome-docs/pull/5587)
- software_coexistence is sibling to scan_parameters, rather than child [docs#5589](https://github.com/esphome/esphome-docs/pull/5589)
- [CI] Add github actions job to quickly find site build errors without relying on netlify [docs#5592](https://github.com/esphome/esphome-docs/pull/5592)
- Replace global links #2 [docs#5585](https://github.com/esphome/esphome-docs/pull/5585)
- Fix local links [docs#5572](https://github.com/esphome/esphome-docs/pull/5572)
- [st7701s] [mipi_rgb] Document deprecation of st7701s in favor of mipi_rgb [docs#5597](https://github.com/esphome/esphome-docs/pull/5597)

<details>
<summary></summary>

- Bump actions/upload-artifact from 4.6.2 to 5.0.0 [docs#5529](https://github.com/esphome/esphome-docs/pull/5529)
- Bump actions/stale from 10.0.0 to 10.1.0 [docs#5448](https://github.com/esphome/esphome-docs/pull/5448)
- Bump actions/github-script from 7.0.1 to 8.0.0 [docs#5336](https://github.com/esphome/esphome-docs/pull/5336)
- Bump dessant/lock-threads from 4.0.1 to 5.0.1 [docs#5415](https://github.com/esphome/esphome-docs/pull/5415)
- Bump docker/login-action from 3.5.0 to 3.6.0 [docs#5431](https://github.com/esphome/esphome-docs/pull/5431)
- Bump docker/setup-qemu-action from 3.6.0 to 3.7.0 [docs#5566](https://github.com/esphome/esphome-docs/pull/5566)
- Bump actions/create-github-app-token from 2.1.1 to 2.1.4 [docs#5361](https://github.com/esphome/esphome-docs/pull/5361)

</details>
<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
