### PR TITLE
Add 2025.11.0 Release Notes

### DIFF
--- a/content/changelog/2025.11.0.md
+++ b/content/changelog/2025.11.0.md
@@ -42,11 +42,11 @@ ESPHome 2025.11.0 delivers substantial memory improvements across the entire fra
 - **WiFi component** ([#11205](https://github.com/esphome/esphome/pull/11205)) - Saves **440-1,192 bytes RAM** depending on network density
 - **Select component** ([#11514](https://github.com/esphome/esphome/pull/11514)) - Saves **270-2,800 bytes per select** depending on option count
 - **Light component** ([#11348](https://github.com/esphome/esphome/pull/11348)) - Saves **1,756 bytes flash** on ESP8266, **~108 bytes RAM** per 6 lights
-- **Climate component** ([#11466](https://github.com/esphome/esphome/pull/11466), [#11621](https://github.com/esphome/esphome/pull/11621)) - Saves **~440 bytes heap** per climate entity
+- **Climate component** ([#11466](https://github.com/esphome/esphome/pull/11466), [#11621](https://github.com/esphome/esphome/pull/11621)) - Saves **~440 bytes RAM** per climate entity
 - **Fan component** ([#11483](https://github.com/esphome/esphome/pull/11483), [#11632](https://github.com/esphome/esphome/pull/11632)) - Saves **~24 bytes per fan**
 - **Event component** ([#11463](https://github.com/esphome/esphome/pull/11463), [#11767](https://github.com/esphome/esphome/pull/11767)) - Saves **1,248 bytes flash**
-- **Global Controller Registry** ([#11772](https://github.com/esphome/esphome/pull/11772)) - Saves **388-6,148 bytes heap** depending on entity count
-- **Action framework** ([#11704](https://github.com/esphome/esphome/pull/11704)) - Saves **356 bytes flash**, eliminates heap allocations in automations
+- **Global Controller Registry** ([#11772](https://github.com/esphome/esphome/pull/11772)) - Saves **388-6,148 bytes RAM** depending on entity count
+- **Action framework** ([#11704](https://github.com/esphome/esphome/pull/11704)) - Saves **356 bytes flash**, eliminates RAM allocations in automations
 - **Script component** ([#11308](https://github.com/esphome/esphome/pull/11308)) - Saves **1,592 bytes flash** on ESP32
 - **ESP32-IDF** ([#10930](https://github.com/esphome/esphome/pull/10930), [#11441](https://github.com/esphome/esphome/pull/11441)) - Saves **~10KB combined** (1.3KB + 8.7KB)
 - **Network component** ([#11707](https://github.com/esphome/esphome/pull/11707)) - Saves **32-72 bytes per network component**

--- a/content/changelog/2025.11.0.md
+++ b/content/changelog/2025.11.0.md
@@ -31,27 +31,27 @@ WiFi security and reliability receive major upgrades with the new `min_auth_mode
 
 ESPHome 2025.11.0 delivers substantial memory improvements across the entire framework, with measured savings ranging from **2-7KB of RAM on typical devices** and up to **31KB of RAM on sensor-heavy configurations**. Flash savings reach **10KB+** on ESP32/ESP8266 platforms.
 
-**Critical Sensor Filter Optimizations:**
+**Sensor Filter Optimizations:**
 
-- **Sliding window filters** ([#11282](https://github.com/esphome/esphome/pull/11282)) - Eliminated heap fragmentation from `std::deque`, saving **22-25KB RAM** on batch windows (99.98% reduction), **90% on sliding windows**. Real-world impact: ESP32 devices with Improv gained **+31KB free heap** (+221% increase), preventing OOM crashes. Also saves **1,748 bytes flash** on ESP8266 and delivers **4-5x faster** moving average, **73-256% faster** median filtering
-- **Filter value lists** ([#11407](https://github.com/esphome/esphome/pull/11407)) - `FixedVector` replaces `std::vector` in filter_out/throttle_priority, saves **444 bytes flash** on ESP8266, **18-52% faster** execution
-- **Calibration/OR filters** ([#11437](https://github.com/esphome/esphome/pull/11437)) - `FixedVector` optimization for calibrate_linear/polynomial/or filters saves **464 bytes flash**, **48 bytes RAM** on ESP8266
+- **Sliding window filters** ([#11282](https://github.com/esphome/esphome/pull/11282)) - Saves **22-25KB RAM** on large batch windows, **90% on sliding windows**, **1,748 bytes flash** on ESP8266. Prevents OOM crashes on ESP32 devices with multiple sensors
+- **Filter value lists** ([#11407](https://github.com/esphome/esphome/pull/11407)) - Saves **444 bytes flash** on ESP8266, 18-52% faster execution
+- **Calibration/OR filters** ([#11437](https://github.com/esphome/esphome/pull/11437)) - Saves **464 bytes flash**, **48 bytes RAM** on ESP8266
 
-**Component Memory Optimizations:**
+**Component Optimizations:**
 
-- **WiFi component** ([#11205](https://github.com/esphome/esphome/pull/11205)) - Frees scan results after connection, saving **440-1,192 bytes RAM** depending on network density
-- **Select component** ([#11514](https://github.com/esphome/esphome/pull/11514)) - Stores options in flash as `const char*`, saving **270-2,800 bytes per select** depending on option count
-- **Light component** ([#11348](https://github.com/esphome/esphome/pull/11348)) - Bitmask-based color mode storage saves **1,756 bytes flash** on ESP8266, **~108 bytes RAM** per 6 lights
-- **Climate component** ([#11466](https://github.com/esphome/esphome/pull/11466), [#11621](https://github.com/esphome/esphome/pull/11621)) - Eliminates red-black tree overhead, saving **~440 bytes heap** per climate entity
-- **Fan component** ([#11483](https://github.com/esphome/esphome/pull/11483), [#11632](https://github.com/esphome/esphome/pull/11632)) - Flash-based preset mode storage saves **~24 bytes per fan**
-- **Event component** ([#11463](https://github.com/esphome/esphome/pull/11463), [#11767](https://github.com/esphome/esphome/pull/11767)) - Eliminated `std::set` overhead, saves **1,248 bytes flash**
-- **Global Controller Registry** ([#11772](https://github.com/esphome/esphome/pull/11772)) - Eliminates per-entity callback overhead, measured savings: **+388 to +6,148 bytes heap** depending on entity count
-- **Action framework optimization** ([#11704](https://github.com/esphome/esphome/pull/11704)) - Reduces argument copies by **83%**, saving **356 bytes flash** and eliminating heap allocations in automations
-- **Script component** ([#11308](https://github.com/esphome/esphome/pull/11308)) - Replaces `std::queue` with fixed array, saves **1,592 bytes flash** on ESP32
-- **ESP32-IDF optimizations** ([#10930](https://github.com/esphome/esphome/pull/10930), [#11441](https://github.com/esphome/esphome/pull/11441)) - Disables unused libc locks and VFS features, saving **~10KB combined** (1.3KB + 8.7KB)
-- **Network component** ([#11707](https://github.com/esphome/esphome/pull/11707)) - Stores addresses in flash, saving **32-72 bytes per network component**
-- **Light effects** ([#11487](https://github.com/esphome/esphome/pull/11487)) - Flash-based effect names save **24-32 bytes per effect**
-- **WiFi priority** ([#11830](https://github.com/esphome/esphome/pull/11830)) - Changed from `float` to `int8_t`, saves **3 bytes per network entry** plus up to **96 bytes** from auto-recovery cleanup
+- **WiFi component** ([#11205](https://github.com/esphome/esphome/pull/11205)) - Saves **440-1,192 bytes RAM** depending on network density
+- **Select component** ([#11514](https://github.com/esphome/esphome/pull/11514)) - Saves **270-2,800 bytes per select** depending on option count
+- **Light component** ([#11348](https://github.com/esphome/esphome/pull/11348)) - Saves **1,756 bytes flash** on ESP8266, **~108 bytes RAM** per 6 lights
+- **Climate component** ([#11466](https://github.com/esphome/esphome/pull/11466), [#11621](https://github.com/esphome/esphome/pull/11621)) - Saves **~440 bytes heap** per climate entity
+- **Fan component** ([#11483](https://github.com/esphome/esphome/pull/11483), [#11632](https://github.com/esphome/esphome/pull/11632)) - Saves **~24 bytes per fan**
+- **Event component** ([#11463](https://github.com/esphome/esphome/pull/11463), [#11767](https://github.com/esphome/esphome/pull/11767)) - Saves **1,248 bytes flash**
+- **Global Controller Registry** ([#11772](https://github.com/esphome/esphome/pull/11772)) - Saves **388-6,148 bytes heap** depending on entity count
+- **Action framework** ([#11704](https://github.com/esphome/esphome/pull/11704)) - Saves **356 bytes flash**, eliminates heap allocations in automations
+- **Script component** ([#11308](https://github.com/esphome/esphome/pull/11308)) - Saves **1,592 bytes flash** on ESP32
+- **ESP32-IDF** ([#10930](https://github.com/esphome/esphome/pull/10930), [#11441](https://github.com/esphome/esphome/pull/11441)) - Saves **~10KB combined** (1.3KB + 8.7KB)
+- **Network component** ([#11707](https://github.com/esphome/esphome/pull/11707)) - Saves **32-72 bytes per network component**
+- **Light effects** ([#11487](https://github.com/esphome/esphome/pull/11487)) - Saves **24-32 bytes per effect**
+- **WiFi priority** ([#11830](https://github.com/esphome/esphome/pull/11830)) - Saves **3 bytes per network entry** plus up to **96 bytes** from auto-recovery
 
 **Note on Breaking Changes:** These optimizations required API changes for external component developers. See Breaking Changes section for migration details. Standard YAML configurations remain fully compatible.
 

--- a/content/changelog/2025.11.0.md
+++ b/content/changelog/2025.11.0.md
@@ -66,13 +66,21 @@ wifi:
   min_auth_mode: WPA2  # Recommended for security
 ```
 
+**Dramatically Improved WiFi Reliability and Connection Times** ([#11805](https://github.com/esphome/esphome/pull/11805))
+
+Fixes critical mesh network connectivity issues where devices would get stuck repeatedly attempting the strongest (but failing) access point. The new implementation delivers:
+
+- **Faster failover**: Automatic switching to working APs when connection fails, instead of getting stuck on failed BSSIDs
+- **Smarter reconnection**: Two-attempt BSSID filtering eliminates false positives from WiFi stack transitions
+- **Better hidden network support**: Explicit hidden network probing phase with intelligent skipping of visible networks (saves 2-6 seconds)
+- **Improved mesh handling**: Simplified 150+ lines of BSID cycling logic—priority degradation now naturally handles mesh networks
+- **Memory savings**: Cleared priority tracking when all BSSIDs fail equally (saves up to 96 bytes)
+
+The fix corrects priority sorting to check connection failure history before signal strength, making the automatic failover system work as designed.
+
 **WiFi Priority Optimization** ([#11830](https://github.com/esphome/esphome/pull/11830))
 
 Network priority optimization dramatically improves WiFi stability on ESP32-C6/H2/P4 by preventing brief ESP-NOW activity or BLE advertisements from disrupting WiFi connectivity. The optimization also changed priority storage from `float` to `int8_t`, saving 3 bytes per network entry.
-
-**WiFi Credentials Cleanup** ([#11805](https://github.com/esphome/esphome/pull/11805))
-
-Prevents stale AP configurations from causing connection issues by properly managing stored credentials and clearing priority tracking when all BSSIDs fail equally (saves up to 96 bytes).
 
 ## High-Performance Networking for Media Streaming
 
@@ -117,8 +125,6 @@ Added `ignore_not_found` option (default `true`) to allow disabling `CONFIG_SPIR
 - **ESP32 Hosted BLE** - Bluetooth support for ESP32-P4 and other chips without native BLE ([#11167](https://github.com/esphome/esphome/pull/11167))
 - **ESP32 Hosted OTA** - Firmware updates for ESP32 co-processors via ESP-Hosted API ([#11562](https://github.com/esphome/esphome/pull/11562))
 - **ESP-NOW transport** - Added ESP-NOW as a transport platform for packet_transport component ([#11025](https://github.com/esphome/esphome/pull/11025))
-- **OpenThread enhancements** - Poll period configuration for MTD devices enables sleep mode ([#11374](https://github.com/esphome/esphome/pull/11374)), OTA support via mDNS ([#11095](https://github.com/esphome/esphome/pull/11095))
-- **USB Host improvements** - Fixed transfer slot exhaustion at high data rates, added configurable `max_transfer_requests` ([#11174](https://github.com/esphome/esphome/pull/11174))
 - **IR Remote protocols** - Dyson AM07 fan support ([#10163](https://github.com/esphome/esphome/pull/10163)), Symphony protocol ([#10777](https://github.com/esphome/esphome/pull/10777)), Toshiba RAS-2819T AC ([#9490](https://github.com/esphome/esphome/pull/9490))
 
 ## ESP32 Platform Enhancements
@@ -162,10 +168,6 @@ openthread:
   device_type: MTD
   poll_period: 40s  # Radio turns off between polls
 ```
-
-### Additional Features
-
-- Dataset TLV import/export ([#11095](https://github.com/esphome/esphome/pull/11095), [#11374](https://github.com/esphome/esphome/pull/11374)) simplifies network provisioning with Thread Border Router compatibility
 
 ## nRF52 Platform Expansion
 
@@ -213,15 +215,6 @@ lvgl:
           if_nan: "--.-°C"  # Show when sensor unavailable
 ```
 
-### Additional Features
-
-- Arc widget support ([#10163](https://github.com/esphome/esphome/pull/10163))
-- Span widget for rich text formatting ([#11346](https://github.com/esphome/esphome/pull/11346))
-- Font/image cleanup automation ([#11562](https://github.com/esphome/esphome/pull/11562))
-- Faster rotary encoder debouncing ([#10564](https://github.com/esphome/esphome/pull/10564))
-- Paused widget support ([#11651](https://github.com/esphome/esphome/pull/11651))
-- LVGL 9.3 integration ([#11540](https://github.com/esphome/esphome/pull/11540))
-
 ## Display Component Improvements
 
 **E-Paper SPI Refactoring** ([#11540](https://github.com/esphome/esphome/pull/11540))
@@ -233,21 +226,6 @@ Major improvements to e-paper displays:
 - **Board-specific configs**: Pre-configured pin mappings (Seeed-reTerminal-E1002)
 - **Improved timing**: Internal delay handling instead of loop disabling
 - **Fixed busy pin logic** ([#11349](https://github.com/esphome/esphome/pull/11349)): Corrected active-low detection
-
-**E-Paper Fast Refresh** ([#9490](https://github.com/esphome/esphome/pull/9490))
-
-Waveshare e-paper displays gain fast refresh mode support, reducing update times from seconds to milliseconds for partial updates.
-
-**Color E-Paper Models** ([#10757](https://github.com/esphome/esphome/pull/10757), [#11125](https://github.com/esphome/esphome/pull/11125))
-
-Expanded support for color e-paper displays with additional Waveshare models.
-
-**MIPI Display Enhancements** ([#11206](https://github.com/esphome/esphome/pull/11206), [#11226](https://github.com/esphome/esphome/pull/11226), [#11585](https://github.com/esphome/esphome/pull/11585))
-
-- ST7701S driver ([#10777](https://github.com/esphome/esphome/pull/10777)) adds RGB interface support with optimizations for ESP32-S3 parallel displays
-- Added Waveshare 5" 1024x600 display support
-- Fixed rotation handling for custom models
-- Configurable `draw_rounding` option
 
 **Component Idle Detection** ([#11651](https://github.com/esphome/esphome/pull/11651))
 
@@ -262,75 +240,7 @@ lvgl:
     - lvgl.resume:
 ```
 
-## USB Host Enhancements
-
-**Transfer Slot Optimization** ([#11174](https://github.com/esphome/esphome/pull/11174))
-
-Fixed USB UART transfer slot exhaustion at high data rates (115200+ baud):
-
-- **Immediate release**: Transfer slots freed in USB task instead of main loop
-- **Configurable slots**: New `max_transfer_requests` option (1-32, default 16)
-- **Prevents failures**: Eliminates "All 16 transfer slots in use" errors at high throughput
-
-**Suspend/Resume Handling** ([#11772](https://github.com/esphome/esphome/pull/11772))
-
-Improved suspend/resume handling maintains connectivity during brief USB power interruptions, critical for automotive and battery-powered applications.
-
-## Climate and Thermostat Features
-
-**Humidity Control** ([#11286](https://github.com/esphome/esphome/pull/11286))
-
-Thermostat component now supports controlling humidity through humidifier/dehumidifier actions:
-
-```yaml
-climate:
-  - platform: thermostat
-    sensor: temp_sensor
-    humidity_sensor: humidity_sensor
-    humidify_action:
-      - switch.turn_on: humidifier
-    dehumidify_action:
-      - switch.turn_on: dehumidifier
-    target_humidity: 50%
-```
-
-**Temperature Differentials** ([#11174](https://github.com/esphome/esphome/pull/11174))
-
-Climate control gains precision temperature differentials for heat/cool mode switching.
-
-**Visual Presets** ([#11628](https://github.com/esphome/esphome/pull/11628))
-
-Visual presets enable better UI integration for climate controls.
-
-**Improved Target Temperature Tracking** ([#11226](https://github.com/esphome/esphome/pull/11226))
-
-Thermostat improvements include better target temperature tracking and restore functionality.
-
-## Remote Control Protocol Support
-
-Added IR protocol decoders/encoders:
-
-- **Toshiba AC heatpump** ([#7726](https://github.com/esphome/esphome/pull/7726))
-- **Dyson AM07** ([#10163](https://github.com/esphome/esphome/pull/10163)) - Tower fan with rolling codes
-- **Symphony** ([#10777](https://github.com/esphome/esphome/pull/10777)) - With configurable command repeats
-
 ## Configuration and Developer Tools
-
-**Python 3.13 Support** ([#11411](https://github.com/esphome/esphome/pull/11411))
-
-Ensures compatibility with the latest Python release.
-
-**Template Number Component** ([#10149](https://github.com/esphome/esphome/pull/10149))
-
-Enables dynamic number entities without C++ code.
-
-**Sensor Force Update Option** ([#10930](https://github.com/esphome/esphome/pull/10930))
-
-Sensor schemas gain `force_update` option for explicit state change control.
-
-**I2C Debugging** ([#11167](https://github.com/esphome/esphome/pull/11167))
-
-Adds device scanning logs for troubleshooting I2C bus issues.
 
 **Advanced Substitution Features** ([#11203](https://github.com/esphome/esphome/pull/11203))
 
@@ -361,10 +271,6 @@ New `esphome analyze-memory <config.yaml>` command provides detailed memory usag
 - Dallas temperature sensors support index-based addressing ([#11346](https://github.com/esphome/esphome/pull/11346)) for devices without programmable addresses
 - INA2xx reset control ([#10787](https://github.com/esphome/esphome/pull/10787)): Preserve counters through ESP resets with `reset_on_boot: false`
 - XGZP68xx oversampling ([#10306](https://github.com/esphome/esphome/pull/10306)): Configurable oversampling up to 32768x for improved accuracy
-
-### Climate/Thermostat
-
-- Thermostat humidity control ([#11286](https://github.com/esphome/esphome/pull/11286)) adds humidity-based comfort control
 
 **Improved Improv WiFi Provisioning** ([#10757](https://github.com/esphome/esphome/pull/10757))
 
@@ -421,22 +327,6 @@ Cleaned up component with improved readability, fixed `warnung_low_pv_energy` ty
 **HM3301 AQI Calculation** ([#9442](https://github.com/esphome/esphome/pull/9442))
 
 Updated to 2024 EPA standard for Air Quality Index calculations.
-
-**WiFi AP Mode SSID Handling** ([#9442](https://github.com/esphome/esphome/pull/9442))
-
-Fixed SSID configuration for access point mode.
-
-**Voice Assistant Audio Corruption** ([#9823](https://github.com/esphome/esphome/pull/9823))
-
-Fixed audio corruption issues in voice assistant component.
-
-**Logger Crash Prevention** ([#11029](https://github.com/esphome/esphome/pull/11029), [#11066](https://github.com/esphome/esphome/pull/11066))
-
-Prevents crashes from malformed log messages.
-
-**API Service Call Validation** ([#11308](https://github.com/esphome/esphome/pull/11308))
-
-Improved validation of API service calls prevents invalid requests.
 
 ### Deprecated Code Cleanup
 

--- a/content/changelog/2025.11.0.md
+++ b/content/changelog/2025.11.0.md
@@ -70,7 +70,7 @@ wifi:
 
 Network priority optimization dramatically improves WiFi stability on ESP32-C6/H2/P4 by preventing brief ESP-NOW activity or BLE advertisements from disrupting WiFi connectivity. The optimization also changed priority storage from `float` to `int8_t`, saving 3 bytes per network entry.
 
-**WiFi Credentials Cleanup** ([#11830](https://github.com/esphome/esphome/pull/11830))
+**WiFi Credentials Cleanup** ([#11805](https://github.com/esphome/esphome/pull/11805))
 
 Prevents stale AP configurations from causing connection issues by properly managing stored credentials and clearing priority tracking when all BSSIDs fail equally (saves up to 96 bytes).
 
@@ -87,7 +87,7 @@ Introduced centralized high-performance networking system where components reque
 
 This optimization is critical for ESP32-S3 devices running voice assistants and media streaming, eliminating audio stuttering caused by insufficient WiFi buffer sizes.
 
-**PSRAM Configuration Options** ([#11388](https://github.com/esphome/esphome/pull/11388))
+**PSRAM Configuration Options** ([#11411](https://github.com/esphome/esphome/pull/11411))
 
 Added `ignore_not_found` option (default `true`) to allow disabling `CONFIG_SPIRAM_IGNORE_NOTFOUND`. When set to `false` on devices with guaranteed PSRAM, enables WiFi driver to configure larger buffers for optimal streaming performance. Also improves boot reliability by managing heap allocations before PSRAM initialization.
 

--- a/content/changelog/2025.11.0.md
+++ b/content/changelog/2025.11.0.md
@@ -117,7 +117,7 @@ Added `ignore_not_found` option (default `true`) to allow disabling `CONFIG_SPIR
 - **ESP32 Hosted BLE** - Bluetooth support for ESP32-P4 and other chips without native BLE ([#11167](https://github.com/esphome/esphome/pull/11167))
 - **ESP32 Hosted OTA** - Firmware updates for ESP32 co-processors via ESP-Hosted API ([#11562](https://github.com/esphome/esphome/pull/11562))
 - **ESP-NOW transport** - Added ESP-NOW as a transport platform for packet_transport component ([#11025](https://github.com/esphome/esphome/pull/11025))
-- **OpenThread enhancements** - Poll period configuration for MTD devices enables sleep mode ([#11374](https://github.com/esphome/esphome/pull/11374)), OTA support via mDNS ([#11095](https://github.com/esphome/esphome/pull/11095)), SRP client ([#10907](https://github.com/esphome/esphome/pull/10907)), TREL radio ([#11712](https://github.com/esphome/esphome/pull/11712))
+- **OpenThread enhancements** - Poll period configuration for MTD devices enables sleep mode ([#11374](https://github.com/esphome/esphome/pull/11374)), OTA support via mDNS ([#11095](https://github.com/esphome/esphome/pull/11095))
 - **USB Host improvements** - Fixed transfer slot exhaustion at high data rates, added configurable `max_transfer_requests` ([#11174](https://github.com/esphome/esphome/pull/11174))
 - **IR Remote protocols** - Dyson AM07 fan support ([#10163](https://github.com/esphome/esphome/pull/10163)), Symphony protocol ([#10777](https://github.com/esphome/esphome/pull/10777)), Toshiba RAS-2819T AC ([#9490](https://github.com/esphome/esphome/pull/9490))
 
@@ -163,11 +163,9 @@ openthread:
   poll_period: 40s  # Radio turns off between polls
 ```
 
-### Enterprise Features
+### Additional Features
 
-- SRP client support ([#10907](https://github.com/esphome/esphome/pull/10907)) enables DNS-SD service registration
 - Dataset TLV import/export ([#11095](https://github.com/esphome/esphome/pull/11095), [#11374](https://github.com/esphome/esphome/pull/11374)) simplifies network provisioning with Thread Border Router compatibility
-- TREL radio support ([#11712](https://github.com/esphome/esphome/pull/11712)) adds UDP-based transport for extended range
 
 ## nRF52 Platform Expansion
 

--- a/content/changelog/2025.11.0.md
+++ b/content/changelog/2025.11.0.md
@@ -19,13 +19,17 @@ params:
 ## Release Overview
 
 <!-- RELEASE_OVERVIEW_START -->
-ESPHome 2025.11.0 delivers substantial performance improvements for resource-constrained devices, with comprehensive memory optimizations saving **2-7KB of RAM on typical devices** and up to **31KB of RAM on sensor-heavy configurations**. Critical sensor filter optimizations prevent OOM crashes on ESP32 devices with multiple sensors, while flash savings reach **10KB+** on ESP32/ESP8266 platforms. These optimizations touch nearly every core component - from WiFi scan result management and select option storage to the global controller registry and action framework. The release includes breaking API changes for external component developers, but standard YAML configurations remain fully compatible (custom code in lambdas may require updates).
+ESPHome 2025.11.0 is a performance-focused release that makes your devices faster, more reliable, and more capable than ever before. WiFi connectivity gets a complete overhaul with intelligent mesh network handling, dramatically faster connection times, and enhanced security controls. Memory optimizations free up **2-31KB of RAM** and **10KB+ of flash**, giving even resource-constrained devices room to grow. A groundbreaking infrastructure change slashes event processing latency by **600-1,300x**—making BLE Proxy GATT operations rival local Bluetooth adapters, even over the network.
 
-A groundbreaking infrastructure change introduces **ultra-low latency event processing** across BLE, USB, MQTT, ESP-NOW, and wake word detection components. The new thread-safe loop wake mechanism reduces event processing latency from 0-16ms to ~12 microseconds—a **600-1,300x speedup**—delivering faster wake word detection, improved BLE pairing times, and reduced MQTT automation latency with no configuration required.
+**WiFi improvements** address the most common connectivity pain points: devices no longer get stuck on failed access points in mesh networks, hidden network connections are 2-6 seconds faster, and the new `min_auth_mode` option provides security controls with WPA2 defaults. The redesigned connection strategy with intelligent AP selection and reliable reconnection logic delivers the rock-solid WiFi performance users expect.
 
-WiFi security and reliability receive major upgrades with the new `min_auth_mode` configuration option enabling control over minimum authentication standards (WPA/WPA2/WPA3) and secure defaults (WPA2 on ESP32, WPA on ESP8266 with planned 2026.6.0 transition). A redesigned connection strategy fixes critical mesh network issues where devices would get stuck on failed access points, delivering intelligent AP selection, faster initial connections (2-6 seconds saved), and reliable reconnections. The high-performance networking system automatically optimizes lwIP and WiFi settings based on PSRAM availability, critical for voice assistants and media streaming.
+**Ultra-low latency event processing** transforms responsiveness across BLE, USB, MQTT, ESP-NOW, and wake word detection—reducing latency from 0-16ms to just ~12 microseconds. Voice assistants respond faster to wake words, BLE devices pair quicker, and MQTT automations trigger with sub-millisecond precision. This zero-configuration optimization automatically benefits all affected components on ESP32 platforms.
 
-New hardware support expands ESPHome's reach with 7 new components including the HDC2010 sensor, MCP3221 ADC, HLK-FM22X face recognition module, BH1900NUX sensor, RX8130 RTC, and TinyUSB foundation support for ESP32-S2/S3. Platform enhancements bring I2C and BLE logging to nRF52, while ESP32 gains hosted BLE for chips without native Bluetooth and ESP-NOW transport capabilities. LVGL users gain simplified layout shortcuts, rendering triggers for e-paper integration, and NaN text substitution, while the e-paper component receives speed optimizations and proper state machine handling for reliable display updates.
+**Comprehensive memory optimizations** touch nearly every core component—WiFi scan management, select options, lights, climate controls, sensors, and the action framework. Sensor filter optimizations deliver the most dramatic gains, with sliding window filters saving up to 25KB of RAM on configurations that previously struggled with memory constraints. These improvements enable more complex configurations on the same hardware.
+
+New hardware support expands ESPHome's reach with 7 new components including the HDC2010 sensor, MCP3221 ADC, HLK-FM22X face recognition module, BH1900NUX sensor, RX8130 RTC, and TinyUSB foundation support for ESP32-S2/S3. Platform enhancements bring I2C and BLE logging to nRF52, while ESP32 gains hosted BLE for chips without native Bluetooth and ESP-NOW transport capabilities.
+
+**Note:** This release includes breaking API changes for external component developers, but standard YAML configurations remain fully compatible (custom code in lambdas may require updates).
 <!-- RELEASE_OVERVIEW_END -->
 
 <!-- FEATURE_HIGHLIGHTS_START -->
@@ -115,7 +119,7 @@ A groundbreaking infrastructure change eliminates event processing delays across
 
 **Real-World Impact:**
 
-- **BLE Proxy performance** now rivals or exceeds BlueZ local adapters in Home Assistant, even when operating over the network
+- **BLE Proxy GATT operations** now rival or exceed BlueZ local adapters in Home Assistant, even when operating over the network
 - Faster wake word detection response for voice assistants
 - Improved BLE connection and pairing times
 - Reduced MQTT automation trigger latency

--- a/content/changelog/2025.11.0.md
+++ b/content/changelog/2025.11.0.md
@@ -91,11 +91,11 @@ ESPHome 2025.11.0 delivers substantial memory improvements across the entire fra
 - **Light effects** ([#11487](https://github.com/esphome/esphome/pull/11487)) - Saves **24-32 bytes per effect**
 - **WiFi priority** ([#11830](https://github.com/esphome/esphome/pull/11830)) - Saves **3 bytes per network entry** plus up to **96 bytes** from auto-recovery
 
-**Note on Breaking Changes:** These optimizations required API changes for external component developers. See Breaking Changes section for migration details. Standard YAML configurations remain fully compatible but custom code in lambdas may require updates.
+**Note on Breaking Changes:** These optimizations required API changes for external component developers. See [Breaking Changes](#breaking-changes) section for migration details. Standard YAML configurations remain fully compatible but custom code in lambdas may require updates.
 
 ## Ultra-Low Latency Event Processing
 
-**Thread-Safe Loop Wake Mechanism** ([#11663](https://github.com/esphome/esphome/pull/11663), [#11683](https://github.com/esphome/esphome/pull/11683), [#11695](https://github.com/esphome/esphome/pull/11695), [#11696](https://github.com/esphome/esphome/pull/11696), [#11698](https://github.com/esphome/esphome/pull/11698))
+**Thread-Safe Loop Wake Mechanism** ([#11681](https://github.com/esphome/esphome/pull/11681))
 
 A groundbreaking infrastructure change eliminates event processing delays across multiple components. Previously, events from background tasks (BLE, USB, MQTT, ESP-NOW, wake word detection) would queue and wait up to 16ms for the next `select()` timeout before processing. The new `wake_loop_threadsafe()` mechanism uses a UDP loopback socket to immediately wake the main event loop when events arrive.
 

--- a/content/changelog/2025.11.0.md
+++ b/content/changelog/2025.11.0.md
@@ -19,42 +19,16 @@ params:
 ## Release Overview
 
 <!-- RELEASE_OVERVIEW_START -->
-ESPHome 2025.11.0 delivers substantial performance improvements for resource-constrained devices, with comprehensive memory optimizations saving **2-7KB of RAM** on typical configurations and up to **10KB of flash** on ESP32/ESP8266 platforms. These optimizations touch nearly every core component - from WiFi scan result management and select option storage to the global controller registry and action framework. The release includes breaking API changes for external component developers, but standard YAML configurations remain fully compatible.
+ESPHome 2025.11.0 delivers substantial performance improvements for resource-constrained devices, with comprehensive memory optimizations saving **2-7KB of RAM on typical devices** and up to **31KB of RAM on sensor-heavy configurations**. Critical sensor filter optimizations prevent OOM crashes on ESP32 devices with multiple sensors, while flash savings reach **10KB+** on ESP32/ESP8266 platforms. These optimizations touch nearly every core component - from WiFi scan result management and select option storage to the global controller registry and action framework. The release includes breaking API changes for external component developers, but standard YAML configurations remain fully compatible (custom code in lambdas may require updates).
 
-New hardware support expands ESPHome's reach with 7 new components including the HDC2010 sensor, MCP3221 ADC, HLK-FM22X face recognition module, BH1900NUX sensor, RX8130 RTC, and TinyUSB foundation support for ESP32-S2/S3. Platform enhancements bring I2C, BLE logging to nRF52, while ESP32 gains hosted BLE for chips without native Bluetooth and ESP-NOW transport capabilities. The OpenThread implementation now supports sleep mode via poll period configuration, and USB Host improvements prevent transfer slot exhaustion at high data rates.
+A groundbreaking infrastructure change introduces **ultra-low latency event processing** across BLE, USB, MQTT, ESP-NOW, and wake word detection components. The new thread-safe loop wake mechanism reduces event processing latency from 0-16ms to ~12 microseconds—a **600-1,300x speedup**—delivering faster wake word detection, improved BLE pairing times, and reduced MQTT automation latency with no configuration required.
 
-WiFi security and reliability receive major upgrades with the new `min_auth_mode` configuration option enabling control over minimum authentication standards (WPA/WPA2/WPA3), secure defaults (WPA2 on ESP32, WPA on ESP8266 with planned 2026.6.0 transition), and a new high-performance networking system that automatically optimizes lwIP and WiFi settings based on PSRAM availability. Network components no longer block during connection setup, improving boot reliability, while the priority system switches from float to int8_t with auto-recovery when all access points fail equally. LVGL users gain simplified layout shortcuts, rendering triggers for e-paper integration, and NaN text substitution, while the e-paper component receives speed optimizations and proper state machine handling for reliable display updates.
+WiFi security and reliability receive major upgrades with the new `min_auth_mode` configuration option enabling control over minimum authentication standards (WPA/WPA2/WPA3) and secure defaults (WPA2 on ESP32, WPA on ESP8266 with planned 2026.6.0 transition). A redesigned connection strategy fixes critical mesh network issues where devices would get stuck on failed access points, delivering intelligent AP selection, faster initial connections (2-6 seconds saved), and reliable reconnections. The high-performance networking system automatically optimizes lwIP and WiFi settings based on PSRAM availability, critical for voice assistants and media streaming.
+
+New hardware support expands ESPHome's reach with 7 new components including the HDC2010 sensor, MCP3221 ADC, HLK-FM22X face recognition module, BH1900NUX sensor, RX8130 RTC, and TinyUSB foundation support for ESP32-S2/S3. Platform enhancements bring I2C and BLE logging to nRF52, while ESP32 gains hosted BLE for chips without native Bluetooth and ESP-NOW transport capabilities. LVGL users gain simplified layout shortcuts, rendering triggers for e-paper integration, and NaN text substitution, while the e-paper component receives speed optimizations and proper state machine handling for reliable display updates.
 <!-- RELEASE_OVERVIEW_END -->
 
 <!-- FEATURE_HIGHLIGHTS_START -->
-## Memory Optimizations for Resource-Constrained Devices
-
-ESPHome 2025.11.0 delivers substantial memory improvements across the entire framework, with measured savings ranging from **2-7KB of RAM on typical devices** and up to **31KB of RAM on sensor-heavy configurations**. Flash savings reach **10KB+** on ESP32/ESP8266 platforms.
-
-**Sensor Filter Optimizations:**
-
-- **Sliding window filters** ([#11282](https://github.com/esphome/esphome/pull/11282)) - Saves **22-25KB RAM** on large batch windows, **90% on sliding windows**, **1,748 bytes flash** on ESP8266. Prevents OOM crashes on ESP32 devices with multiple sensors
-- **Filter value lists** ([#11407](https://github.com/esphome/esphome/pull/11407)) - Saves **444 bytes flash** on ESP8266, 18-52% faster execution
-- **Calibration/OR filters** ([#11437](https://github.com/esphome/esphome/pull/11437)) - Saves **464 bytes flash**, **48 bytes RAM** on ESP8266
-
-**Component Optimizations:**
-
-- **WiFi component** ([#11205](https://github.com/esphome/esphome/pull/11205)) - Saves **440-1,192 bytes RAM** depending on network density
-- **Select component** ([#11514](https://github.com/esphome/esphome/pull/11514)) - Saves **270-2,800 bytes per select** depending on option count
-- **Light component** ([#11348](https://github.com/esphome/esphome/pull/11348)) - Saves **1,756 bytes flash** on ESP8266, **~108 bytes RAM** per 6 lights
-- **Climate component** ([#11466](https://github.com/esphome/esphome/pull/11466), [#11621](https://github.com/esphome/esphome/pull/11621)) - Saves **~440 bytes RAM** per climate entity
-- **Fan component** ([#11483](https://github.com/esphome/esphome/pull/11483), [#11632](https://github.com/esphome/esphome/pull/11632)) - Saves **~24 bytes per fan**
-- **Event component** ([#11463](https://github.com/esphome/esphome/pull/11463), [#11767](https://github.com/esphome/esphome/pull/11767)) - Saves **1,248 bytes flash**
-- **Global Controller Registry** ([#11772](https://github.com/esphome/esphome/pull/11772)) - Saves **388-6,148 bytes RAM** depending on entity count
-- **Action framework** ([#11704](https://github.com/esphome/esphome/pull/11704)) - Saves **356 bytes flash**, eliminates RAM allocations in automations
-- **Script component** ([#11308](https://github.com/esphome/esphome/pull/11308)) - Saves **1,592 bytes flash** on ESP32
-- **ESP32-IDF** ([#10930](https://github.com/esphome/esphome/pull/10930), [#11441](https://github.com/esphome/esphome/pull/11441)) - Saves **~10KB combined** (1.3KB + 8.7KB)
-- **Network component** ([#11707](https://github.com/esphome/esphome/pull/11707)) - Saves **32-72 bytes per network component**
-- **Light effects** ([#11487](https://github.com/esphome/esphome/pull/11487)) - Saves **24-32 bytes per effect**
-- **WiFi priority** ([#11830](https://github.com/esphome/esphome/pull/11830)) - Saves **3 bytes per network entry** plus up to **96 bytes** from auto-recovery
-
-**Note on Breaking Changes:** These optimizations required API changes for external component developers. See Breaking Changes section for migration details. Standard YAML configurations remain fully compatible but custom code in lambdas may require updates.
-
 ## Enhanced WiFi Security and Reliability
 
 **Configurable Minimum Authentication Mode** ([#11814](https://github.com/esphome/esphome/pull/11814))
@@ -91,6 +65,34 @@ This release restores and improves upon the reliable failover behavior users exp
 
 Network priority optimization dramatically improves WiFi stability on ESP32-C6/H2/P4 by preventing brief ESP-NOW activity or BLE advertisements from disrupting WiFi connectivity. The optimization also changed priority storage from `float` to `int8_t`, saving 3 bytes per network entry.
 
+## Memory Optimizations for Resource-Constrained Devices
+
+ESPHome 2025.11.0 delivers substantial memory improvements across the entire framework, with measured savings ranging from **2-7KB of RAM on typical devices** and up to **31KB of RAM on sensor-heavy configurations**. Flash savings reach **10KB+** on ESP32/ESP8266 platforms.
+
+**Sensor Filter Optimizations:**
+
+- **Sliding window filters** ([#11282](https://github.com/esphome/esphome/pull/11282)) - Saves **22-25KB RAM** on large batch windows, **90% on sliding windows**, **1,748 bytes flash** on ESP8266. Prevents OOM crashes on ESP32 devices with multiple sensors
+- **Filter value lists** ([#11407](https://github.com/esphome/esphome/pull/11407)) - Saves **444 bytes flash** on ESP8266, 18-52% faster execution
+- **Calibration/OR filters** ([#11437](https://github.com/esphome/esphome/pull/11437)) - Saves **464 bytes flash**, **48 bytes RAM** on ESP8266
+
+**Component Optimizations:**
+
+- **WiFi component** ([#11205](https://github.com/esphome/esphome/pull/11205)) - Saves **440-1,192 bytes RAM** depending on network density
+- **Select component** ([#11514](https://github.com/esphome/esphome/pull/11514)) - Saves **270-2,800 bytes per select** depending on option count
+- **Light component** ([#11348](https://github.com/esphome/esphome/pull/11348)) - Saves **1,756 bytes flash** on ESP8266, **~108 bytes RAM** per 6 lights
+- **Climate component** ([#11466](https://github.com/esphome/esphome/pull/11466), [#11621](https://github.com/esphome/esphome/pull/11621)) - Saves **~440 bytes RAM** per climate entity
+- **Fan component** ([#11483](https://github.com/esphome/esphome/pull/11483), [#11632](https://github.com/esphome/esphome/pull/11632)) - Saves **~24 bytes per fan**
+- **Event component** ([#11463](https://github.com/esphome/esphome/pull/11463), [#11767](https://github.com/esphome/esphome/pull/11767)) - Saves **1,248 bytes flash**
+- **Global Controller Registry** ([#11772](https://github.com/esphome/esphome/pull/11772)) - Saves **388-6,148 bytes RAM** depending on entity count
+- **Action framework** ([#11704](https://github.com/esphome/esphome/pull/11704)) - Saves **356 bytes flash**, eliminates RAM allocations in automations
+- **Script component** ([#11308](https://github.com/esphome/esphome/pull/11308)) - Saves **1,592 bytes flash** on ESP32
+- **ESP32-IDF** ([#10930](https://github.com/esphome/esphome/pull/10930), [#11441](https://github.com/esphome/esphome/pull/11441)) - Saves **~10KB combined** (1.3KB + 8.7KB)
+- **Network component** ([#11707](https://github.com/esphome/esphome/pull/11707)) - Saves **32-72 bytes per network component**
+- **Light effects** ([#11487](https://github.com/esphome/esphome/pull/11487)) - Saves **24-32 bytes per effect**
+- **WiFi priority** ([#11830](https://github.com/esphome/esphome/pull/11830)) - Saves **3 bytes per network entry** plus up to **96 bytes** from auto-recovery
+
+**Note on Breaking Changes:** These optimizations required API changes for external component developers. See Breaking Changes section for migration details. Standard YAML configurations remain fully compatible but custom code in lambdas may require updates.
+
 ## Ultra-Low Latency Event Processing
 
 **Thread-Safe Loop Wake Mechanism** ([#11663](https://github.com/esphome/esphome/pull/11663), [#11683](https://github.com/esphome/esphome/pull/11683), [#11695](https://github.com/esphome/esphome/pull/11695), [#11696](https://github.com/esphome/esphome/pull/11696), [#11698](https://github.com/esphome/esphome/pull/11698))
@@ -113,6 +115,7 @@ A groundbreaking infrastructure change eliminates event processing delays across
 
 **Real-World Impact:**
 
+- **BLE Proxy performance** now rivals or exceeds BlueZ local adapters in Home Assistant, even when operating over the network
 - Faster wake word detection response for voice assistants
 - Improved BLE connection and pairing times
 - Reduced MQTT automation trigger latency

--- a/content/changelog/2025.11.0.md
+++ b/content/changelog/2025.11.0.md
@@ -163,6 +163,8 @@ Added `ignore_not_found` option (default `true`) to allow disabling `CONFIG_SPIR
 - **nRF52 platform** - I2C support ([#8150](https://github.com/esphome/esphome/pull/8150)), BLE NUS logging ([#9846](https://github.com/esphome/esphome/pull/9846), [#9861](https://github.com/esphome/esphome/pull/9861)), GPIO voltage control ([#9858](https://github.com/esphome/esphome/pull/9858)), and Seeed XIAO BLE board improvements ([#10698](https://github.com/esphome/esphome/pull/10698))
 - **ESP-NOW transport** - Added ESP-NOW as a transport platform for packet_transport component ([#11025](https://github.com/esphome/esphome/pull/11025))
 - **IR Remote protocols** - Dyson AM07 fan support ([#10163](https://github.com/esphome/esphome/pull/10163)), Symphony protocol ([#10777](https://github.com/esphome/esphome/pull/10777)), Toshiba RAS-2819T AC ([#9490](https://github.com/esphome/esphome/pull/9490))
+- **GPIO input** - Fix GPIO input by switching to polling mode ([#11664](https://github.com/esphome/esphome/pull/11664))
+- 
 
 ## ESP32 Platform Enhancements
 

--- a/content/changelog/2025.11.0.md
+++ b/content/changelog/2025.11.0.md
@@ -1,6 +1,6 @@
 ---
 description: "Changelog for ESPHome 2025.11.0."
-title: "ESPHome 2025.11.0 - 13th November 2025"
+title: "ESPHome 2025.11.0 - 14th November 2025"
 params:
   seo:
     description: Changelog for ESPHome 2025.11.0.
@@ -21,7 +21,7 @@ params:
 <!-- RELEASE_OVERVIEW_START -->
 ESPHome 2025.11.0 delivers substantial performance improvements for resource-constrained devices, with comprehensive memory optimizations saving **2-7KB of RAM** on typical configurations and up to **10KB of flash** on ESP32/ESP8266 platforms. These optimizations touch nearly every core component - from WiFi scan result management and select option storage to the global controller registry and action framework. The release includes breaking API changes for external component developers, but standard YAML configurations remain fully compatible.
 
-New hardware support expands ESPHome's reach with 7 new components including the HDC2010 sensor, MCP3221 ADC, HLK-FM22X face recognition module, BH1900NUX sensor, RX8130 RTC, and TinyUSB foundation support for ESP32-S2/S3. Platform enhancements bring I2C, BLE logging, and API support to nRF52, while ESP32 gains hosted BLE for chips without native Bluetooth and ESP-NOW transport capabilities. The OpenThread implementation now supports sleep mode via poll period configuration, and USB Host improvements prevent transfer slot exhaustion at high data rates.
+New hardware support expands ESPHome's reach with 7 new components including the HDC2010 sensor, MCP3221 ADC, HLK-FM22X face recognition module, BH1900NUX sensor, RX8130 RTC, and TinyUSB foundation support for ESP32-S2/S3. Platform enhancements bring I2C, BLE logging to nRF52, while ESP32 gains hosted BLE for chips without native Bluetooth and ESP-NOW transport capabilities. The OpenThread implementation now supports sleep mode via poll period configuration, and USB Host improvements prevent transfer slot exhaustion at high data rates.
 
 WiFi security and reliability receive major upgrades with the new `min_auth_mode` configuration option enabling control over minimum authentication standards (WPA/WPA2/WPA3), secure defaults (WPA2 on ESP32, WPA on ESP8266 with planned 2026.6.0 transition), and a new high-performance networking system that automatically optimizes lwIP and WiFi settings based on PSRAM availability. Network components no longer block during connection setup, improving boot reliability, while the priority system switches from float to int8_t with auto-recovery when all access points fail equally. LVGL users gain simplified layout shortcuts, rendering triggers for e-paper integration, and NaN text substitution, while the e-paper component receives speed optimizations and proper state machine handling for reliable display updates.
 <!-- RELEASE_OVERVIEW_END -->
@@ -45,243 +45,565 @@ ESPHome 2025.11.0 delivers substantial memory improvements across the entire fra
 - **ESP32-IDF optimizations** ([#10930](https://github.com/esphome/esphome/pull/10930), [#11441](https://github.com/esphome/esphome/pull/11441)) - Disables unused libc locks and VFS features, saving **~10KB combined** (1.3KB + 8.7KB)
 - **Network component** ([#11707](https://github.com/esphome/esphome/pull/11707)) - Stores addresses in flash, saving **32-72 bytes per network component**
 - **Light effects** ([#11487](https://github.com/esphome/esphome/pull/11487)) - Flash-based effect names save **24-32 bytes per effect**
+- **WiFi priority** ([#11830](https://github.com/esphome/esphome/pull/11830)) - Changed from `float` to `int8_t`, saves **3 bytes per network entry** plus up to **96 bytes** from auto-recovery cleanup
 
 **Note on Breaking Changes:** These optimizations required API changes for external component developers. See Breaking Changes section for migration details. Standard YAML configurations remain fully compatible.
 
-## New Hardware & Platform Support
+## Enhanced WiFi Security and Reliability
 
-**New Components (7 total):**
+**Configurable Minimum Authentication Mode** ([#11814](https://github.com/esphome/esphome/pull/11814))
 
-- {{< docref "/components/sensor/hdc2010" >}} - HDC2010 temperature and humidity sensor ([#6674](https://github.com/esphome/esphome/pull/6674))
-- {{< docref "/components/sensor/mcp3221" >}} - MCP3221 12-bit I2C ADC ([#7764](https://github.com/esphome/esphome/pull/7764))
-- {{< docref "/components/hlk_fm22x" >}} - HLK-FM22X face recognition module ([#8059](https://github.com/esphome/esphome/pull/8059))
-- {{< docref "/components/sensor/bh1900nux" >}} - BH1900NUX temperature sensor ([#8631](https://github.com/esphome/esphome/pull/8631))
-- {{< docref "/components/time/rx8130" >}} - RX8130 RTC chip (used in M5Stack devices) ([#10511](https://github.com/esphome/esphome/pull/10511))
-- {{< docref "/components/tinyusb" >}} - TinyUSB foundation component for ESP32-S2/S3 USB device functionality ([#11678](https://github.com/esphome/esphome/pull/11678))
-- {{< docref "/components/sensor/dallas_temp" >}} - Added index-based sensor addressing for devices with multiple Dallas sensors ([#11346](https://github.com/esphome/esphome/pull/11346))
+Added `min_auth_mode` configuration option to control WiFi authentication security:
 
-**Platform & Feature Expansions:**
-
-- **nRF52 platform** - I2C support ([#8150](https://github.com/esphome/esphome/pull/8150)), BLE NUS logging ([#9846](https://github.com/esphome/esphome/pull/9846), [#9861](https://github.com/esphome/esphome/pull/9861)), GPIO voltage control ([#9858](https://github.com/esphome/esphome/pull/9858)), API support ([#11751](https://github.com/esphome/esphome/pull/11751)), and Seeed XIAO BLE board improvements ([#10698](https://github.com/esphome/esphome/pull/10698))
-- **ESP32 Hosted BLE** - Bluetooth support for ESP32-P4 and other chips without native BLE ([#11167](https://github.com/esphome/esphome/pull/11167))
-- **ESP32 Hosted OTA** - Firmware updates for ESP32 co-processors via ESP-Hosted API ([#11562](https://github.com/esphome/esphome/pull/11562))
-- **ESP-NOW transport** - Added ESP-NOW as a transport platform for packet_transport component ([#11025](https://github.com/esphome/esphome/pull/11025))
-- **OpenThread enhancements** - Poll period configuration for MTD devices enables sleep mode ([#11374](https://github.com/esphome/esphome/pull/11374)), OTA support via mDNS ([#11095](https://github.com/esphome/esphome/pull/11095))
-- **USB Host improvements** - Fixed transfer slot exhaustion at high data rates, added configurable `max_transfer_requests` ([#11174](https://github.com/esphome/esphome/pull/11174))
-- **IR Remote protocols** - Dyson AM07 fan support ([#10163](https://github.com/esphome/esphome/pull/10163)), Symphony protocol ([#10777](https://github.com/esphome/esphome/pull/10777)), Toshiba RAS-2819T AC ([#9490](https://github.com/esphome/esphome/pull/9490))
-
-**Hardware Additions:**
-
-- GP8413 15-bit DAC model for gp8403 component ([#7726](https://github.com/esphome/esphome/pull/7726))
-- Waveshare 5" 1024x600 MIPI RGB display ([#11206](https://github.com/esphome/esphome/pull/11206))
-- Mopeka standard sensor alternate ID (0x44) support ([#10907](https://github.com/esphome/esphome/pull/10907))
-- SX126x GPIO expander support for BUSY/RST/DIO1 pins ([#11782](https://github.com/esphome/esphome/pull/11782))
-
-## WiFi Security & Reliability
-
-**New Security Feature:**
-
-The `wifi` component now supports configurable minimum authentication modes via the new `min_auth_mode` option ([#11814](https://github.com/esphome/esphome/pull/11814)). This allows control over WiFi security standards:
-
-- **ESP32 default**: `WPA2` (secure by default)
-- **ESP8266 default**: `WPA` (for compatibility, will change to `WPA2` in 2026.6.0)
-- **Supported values**: `WPA`, `WPA2`, `WPA3`
-
-Example configuration:
+- **Secure default**: WPA2 minimum authentication mode protects against downgrade attacks
+- **Explicit security control**: Choose between WPA, WPA2, or WPA3 (ESP32 only)
+- **Backward compatibility**: Can be lowered to WPA for legacy routers
 
 ```yaml
 wifi:
   ssid: "MyNetwork"
-  password: "password"
+  password: "password123"
   min_auth_mode: WPA2  # Recommended for security
 ```
 
-**Network Setup Improvements:**
+**WiFi Priority Optimization** ([#11830](https://github.com/esphome/esphome/pull/11830))
 
-WiFi and Ethernet components no longer block other components during network connection ([#9823](https://github.com/esphome/esphome/pull/9823)). Components now check connection state in `loop()` instead of waiting during `setup()`, improving boot reliability.
+Network priority optimization dramatically improves WiFi stability on ESP32-C6/H2/P4 by preventing brief ESP-NOW activity or BLE advertisements from disrupting WiFi connectivity. The optimization also changed priority storage from `float` to `int8_t`, saving 3 bytes per network entry.
 
-**High-Performance Networking:**
+**WiFi Credentials Cleanup** ([#11830](https://github.com/esphome/esphome/pull/11830))
 
-New centralized high-performance networking system ([#11812](https://github.com/esphome/esphome/pull/11812)) automatically applies PSRAM-aware lwIP and WiFi optimizations. Components request optimized settings via `network.require_high_performance_networking()`, enabling:
+Prevents stale AP configurations from causing connection issues by properly managing stored credentials and clearing priority tracking when all BSSIDs fail equally (saves up to 96 bytes).
 
-- **With PSRAM guaranteed**: 512KB TCP windows for maximum throughput
-- **Without PSRAM**: Conservative 65KB windows that work reliably on all devices
+## High-Performance Networking for Media Streaming
 
-**Priority System Improvements:**
+**Automatic Network Performance Tuning** ([#11812](https://github.com/esphome/esphome/pull/11812))
 
-WiFi priority changed from `float` to `int8_t` ([#11830](https://github.com/esphome/esphome/pull/11830)), saving memory and adding auto-recovery when all BSSIDs fail equally. System automatically clears tracking when all access points reach minimum priority, allowing fresh connection attempts.
+Introduced centralized high-performance networking system where components request optimized settings through `network.require_high_performance_networking()`:
 
-## LVGL & Display Enhancements
+- **PSRAM-aware configuration**: Aggressive settings (512KB TCP windows) when PSRAM guaranteed, conservative (65KB windows) otherwise
+- **WiFi optimization**: Automatically applies optimized WiFi driver settings when high-performance mode enabled
+- **Automatic enablement**: Speaker media player automatically enables high-performance networking (fixes streaming stuttering issues)
+- **User control**: New `network.enable_high_performance` option to explicitly enable/disable
 
-**LVGL Improvements:**
+This optimization is critical for ESP32-S3 devices running voice assistants and media streaming, eliminating audio stuttering caused by insufficient WiFi buffer sizes.
 
-- **Layout shortcuts** ([#10149](https://github.com/esphome/esphome/pull/10149)) - Simple grid (`layout: 3x2`) and flex layouts (`layout: horizontal/vertical`), new `container` widget, and `stretch` option for flex layouts
-- **Rendering triggers** ([#11628](https://github.com/esphome/esphome/pull/11628)) - New `on_draw_start` and `on_draw_end` triggers facilitate e-paper display updates
-- **NaN text substitution** ([#11712](https://github.com/esphome/esphome/pull/11712)) - Display custom text when sensor values are invalid (NaN/inf)
-- **Validation speedup** - Substantial configuration validation performance improvements
+**PSRAM Configuration Options** ([#11388](https://github.com/esphome/esphome/pull/11388))
 
-**E-Paper Display Optimizations:**
+Added `ignore_not_found` option (default `true`) to allow disabling `CONFIG_SPIRAM_IGNORE_NOTFOUND`. When set to `false` on devices with guaranteed PSRAM, enables WiFi driver to configure larger buffers for optimal streaming performance. Also improves boot reliability by managing heap allocations before PSRAM initialization.
 
-The `epaper_spi` component received major improvements ([#11540](https://github.com/esphome/esphome/pull/11540)):
+## New Hardware Support
 
-- Larger SPI data blocks for faster transfers on Spectra displays
-- Revised E6 pixel format for speed improvements
-- Pre-configured board-specific pins including Seeed-reTerminal-E1002
-- Proper state machine allows reliable detection when display is ready
-- Busy pin logic corrected ([#11349](https://github.com/esphome/esphome/pull/11349))
+**7 New Sensor/Device Components:**
 
-**Display Features:**
+- [HDC2010](https://esphome.io/components/sensor/hdc2010.html) ([#6674](https://github.com/esphome/esphome/pull/6674)) - Texas Instruments temperature and humidity sensor
+- [MCP3221](https://esphome.io/components/sensor/mcp3221.html) ([#7764](https://github.com/esphome/esphome/pull/7764)) - I2C A-D converter with configurable reference voltage
+- [HLK-FM22X](https://esphome.io/components/hlk_fm22x.html) ([#8059](https://github.com/esphome/esphome/pull/8059)) - Face recognition module family
+- [BH1900NUX](https://esphome.io/components/sensor/bh1900nux.html) ([#8631](https://github.com/esphome/esphome/pull/8631)) - Rohm Semiconductor temperature sensor
+- [RX8130](https://esphome.io/components/time/rx8130.html) ([#10511](https://github.com/esphome/esphome/pull/10511)) - Epson RTC chip (used in M5Stack devices)
+- [BLE NUS Logger](https://esphome.io/components/logger.html#ble-logging) ([#9846](https://github.com/esphome/esphome/pull/9846)) - Logging over BLE for nRF52 platform
+- [TinyUSB](https://esphome.io/components/tinyusb.html) ([#11678](https://github.com/esphome/esphome/pull/11678)) - USB device functionality foundation for ESP32-S2/S3
 
-- MIPI rotation fixes for custom models ([#11226](https://github.com/esphome/esphome/pull/11226), [#11585](https://github.com/esphome/esphome/pull/11585))
-- Component `is_idle` method and condition for automations ([#11651](https://github.com/esphome/esphome/pull/11651))
+**Extended Hardware Support:**
 
-Example e-paper integration with LVGL:
+- GP8403 DAC now supports GP8413 (15-bit) model ([#7726](https://github.com/esphome/esphome/pull/7726)) with higher precision
+- Toshiba climate supports RAS-2819T air conditioner ([#9490](https://github.com/esphome/esphome/pull/9490)) with two-packet IR protocol
+- Dallas temperature sensors support index-based addressing ([#11346](https://github.com/esphome/esphome/pull/11346)) for devices without programmable addresses
+- SX126x LoRa module pins now support GPIO port expanders ([#11782](https://github.com/esphome/esphome/pull/11782)) for SeeedStudio SenseCAP Indicator
+- Mopeka Standard Check sensors support alternate ID 0x44 ([#10907](https://github.com/esphome/esphome/pull/10907))
+
+**Platform & Feature Expansions:**
+
+- **nRF52 platform** - I2C support ([#8150](https://github.com/esphome/esphome/pull/8150)), BLE NUS logging ([#9846](https://github.com/esphome/esphome/pull/9846), [#9861](https://github.com/esphome/esphome/pull/9861)), GPIO voltage control ([#9858](https://github.com/esphome/esphome/pull/9858)), and Seeed XIAO BLE board improvements ([#10698](https://github.com/esphome/esphome/pull/10698))
+- **ESP32 Hosted BLE** - Bluetooth support for ESP32-P4 and other chips without native BLE ([#11167](https://github.com/esphome/esphome/pull/11167))
+- **ESP32 Hosted OTA** - Firmware updates for ESP32 co-processors via ESP-Hosted API ([#11562](https://github.com/esphome/esphome/pull/11562))
+- **ESP-NOW transport** - Added ESP-NOW as a transport platform for packet_transport component ([#11025](https://github.com/esphome/esphome/pull/11025))
+- **OpenThread enhancements** - Poll period configuration for MTD devices enables sleep mode ([#11374](https://github.com/esphome/esphome/pull/11374)), OTA support via mDNS ([#11095](https://github.com/esphome/esphome/pull/11095)), SRP client ([#10907](https://github.com/esphome/esphome/pull/10907)), TREL radio ([#11712](https://github.com/esphome/esphome/pull/11712))
+- **USB Host improvements** - Fixed transfer slot exhaustion at high data rates, added configurable `max_transfer_requests` ([#11174](https://github.com/esphome/esphome/pull/11174))
+- **IR Remote protocols** - Dyson AM07 fan support ([#10163](https://github.com/esphome/esphome/pull/10163)), Symphony protocol ([#10777](https://github.com/esphome/esphome/pull/10777)), Toshiba RAS-2819T AC ([#9490](https://github.com/esphome/esphome/pull/9490))
+
+## ESP32 Platform Enhancements
+
+**Hosted BLE Support** ([#11167](https://github.com/esphome/esphome/pull/11167))
+
+ESP32 P4 and other chips without integrated Bluetooth now support BLE through external controllers using ESP-Hosted API. Enables Bluetooth Proxy functionality on previously unsupported ESP32 variants.
+
+**Brownout Protection** ([#11306](https://github.com/esphome/esphome/pull/11306))
+
+ESP-IDF builds now automatically reduce PHY TX power during brownout conditions to prevent boot loops. This feature was previously only available in Arduino framework builds. Can be disabled if needed through sdkconfig options.
+
+**Configurable Main Loop Stack Size** ([#10564](https://github.com/esphome/esphome/pull/10564))
+
+ESP32 ESP-IDF configurations can now tune the main loop stack size for complex setups:
 
 ```yaml
-display:
-  - platform: epaper_spi
-    id: epaper_display
-    model: Seeed-reTerminal-E1002
-    update_interval: never
-    auto_clear_enabled: false
+esp32:
+  framework:
+    type: esp-idf
+    advanced:
+      main_loop_stack_size: 16384  # Increase for deeply nested components
+```
 
+**Framework Source Options** ([#11125](https://github.com/esphome/esphome/pull/11125))
+
+ESP32 framework configuration now accepts additional PlatformIO source schemes beyond HTTP, including `symlink://`, `git://`, and other repository protocols for local development.
+
+## OpenThread Improvements
+
+**Over-The-Air Updates** ([#11095](https://github.com/esphome/esphome/pull/11095))
+
+OpenThread devices (ESP32-H2) now support OTA updates via `esphome run`. The mDNS address is automatically populated as the device's default address, eliminating the need to manually specify `--device <address>`.
+
+**Sleepy End Device Support** ([#11374](https://github.com/esphome/esphome/pull/11374))
+
+Added `poll_period` configuration for MTD (Minimal Thread Device) mode, enabling Sleep End Device (SED) behavior for battery-powered Thread devices:
+
+```yaml
+openthread:
+  device_type: MTD
+  poll_period: 40s  # Radio turns off between polls
+```
+
+### Enterprise Features
+
+- SRP client support ([#10907](https://github.com/esphome/esphome/pull/10907)) enables DNS-SD service registration
+- Dataset TLV import/export ([#11095](https://github.com/esphome/esphome/pull/11095), [#11374](https://github.com/esphome/esphome/pull/11374)) simplifies network provisioning with Thread Border Router compatibility
+- TREL radio support ([#11712](https://github.com/esphome/esphome/pull/11712)) adds UDP-based transport for extended range
+
+## nRF52 Platform Expansion
+
+The nRF52 (Zephyr) platform received extensive new functionality:
+
+- **I2C Support** ([#8150](https://github.com/esphome/esphome/pull/8150)) - Full I2C bus support for sensors and peripherals
+- **BLE Logging** ([#9846](https://github.com/esphome/esphome/pull/9846), [#9861](https://github.com/esphome/esphome/pull/9861)) - Log viewing via `esphome logs --device BLE` or MAC address
+- **GPIO High Voltage Mode** ([#9858](https://github.com/esphome/esphome/pull/9858)) - Adjustable voltage levels for USB-powered operation
+- **Xiao BLE Bootloader Fix** ([#10698](https://github.com/esphome/esphome/pull/10698)) - Corrected default bootloader, fixed upload, added runtime mismatch detection
+
+## LVGL Display Enhancements
+
+**Simplified Layout System** ([#10149](https://github.com/esphome/esphome/pull/10149))
+
+LVGL widgets now support shorthand layout methods for easier configuration:
+
+```yaml
+lvgl:
+  widgets:
+    - container:
+        layout: vertical  # Simple flex layout
+        widgets:
+          - label:
+              text: "Item 1"
+          - label:
+              text: "Item 2"
+
+    - container:
+        layout: 3x2  # Simple grid layout
+```
+
+New `container` widget provides styling-free base with 100% default dimensions. Added `stretch` option for flex layouts and substantial speedup of config validation.
+
+**Rendering Triggers and NaN Substitution** ([#11628](https://github.com/esphome/esphome/pull/11628), [#11712](https://github.com/esphome/esphome/pull/11712))
+
+Added `on_draw_start` and `on_draw_end` triggers for coordinating e-paper display updates. Text formatting now supports NaN substitution for graceful handling of unavailable sensor values:
+
+```yaml
+lvgl:
+  widgets:
+    - label:
+        text:
+          format: "%.1f°C"
+          args: [id(temp_sensor)]
+          if_nan: "--.-°C"  # Show when sensor unavailable
+```
+
+### Additional Features
+
+- Arc widget support ([#10163](https://github.com/esphome/esphome/pull/10163))
+- Span widget for rich text formatting ([#11346](https://github.com/esphome/esphome/pull/11346))
+- Font/image cleanup automation ([#11562](https://github.com/esphome/esphome/pull/11562))
+- Faster rotary encoder debouncing ([#10564](https://github.com/esphome/esphome/pull/10564))
+- Paused widget support ([#11651](https://github.com/esphome/esphome/pull/11651))
+- LVGL 9.3 integration ([#11540](https://github.com/esphome/esphome/pull/11540))
+
+## Display Component Improvements
+
+**E-Paper SPI Refactoring** ([#11540](https://github.com/esphome/esphome/pull/11540))
+
+Major improvements to e-paper displays:
+
+- **Faster transfers**: Larger data blocks for Spectra displays
+- **Optimized state machine**: Code-based sequence instead of linear queue saves memory
+- **Board-specific configs**: Pre-configured pin mappings (Seeed-reTerminal-E1002)
+- **Improved timing**: Internal delay handling instead of loop disabling
+- **Fixed busy pin logic** ([#11349](https://github.com/esphome/esphome/pull/11349)): Corrected active-low detection
+
+**E-Paper Fast Refresh** ([#9490](https://github.com/esphome/esphome/pull/9490))
+
+Waveshare e-paper displays gain fast refresh mode support, reducing update times from seconds to milliseconds for partial updates.
+
+**Color E-Paper Models** ([#10757](https://github.com/esphome/esphome/pull/10757), [#11125](https://github.com/esphome/esphome/pull/11125))
+
+Expanded support for color e-paper displays with additional Waveshare models.
+
+**MIPI Display Enhancements** ([#11206](https://github.com/esphome/esphome/pull/11206), [#11226](https://github.com/esphome/esphome/pull/11226), [#11585](https://github.com/esphome/esphome/pull/11585))
+
+- ST7701S driver ([#10777](https://github.com/esphome/esphome/pull/10777)) adds RGB interface support with optimizations for ESP32-S3 parallel displays
+- Added Waveshare 5" 1024x600 display support
+- Fixed rotation handling for custom models
+- Configurable `draw_rounding` option
+
+**Component Idle Detection** ([#11651](https://github.com/esphome/esphome/pull/11651))
+
+New `component.is_idle` condition and `is_idle()` method for automations that need to wait for displays to finish updating before proceeding:
+
+```yaml
 lvgl:
   on_draw_end:
-    - lvgl.pause:
-    - wait_until:
-        component.is_idle: epaper_display
     - component.update: epaper_display
     - wait_until:
-        component.is_idle: epaper_display
+        component.is_idle: epaper_display  # Wait for display ready
     - lvgl.resume:
 ```
 
-## CLI & Development Tools
+## USB Host Enhancements
 
-**New CLI Commands:**
+**Transfer Slot Optimization** ([#11174](https://github.com/esphome/esphome/pull/11174))
 
-- `esphome analyze-memory <config.yaml>` ([#11395](https://github.com/esphome/esphome/pull/11395)) - Dedicated command for memory usage analysis by component with proper external component detection
+Fixed USB UART transfer slot exhaustion at high data rates (115200+ baud):
 
-**Configuration Improvements:**
+- **Immediate release**: Transfer slots freed in USB task instead of main loop
+- **Configurable slots**: New `max_transfer_requests` option (1-32, default 16)
+- **Prevents failures**: Eliminates "All 16 transfer slots in use" errors at high throughput
 
-- Substitutions and Jinja support in `!extend` and `!remove` tags ([#11203](https://github.com/esphome/esphome/pull/11203)) - Enables conditional component modification
-- ESP32 framework URL schemes expanded ([#11125](https://github.com/esphome/esphome/pull/11125)) - Supports PlatformIO's git, symlink, and other schemes
+**Suspend/Resume Handling** ([#11772](https://github.com/esphome/esphome/pull/11772))
 
-**ESP32 Platform Enhancements:**
+Improved suspend/resume handling maintains connectivity during brief USB power interruptions, critical for automotive and battery-powered applications.
 
-- Configurable loop task stack size ([#10564](https://github.com/esphome/esphome/pull/10564)) - Helps complex configurations avoid boot loops
-- PSRAM mode now required for ESP32-S3 ([#11470](https://github.com/esphome/esphome/pull/11470)) - Prevents configuration errors
-- PSRAM `ignore_not_found` option ([#11411](https://github.com/esphome/esphome/pull/11411)) - Allows WiFi buffer optimization when PSRAM is guaranteed
-- Brownout TX power reduction enabled by default ([#11306](https://github.com/esphome/esphome/pull/11306)) - Prevents boot loops on marginal power supplies
+## Climate and Thermostat Features
 
-## Component Enhancements
+**Humidity Control** ([#11286](https://github.com/esphome/esphome/pull/11286))
 
-**Climate Component:**
+Thermostat component now supports controlling humidity through humidifier/dehumidifier actions:
 
-- Humidity control support in thermostat ([#11286](https://github.com/esphome/esphome/pull/11286)) - Adds humidification and dehumidification actions
+```yaml
+climate:
+  - platform: thermostat
+    sensor: temp_sensor
+    humidity_sensor: humidity_sensor
+    humidify_action:
+      - switch.turn_on: humidifier
+    dehumidify_action:
+      - switch.turn_on: dehumidifier
+    target_humidity: 50%
+```
 
-**Sensor Filters:**
+**Temperature Differentials** ([#11174](https://github.com/esphome/esphome/pull/11174))
 
-- Heartbeat filter `optimistic` option ([#10993](https://github.com/esphome/esphome/pull/10993)) - Forwards new values immediately while maintaining periodic repeats
+Climate control gains precision temperature differentials for heat/cool mode switching.
 
-**Select Component:**
+**Visual Presets** ([#11628](https://github.com/esphome/esphome/pull/11628))
 
-- Index-based operations ([#11623](https://github.com/esphome/esphome/pull/11623)) - Saves ~32 bytes per SelectCall, enables future ~28 bytes/instance savings (`.state` deprecated, removed in 2026.5.0)
+Visual presets enable better UI integration for climate controls.
 
-**Script Component:**
+**Improved Target Temperature Tracking** ([#11226](https://github.com/esphome/esphome/pull/11226))
 
-- Queued mode now defaults to `max_runs: 5` ([#11308](https://github.com/esphome/esphome/pull/11308)) instead of unlimited to prevent crashes from unbounded memory growth
+Thermostat improvements include better target temperature tracking and restore functionality.
 
-**Remote Transmitter:**
+## Remote Control Protocol Support
 
-- Non-blocking mode ([#11524](https://github.com/esphome/esphome/pull/11524)) - Prevents long blocking operations (enabled by default with warnings)
+Added IR protocol decoders/encoders:
 
-**Improv WiFi:**
+- **Toshiba AC heatpump** ([#7726](https://github.com/esphome/esphome/pull/7726))
+- **Dyson AM07** ([#10163](https://github.com/esphome/esphome/pull/10163)) - Tower fan with rolling codes
+- **Symphony** ([#10777](https://github.com/esphome/esphome/pull/10777)) - With configurable command repeats
 
-- `next_url` support ([#10757](https://github.com/esphome/esphome/pull/10757)) - Redirects users after provisioning with device info substitution
+## Configuration and Developer Tools
 
-**INA2xx Sensors:**
+**Python 3.13 Support** ([#11411](https://github.com/esphome/esphome/pull/11411))
 
-- `reset_on_boot` disablement option ([#10787](https://github.com/esphome/esphome/pull/10787)) - Preserves counters through ESP device resets
+Ensures compatibility with the latest Python release.
 
-**XGZP68xx Sensor:**
+**Template Number Component** ([#10149](https://github.com/esphome/esphome/pull/10149))
 
-- Oversampling configuration and implementation improvements ([#10306](https://github.com/esphome/esphome/pull/10306))
+Enables dynamic number entities without C++ code.
 
-**HTTP Request:**
+**Sensor Force Update Option** ([#10930](https://github.com/esphome/esphome/pull/10930))
 
-- Trigger variables now passed to `on_response`/`on_error` handlers ([#11464](https://github.com/esphome/esphome/pull/11464))
+Sensor schemas gain `force_update` option for explicit state change control.
 
-## Notable Bug Fixes & Quality Improvements
+**I2C Debugging** ([#11167](https://github.com/esphome/esphome/pull/11167))
 
-**Critical Fixes:**
+Adds device scanning logs for troubleshooting I2C bus issues.
 
-- `.local` address resolution now requires mDNS ([#11508](https://github.com/esphome/esphome/pull/11508)) - Eliminates 10+ second delays when mDNS is disabled
-- Uponor Smatrix addressing corrected to 32-bit ([#11066](https://github.com/esphome/esphome/pull/11066)) - Fixes installations with non-uniform address prefixes
-- GDK101 firmware version reporting fixed ([#11029](https://github.com/esphome/esphome/pull/11029)) - Now correctly displays as string
+**Advanced Substitution Features** ([#11203](https://github.com/esphome/esphome/pull/11203))
 
-**Code Quality:**
+The `!extend` and `!remove` tags now support substitutions and Jinja templates:
 
-- HM3301 AQI calculation updated to EPA 2024 standard ([#9442](https://github.com/esphome/esphome/pull/9442))
-- PIPsolar cleanup and refactoring ([#10291](https://github.com/esphome/esphome/pull/10291)) - Fixed typo `warnung_low_pv_energy` → `warning_low_pv_energy`
-- Deprecated code removal - Cleaned up deprecations from 2021-2022 ([#11383](https://github.com/esphome/esphome/pull/11383), [#11388](https://github.com/esphome/esphome/pull/11388), [#11389](https://github.com/esphome/esphome/pull/11389), [#11391](https://github.com/esphome/esphome/pull/11391), [#11392](https://github.com/esphome/esphome/pull/11392), [#11393](https://github.com/esphome/esphome/pull/11393), [#11591](https://github.com/esphome/esphome/pull/11591), [#11783](https://github.com/esphome/esphome/pull/11783))
+```yaml
+substitutions:
+  COMPONENT_TO_REMOVE: component3
+
+packages:
+  base:
+    - id: !remove ${COMPONENT_TO_REMOVE}  # Conditional removal
+```
+
+**Memory Analysis Command** ([#11395](https://github.com/esphome/esphome/pull/11395))
+
+New `esphome analyze-memory <config.yaml>` command provides detailed memory usage breakdown by component:
+
+- Compiles configuration (fast relink if cached)
+- Analyzes memory usage by component and external components
+- Displays comprehensive memory report
+- Helps identify optimization opportunities
+
+**ESP-IDF Logging Configuration** ([#11782](https://github.com/esphome/esphome/pull/11782))
+
+Auto-enables UART output when WiFi logging is unavailable, preventing silent failures during debugging.
+
+## Component-Specific Enhancements
+
+### Bluetooth
+
+- BLE connection interval tuning ([#11410](https://github.com/esphome/esphome/pull/11410)) improves power efficiency and reliability
+- Maximum connections now default to 3 ([#11383](https://github.com/esphome/esphome/pull/11383))
+- Connection-on-demand ([#11704](https://github.com/esphome/esphome/pull/11704)) reduces idle power consumption
+- Bluetooth proxy reliability improvements ([#10291](https://github.com/esphome/esphome/pull/10291))
+
+### NTP/SNTP
+
+Multiple SNTP instances can now share a single underlying client ([#11707](https://github.com/esphome/esphome/pull/11707)), reducing memory usage in multi-timezone configurations.
+
+### Sensors
+
+- Dallas temperature sensors gain resolution control per device ([#11025](https://github.com/esphome/esphome/pull/11025))
+- CSE7766 power sensor ([#11524](https://github.com/esphome/esphome/pull/11524)) adds energy tracking
+- SCD4x ([#11585](https://github.com/esphome/esphome/pull/11585)) adds single-shot measurement mode for ultra-low-power applications
+- INA2xx reset control ([#10787](https://github.com/esphome/esphome/pull/10787)): Preserve counters through ESP resets with `reset_on_boot: false`
+- XGZP68xx oversampling ([#10306](https://github.com/esphome/esphome/pull/10306)): Configurable oversampling up to 32768x for improved accuracy
+
+### Voice Assistant
+
+STT/TTS endpoint configuration ([#11725](https://github.com/esphome/esphome/pull/11725)) enables custom voice service backends.
+
+**Improved Improv WiFi Provisioning** ([#10757](https://github.com/esphome/esphome/pull/10757))
+
+ESP32 Improv now supports `next_url` with template substitutions for post-provisioning redirection:
+
+```yaml
+esp32_improv:
+  next_url: "https://example.com/setup?device={{device_name}}&ip={{ip_address}}"
+```
+
+**Sensor Heartbeat Filter Options** ([#10993](https://github.com/esphome/esphome/pull/10993))
+
+Heartbeat filter adds `optimistic` mode to forward new values immediately while still repeating periodically:
+
+```yaml
+sensor:
+  - platform: template
+    filters:
+      - heartbeat:
+          period: 100ms
+          optimistic: true  # Forward immediately + repeat
+```
+
+**ESP-NOW Packet Transport** ([#11025](https://github.com/esphome/esphome/pull/11025))
+
+ESP-NOW now available as transport platform for packet_transport component, enabling direct ESP32-to-ESP32 wireless sensor data transmission.
+
+**Remote Transmitter Non-Blocking Mode** ([#11524](https://github.com/esphome/esphome/pull/11524))
+
+Remote transmitter operations no longer block the main loop by default, preventing "took a long time for an operation" warnings during long IR transmissions.
+
+**HTTP Request Trigger Variables** ([#11464](https://github.com/esphome/esphome/pull/11464))
+
+HTTP request actions now pass trigger variables correctly into `on_response` and `on_error` triggers.
+
+## Component Bug Fixes and Quality Improvements
+
+**Uponor Smatrix Addressing** ([#11066](https://github.com/esphome/esphome/pull/11066))
+
+Fixed addressing system to use full 32-bit addresses instead of split 16-bit system/device addresses, supporting installations where thermostats don't share common prefix.
+
+**GDK101 Firmware Version** ([#11029](https://github.com/esphome/esphome/pull/11029))
+
+Fixed firmware version attribute to display as string instead of floating-point division result.
+
+**PiPsolar Refactoring** ([#10291](https://github.com/esphome/esphome/pull/10291))
+
+Cleaned up component with improved readability, fixed `warnung_low_pv_energy` typo, replaced `sscanf` with explicit reads, and fixed potential buffer overrun.
+
+**.local DNS Resolution** ([#11508](https://github.com/esphome/esphome/pull/11508))
+
+`.local` addresses now only resolve when mDNS is enabled, avoiding 10+ second delays when mDNS unavailable.
+
+**HM3301 AQI Calculation** ([#9442](https://github.com/esphome/esphome/pull/9442))
+
+Updated to 2024 EPA standard for Air Quality Index calculations.
+
+**WiFi AP Mode SSID Handling** ([#9442](https://github.com/esphome/esphome/pull/9442))
+
+Fixed SSID configuration for access point mode.
+
+**Voice Assistant Audio Corruption** ([#9823](https://github.com/esphome/esphome/pull/9823))
+
+Fixed audio corruption issues in voice assistant component.
+
+**Logger Crash Prevention** ([#11029](https://github.com/esphome/esphome/pull/11029), [#11066](https://github.com/esphome/esphome/pull/11066))
+
+Prevents crashes from malformed log messages.
+
+**API Service Call Validation** ([#11308](https://github.com/esphome/esphome/pull/11308))
+
+Improved validation of API service calls prevents invalid requests.
+
+### Deprecated Code Cleanup
+
+Removed long-obsolete APIs from 2021-era releases:
+
+- Nextion ([#11393](https://github.com/esphome/esphome/pull/11393))
+- Logger ([#11392](https://github.com/esphome/esphome/pull/11392))
+- Servo ([#11389](https://github.com/esphome/esphome/pull/11389))
 <!-- FEATURE_HIGHLIGHTS_END -->
 
 ## Breaking Changes
 
 <!-- BREAKING_CHANGES_USERS_START -->
-### Component Changes
 
-- **HM3301**: AQI calculation updated to EPA 2024 standard (values will change) [#9442](https://github.com/esphome/esphome/pull/9442)
-- **PIPsolar**: Fixed typo `warnung_low_pv_energy` → `warning_low_pv_energy` in configuration [#10291](https://github.com/esphome/esphome/pull/10291)
-- **GDK101**: Firmware version now reported as string instead of float [#11029](https://github.com/esphome/esphome/pull/11029)
-- **Uponor Smatrix**: Changed to 32-bit addresses - `address` property removed from base component, device addresses must now be 32-bit (prepend old system address to device addresses) [#11066](https://github.com/esphome/esphome/pull/11066)
-- **E-paper SPI**: Fixed busy pin logic (was inverted, now correctly reads HIGH=idle) [#11349](https://github.com/esphome/esphome/pull/11349)
-- **Script**: Queued mode now defaults to `max_runs: 5` instead of unlimited to prevent crashes [#11308](https://github.com/esphome/esphome/pull/11308)
-- **Remote Transmitter**: Non-blocking mode enabled by default with warnings for long operations [#11524](https://github.com/esphome/esphome/pull/11524)
+### User-Facing Breaking Changes
 
-### Platform & Network Changes
+#### Configuration Changes
 
-- **nRF52**: Default bootloader changed for `xiao_ble` and `adafruit_itsybitsy_nrf52840` boards [#10698](https://github.com/esphome/esphome/pull/10698)
-- **WiFi/Ethernet**: No longer blocks other components during setup - components must check network state in `loop()` instead of assuming network is ready in `setup()` [#9823](https://github.com/esphome/esphome/pull/9823)
-- **WiFi**: Priority changed from float to int8_t (only integers -128 to 127 accepted) [#11830](https://github.com/esphome/esphome/pull/11830)
-- **WiFi**: New `min_auth_mode` option controls minimum security (ESP32 defaults to WPA2, ESP8266 defaults to WPA with planned 2026.6.0 change to WPA2) [#11814](https://github.com/esphome/esphome/pull/11814)
-- **Network**: `.local` addresses now require mDNS to be enabled (eliminates 10+ second delays when mDNS is disabled) [#11508](https://github.com/esphome/esphome/pull/11508)
-- **Speaker**: High-performance networking mode now always enabled (previously only with codec support) [#11812](https://github.com/esphome/esphome/pull/11812)
+### WiFi & Network
 
-### ESP32 Platform Changes
+- **WiFi**: WiFi and Ethernet components no longer block other components' setup until connected. Components with setup priority > WIFI (802.3) now initialize immediately, even if network is disconnected. [#9823](https://github.com/esphome/esphome/pull/9823)
 
-- **ESP32-IDF**: Brownout TX power reduction enabled by default to prevent boot loops on marginal power supplies [#11306](https://github.com/esphome/esphome/pull/11306)
-- **ESP32-IDF**: Unused VFS features disabled by default (saves ~8.7KB flash), automatically re-enabled by components that need them [#11441](https://github.com/esphome/esphome/pull/11441)
-- **ESP32-IDF**: Libc locks in IRAM disabled by default (saves ~1.3KB RAM), can be re-enabled with `disable_libc_locks_in_iram: false` [#10930](https://github.com/esphome/esphome/pull/10930)
-- **ESP32-S3**: PSRAM mode now required when using components that need PSRAM [#11470](https://github.com/esphome/esphome/pull/11470)
+- **WiFi min_auth_mode**: ESP8266 default will change from `WPA` to `WPA2` in 2026.6.0. Users with WPA-only routers must explicitly set `min_auth_mode: WPA` before then. [#11814](https://github.com/esphome/esphome/pull/11814)
+
+- **WiFi priority**: The `priority` configuration option now only accepts integers (-128 to 127) instead of floats. Change `priority: 5.5` to `priority: 5`. [#11830](https://github.com/esphome/esphome/pull/11830)
+
+- **.local addresses**: .local addresses now require mDNS to be enabled for DNS resolution. Previously attempted DNS resolution could add 10+ second delays. [#11508](https://github.com/esphome/esphome/pull/11508)
+
+- **Network high performance**: Speaker media player now always enables high performance networking mode (previously only with codec support). Users can override with `enable_high_performance` under the network component if needed. [#11812](https://github.com/esphome/esphome/pull/11812)
+
+### ESP32 Platform
+
+- **ESP32 brownout protection**: ESP-IDF now reduces PHY TX power during brownout to prevent boot loops. Can be disabled with `sdkconfig_options: CONFIG_ESP_PHY_REDUCE_TX_POWER: n` if needed. [#11306](https://github.com/esphome/esphome/pull/11306)
+
+- **ESP32-S3 PSRAM**: PSRAM mode is now required when multiple PSRAM modes are available (ESP32-S3 only). Users must explicitly choose PSRAM mode in configuration. [#11470](https://github.com/esphome/esphome/pull/11470)
+
+### Component Behavior Changes
+
+- **Script max_runs**: Queued scripts now default to `max_runs: 5` (allowing 1 running + 4 queued instances) instead of unlimited to prevent crashes from unbounded memory growth. Set `max_runs` explicitly if you need more capacity. [#11308](https://github.com/esphome/esphome/pull/11308)
+
+- **Remote transmitter**: Remote transmitter now defaults to non-blocking mode to prevent long blocking operations (>30ms). [#11524](https://github.com/esphome/esphome/pull/11524)
+
+- **Fan preset modes**: Fan preset modes now preserve the order defined in YAML instead of being sorted alphabetically. The order in Home Assistant will match your YAML configuration order. [#11483](https://github.com/esphome/esphome/pull/11483)
+
+- **Select state**: The public `state` member has been deprecated and will be removed in 2026.5.0. Use `current_option()` method instead. Deprecation warnings will be shown during compilation. [#11623](https://github.com/esphome/esphome/pull/11623)
+
+### Component-Specific Changes
+
+- **HM3301**: AQI calculation updated to EPA 2024 standard. Values will change compared to the old 2012 formula. [#9442](https://github.com/esphome/esphome/pull/9442)
+
+- **GDK101**: Firmware version is now reported as a string instead of a float division result. [#11029](https://github.com/esphome/esphome/pull/11029)
+
+- **Uponor Smatrix**: The `address` property of the `uponor_smatrix` component was removed. Device addresses are now 32-bit instead of separate 16-bit system and device addresses. Update configurations by prepending the previous system address to individual device addresses. [#11066](https://github.com/esphome/esphome/pull/11066)
+
+- **Pipsolar**: Fixed typo `warnung_low_pv_energy` renamed to `warning_low_pv_energy`. Update YAML configurations. [#10291](https://github.com/esphome/esphome/pull/10291)
+
+- **E-Paper SPI**: Busy pin logic corrected to match datasheet (active low). Some e-paper displays may behave differently. [#11349](https://github.com/esphome/esphome/pull/11349)
+
+- **nRF52 bootloader**: Default bootloader changed for `xiao_ble` and `adafruit_itsybitsy_nrf52840` boards. Warning shown if generic Adafruit bootloader is used. [#10698](https://github.com/esphome/esphome/pull/10698)
+
+- **HTTP request triggers**: Changed from multiple on_response/on_error triggers to a single trigger that receives variables. Update automation configurations to use the new variable-based trigger format. [#11464](https://github.com/esphome/esphome/pull/11464)
+
+## YAML Lambda Changes
+
+Users who access component members directly in YAML lambdas may need updates:
+
+- **Select**: Change `id(my_select).state` to `id(my_select).current_option()` (deprecated, will be removed in 2026.5.0). [#11623](https://github.com/esphome/esphome/pull/11623)
+
+- **Fan**: Change `id(my_fan).preset_mode` to `id(my_fan).get_preset_mode()`. [#11632](https://github.com/esphome/esphome/pull/11632)
+
+- **Event**: Change `id(my_event).last_event_type` to `id(my_event).get_last_event_type()`. [#11767](https://github.com/esphome/esphome/pull/11767)
 <!-- BREAKING_CHANGES_USERS_END -->
 
 ### Breaking Changes for Developers
 
 <!-- BREAKING_CHANGES_DEVELOPERS_START -->
-- **WiFi API**: `WiFiComponent::get_scan_result()` returns empty vector after connection unless `wifi.request_wifi_scan_results()` called during code generation [#11205](https://github.com/esphome/esphome/pull/11205)
-- **Select API**: Changed to `const char *` storage, added index-based operations, `.state` deprecated (removed in 2026.5.0) [#11514](https://github.com/esphome/esphome/pull/11514), [#11623](https://github.com/esphome/esphome/pull/11623)
-- **Light API**: Effect names changed from `std::string` to `const char *`, `get_name()` returns `const char *` [#11487](https://github.com/esphome/esphome/pull/11487)
-- **Light API**: Color modes storage changed from `std::set<ColorMode>` to `ColorModeMask` bitmask class [#11348](https://github.com/esphome/esphome/pull/11348)
-- **Fan API**: Preset modes changed from `std::set<std::string>` to `std::vector<const char *>` [#11483](https://github.com/esphome/esphome/pull/11483)
-- **Fan API**: Removed public `.preset_mode` member, use `get_preset_mode()` / `set_preset_mode_()` instead [#11632](https://github.com/esphome/esphome/pull/11632)
-- **Climate API**: Replaced `std::set<EnumType>` with `FiniteSetMask` for trait storage, custom modes changed to `std::vector` [#11466](https://github.com/esphome/esphome/pull/11466), [#11621](https://github.com/esphome/esphome/pull/11621)
-- **Event API**: Event types changed from `std::set<std::string>` to `FixedVector<const char *>`, `.last_event_type` now private with `get_last_event_type()` getter [#11463](https://github.com/esphome/esphome/pull/11463), [#11767](https://github.com/esphome/esphome/pull/11767)
-- **Network API**: `get_use_address()` now returns `const char *` instead of `const std::string &` [#11707](https://github.com/esphome/esphome/pull/11707)
-- **Action Framework**: All action/trigger signatures changed to use `const Ts&...` instead of `Ts...` (pass-by-reference) [#11704](https://github.com/esphome/esphome/pull/11704)
-- **Controller API**: Removed state parameters from all `on_*_update()` methods - controllers now read state directly from entities via Global Controller Registry [#11772](https://github.com/esphome/esphome/pull/11772)
-- **HTTP Request**: Changed from multiple triggers to single `on_response`/`on_error` trigger with variables passed through [#11464](https://github.com/esphome/esphome/pull/11464)
-- **Core API**: Removed deprecated `hexencode()` function (deprecated since 2022.1) [#11383](https://github.com/esphome/esphome/pull/11383)
-- **Core API**: Removed deprecated schema constants [#11591](https://github.com/esphome/esphome/pull/11591)
-- **Core API**: Removed deprecated `EntityBase::hash_base()` method (deprecated since 2022.6) [#11783](https://github.com/esphome/esphome/pull/11783)
-- **Climate API**: Removed deprecated functions from 1.20 (July 2021) [#11388](https://github.com/esphome/esphome/pull/11388)
-- **Light API**: Removed deprecated functions from 2021.8.0 [#11389](https://github.com/esphome/esphome/pull/11389)
-- **Cover API**: Removed deprecated functions from 2021.9 [#11391](https://github.com/esphome/esphome/pull/11391)
-- **Fan/MQTT API**: Removed deprecated code from 2022.2 [#11392](https://github.com/esphome/esphome/pull/11392)
-- **Nextion API**: Removed deprecated functions from 1.20 (July 2021) [#11393](https://github.com/esphome/esphome/pull/11393)
 
-For detailed migration guides and API documentation, see the [ESPHome Developers Documentation](https://developers.esphome.io/).
+The following changes affect external component developers. Standard YAML configurations are generally not affected.
+
+## Core Framework Changes
+
+- **Action/Trigger Framework**: All action/trigger/condition method signatures changed to use const references (`const Ts&... x`) instead of pass-by-value (`Ts... x`). Update custom actions to add `const&` to parameter packs. [#11704](https://github.com/esphome/esphome/pull/11704)
+
+- **Controller API**: Controllers now use global registry pattern. Method signatures changed to remove unused state parameters (e.g., `on_sensor_update(sensor::Sensor *obj)` instead of `on_sensor_update(sensor::Sensor *obj, float state)`). External controller implementations extremely rare. [#11772](https://github.com/esphome/esphome/pull/11772)
+
+- **EntityBase::hash_base()**: Removed deprecated virtual method (deprecated since June 2022). Remove `hash_base()` overrides from external components. [#11783](https://github.com/esphome/esphome/pull/11783)
+
+- **hexencode()**: Removed function deprecated since 2022.1. Use alternative encoding methods. [#11383](https://github.com/esphome/esphome/pull/11383)
+
+- **Schema constants**: Removed deprecated schema constants from core. Update external components to use current schema helpers. [#11591](https://github.com/esphome/esphome/pull/11591)
+
+## Component-Specific API Changes
+
+### Climate
+
+- **Custom modes storage**: Changed from `std::set<std::string>` to `FiniteSetMask` for supported modes, and from `std::vector<std::string>` to `std::vector<const char *>` for custom fan modes and presets. Update custom climate components to use new container types and string literal storage. [#11466](https://github.com/esphome/esphome/pull/11466), [#11621](https://github.com/esphome/esphome/pull/11621)
+
+- **Member access**: Climate device members (`custom_fan_mode_`, `custom_preset_`) are now private. Use protected setter methods (`set_custom_fan_mode_()`, `set_custom_preset_()`) in derived classes instead of direct assignment. [#11621](https://github.com/esphome/esphome/pull/11621)
+
+- **Deprecated methods**: Removed methods deprecated in 1.20 (July 2021). Update to current climate API. [#11388](https://github.com/esphome/esphome/pull/11388)
+
+### Light
+
+- **Color modes**: Replaced `std::set<ColorMode>` with `ColorModeMask` bitmask class. Update custom light components to use `ColorModeMask` type and initializer list syntax. [#11348](https://github.com/esphome/esphome/pull/11348)
+
+- **Effect names**: Changed from `std::string` to `const char *` for effect names. Custom light effect constructors must accept `const char *name` instead of `const std::string &name`. [#11487](https://github.com/esphome/esphome/pull/11487)
+
+- **Deprecated methods**: Removed methods deprecated in 2021.8.0. Update to current light API. [#11389](https://github.com/esphome/esphome/pull/11389)
+
+### Fan
+
+- **Preset modes**: Changed from `std::set<std::string>` to `std::vector<const char *>`. The `.preset_mode` public member has been removed - use `get_preset_mode()` for reading and `set_preset_mode_()` for writing in derived classes. [#11483](https://github.com/esphome/esphome/pull/11483), [#11632](https://github.com/esphome/esphome/pull/11632)
+
+- **Deprecated code**: Removed code deprecated in 2022.2. Update to current fan API. [#11392](https://github.com/esphome/esphome/pull/11392)
+
+### Select
+
+- **Options storage**: Changed from `std::vector<std::string>` to `FixedVector<const char *>`. Custom select components must use string literals or const char pointers for options. [#11514](https://github.com/esphome/esphome/pull/11514)
+
+- **State member**: Public `state` member deprecated (will be removed in 2026.5.0). Use `current_option()` method instead. [#11623](https://github.com/esphome/esphome/pull/11623)
+
+- **Index-based operations**: Added optional `control(size_t index)` override for more efficient implementations. [#11623](https://github.com/esphome/esphome/pull/11623)
+
+### Event
+
+- **Event types storage**: Changed from `FixedVector<std::string>` to `FixedVector<const char *>`. String comparisons now use `strcmp()`. The `last_event_type` field is now private - use `get_last_event_type()` getter instead. [#11463](https://github.com/esphome/esphome/pull/11463), [#11767](https://github.com/esphome/esphome/pull/11767)
+
+### Network Components
+
+- **WiFi scan results**: Custom components that access WiFi scan results after connection must call `wifi.request_wifi_scan_results()` in their `to_code()` function to prevent cleanup. [#11205](https://github.com/esphome/esphome/pull/11205)
+
+- **use_address**: Changed from `const std::string &` to `const char *` in WiFi, Ethernet, and OpenThread components. Update external components calling `get_use_address()` or `set_use_address()`. [#11707](https://github.com/esphome/esphome/pull/11707)
+
+### Other Components
+
+- **Cover**: Removed methods deprecated in 2021.9. Update to current cover API. [#11391](https://github.com/esphome/esphome/pull/11391)
+
+- **Nextion**: Removed methods deprecated in 1.20 (July 2021). Update to current nextion API. [#11393](https://github.com/esphome/esphome/pull/11393)
+
+## ESP32-Specific Changes
+
+- **ESP-IDF advanced options**: New options to disable libc locks in IRAM and VFS features. External components using these features must call helper functions to register needs. [#10930](https://github.com/esphome/esphome/pull/10930), [#11441](https://github.com/esphome/esphome/pull/11441)
+
+## Migration Resources
+
+For detailed migration guides and examples, see the [ESPHome developer documentation](https://developers.esphome.io/).
+
+The 2025.11 release blog post includes comprehensive migration examples for common use cases.
 <!-- BREAKING_CHANGES_DEVELOPERS_END -->
 
 <!-- markdownlint-disable MD013 -->

--- a/content/changelog/2025.11.0.md
+++ b/content/changelog/2025.11.0.md
@@ -160,11 +160,9 @@ Added `ignore_not_found` option (default `true`) to allow disabling `CONFIG_SPIR
 
 **Platform & Feature Expansions:**
 
-- **nRF52 platform** - I2C support ([#8150](https://github.com/esphome/esphome/pull/8150)), BLE NUS logging ([#9846](https://github.com/esphome/esphome/pull/9846), [#9861](https://github.com/esphome/esphome/pull/9861)), GPIO voltage control ([#9858](https://github.com/esphome/esphome/pull/9858)), and Seeed XIAO BLE board improvements ([#10698](https://github.com/esphome/esphome/pull/10698))
+- **nRF52 platform** - I2C support ([#8150](https://github.com/esphome/esphome/pull/8150)), BLE NUS logging ([#9846](https://github.com/esphome/esphome/pull/9846), [#9861](https://github.com/esphome/esphome/pull/9861)), GPIO voltage control ([#9858](https://github.com/esphome/esphome/pull/9858)), GPIO input by switching to polling mode ([#11664](https://github.com/esphome/esphome/pull/11664)), and Seeed XIAO BLE board improvements ([#10698](https://github.com/esphome/esphome/pull/10698))
 - **ESP-NOW transport** - Added ESP-NOW as a transport platform for packet_transport component ([#11025](https://github.com/esphome/esphome/pull/11025))
 - **IR Remote protocols** - Dyson AM07 fan support ([#10163](https://github.com/esphome/esphome/pull/10163)), Symphony protocol ([#10777](https://github.com/esphome/esphome/pull/10777)), Toshiba RAS-2819T AC ([#9490](https://github.com/esphome/esphome/pull/9490))
-- **GPIO input** - Fix GPIO input by switching to polling mode ([#11664](https://github.com/esphome/esphome/pull/11664))
-
 ## ESP32 Platform Enhancements
 
 **ESP-IDF 5.5.1 and Arduino 3.3.2** ([#9839](https://github.com/esphome/esphome/pull/9839))

--- a/content/changelog/2025.11.0.md
+++ b/content/changelog/2025.11.0.md
@@ -19,7 +19,7 @@ params:
 ## Release Overview
 
 <!-- RELEASE_OVERVIEW_START -->
-ESPHome 2025.11.0 is a performance and reliability-focused release that makes your devices faster, more reliable, and more capable than ever before. WiFi connectivity gets a complete overhaul with intelligent mesh network handling, dramatically faster connection times, and enhanced security controls. Memory optimizations free up **2-31KB of RAM** and **10KB+ of flash**, giving even resource-constrained devices room to grow. A groundbreaking infrastructure change slashes event processing latency by **600-1,300x**—making BLE Proxy GATT operations rival local Bluetooth adapters, even over the network.
+ESPHome 2025.11.0 is a performance and reliability-focused release that makes your devices faster, more reliable, and more capable than ever before. WiFi connectivity gets a complete overhaul with intelligent mesh network handling, dramatically faster connection times, and enhanced security controls. Memory optimizations free up **2-31KB of RAM** and **10KB+ of flash**, giving even resource-constrained devices room to grow. A new infrastructure change slashes event processing latency by **600-1,300x**—making BLE Proxy GATT operations rival local Bluetooth adapters, even over the network.
 
 **WiFi improvements** address the most common connectivity pain points: devices no longer get stuck on failed access points in mesh networks, hidden network connections are 2-6 seconds faster, and the new `min_auth_mode` option provides security controls with WPA2 defaults. The redesigned connection strategy with intelligent AP selection and reliable reconnection logic delivers the rock-solid WiFi performance users expect.
 
@@ -97,7 +97,7 @@ ESPHome 2025.11.0 delivers substantial memory improvements across the entire fra
 
 **Thread-Safe Loop Wake Mechanism** ([#11681](https://github.com/esphome/esphome/pull/11681))
 
-A groundbreaking infrastructure change eliminates event processing delays across multiple components. Previously, events from background tasks (BLE, USB, MQTT, ESP-NOW, wake word detection) would queue and wait up to 16ms for the next `select()` timeout before processing. The new `wake_loop_threadsafe()` mechanism uses a UDP loopback socket to immediately wake the main event loop when events arrive.
+A new infrastructure change eliminates event processing delays across multiple components. Previously, events from background tasks (BLE, USB, MQTT, ESP-NOW, wake word detection) would queue and wait up to 16ms for the next `select()` timeout before processing. The new `wake_loop_threadsafe()` mechanism uses a UDP loopback socket to immediately wake the main event loop when events arrive.
 
 **Latency Improvements:**
 

--- a/content/changelog/2025.11.0.md
+++ b/content/changelog/2025.11.0.md
@@ -356,34 +356,17 @@ New `esphome analyze-memory <config.yaml>` command provides detailed memory usag
 - Displays comprehensive memory report
 - Helps identify optimization opportunities
 
-**ESP-IDF Logging Configuration** ([#11782](https://github.com/esphome/esphome/pull/11782))
-
-Auto-enables UART output when WiFi logging is unavailable, preventing silent failures during debugging.
-
 ## Component-Specific Enhancements
-
-### Bluetooth
-
-- BLE connection interval tuning ([#11410](https://github.com/esphome/esphome/pull/11410)) improves power efficiency and reliability
-- Maximum connections now default to 3 ([#11383](https://github.com/esphome/esphome/pull/11383))
-- Connection-on-demand ([#11704](https://github.com/esphome/esphome/pull/11704)) reduces idle power consumption
-- Bluetooth proxy reliability improvements ([#10291](https://github.com/esphome/esphome/pull/10291))
-
-### NTP/SNTP
-
-Multiple SNTP instances can now share a single underlying client ([#11707](https://github.com/esphome/esphome/pull/11707)), reducing memory usage in multi-timezone configurations.
 
 ### Sensors
 
-- Dallas temperature sensors gain resolution control per device ([#11025](https://github.com/esphome/esphome/pull/11025))
-- CSE7766 power sensor ([#11524](https://github.com/esphome/esphome/pull/11524)) adds energy tracking
-- SCD4x ([#11585](https://github.com/esphome/esphome/pull/11585)) adds single-shot measurement mode for ultra-low-power applications
+- Dallas temperature sensors support index-based addressing ([#11346](https://github.com/esphome/esphome/pull/11346)) for devices without programmable addresses
 - INA2xx reset control ([#10787](https://github.com/esphome/esphome/pull/10787)): Preserve counters through ESP resets with `reset_on_boot: false`
 - XGZP68xx oversampling ([#10306](https://github.com/esphome/esphome/pull/10306)): Configurable oversampling up to 32768x for improved accuracy
 
-### Voice Assistant
+### Climate/Thermostat
 
-STT/TTS endpoint configuration ([#11725](https://github.com/esphome/esphome/pull/11725)) enables custom voice service backends.
+- Thermostat humidity control ([#11286](https://github.com/esphome/esphome/pull/11286)) adds humidity-based comfort control
 
 **Improved Improv WiFi Provisioning** ([#10757](https://github.com/esphome/esphome/pull/10757))
 

--- a/content/changelog/2025.11.0.md
+++ b/content/changelog/2025.11.0.md
@@ -68,15 +68,18 @@ wifi:
 
 **Dramatically Improved WiFi Reliability and Connection Times** ([#11805](https://github.com/esphome/esphome/pull/11805))
 
-Fixes critical mesh network connectivity issues where devices would get stuck repeatedly attempting the strongest (but failing) access point. The new implementation delivers:
+A major step forward in WiFi reliability addresses critical connectivity issues in mesh networks and multi-AP environments. Previously, devices would get stuck repeatedly trying the strongest signal even when that access point was rejecting connections—a bug introduced in 2025.8.2 that made the priority-based failover system ineffective.
 
-- **Faster failover**: Automatic switching to working APs when connection fails, instead of getting stuck on failed BSSIDs
-- **Smarter reconnection**: Two-attempt BSSID filtering eliminates false positives from WiFi stack transitions
-- **Better hidden network support**: Explicit hidden network probing phase with intelligent skipping of visible networks (saves 2-6 seconds)
-- **Improved mesh handling**: Simplified 150+ lines of BSID cycling logic—priority degradation now naturally handles mesh networks
-- **Memory savings**: Cleared priority tracking when all BSSIDs fail equally (saves up to 96 bytes)
+The redesigned connection strategy delivers measurable improvements:
 
-The fix corrects priority sorting to check connection failure history before signal strength, making the automatic failover system work as designed.
+- **Intelligent AP selection**: Connection failure history now takes precedence over signal strength, enabling automatic failover to working access points instead of getting stuck on failed BSSIDs
+- **Faster initial connections**: Explicit hidden network probing phase with smart skipping of visible networks reduces connection time by 2-6 seconds
+- **Reliable reconnections**: Two-attempt BSSID filtering eliminates false positives from normal WiFi stack transitions
+- **Natural mesh handling**: Simplified architecture removes 150+ lines of complex BSSID cycling logic—the priority degradation system now naturally handles mesh networks through scan-based retry cycles
+- **Clearer diagnostics**: State machine-based retry phases with improved logging make connection issues easier to troubleshoot
+- **Memory efficiency**: Automatic priority reset when all BSSIDs fail equally (saves up to 96 bytes)
+
+This release restores and improves upon the reliable failover behavior users expect in multi-AP deployments, while reducing connection latency and memory overhead.
 
 **WiFi Priority Optimization** ([#11830](https://github.com/esphome/esphome/pull/11830))
 
@@ -328,13 +331,6 @@ Cleaned up component with improved readability, fixed `warnung_low_pv_energy` ty
 
 Updated to 2024 EPA standard for Air Quality Index calculations.
 
-### Deprecated Code Cleanup
-
-Removed long-obsolete APIs from 2021-era releases:
-
-- Nextion ([#11393](https://github.com/esphome/esphome/pull/11393))
-- Logger ([#11392](https://github.com/esphome/esphome/pull/11392))
-- Servo ([#11389](https://github.com/esphome/esphome/pull/11389))
 <!-- FEATURE_HIGHLIGHTS_END -->
 
 ## Breaking Changes

--- a/content/changelog/2025.11.0.md
+++ b/content/changelog/2025.11.0.md
@@ -1,6 +1,6 @@
 ---
 description: "Changelog for ESPHome 2025.11.0."
-title: "ESPHome 2025.11.0 - 14th November 2025"
+title: "ESPHome 2025.11.0 - 19th November 2025"
 params:
   seo:
     description: Changelog for ESPHome 2025.11.0.
@@ -19,7 +19,7 @@ params:
 ## Release Overview
 
 <!-- RELEASE_OVERVIEW_START -->
-ESPHome 2025.11.0 is a performance-focused release that makes your devices faster, more reliable, and more capable than ever before. WiFi connectivity gets a complete overhaul with intelligent mesh network handling, dramatically faster connection times, and enhanced security controls. Memory optimizations free up **2-31KB of RAM** and **10KB+ of flash**, giving even resource-constrained devices room to grow. A groundbreaking infrastructure change slashes event processing latency by **600-1,300x**—making BLE Proxy GATT operations rival local Bluetooth adapters, even over the network.
+ESPHome 2025.11.0 is a performance and reliability-focused release that makes your devices faster, more reliable, and more capable than ever before. WiFi connectivity gets a complete overhaul with intelligent mesh network handling, dramatically faster connection times, and enhanced security controls. Memory optimizations free up **2-31KB of RAM** and **10KB+ of flash**, giving even resource-constrained devices room to grow. A groundbreaking infrastructure change slashes event processing latency by **600-1,300x**—making BLE Proxy GATT operations rival local Bluetooth adapters, even over the network.
 
 **WiFi improvements** address the most common connectivity pain points: devices no longer get stuck on failed access points in mesh networks, hidden network connections are 2-6 seconds faster, and the new `min_auth_mode` option provides security controls with WPA2 defaults. The redesigned connection strategy with intelligent AP selection and reliable reconnection logic delivers the rock-solid WiFi performance users expect.
 

--- a/content/changelog/2025.11.0.md
+++ b/content/changelog/2025.11.0.md
@@ -1,6 +1,6 @@
 ---
 description: "Changelog for ESPHome 2025.11.0."
-title: "ESPHome 2025.11.0 - 19th November 2025"
+title: "ESPHome 2025.11.0 - November 2025"
 params:
   seo:
     description: Changelog for ESPHome 2025.11.0.

--- a/content/changelog/2025.11.0.md
+++ b/content/changelog/2025.11.0.md
@@ -28,8 +28,6 @@ ESPHome 2025.11.0 is a performance and reliability-focused release that makes yo
 **Memory optimizations** touch nearly every core component—WiFi scan management, select options, lights, climate controls, sensors, and the action framework. Sensor filter optimizations deliver the most dramatic gains, with sliding window filters saving up to 25KB of RAM on configurations that previously struggled with memory constraints. These improvements enable more complex configurations on the same hardware.
 
 New hardware support expands ESPHome's reach with 7 new components including the HDC2010 sensor, MCP3221 ADC, HLK-FM22X face recognition module, BH1900NUX sensor, RX8130 RTC, and TinyUSB foundation support for ESP32-S2/S3. Platform enhancements bring I2C and BLE logging to nRF52, while ESP32 gains hosted BLE for chips without native Bluetooth and ESP-NOW transport capabilities.
-
-**Note:** This release includes breaking API changes for external component developers, but standard YAML configurations remain fully compatible (custom code in lambdas may require updates).
 <!-- RELEASE_OVERVIEW_END -->
 
 <!-- FEATURE_HIGHLIGHTS_START -->

--- a/content/changelog/2025.11.0.md
+++ b/content/changelog/2025.11.0.md
@@ -50,10 +50,6 @@ The redesigned connection strategy delivers measurable improvements:
 
 This release restores and improves upon the reliable failover behavior users expect in multi-AP deployments, while reducing connection latency and memory overhead.
 
-**WiFi Priority Optimization** ([#11830](https://github.com/esphome/esphome/pull/11830))
-
-Network priority optimization dramatically improves WiFi stability on ESP32-C6/H2/P4 by preventing brief ESP-NOW activity or BLE advertisements from disrupting WiFi connectivity. The optimization also changed priority storage from `float` to `int8_t`, saving 3 bytes per network entry.
-
 **Configurable Minimum Authentication Mode** ([#11814](https://github.com/esphome/esphome/pull/11814))
 
 Added `min_auth_mode` configuration option to control WiFi authentication security:

--- a/content/changelog/2025.11.0.md
+++ b/content/changelog/2025.11.0.md
@@ -164,7 +164,6 @@ Added `ignore_not_found` option (default `true`) to allow disabling `CONFIG_SPIR
 - **ESP-NOW transport** - Added ESP-NOW as a transport platform for packet_transport component ([#11025](https://github.com/esphome/esphome/pull/11025))
 - **IR Remote protocols** - Dyson AM07 fan support ([#10163](https://github.com/esphome/esphome/pull/10163)), Symphony protocol ([#10777](https://github.com/esphome/esphome/pull/10777)), Toshiba RAS-2819T AC ([#9490](https://github.com/esphome/esphome/pull/9490))
 - **GPIO input** - Fix GPIO input by switching to polling mode ([#11664](https://github.com/esphome/esphome/pull/11664))
-- 
 
 ## ESP32 Platform Enhancements
 

--- a/content/changelog/2025.11.0.md
+++ b/content/changelog/2025.11.0.md
@@ -1,6 +1,6 @@
 ---
-description: "Changelog for ESPHome 2025.10.0."
-title: "ESPHome 2025.11.0 - November 2025"
+description: "Changelog for ESPHome 2025.11.0."
+title: "ESPHome 2025.11.0 - 13th November 2025"
 params:
   seo:
     description: Changelog for ESPHome 2025.11.0.
@@ -15,6 +15,274 @@ params:
 "HLK-FM22x Face Recognition Module","components/hlk_fm22x","face.svg","dark-invert"
 "RX8130 RTC","components/time/rx8130","clock-outline.svg","dark-invert"
 {{< /imgtable >}}
+
+## Release Overview
+
+<!-- RELEASE_OVERVIEW_START -->
+ESPHome 2025.11.0 delivers substantial performance improvements for resource-constrained devices, with comprehensive memory optimizations saving **2-7KB of RAM** on typical configurations and up to **10KB of flash** on ESP32/ESP8266 platforms. These optimizations touch nearly every core component - from WiFi scan result management and select option storage to the global controller registry and action framework. The release includes breaking API changes for external component developers, but standard YAML configurations remain fully compatible.
+
+New hardware support expands ESPHome's reach with 7 new components including the HDC2010 sensor, MCP3221 ADC, HLK-FM22X face recognition module, BH1900NUX sensor, RX8130 RTC, and TinyUSB foundation support for ESP32-S2/S3. Platform enhancements bring I2C, BLE logging, and API support to nRF52, while ESP32 gains hosted BLE for chips without native Bluetooth and ESP-NOW transport capabilities. The OpenThread implementation now supports sleep mode via poll period configuration, and USB Host improvements prevent transfer slot exhaustion at high data rates.
+
+WiFi security and reliability receive major upgrades with the new `min_auth_mode` configuration option enabling control over minimum authentication standards (WPA/WPA2/WPA3), secure defaults (WPA2 on ESP32, WPA on ESP8266 with planned 2026.6.0 transition), and a new high-performance networking system that automatically optimizes lwIP and WiFi settings based on PSRAM availability. Network components no longer block during connection setup, improving boot reliability, while the priority system switches from float to int8_t with auto-recovery when all access points fail equally. LVGL users gain simplified layout shortcuts, rendering triggers for e-paper integration, and NaN text substitution, while the e-paper component receives speed optimizations and proper state machine handling for reliable display updates.
+<!-- RELEASE_OVERVIEW_END -->
+
+<!-- FEATURE_HIGHLIGHTS_START -->
+## Memory Optimizations for Resource-Constrained Devices
+
+ESPHome 2025.11.0 delivers substantial memory improvements across the entire framework, with measured savings ranging from **2-7KB of RAM on typical devices** and up to **10KB of flash** on ESP32/ESP8266 platforms.
+
+**Major Optimizations:**
+
+- **WiFi component** ([#11205](https://github.com/esphome/esphome/pull/11205)) - Frees scan results after connection, saving **440-1,192 bytes RAM** depending on network density
+- **Select component** ([#11514](https://github.com/esphome/esphome/pull/11514)) - Stores options in flash as `const char*`, saving **270-2,800 bytes per select** depending on option count
+- **Light component** ([#11348](https://github.com/esphome/esphome/pull/11348)) - Bitmask-based color mode storage saves **1,756 bytes flash** on ESP8266, **~108 bytes RAM** per 6 lights
+- **Climate component** ([#11466](https://github.com/esphome/esphome/pull/11466), [#11621](https://github.com/esphome/esphome/pull/11621)) - Eliminates red-black tree overhead, saving **~440 bytes heap** per climate entity
+- **Fan component** ([#11483](https://github.com/esphome/esphome/pull/11483), [#11632](https://github.com/esphome/esphome/pull/11632)) - Flash-based preset mode storage saves **~24 bytes per fan**
+- **Event component** ([#11463](https://github.com/esphome/esphome/pull/11463), [#11767](https://github.com/esphome/esphome/pull/11767)) - Eliminated `std::set` overhead, saves **1,248 bytes flash**
+- **Global Controller Registry** ([#11772](https://github.com/esphome/esphome/pull/11772)) - Eliminates per-entity callback overhead, measured savings: **+388 to +6,148 bytes heap** depending on entity count
+- **Action framework optimization** ([#11704](https://github.com/esphome/esphome/pull/11704)) - Reduces argument copies by **83%**, saving **356 bytes flash** and eliminating heap allocations in automations
+- **Script component** ([#11308](https://github.com/esphome/esphome/pull/11308)) - Replaces `std::queue` with fixed array, saves **1,592 bytes flash** on ESP32
+- **ESP32-IDF optimizations** ([#10930](https://github.com/esphome/esphome/pull/10930), [#11441](https://github.com/esphome/esphome/pull/11441)) - Disables unused libc locks and VFS features, saving **~10KB combined** (1.3KB + 8.7KB)
+- **Network component** ([#11707](https://github.com/esphome/esphome/pull/11707)) - Stores addresses in flash, saving **32-72 bytes per network component**
+- **Light effects** ([#11487](https://github.com/esphome/esphome/pull/11487)) - Flash-based effect names save **24-32 bytes per effect**
+
+**Note on Breaking Changes:** These optimizations required API changes for external component developers. See Breaking Changes section for migration details. Standard YAML configurations remain fully compatible.
+
+## New Hardware & Platform Support
+
+**New Components (7 total):**
+
+- {{< docref "/components/sensor/hdc2010" >}} - HDC2010 temperature and humidity sensor ([#6674](https://github.com/esphome/esphome/pull/6674))
+- {{< docref "/components/sensor/mcp3221" >}} - MCP3221 12-bit I2C ADC ([#7764](https://github.com/esphome/esphome/pull/7764))
+- {{< docref "/components/hlk_fm22x" >}} - HLK-FM22X face recognition module ([#8059](https://github.com/esphome/esphome/pull/8059))
+- {{< docref "/components/sensor/bh1900nux" >}} - BH1900NUX temperature sensor ([#8631](https://github.com/esphome/esphome/pull/8631))
+- {{< docref "/components/time/rx8130" >}} - RX8130 RTC chip (used in M5Stack devices) ([#10511](https://github.com/esphome/esphome/pull/10511))
+- {{< docref "/components/tinyusb" >}} - TinyUSB foundation component for ESP32-S2/S3 USB device functionality ([#11678](https://github.com/esphome/esphome/pull/11678))
+- {{< docref "/components/sensor/dallas_temp" >}} - Added index-based sensor addressing for devices with multiple Dallas sensors ([#11346](https://github.com/esphome/esphome/pull/11346))
+
+**Platform & Feature Expansions:**
+
+- **nRF52 platform** - I2C support ([#8150](https://github.com/esphome/esphome/pull/8150)), BLE NUS logging ([#9846](https://github.com/esphome/esphome/pull/9846), [#9861](https://github.com/esphome/esphome/pull/9861)), GPIO voltage control ([#9858](https://github.com/esphome/esphome/pull/9858)), API support ([#11751](https://github.com/esphome/esphome/pull/11751)), and Seeed XIAO BLE board improvements ([#10698](https://github.com/esphome/esphome/pull/10698))
+- **ESP32 Hosted BLE** - Bluetooth support for ESP32-P4 and other chips without native BLE ([#11167](https://github.com/esphome/esphome/pull/11167))
+- **ESP32 Hosted OTA** - Firmware updates for ESP32 co-processors via ESP-Hosted API ([#11562](https://github.com/esphome/esphome/pull/11562))
+- **ESP-NOW transport** - Added ESP-NOW as a transport platform for packet_transport component ([#11025](https://github.com/esphome/esphome/pull/11025))
+- **OpenThread enhancements** - Poll period configuration for MTD devices enables sleep mode ([#11374](https://github.com/esphome/esphome/pull/11374)), OTA support via mDNS ([#11095](https://github.com/esphome/esphome/pull/11095))
+- **USB Host improvements** - Fixed transfer slot exhaustion at high data rates, added configurable `max_transfer_requests` ([#11174](https://github.com/esphome/esphome/pull/11174))
+- **IR Remote protocols** - Dyson AM07 fan support ([#10163](https://github.com/esphome/esphome/pull/10163)), Symphony protocol ([#10777](https://github.com/esphome/esphome/pull/10777)), Toshiba RAS-2819T AC ([#9490](https://github.com/esphome/esphome/pull/9490))
+
+**Hardware Additions:**
+
+- GP8413 15-bit DAC model for gp8403 component ([#7726](https://github.com/esphome/esphome/pull/7726))
+- Waveshare 5" 1024x600 MIPI RGB display ([#11206](https://github.com/esphome/esphome/pull/11206))
+- Mopeka standard sensor alternate ID (0x44) support ([#10907](https://github.com/esphome/esphome/pull/10907))
+- SX126x GPIO expander support for BUSY/RST/DIO1 pins ([#11782](https://github.com/esphome/esphome/pull/11782))
+
+## WiFi Security & Reliability
+
+**New Security Feature:**
+
+The `wifi` component now supports configurable minimum authentication modes via the new `min_auth_mode` option ([#11814](https://github.com/esphome/esphome/pull/11814)). This allows control over WiFi security standards:
+
+- **ESP32 default**: `WPA2` (secure by default)
+- **ESP8266 default**: `WPA` (for compatibility, will change to `WPA2` in 2026.6.0)
+- **Supported values**: `WPA`, `WPA2`, `WPA3`
+
+Example configuration:
+
+```yaml
+wifi:
+  ssid: "MyNetwork"
+  password: "password"
+  min_auth_mode: WPA2  # Recommended for security
+```
+
+**Network Setup Improvements:**
+
+WiFi and Ethernet components no longer block other components during network connection ([#9823](https://github.com/esphome/esphome/pull/9823)). Components now check connection state in `loop()` instead of waiting during `setup()`, improving boot reliability.
+
+**High-Performance Networking:**
+
+New centralized high-performance networking system ([#11812](https://github.com/esphome/esphome/pull/11812)) automatically applies PSRAM-aware lwIP and WiFi optimizations. Components request optimized settings via `network.require_high_performance_networking()`, enabling:
+
+- **With PSRAM guaranteed**: 512KB TCP windows for maximum throughput
+- **Without PSRAM**: Conservative 65KB windows that work reliably on all devices
+
+**Priority System Improvements:**
+
+WiFi priority changed from `float` to `int8_t` ([#11830](https://github.com/esphome/esphome/pull/11830)), saving memory and adding auto-recovery when all BSSIDs fail equally. System automatically clears tracking when all access points reach minimum priority, allowing fresh connection attempts.
+
+## LVGL & Display Enhancements
+
+**LVGL Improvements:**
+
+- **Layout shortcuts** ([#10149](https://github.com/esphome/esphome/pull/10149)) - Simple grid (`layout: 3x2`) and flex layouts (`layout: horizontal/vertical`), new `container` widget, and `stretch` option for flex layouts
+- **Rendering triggers** ([#11628](https://github.com/esphome/esphome/pull/11628)) - New `on_draw_start` and `on_draw_end` triggers facilitate e-paper display updates
+- **NaN text substitution** ([#11712](https://github.com/esphome/esphome/pull/11712)) - Display custom text when sensor values are invalid (NaN/inf)
+- **Validation speedup** - Substantial configuration validation performance improvements
+
+**E-Paper Display Optimizations:**
+
+The `epaper_spi` component received major improvements ([#11540](https://github.com/esphome/esphome/pull/11540)):
+
+- Larger SPI data blocks for faster transfers on Spectra displays
+- Revised E6 pixel format for speed improvements
+- Pre-configured board-specific pins including Seeed-reTerminal-E1002
+- Proper state machine allows reliable detection when display is ready
+- Busy pin logic corrected ([#11349](https://github.com/esphome/esphome/pull/11349))
+
+**Display Features:**
+
+- MIPI rotation fixes for custom models ([#11226](https://github.com/esphome/esphome/pull/11226), [#11585](https://github.com/esphome/esphome/pull/11585))
+- Component `is_idle` method and condition for automations ([#11651](https://github.com/esphome/esphome/pull/11651))
+
+Example e-paper integration with LVGL:
+
+```yaml
+display:
+  - platform: epaper_spi
+    id: epaper_display
+    model: Seeed-reTerminal-E1002
+    update_interval: never
+    auto_clear_enabled: false
+
+lvgl:
+  on_draw_end:
+    - lvgl.pause:
+    - wait_until:
+        component.is_idle: epaper_display
+    - component.update: epaper_display
+    - wait_until:
+        component.is_idle: epaper_display
+    - lvgl.resume:
+```
+
+## CLI & Development Tools
+
+**New CLI Commands:**
+
+- `esphome analyze-memory <config.yaml>` ([#11395](https://github.com/esphome/esphome/pull/11395)) - Dedicated command for memory usage analysis by component with proper external component detection
+
+**Configuration Improvements:**
+
+- Substitutions and Jinja support in `!extend` and `!remove` tags ([#11203](https://github.com/esphome/esphome/pull/11203)) - Enables conditional component modification
+- ESP32 framework URL schemes expanded ([#11125](https://github.com/esphome/esphome/pull/11125)) - Supports PlatformIO's git, symlink, and other schemes
+
+**ESP32 Platform Enhancements:**
+
+- Configurable loop task stack size ([#10564](https://github.com/esphome/esphome/pull/10564)) - Helps complex configurations avoid boot loops
+- PSRAM mode now required for ESP32-S3 ([#11470](https://github.com/esphome/esphome/pull/11470)) - Prevents configuration errors
+- PSRAM `ignore_not_found` option ([#11411](https://github.com/esphome/esphome/pull/11411)) - Allows WiFi buffer optimization when PSRAM is guaranteed
+- Brownout TX power reduction enabled by default ([#11306](https://github.com/esphome/esphome/pull/11306)) - Prevents boot loops on marginal power supplies
+
+## Component Enhancements
+
+**Climate Component:**
+
+- Humidity control support in thermostat ([#11286](https://github.com/esphome/esphome/pull/11286)) - Adds humidification and dehumidification actions
+
+**Sensor Filters:**
+
+- Heartbeat filter `optimistic` option ([#10993](https://github.com/esphome/esphome/pull/10993)) - Forwards new values immediately while maintaining periodic repeats
+
+**Select Component:**
+
+- Index-based operations ([#11623](https://github.com/esphome/esphome/pull/11623)) - Saves ~32 bytes per SelectCall, enables future ~28 bytes/instance savings (`.state` deprecated, removed in 2026.5.0)
+
+**Script Component:**
+
+- Queued mode now defaults to `max_runs: 5` ([#11308](https://github.com/esphome/esphome/pull/11308)) instead of unlimited to prevent crashes from unbounded memory growth
+
+**Remote Transmitter:**
+
+- Non-blocking mode ([#11524](https://github.com/esphome/esphome/pull/11524)) - Prevents long blocking operations (enabled by default with warnings)
+
+**Improv WiFi:**
+
+- `next_url` support ([#10757](https://github.com/esphome/esphome/pull/10757)) - Redirects users after provisioning with device info substitution
+
+**INA2xx Sensors:**
+
+- `reset_on_boot` disablement option ([#10787](https://github.com/esphome/esphome/pull/10787)) - Preserves counters through ESP device resets
+
+**XGZP68xx Sensor:**
+
+- Oversampling configuration and implementation improvements ([#10306](https://github.com/esphome/esphome/pull/10306))
+
+**HTTP Request:**
+
+- Trigger variables now passed to `on_response`/`on_error` handlers ([#11464](https://github.com/esphome/esphome/pull/11464))
+
+## Notable Bug Fixes & Quality Improvements
+
+**Critical Fixes:**
+
+- `.local` address resolution now requires mDNS ([#11508](https://github.com/esphome/esphome/pull/11508)) - Eliminates 10+ second delays when mDNS is disabled
+- Uponor Smatrix addressing corrected to 32-bit ([#11066](https://github.com/esphome/esphome/pull/11066)) - Fixes installations with non-uniform address prefixes
+- GDK101 firmware version reporting fixed ([#11029](https://github.com/esphome/esphome/pull/11029)) - Now correctly displays as string
+
+**Code Quality:**
+
+- HM3301 AQI calculation updated to EPA 2024 standard ([#9442](https://github.com/esphome/esphome/pull/9442))
+- PIPsolar cleanup and refactoring ([#10291](https://github.com/esphome/esphome/pull/10291)) - Fixed typo `warnung_low_pv_energy` → `warning_low_pv_energy`
+- Deprecated code removal - Cleaned up deprecations from 2021-2022 ([#11383](https://github.com/esphome/esphome/pull/11383), [#11388](https://github.com/esphome/esphome/pull/11388), [#11389](https://github.com/esphome/esphome/pull/11389), [#11391](https://github.com/esphome/esphome/pull/11391), [#11392](https://github.com/esphome/esphome/pull/11392), [#11393](https://github.com/esphome/esphome/pull/11393), [#11591](https://github.com/esphome/esphome/pull/11591), [#11783](https://github.com/esphome/esphome/pull/11783))
+<!-- FEATURE_HIGHLIGHTS_END -->
+
+## Breaking Changes
+
+<!-- BREAKING_CHANGES_USERS_START -->
+### Component Changes
+
+- **HM3301**: AQI calculation updated to EPA 2024 standard (values will change) [#9442](https://github.com/esphome/esphome/pull/9442)
+- **PIPsolar**: Fixed typo `warnung_low_pv_energy` → `warning_low_pv_energy` in configuration [#10291](https://github.com/esphome/esphome/pull/10291)
+- **GDK101**: Firmware version now reported as string instead of float [#11029](https://github.com/esphome/esphome/pull/11029)
+- **Uponor Smatrix**: Changed to 32-bit addresses - `address` property removed from base component, device addresses must now be 32-bit (prepend old system address to device addresses) [#11066](https://github.com/esphome/esphome/pull/11066)
+- **E-paper SPI**: Fixed busy pin logic (was inverted, now correctly reads HIGH=idle) [#11349](https://github.com/esphome/esphome/pull/11349)
+- **Script**: Queued mode now defaults to `max_runs: 5` instead of unlimited to prevent crashes [#11308](https://github.com/esphome/esphome/pull/11308)
+- **Remote Transmitter**: Non-blocking mode enabled by default with warnings for long operations [#11524](https://github.com/esphome/esphome/pull/11524)
+
+### Platform & Network Changes
+
+- **nRF52**: Default bootloader changed for `xiao_ble` and `adafruit_itsybitsy_nrf52840` boards [#10698](https://github.com/esphome/esphome/pull/10698)
+- **WiFi/Ethernet**: No longer blocks other components during setup - components must check network state in `loop()` instead of assuming network is ready in `setup()` [#9823](https://github.com/esphome/esphome/pull/9823)
+- **WiFi**: Priority changed from float to int8_t (only integers -128 to 127 accepted) [#11830](https://github.com/esphome/esphome/pull/11830)
+- **WiFi**: New `min_auth_mode` option controls minimum security (ESP32 defaults to WPA2, ESP8266 defaults to WPA with planned 2026.6.0 change to WPA2) [#11814](https://github.com/esphome/esphome/pull/11814)
+- **Network**: `.local` addresses now require mDNS to be enabled (eliminates 10+ second delays when mDNS is disabled) [#11508](https://github.com/esphome/esphome/pull/11508)
+- **Speaker**: High-performance networking mode now always enabled (previously only with codec support) [#11812](https://github.com/esphome/esphome/pull/11812)
+
+### ESP32 Platform Changes
+
+- **ESP32-IDF**: Brownout TX power reduction enabled by default to prevent boot loops on marginal power supplies [#11306](https://github.com/esphome/esphome/pull/11306)
+- **ESP32-IDF**: Unused VFS features disabled by default (saves ~8.7KB flash), automatically re-enabled by components that need them [#11441](https://github.com/esphome/esphome/pull/11441)
+- **ESP32-IDF**: Libc locks in IRAM disabled by default (saves ~1.3KB RAM), can be re-enabled with `disable_libc_locks_in_iram: false` [#10930](https://github.com/esphome/esphome/pull/10930)
+- **ESP32-S3**: PSRAM mode now required when using components that need PSRAM [#11470](https://github.com/esphome/esphome/pull/11470)
+<!-- BREAKING_CHANGES_USERS_END -->
+
+### Breaking Changes for Developers
+
+<!-- BREAKING_CHANGES_DEVELOPERS_START -->
+- **WiFi API**: `WiFiComponent::get_scan_result()` returns empty vector after connection unless `wifi.request_wifi_scan_results()` called during code generation [#11205](https://github.com/esphome/esphome/pull/11205)
+- **Select API**: Changed to `const char *` storage, added index-based operations, `.state` deprecated (removed in 2026.5.0) [#11514](https://github.com/esphome/esphome/pull/11514), [#11623](https://github.com/esphome/esphome/pull/11623)
+- **Light API**: Effect names changed from `std::string` to `const char *`, `get_name()` returns `const char *` [#11487](https://github.com/esphome/esphome/pull/11487)
+- **Light API**: Color modes storage changed from `std::set<ColorMode>` to `ColorModeMask` bitmask class [#11348](https://github.com/esphome/esphome/pull/11348)
+- **Fan API**: Preset modes changed from `std::set<std::string>` to `std::vector<const char *>` [#11483](https://github.com/esphome/esphome/pull/11483)
+- **Fan API**: Removed public `.preset_mode` member, use `get_preset_mode()` / `set_preset_mode_()` instead [#11632](https://github.com/esphome/esphome/pull/11632)
+- **Climate API**: Replaced `std::set<EnumType>` with `FiniteSetMask` for trait storage, custom modes changed to `std::vector` [#11466](https://github.com/esphome/esphome/pull/11466), [#11621](https://github.com/esphome/esphome/pull/11621)
+- **Event API**: Event types changed from `std::set<std::string>` to `FixedVector<const char *>`, `.last_event_type` now private with `get_last_event_type()` getter [#11463](https://github.com/esphome/esphome/pull/11463), [#11767](https://github.com/esphome/esphome/pull/11767)
+- **Network API**: `get_use_address()` now returns `const char *` instead of `const std::string &` [#11707](https://github.com/esphome/esphome/pull/11707)
+- **Action Framework**: All action/trigger signatures changed to use `const Ts&...` instead of `Ts...` (pass-by-reference) [#11704](https://github.com/esphome/esphome/pull/11704)
+- **Controller API**: Removed state parameters from all `on_*_update()` methods - controllers now read state directly from entities via Global Controller Registry [#11772](https://github.com/esphome/esphome/pull/11772)
+- **HTTP Request**: Changed from multiple triggers to single `on_response`/`on_error` trigger with variables passed through [#11464](https://github.com/esphome/esphome/pull/11464)
+- **Core API**: Removed deprecated `hexencode()` function (deprecated since 2022.1) [#11383](https://github.com/esphome/esphome/pull/11383)
+- **Core API**: Removed deprecated schema constants [#11591](https://github.com/esphome/esphome/pull/11591)
+- **Core API**: Removed deprecated `EntityBase::hash_base()` method (deprecated since 2022.6) [#11783](https://github.com/esphome/esphome/pull/11783)
+- **Climate API**: Removed deprecated functions from 1.20 (July 2021) [#11388](https://github.com/esphome/esphome/pull/11388)
+- **Light API**: Removed deprecated functions from 2021.8.0 [#11389](https://github.com/esphome/esphome/pull/11389)
+- **Cover API**: Removed deprecated functions from 2021.9 [#11391](https://github.com/esphome/esphome/pull/11391)
+- **Fan/MQTT API**: Removed deprecated code from 2022.2 [#11392](https://github.com/esphome/esphome/pull/11392)
+- **Nextion API**: Removed deprecated functions from 1.20 (July 2021) [#11393](https://github.com/esphome/esphome/pull/11393)
+
+For detailed migration guides and API documentation, see the [ESPHome Developers Documentation](https://developers.esphome.io/).
+<!-- BREAKING_CHANGES_DEVELOPERS_END -->
 
 <!-- markdownlint-disable MD013 -->
 

--- a/content/changelog/2025.11.0.md
+++ b/content/changelog/2025.11.0.md
@@ -357,9 +357,7 @@ HTTP request actions now pass trigger variables correctly into `on_response` and
 
 ### User-Facing Breaking Changes
 
-#### Configuration Changes
-
-### WiFi & Network
+#### WiFi & Network
 
 - **WiFi**: WiFi and Ethernet components no longer block other components' setup until connected. Components with setup priority > WIFI (802.3) now initialize immediately, even if network is disconnected. [#9823](https://github.com/esphome/esphome/pull/9823)
 
@@ -422,7 +420,7 @@ The following changes affect external component developers. Standard YAML config
 
 ## Core Framework Changes
 
-- **Action/Trigger Framework**: All action/trigger/condition method signatures changed to use const references (`const Ts&... x`) instead of pass-by-value (`Ts... x`). Update custom actions to add `const&` to parameter packs. [#11704](https://github.com/esphome/esphome/pull/11704)
+- **Action/Trigger Framework**: All action/trigger/condition method signatures changed to use const references (`const Ts&... x`) instead of pass-by-value (`Ts... x`). See the [Action Framework Performance Optimization](https://developers.esphome.io/blog/2025/11/action-framework-performance-optimization.html) blog post for migration details. [#11704](https://github.com/esphome/esphome/pull/11704)
 
 - **Controller API**: Controllers now use global registry pattern. Method signatures changed to remove unused state parameters (e.g., `on_sensor_update(sensor::Sensor *obj)` instead of `on_sensor_update(sensor::Sensor *obj, float state)`). External controller implementations extremely rare. [#11772](https://github.com/esphome/esphome/pull/11772)
 
@@ -436,29 +434,37 @@ The following changes affect external component developers. Standard YAML config
 
 ### Climate
 
-- **Custom modes storage**: Changed from `std::set<std::string>` to `FiniteSetMask` for supported modes, and from `std::vector<std::string>` to `std::vector<const char *>` for custom fan modes and presets. Update custom climate components to use new container types and string literal storage. [#11466](https://github.com/esphome/esphome/pull/11466), [#11621](https://github.com/esphome/esphome/pull/11621)
+See the [Climate Entity Class: FiniteSetMask and Flash Storage Optimizations](https://developers.esphome.io/blog/2025/11/climate-entity-class-memory-optimizations.html) blog post for migration details.
 
-- **Member access**: Climate device members (`custom_fan_mode_`, `custom_preset_`) are now private. Use protected setter methods (`set_custom_fan_mode_()`, `set_custom_preset_()`) in derived classes instead of direct assignment. [#11621](https://github.com/esphome/esphome/pull/11621)
+- **Custom modes storage**: Changed from `std::set<std::string>` to `FiniteSetMask` for supported modes, and from `std::vector<std::string>` to `std::vector<const char *>` for custom fan modes and presets. [#11466](https://github.com/esphome/esphome/pull/11466), [#11621](https://github.com/esphome/esphome/pull/11621)
 
-- **Deprecated methods**: Removed methods deprecated in 1.20 (July 2021). Update to current climate API. [#11388](https://github.com/esphome/esphome/pull/11388)
+- **Member access**: Climate device members (`custom_fan_mode_`, `custom_preset_`) are now private. Use protected setter methods (`set_custom_fan_mode_()`, `set_custom_preset_()`) in derived classes. [#11621](https://github.com/esphome/esphome/pull/11621)
+
+- **Deprecated methods**: Removed methods deprecated in 1.20 (July 2021). [#11388](https://github.com/esphome/esphome/pull/11388)
 
 ### Light
 
-- **Color modes**: Replaced `std::set<ColorMode>` with `ColorModeMask` bitmask class. Update custom light components to use `ColorModeMask` type and initializer list syntax. [#11348](https://github.com/esphome/esphome/pull/11348)
+See the [Light Entity Class: Memory Optimizations](https://developers.esphome.io/blog/2025/11/light-entity-class-memory-optimizations.html) blog post for migration details.
 
-- **Effect names**: Changed from `std::string` to `const char *` for effect names. Custom light effect constructors must accept `const char *name` instead of `const std::string &name`. [#11487](https://github.com/esphome/esphome/pull/11487)
+- **Color modes**: Replaced `std::set<ColorMode>` with `ColorModeMask` bitmask class. [#11348](https://github.com/esphome/esphome/pull/11348)
 
-- **Deprecated methods**: Removed methods deprecated in 2021.8.0. Update to current light API. [#11389](https://github.com/esphome/esphome/pull/11389)
+- **Effect names**: Changed from `std::string` to `const char *` for effect names. [#11487](https://github.com/esphome/esphome/pull/11487)
+
+- **Deprecated methods**: Removed methods deprecated in 2021.8.0. [#11389](https://github.com/esphome/esphome/pull/11389)
 
 ### Fan
 
+See the [Fan Entity Class: Preset Mode Flash Storage and Order Preservation](https://developers.esphome.io/blog/2025/11/fan-entity-class-memory-optimizations.html) blog post for migration details.
+
 - **Preset modes**: Changed from `std::set<std::string>` to `std::vector<const char *>`. The `.preset_mode` public member has been removed - use `get_preset_mode()` for reading and `set_preset_mode_()` for writing in derived classes. [#11483](https://github.com/esphome/esphome/pull/11483), [#11632](https://github.com/esphome/esphome/pull/11632)
 
-- **Deprecated code**: Removed code deprecated in 2022.2. Update to current fan API. [#11392](https://github.com/esphome/esphome/pull/11392)
+- **Deprecated code**: Removed code deprecated in 2022.2. [#11392](https://github.com/esphome/esphome/pull/11392)
 
 ### Select
 
-- **Options storage**: Changed from `std::vector<std::string>` to `FixedVector<const char *>`. Custom select components must use string literals or const char pointers for options. [#11514](https://github.com/esphome/esphome/pull/11514)
+See the [Select Entity Class: Index-Based Operations and Flash Storage](https://developers.esphome.io/blog/2025/11/select-entity-class-memory-optimizations.html) blog post for migration details.
+
+- **Options storage**: Changed from `std::vector<std::string>` to `FixedVector<const char *>`. [#11514](https://github.com/esphome/esphome/pull/11514)
 
 - **State member**: Public `state` member deprecated (will be removed in 2026.5.0). Use `current_option()` method instead. [#11623](https://github.com/esphome/esphome/pull/11623)
 
@@ -466,11 +472,13 @@ The following changes affect external component developers. Standard YAML config
 
 ### Event
 
-- **Event types storage**: Changed from `FixedVector<std::string>` to `FixedVector<const char *>`. String comparisons now use `strcmp()`. The `last_event_type` field is now private - use `get_last_event_type()` getter instead. [#11463](https://github.com/esphome/esphome/pull/11463), [#11767](https://github.com/esphome/esphome/pull/11767)
+See the [Event Entity Class: Memory Optimizations](https://developers.esphome.io/blog/2025/11/event-entity-class-memory-optimizations.html) blog post for migration details.
+
+- **Event types storage**: Changed from `FixedVector<std::string>` to `FixedVector<const char *>`. The `last_event_type` field is now private - use `get_last_event_type()` getter instead. [#11463](https://github.com/esphome/esphome/pull/11463), [#11767](https://github.com/esphome/esphome/pull/11767)
 
 ### Network Components
 
-- **WiFi scan results**: Custom components that access WiFi scan results after connection must call `wifi.request_wifi_scan_results()` in their `to_code()` function to prevent cleanup. [#11205](https://github.com/esphome/esphome/pull/11205)
+- **WiFi scan results**: External components that access WiFi scan results after connection must call `wifi.request_wifi_scan_results()` in their `to_code()` function to prevent cleanup. [#11205](https://github.com/esphome/esphome/pull/11205)
 
 - **use_address**: Changed from `const std::string &` to `const char *` in WiFi, Ethernet, and OpenThread components. Update external components calling `get_use_address()` or `set_use_address()`. [#11707](https://github.com/esphome/esphome/pull/11707)
 
@@ -488,7 +496,7 @@ The following changes affect external component developers. Standard YAML config
 
 For detailed migration guides and examples, see the [ESPHome developer documentation](https://developers.esphome.io/).
 
-The 2025.11 release blog post includes comprehensive migration examples for common use cases.
+The 2025.11 release blog posts include comprehensive migration examples for common use cases.
 <!-- BREAKING_CHANGES_DEVELOPERS_END -->
 
 <!-- markdownlint-disable MD013 -->

--- a/content/changelog/2025.11.0.md
+++ b/content/changelog/2025.11.0.md
@@ -166,6 +166,17 @@ Added `ignore_not_found` option (default `true`) to allow disabling `CONFIG_SPIR
 
 ## ESP32 Platform Enhancements
 
+**ESP-IDF 5.5.1 and Arduino 3.3.2** ([#9839](https://github.com/esphome/esphome/pull/9839))
+
+Major framework updates bring the latest ESP-IDF 5.5.1 and Arduino 3.3.2 to ESPHome:
+
+- **ESP-IDF 5.5.1**: Latest features and bug fixes from Espressif
+- **Arduino 3.3.2**: Updated Arduino framework with improved stability
+- **Memory improvements**: Significant RAM gains (+3.1-3.3MB free RAM)
+- **Platform version**: Updated to 55.03.31-1
+
+These updates are automatically applied when using the default framework versions.
+
 **Hosted BLE Support** ([#11167](https://github.com/esphome/esphome/pull/11167))
 
 ESP32 P4 and other chips without integrated Bluetooth now support BLE through external controllers using ESP-Hosted API. Enables Bluetooth Proxy functionality on previously unsupported ESP32 variants.

--- a/content/changelog/2025.11.0.md
+++ b/content/changelog/2025.11.0.md
@@ -309,28 +309,6 @@ Remote transmitter operations no longer block the main loop by default, preventi
 
 HTTP request actions now pass trigger variables correctly into `on_response` and `on_error` triggers.
 
-## Component Bug Fixes and Quality Improvements
-
-**Uponor Smatrix Addressing** ([#11066](https://github.com/esphome/esphome/pull/11066))
-
-Fixed addressing system to use full 32-bit addresses instead of split 16-bit system/device addresses, supporting installations where thermostats don't share common prefix.
-
-**GDK101 Firmware Version** ([#11029](https://github.com/esphome/esphome/pull/11029))
-
-Fixed firmware version attribute to display as string instead of floating-point division result.
-
-**PiPsolar Refactoring** ([#10291](https://github.com/esphome/esphome/pull/10291))
-
-Cleaned up component with improved readability, fixed `warnung_low_pv_energy` typo, replaced `sscanf` with explicit reads, and fixed potential buffer overrun.
-
-**.local DNS Resolution** ([#11508](https://github.com/esphome/esphome/pull/11508))
-
-`.local` addresses now only resolve when mDNS is enabled, avoiding 10+ second delays when mDNS unavailable.
-
-**HM3301 AQI Calculation** ([#9442](https://github.com/esphome/esphome/pull/9442))
-
-Updated to 2024 EPA standard for Air Quality Index calculations.
-
 <!-- FEATURE_HIGHLIGHTS_END -->
 
 ## Breaking Changes

--- a/content/changelog/2025.11.0.md
+++ b/content/changelog/2025.11.0.md
@@ -25,7 +25,7 @@ ESPHome 2025.11.0 is a performance-focused release that makes your devices faste
 
 **Ultra-low latency event processing** transforms responsiveness across BLE, USB, MQTT, ESP-NOW, and wake word detection—reducing latency from 0-16ms to just ~12 microseconds. Voice assistants respond faster to wake words, BLE devices pair quicker, and MQTT automations trigger with sub-millisecond precision. This zero-configuration optimization automatically benefits all affected components on ESP32 platforms.
 
-**Comprehensive memory optimizations** touch nearly every core component—WiFi scan management, select options, lights, climate controls, sensors, and the action framework. Sensor filter optimizations deliver the most dramatic gains, with sliding window filters saving up to 25KB of RAM on configurations that previously struggled with memory constraints. These improvements enable more complex configurations on the same hardware.
+**Memory optimizations** touch nearly every core component—WiFi scan management, select options, lights, climate controls, sensors, and the action framework. Sensor filter optimizations deliver the most dramatic gains, with sliding window filters saving up to 25KB of RAM on configurations that previously struggled with memory constraints. These improvements enable more complex configurations on the same hardware.
 
 New hardware support expands ESPHome's reach with 7 new components including the HDC2010 sensor, MCP3221 ADC, HLK-FM22X face recognition module, BH1900NUX sensor, RX8130 RTC, and TinyUSB foundation support for ESP32-S2/S3. Platform enhancements bring I2C and BLE logging to nRF52, while ESP32 gains hosted BLE for chips without native Bluetooth and ESP-NOW transport capabilities.
 
@@ -34,21 +34,6 @@ New hardware support expands ESPHome's reach with 7 new components including the
 
 <!-- FEATURE_HIGHLIGHTS_START -->
 ## Enhanced WiFi Security and Reliability
-
-**Configurable Minimum Authentication Mode** ([#11814](https://github.com/esphome/esphome/pull/11814))
-
-Added `min_auth_mode` configuration option to control WiFi authentication security:
-
-- **Secure default**: WPA2 minimum authentication mode protects against downgrade attacks
-- **Explicit security control**: Choose between WPA, WPA2, or WPA3 (ESP32 only)
-- **Backward compatibility**: Can be lowered to WPA for legacy routers
-
-```yaml
-wifi:
-  ssid: "MyNetwork"
-  password: "password123"
-  min_auth_mode: WPA2  # Recommended for security
-```
 
 **Dramatically Improved WiFi Reliability and Connection Times** ([#11805](https://github.com/esphome/esphome/pull/11805))
 
@@ -68,6 +53,21 @@ This release restores and improves upon the reliable failover behavior users exp
 **WiFi Priority Optimization** ([#11830](https://github.com/esphome/esphome/pull/11830))
 
 Network priority optimization dramatically improves WiFi stability on ESP32-C6/H2/P4 by preventing brief ESP-NOW activity or BLE advertisements from disrupting WiFi connectivity. The optimization also changed priority storage from `float` to `int8_t`, saving 3 bytes per network entry.
+
+**Configurable Minimum Authentication Mode** ([#11814](https://github.com/esphome/esphome/pull/11814))
+
+Added `min_auth_mode` configuration option to control WiFi authentication security:
+
+- **Secure default**: WPA2 minimum authentication mode protects against downgrade attacks
+- **Explicit security control**: Choose between WPA, WPA2, or WPA3 (ESP32 only)
+- **Backward compatibility**: Can be lowered to WPA for legacy routers
+
+```yaml
+wifi:
+  ssid: "MyNetwork"
+  password: "password123"
+  min_auth_mode: WPA2  # Recommended for security
+```
 
 ## Memory Optimizations for Resource-Constrained Devices
 

--- a/content/changelog/2025.11.0.md
+++ b/content/changelog/2025.11.0.md
@@ -119,7 +119,7 @@ A groundbreaking infrastructure change eliminates event processing delays across
 - Faster wake word detection response for voice assistants
 - Improved BLE connection and pairing times
 - Reduced MQTT automation trigger latency
-- Faster USB event handling
+- Faster USB event handling (e.g., Z-Wave PoE proxies)
 
 This optimization requires no configuration changes and automatically benefits all affected components on ESP32 platforms.
 
@@ -163,8 +163,6 @@ Added `ignore_not_found` option (default `true`) to allow disabling `CONFIG_SPIR
 **Platform & Feature Expansions:**
 
 - **nRF52 platform** - I2C support ([#8150](https://github.com/esphome/esphome/pull/8150)), BLE NUS logging ([#9846](https://github.com/esphome/esphome/pull/9846), [#9861](https://github.com/esphome/esphome/pull/9861)), GPIO voltage control ([#9858](https://github.com/esphome/esphome/pull/9858)), and Seeed XIAO BLE board improvements ([#10698](https://github.com/esphome/esphome/pull/10698))
-- **ESP32 Hosted BLE** - Bluetooth support for ESP32-P4 and other chips without native BLE ([#11167](https://github.com/esphome/esphome/pull/11167))
-- **ESP32 Hosted OTA** - Firmware updates for ESP32 co-processors via ESP-Hosted API ([#11562](https://github.com/esphome/esphome/pull/11562))
 - **ESP-NOW transport** - Added ESP-NOW as a transport platform for packet_transport component ([#11025](https://github.com/esphome/esphome/pull/11025))
 - **IR Remote protocols** - Dyson AM07 fan support ([#10163](https://github.com/esphome/esphome/pull/10163)), Symphony protocol ([#10777](https://github.com/esphome/esphome/pull/10777)), Toshiba RAS-2819T AC ([#9490](https://github.com/esphome/esphome/pull/9490))
 
@@ -173,6 +171,10 @@ Added `ignore_not_found` option (default `true`) to allow disabling `CONFIG_SPIR
 **Hosted BLE Support** ([#11167](https://github.com/esphome/esphome/pull/11167))
 
 ESP32 P4 and other chips without integrated Bluetooth now support BLE through external controllers using ESP-Hosted API. Enables Bluetooth Proxy functionality on previously unsupported ESP32 variants.
+
+**Hosted OTA Support** ([#11562](https://github.com/esphome/esphome/pull/11562))
+
+Firmware updates for ESP32 co-processors are now supported via ESP-Hosted API, enabling OTA functionality for hosted configurations.
 
 **Brownout Protection** ([#11306](https://github.com/esphome/esphome/pull/11306))
 

--- a/content/changelog/2025.11.0.md
+++ b/content/changelog/2025.11.0.md
@@ -29,9 +29,15 @@ WiFi security and reliability receive major upgrades with the new `min_auth_mode
 <!-- FEATURE_HIGHLIGHTS_START -->
 ## Memory Optimizations for Resource-Constrained Devices
 
-ESPHome 2025.11.0 delivers substantial memory improvements across the entire framework, with measured savings ranging from **2-7KB of RAM on typical devices** and up to **10KB of flash** on ESP32/ESP8266 platforms.
+ESPHome 2025.11.0 delivers substantial memory improvements across the entire framework, with measured savings ranging from **2-7KB of RAM on typical devices** and up to **31KB of RAM on sensor-heavy configurations**. Flash savings reach **10KB+** on ESP32/ESP8266 platforms.
 
-**Major Optimizations:**
+**Critical Sensor Filter Optimizations:**
+
+- **Sliding window filters** ([#11282](https://github.com/esphome/esphome/pull/11282)) - Eliminated heap fragmentation from `std::deque`, saving **22-25KB RAM** on batch windows (99.98% reduction), **90% on sliding windows**. Real-world impact: ESP32 devices with Improv gained **+31KB free heap** (+221% increase), preventing OOM crashes. Also saves **1,748 bytes flash** on ESP8266 and delivers **4-5x faster** moving average, **73-256% faster** median filtering
+- **Filter value lists** ([#11407](https://github.com/esphome/esphome/pull/11407)) - `FixedVector` replaces `std::vector` in filter_out/throttle_priority, saves **444 bytes flash** on ESP8266, **18-52% faster** execution
+- **Calibration/OR filters** ([#11437](https://github.com/esphome/esphome/pull/11437)) - `FixedVector` optimization for calibrate_linear/polynomial/or filters saves **464 bytes flash**, **48 bytes RAM** on ESP8266
+
+**Component Memory Optimizations:**
 
 - **WiFi component** ([#11205](https://github.com/esphome/esphome/pull/11205)) - Frees scan results after connection, saving **440-1,192 bytes RAM** depending on network density
 - **Select component** ([#11514](https://github.com/esphome/esphome/pull/11514)) - Stores options in flash as `const char*`, saving **270-2,800 bytes per select** depending on option count

--- a/content/changelog/2025.11.0.md
+++ b/content/changelog/2025.11.0.md
@@ -163,6 +163,7 @@ Added `ignore_not_found` option (default `true`) to allow disabling `CONFIG_SPIR
 - **nRF52 platform** - I2C support ([#8150](https://github.com/esphome/esphome/pull/8150)), BLE NUS logging ([#9846](https://github.com/esphome/esphome/pull/9846), [#9861](https://github.com/esphome/esphome/pull/9861)), GPIO voltage control ([#9858](https://github.com/esphome/esphome/pull/9858)), GPIO input by switching to polling mode ([#11664](https://github.com/esphome/esphome/pull/11664)), and Seeed XIAO BLE board improvements ([#10698](https://github.com/esphome/esphome/pull/10698))
 - **ESP-NOW transport** - Added ESP-NOW as a transport platform for packet_transport component ([#11025](https://github.com/esphome/esphome/pull/11025))
 - **IR Remote protocols** - Dyson AM07 fan support ([#10163](https://github.com/esphome/esphome/pull/10163)), Symphony protocol ([#10777](https://github.com/esphome/esphome/pull/10777)), Toshiba RAS-2819T AC ([#9490](https://github.com/esphome/esphome/pull/9490))
+
 ## ESP32 Platform Enhancements
 
 **ESP-IDF 5.5.1 and Arduino 3.3.2** ([#9839](https://github.com/esphome/esphome/pull/9839))

--- a/content/changelog/2025.11.0.md
+++ b/content/changelog/2025.11.0.md
@@ -53,7 +53,7 @@ ESPHome 2025.11.0 delivers substantial memory improvements across the entire fra
 - **Light effects** ([#11487](https://github.com/esphome/esphome/pull/11487)) - Saves **24-32 bytes per effect**
 - **WiFi priority** ([#11830](https://github.com/esphome/esphome/pull/11830)) - Saves **3 bytes per network entry** plus up to **96 bytes** from auto-recovery
 
-**Note on Breaking Changes:** These optimizations required API changes for external component developers. See Breaking Changes section for migration details. Standard YAML configurations remain fully compatible.
+**Note on Breaking Changes:** These optimizations required API changes for external component developers. See Breaking Changes section for migration details. Standard YAML configurations remain fully compatible but custom code in lambdas may require updates.
 
 ## Enhanced WiFi Security and Reliability
 
@@ -90,6 +90,35 @@ This release restores and improves upon the reliable failover behavior users exp
 **WiFi Priority Optimization** ([#11830](https://github.com/esphome/esphome/pull/11830))
 
 Network priority optimization dramatically improves WiFi stability on ESP32-C6/H2/P4 by preventing brief ESP-NOW activity or BLE advertisements from disrupting WiFi connectivity. The optimization also changed priority storage from `float` to `int8_t`, saving 3 bytes per network entry.
+
+## Ultra-Low Latency Event Processing
+
+**Thread-Safe Loop Wake Mechanism** ([#11663](https://github.com/esphome/esphome/pull/11663), [#11683](https://github.com/esphome/esphome/pull/11683), [#11695](https://github.com/esphome/esphome/pull/11695), [#11696](https://github.com/esphome/esphome/pull/11696), [#11698](https://github.com/esphome/esphome/pull/11698))
+
+A groundbreaking infrastructure change eliminates event processing delays across multiple components. Previously, events from background tasks (BLE, USB, MQTT, ESP-NOW, wake word detection) would queue and wait up to 16ms for the next `select()` timeout before processing. The new `wake_loop_threadsafe()` mechanism uses a UDP loopback socket to immediately wake the main event loop when events arrive.
+
+**Latency Improvements:**
+
+- **Before**: 0-16ms average ~8ms
+- **After**: ~12 microseconds
+- **Speedup**: 600-1,300x faster event processing
+
+**Components with Ultra-Low Latency:**
+
+- **BLE operations** ([#11663](https://github.com/esphome/esphome/pull/11663)) - Bluetooth Proxy, BLE Client GATT operations, HomeKit pairing
+- **USB Host** ([#11683](https://github.com/esphome/esphome/pull/11683)) - USB event processing over 1000x faster
+- **MQTT** ([#11695](https://github.com/esphome/esphome/pull/11695)) - ESP32 only (ESP8266 already runs in main loop)
+- **ESP-NOW** ([#11696](https://github.com/esphome/esphome/pull/11696)) - Packet reception and transmission completion
+- **Micro Wake Word** ([#11698](https://github.com/esphome/esphome/pull/11698)) - Near-instant automation responses, all triggers fire within same millisecond
+
+**Real-World Impact:**
+
+- Faster wake word detection response for voice assistants
+- Improved BLE connection and pairing times
+- Reduced MQTT automation trigger latency
+- Faster USB event handling
+
+This optimization requires no configuration changes and automatically benefits all affected components on ESP32 platforms.
 
 ## High-Performance Networking for Media Streaming
 


### PR DESCRIPTION
## Description:

Generated release notes summary for 2025.11.0.  I spent a few hours cleaning up and curating it as well.  It was sure a lot easier to get it started after Claude generated the initial version though.

Generated with https://github.com/esphome/esphome-docs/pull/5616

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
