### PR TITLE
[bh1900nux] Add to component index

### DIFF
--- a/content/components/_index.md
+++ b/content/components/_index.md
@@ -364,6 +364,7 @@ Sensors are organized into categories; if a given sensor fits into more than one
 "AM2315C","components/sensor/am2315c","am2315c.jpg","Temperature & Humidity",""
 "AM2320","components/sensor/am2320","am2320.jpg","Temperature & Humidity",""
 "b-parasite","components/sensor/b_parasite","b_parasite.jpg","Moisture & Temperature & Humidity & Light",""
+"BH1900NUX","components/sensor/bh1900nux","bh1900nux-evk-001.png","Temperature",""
 "BME280","components/sensor/bme280","bme280.jpg","Temperature & Humidity & Pressure",""
 "BME68x via BSEC2","components/sensor/bme68x_bsec2","bme680.jpg","Temperature & Humidity & Pressure & Gas",""
 "BME680 via BSEC","components/sensor/bme680_bsec","bme680.jpg","Temperature & Humidity & Pressure & Gas",""


### PR DESCRIPTION
## Description:

Add to component index

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
