### PR TITLE
Add RX8130 RTC documentation

### DIFF
--- a/content/components/time/rx8130.md
+++ b/content/components/time/rx8130.md
@@ -1,5 +1,5 @@
 ---
-description: "RX8130 Time Source"
+description: "The RX8130 is a high-accuracy real-time clock (RTC) with a built-in temperature-compensated oscillator that keeps precise time even during power loss. It serves as a stable time source for systems requiring reliable timestamps or scheduled wake-ups."
 title: "RX8130 Time Source"
 ---
 


### PR DESCRIPTION
## Description:
Adds detailed documentation for the RX8130 real-time clock (RTC) component.
Covers configuration options, available actions (rx8130.read_time / rx8130.write_time), example YAML configuration, and best practices for synchronizing system time with the RTC.
The RX8130 has a temperature-compensated oscillator that ensures high-accuracy timekeeping, even during power loss.

**Related issue (if applicable):** fixes <link to issue>
N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ x] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image RX8130
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
