### PR TITLE
Add 2025.11.0 Release Notes via skill generator (Option 2)

### DIFF
--- a/content/changelog/2025.11.0.md
+++ b/content/changelog/2025.11.0.md
@@ -1,6 +1,6 @@
 ---
-description: "Changelog for ESPHome 2025.10.0."
-title: "ESPHome 2025.11.0 - November 2025"
+description: "Changelog for ESPHome 2025.11.0."
+title: "ESPHome 2025.11.0 - 13th November 2025"
 params:
   seo:
     description: Changelog for ESPHome 2025.11.0.
@@ -15,6 +15,264 @@ params:
 "HLK-FM22x Face Recognition Module","components/hlk_fm22x","face.svg","dark-invert"
 "RX8130 RTC","components/time/rx8130","clock-outline.svg","dark-invert"
 {{< /imgtable >}}
+
+## Release Overview
+
+<!-- RELEASE_OVERVIEW_START -->
+ESPHome 2025.11.0 delivers extensive memory optimizations, enhanced WiFi security, and major architectural improvements. Memory optimizations collectively save 5-15KB+ of flash and 1-8KB+ of RAM across the framework through bitmask-based storage, flash string allocation, and elimination of STL container overhead. The release introduces ESP32 co-processor OTA updates for the "native" platform and a centralized high-performance networking system that automatically optimizes lwIP settings based on PSRAM availability. WiFi security improvements include the new `min_auth_mode` option for fine-grained authentication control with platform-specific secure defaults.
+
+Major enhancements include LVGL layout system improvements with shorthand syntax and rendering triggers, USB Host high-speed data support preventing transfer slot exhaustion, and seven new hardware components including sensors, RTC chips, face recognition modules, and TinyUSB foundation support for ESP32-S2/S3. The nRF52 platform gains I2C, BLE logging, and API support with OpenThread, while notable features include hosted BLE support for chips without native Bluetooth, OpenThread MTD sleep mode, Dallas sensor indexing, component idle detection, and expanded IR protocol support.
+<!-- RELEASE_OVERVIEW_END -->
+
+<!-- FEATURE_HIGHLIGHTS_START -->
+## Memory Optimizations
+
+This release delivers extensive memory savings across the entire framework, with multiple PRs collectively saving tens of kilobytes of RAM and flash memory.
+
+**Major Optimizations:**
+
+- **Climate Traits** ([#11466](https://github.com/esphome/esphome/pull/11466), [#11621](https://github.com/esphome/esphome/pull/11621)) - Replaced `std::set` with bitmask storage and moved strings to flash, saving ~440 bytes heap per climate entity plus 2,587 bytes core flash
+- **Light Color Modes** ([#11348](https://github.com/esphome/esphome/pull/11348)) - Bitmask instead of `std::set`, saving 1,756 bytes flash (ESP8266) and 84-108 bytes RAM per 6 lights
+- **Select Options** ([#11514](https://github.com/esphome/esphome/pull/11514), [#11623](https://github.com/esphome/esphome/pull/11623)) - Flash storage for option strings, saving 270-1,500 bytes per select (ESP32) with production cases showing ~2,800 bytes saved
+- **Fan Presets** ([#11483](https://github.com/esphome/esphome/pull/11483), [#11632](https://github.com/esphome/esphome/pull/11632)) - Flash storage and eliminated duplicate storage, saving ~24-94 bytes per fan
+- **Event Types** ([#11463](https://github.com/esphome/esphome/pull/11463), [#11767](https://github.com/esphome/esphome/pull/11767)) - Flash storage for event type strings, saving 1,248 bytes plus 24+ bytes per event type
+- **Action Framework** ([#11704](https://github.com/esphome/esphome/pull/11704)) - Const references instead of copies, reducing argument copies by 83% and saving 356 bytes flash
+- **Global Controller Registry** ([#11772](https://github.com/esphome/esphome/pull/11772)) - Replaces per-entity callbacks with global pattern, saving 388-6,148 bytes heap and 1,252 bytes flash
+- **WiFi Scan Results** ([#11205](https://github.com/esphome/esphome/pull/11205)) - Frees scan memory after connection, saving 440-1,192 bytes (ESP8266)
+- **Network use_address** ([#11707](https://github.com/esphome/esphome/pull/11707)) - Flash storage, saving 32-72 bytes per component and ~100-300 bytes flash
+- **Script Queue Limits** ([#11308](https://github.com/esphome/esphome/pull/11308)) - Eliminated `std::queue`, saving 1,592 bytes flash
+- **Disabled VFS Features** ([#11441](https://github.com/esphome/esphome/pull/11441)) - Saves ~8.7 KB flash and 316 bytes heap by default on ESP-IDF
+- **libc Locks in IRAM** ([#10930](https://github.com/esphome/esphome/pull/10930)) - Optional disabling saves ~1.3KB RAM on ESP32
+- **WiFi Priority Storage** ([#11830](https://github.com/esphome/esphome/pull/11830)) - Changed from float to int8_t, saving 33% per priority entry
+
+**Total Impact:** These optimizations collectively save 5-15KB+ of flash memory and 1-8KB+ of RAM depending on configuration, with the largest savings on devices with many entities.
+
+## ESP32 Co-Processor OTA Updates
+
+The {{< docref "/components/esp32_hosted" >}} component now supports firmware updates for ESP32 co-processors, enabling complete remote management of networked ESP32 chips ([#11562](https://github.com/esphome/esphome/pull/11562)).
+
+**Key Features:**
+
+- **Automatic version detection** - Compares embedded firmware with running co-processor version
+- **Chunked transfer protocol** - Reliable 1500-byte chunks with progress tracking
+- **Automatic rollback** - Watchdog and error handling prevent bricking
+- **Home Assistant integration** - Manage co-processor updates directly from HA UI
+- **Embedded firmware** - Co-processor binary compiled into host device at build time
+
+This enables the "native" platform use case where multiple ESP32 chips work together via networking, with the host device managing firmware updates for networked co-processors.
+
+## High-Performance Networking System
+
+ESPHome 2025.11.0 introduces a centralized high-performance networking system that automatically optimizes lwIP TCP settings based on available PSRAM ([#11812](https://github.com/esphome/esphome/pull/11812)).
+
+**How It Works:**
+
+Components like {{< docref "/components/speaker/i2s_audio" >}} can request high-performance networking via a helper function. The network component then applies PSRAM-aware optimizations:
+
+- **Aggressive mode (512KB windows)** - When PSRAM is guaranteed via `psram.ignore_not_found: false`
+- **Conservative mode (65KB windows)** - Without PSRAM guarantee
+
+**Benefits:**
+
+- **Eliminates audio stuttering** - Voice assistant firmware streaming is smooth and reliable
+- **Automatic optimization** - No manual sdkconfig tweaks required
+- **Safe defaults** - Matches available memory to prevent crashes
+
+This replaces component-specific sdkconfig settings with a centralized, intelligent approach that ensures optimal performance without manual tuning.
+
+## WiFi Security Enhancements
+
+The new `min_auth_mode` configuration option ([#11814](https://github.com/esphome/esphome/pull/11814)) gives users fine-grained control over WiFi security standards, addressing compatibility issues with legacy routers while maintaining secure defaults.
+
+**Security Improvements:**
+
+- **Platform-specific defaults** - ESP32 defaults to WPA2, ESP8266 defaults to WPA (with deprecation warning)
+- **WPA3 support** - ESP32 can require WPA3 for maximum security
+- **Legacy compatibility** - Explicitly support WPA-only routers when needed
+
+**Configuration:**
+
+```yaml
+# Modern router (WPA2 or WPA3)
+wifi:
+  ssid: "MyNetwork"
+  password: "password"
+  min_auth_mode: WPA2  # Default for ESP32
+
+# Legacy WPA-only router
+wifi:
+  ssid: "OldRouter"
+  password: "password"
+  min_auth_mode: WPA  # Explicit support
+```
+
+**Migration Note:** ESP8266 users with WPA-only routers should add `min_auth_mode: WPA` before ESPHome 2026.6.0 when the default will change to WPA2.
+
+## New Hardware Support
+
+Seven new components expand ESPHome's hardware compatibility:
+
+- **{{< docref "/components/sensor/hdc2010" >}}** ([#6674](https://github.com/esphome/esphome/pull/6674)) - High-precision temperature and humidity sensor from Texas Instruments
+- **{{< docref "/components/sensor/mcp3221" >}}** ([#7764](https://github.com/esphome/esphome/pull/7764)) - 12-bit I2C analog-to-digital converter with configurable reference voltage
+- **{{< docref "/components/sensor/bh1900nux" >}}** ([#8631](https://github.com/esphome/esphome/pull/8631)) - I2C temperature sensor from Rohm Semiconductor
+- **{{< docref "/components/time/rx8130" >}}** ([#10511](https://github.com/esphome/esphome/pull/10511)) - Epson RX8130 real-time clock chip used in M5Stack devices, with read/write time actions
+- **HLK-FM22X Face Recognition Module** ([#8059](https://github.com/esphome/esphome/pull/8059)) - UART-based face recognition hardware with binary sensor and trigger support
+- **{{< docref "/components/output/gp8403" >}} GP8413 Model** ([#7726](https://github.com/esphome/esphome/pull/7726)) - 15-bit DAC support (32,767 steps vs 12-bit's 4,095 steps)
+- **{{< docref "/components/tinyusb" >}}** ([#11678](https://github.com/esphome/esphome/pull/11678)) - TinyUSB foundation for ESP32-S2/S3, enabling future USB CDC, HID, and MSC implementations
+
+**Additional Display Support:**
+
+- Waveshare 5" 1024x600 MIPI RGB display ([#11206](https://github.com/esphome/esphome/pull/11206))
+- Seeed reTerminal E1002 e-paper configuration ([#11540](https://github.com/esphome/esphome/pull/11540))
+
+## LVGL Layout System Improvements
+
+The {{< docref "/components/display/lvgl" >}} component receives major layout system enhancements ([#10149](https://github.com/esphome/esphome/pull/10149), [#11628](https://github.com/esphome/esphome/pull/11628)) making it easier to create responsive UIs without absolute positioning.
+
+**New Features:**
+
+- **Shorthand layouts** - Simple syntax for common patterns:
+  - `layout: 3x2` for grid layouts
+  - `layout: horizontal` or `layout: vertical` for flex layouts
+- **Container widget** - New widget with default styling removed and 100% width/height
+- **Stretch alignment** - New `stretch` option for `flex_align_cross`
+- **Rendering triggers** - `on_draw_start` and `on_draw_end` events for e-paper display updates
+
+**Performance Improvements:**
+
+- Substantial speedup of configuration validation via per-widget schema customization
+- Simplified layout management with dedicated `layout.py` module
+
+**Example:**
+
+```yaml
+lvgl:
+  on_draw_end:
+    - lvgl.pause:
+    - component.update: epaper_display
+    - wait_until:
+        component.is_idle: epaper_display
+    - lvgl.resume:
+
+  pages:
+    - id: main_page
+      layout: 3x2  # Simple grid layout
+      widgets:
+        - button:
+            text: "Button 1"
+        - button:
+            text: "Button 2"
+```
+
+## USB Host High-Speed Data Support
+
+USB UART devices can now reliably operate at high baud rates (115200+) without transfer slot exhaustion ([#11174](https://github.com/esphome/esphome/pull/11174)).
+
+**What Was Fixed:**
+
+At 115200 baud with 32-byte packets, all 16 transfer slots would exhaust before the main loop could release them, causing communication failures.
+
+**Solution:**
+
+- **Immediate slot release** - Transfer slots released in USB task callback using thread-safe atomic operations
+- **Configurable slot count** - New `max_transfer_requests` option (1-32, default 16) for high-throughput scenarios
+
+**Configuration:**
+
+```yaml
+# Default (backward compatible)
+usb_host:
+
+# High throughput applications
+usb_host:
+  max_transfer_requests: 32  # Range: 1-32
+```
+
+This completes a series of optimizations started in PR #10859 (USB task) and PR #10926 (thread-safety).
+
+## Additional Notable Features
+
+**Hosted BLE Support** ([#11167](https://github.com/esphome/esphome/pull/11167)) - Chips without integrated Bluetooth hardware (like ESP32-P4) can now use external BLE modules, enabling BLE proxy, tracker, server, and beacon functionality.
+
+**OpenThread MTD Sleep End Devices** ([#11374](https://github.com/esphome/esphome/pull/11374)) - Configurable `poll_period` enables Sleep End Device (SED) mode for Thread MTD devices, turning off radio during idle for power savings.
+
+**Dallas Temperature Sensor Indexing** ([#11346](https://github.com/esphome/esphome/pull/11346)) - Index-based configuration for devices with multiple OneWire sensors where individual addresses aren't known.
+
+**Component Idle Detection** ([#11651](https://github.com/esphome/esphome/pull/11651)) - New `component.is_idle` condition determines when components (like e-paper displays) finish processing and can accept updates.
+
+**Remote Transmitter Non-Blocking Mode** ([#11524](https://github.com/esphome/esphome/pull/11524)) - Prevents long blocking operations (146ms observed) that caused main loop warnings.
+
+**HTTP Request Trigger Variables** ([#11464](https://github.com/esphome/esphome/pull/11464)) - `on_response` and `on_error` triggers now receive response data as variables instead of requiring lambdas.
+
+**ESP-NOW Transport for packet_transport** ([#11025](https://github.com/esphome/esphome/pull/11025)) - Enables wireless communication between ESP32 devices without WiFi infrastructure.
+
+**nRF52 Platform Enhancements** - I2C support ([#8150](https://github.com/esphome/esphome/pull/8150)), BLE logging ([#9846](https://github.com/esphome/esphome/pull/9846), [#9861](https://github.com/esphome/esphome/pull/9861)), GPIO voltage levels ([#9858](https://github.com/esphome/esphome/pull/9858)), and API support with OpenThread ([#11751](https://github.com/esphome/esphome/pull/11751)).
+
+**IR Protocol Support** - Symphony ([#10777](https://github.com/esphome/esphome/pull/10777)), Toshiba RAS-2819T AC ([#9490](https://github.com/esphome/esphome/pull/9490)), and Dyson Cool AM07 fan ([#10163](https://github.com/esphome/esphome/pull/10163)).
+
+**Thermostat Humidity Control** ([#11286](https://github.com/esphome/esphome/pull/11286)) - Adds humidification and dehumidification actions to the thermostat component.
+
+**SX126x GPIO Port Expander Support** ([#11782](https://github.com/esphome/esphome/pull/11782)) - Enables use of I2C port expanders for SX126x radio pins, required for SeeedStudio SenseCAP Indicator D1L.
+
+**analyze-memory CLI Command** ([#11395](https://github.com/esphome/esphome/pull/11395)) - New dedicated command provides detailed memory usage breakdown by component.
+<!-- FEATURE_HIGHLIGHTS_END -->
+
+## Breaking Changes
+
+<!-- BREAKING_CHANGES_USERS_START -->
+### Component Changes
+
+- **HM3301**: AQI calculation updated to EPA 2024 standard (values will change) [#9442](https://github.com/esphome/esphome/pull/9442)
+- **PIPsolar**: Fixed typo `warnung_low_pv_energy` → `warning_low_pv_energy` in configuration [#10291](https://github.com/esphome/esphome/pull/10291)
+- **GDK101**: Firmware version now reported as string instead of float [#11029](https://github.com/esphome/esphome/pull/11029)
+- **Uponor Smatrix**: Changed to 32-bit addresses - `address` property removed from base component, device addresses must now be 32-bit (prepend old system address to device addresses) [#11066](https://github.com/esphome/esphome/pull/11066)
+- **E-paper SPI**: Fixed busy pin logic (was inverted, now correctly reads HIGH=idle) [#11349](https://github.com/esphome/esphome/pull/11349)
+- **Script**: Queued mode now defaults to `max_runs: 5` instead of unlimited to prevent crashes [#11308](https://github.com/esphome/esphome/pull/11308)
+- **Remote Transmitter**: Non-blocking mode enabled by default with warnings for long operations [#11524](https://github.com/esphome/esphome/pull/11524)
+
+### Platform & Network Changes
+
+- **nRF52**: Default bootloader changed for `xiao_ble` and `adafruit_itsybitsy_nrf52840` boards [#10698](https://github.com/esphome/esphome/pull/10698)
+- **WiFi/Ethernet**: No longer blocks other components during setup - components must check network state in `loop()` instead of assuming network is ready in `setup()` [#9823](https://github.com/esphome/esphome/pull/9823)
+- **WiFi**: Priority changed from float to int8_t (only integers -128 to 127 accepted) [#11830](https://github.com/esphome/esphome/pull/11830)
+- **WiFi**: New `min_auth_mode` option controls minimum security (ESP32 defaults to WPA2, ESP8266 defaults to WPA with planned 2026.6.0 change to WPA2) [#11814](https://github.com/esphome/esphome/pull/11814)
+- **Network**: `.local` addresses now require mDNS to be enabled (eliminates 10+ second delays when mDNS is disabled) [#11508](https://github.com/esphome/esphome/pull/11508)
+- **Speaker**: High-performance networking mode now always enabled (previously only with codec support) [#11812](https://github.com/esphome/esphome/pull/11812)
+
+### ESP32 Platform Changes
+
+- **ESP32-IDF**: Brownout TX power reduction enabled by default to prevent boot loops on marginal power supplies [#11306](https://github.com/esphome/esphome/pull/11306)
+- **ESP32-IDF**: Unused VFS features disabled by default (saves ~8.7KB flash), automatically re-enabled by components that need them [#11441](https://github.com/esphome/esphome/pull/11441)
+- **ESP32-IDF**: Libc locks in IRAM disabled by default (saves ~1.3KB RAM), can be re-enabled with `disable_libc_locks_in_iram: false` [#10930](https://github.com/esphome/esphome/pull/10930)
+- **ESP32-S3**: PSRAM mode now required when using components that need PSRAM [#11470](https://github.com/esphome/esphome/pull/11470)
+<!-- BREAKING_CHANGES_USERS_END -->
+
+### Breaking Changes for Developers
+
+<!-- BREAKING_CHANGES_DEVELOPERS_START -->
+- **WiFi API**: `WiFiComponent::get_scan_result()` returns empty vector after connection unless `wifi.request_wifi_scan_results()` called during code generation [#11205](https://github.com/esphome/esphome/pull/11205)
+- **Select API**: Changed to `const char *` storage, added index-based operations, `.state` deprecated (removed in 2026.5.0) [#11514](https://github.com/esphome/esphome/pull/11514), [#11623](https://github.com/esphome/esphome/pull/11623)
+- **Light API**: Effect names changed from `std::string` to `const char *`, `get_name()` returns `const char *` [#11487](https://github.com/esphome/esphome/pull/11487)
+- **Light API**: Color modes storage changed from `std::set<ColorMode>` to `ColorModeMask` bitmask class [#11348](https://github.com/esphome/esphome/pull/11348)
+- **Fan API**: Preset modes changed from `std::set<std::string>` to `std::vector<const char *>` [#11483](https://github.com/esphome/esphome/pull/11483)
+- **Fan API**: Removed public `.preset_mode` member, use `get_preset_mode()` / `set_preset_mode_()` instead [#11632](https://github.com/esphome/esphome/pull/11632)
+- **Climate API**: Replaced `std::set<EnumType>` with `FiniteSetMask` for trait storage, custom modes changed to `std::vector` [#11466](https://github.com/esphome/esphome/pull/11466), [#11621](https://github.com/esphome/esphome/pull/11621)
+- **Event API**: Event types changed from `std::set<std::string>` to `FixedVector<const char *>`, `.last_event_type` now private with `get_last_event_type()` getter [#11463](https://github.com/esphome/esphome/pull/11463), [#11767](https://github.com/esphome/esphome/pull/11767)
+- **Network API**: `get_use_address()` now returns `const char *` instead of `const std::string &` [#11707](https://github.com/esphome/esphome/pull/11707)
+- **Action Framework**: All action/trigger signatures changed to use `const Ts&...` instead of `Ts...` (pass-by-reference) [#11704](https://github.com/esphome/esphome/pull/11704)
+- **Controller API**: Removed state parameters from all `on_*_update()` methods - controllers now read state directly from entities via Global Controller Registry [#11772](https://github.com/esphome/esphome/pull/11772)
+- **HTTP Request**: Changed from multiple triggers to single `on_response`/`on_error` trigger with variables passed through [#11464](https://github.com/esphome/esphome/pull/11464)
+- **Core API**: Removed deprecated `hexencode()` function (deprecated since 2022.1) [#11383](https://github.com/esphome/esphome/pull/11383)
+- **Core API**: Removed deprecated schema constants [#11591](https://github.com/esphome/esphome/pull/11591)
+- **Core API**: Removed deprecated `EntityBase::hash_base()` method (deprecated since 2022.6) [#11783](https://github.com/esphome/esphome/pull/11783)
+- **Climate API**: Removed deprecated functions from 1.20 (July 2021) [#11388](https://github.com/esphome/esphome/pull/11388)
+- **Light API**: Removed deprecated functions from 2021.8.0 [#11389](https://github.com/esphome/esphome/pull/11389)
+- **Cover API**: Removed deprecated functions from 2021.9 [#11391](https://github.com/esphome/esphome/pull/11391)
+- **Fan/MQTT API**: Removed deprecated code from 2022.2 [#11392](https://github.com/esphome/esphome/pull/11392)
+- **Nextion API**: Removed deprecated functions from 1.20 (July 2021) [#11393](https://github.com/esphome/esphome/pull/11393)
+
+For detailed migration guides and API documentation, see the [ESPHome Developers Documentation](https://developers.esphome.io/).
+<!-- BREAKING_CHANGES_DEVELOPERS_END -->
 
 <!-- markdownlint-disable MD013 -->
 

--- a/content/changelog/2025.11.0.md
+++ b/content/changelog/2025.11.0.md
@@ -127,7 +127,7 @@ Seven new components expand ESPHome's hardware compatibility:
 
 ## LVGL Layout System Improvements
 
-The {{< docref "/components/display/lvgl" >}} component receives major layout system enhancements ([#10149](https://github.com/esphome/esphome/pull/10149), [#11628](https://github.com/esphome/esphome/pull/11628)) making it easier to create responsive UIs without absolute positioning.
+The {{< docref "/components/lvgl" >}} component receives major layout system enhancements ([#10149](https://github.com/esphome/esphome/pull/10149), [#11628](https://github.com/esphome/esphome/pull/11628)) making it easier to create responsive UIs without absolute positioning.
 
 **New Features:**
 


### PR DESCRIPTION
## Description:

Generated release notes summary for 2025.11.0 

Generated with https://github.com/esphome/esphome-docs/pull/5619

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
