### PR TITLE
[network] Add is_available()

### DIFF
--- a/content/components/network.md
+++ b/content/components/network.md
@@ -51,6 +51,27 @@ The optimization level depends on whether PSRAM is guaranteed to be available (c
 > This has various security and privacy implications decribed in [RFC7721](https://datatracker.ietf.org/doc/rfc7721/), as this might leak outside of the smart home network and makes the device uniquely identifiable.
 > Therefore, the address generation does not comply to [RFC7217](https://datatracker.ietf.org/doc/rfc7217/).
 
+## Lambda: Check if any network component is available
+
+This function is more useful for developing external components, such as a status indicator.
+
+```yaml
+network:
+  id: network_id
+
+button:
+  id: update_now
+  name: "Update now"
+  on_press:
+    then:
+      - if:
+          condition:
+            lambda: |-
+              return id(network_id).is_available();
+          then:
+            - logger.log: "A Network component is available!"
+```
+
 ## See Also
 
 - {{< docref "wifi/" >}}

--- a/content/components/network.md
+++ b/content/components/network.md
@@ -51,7 +51,9 @@ The optimization level depends on whether PSRAM is guaranteed to be available (c
 > This has various security and privacy implications decribed in [RFC7721](https://datatracker.ietf.org/doc/rfc7721/), as this might leak outside of the smart home network and makes the device uniquely identifiable.
 > Therefore, the address generation does not comply to [RFC7217](https://datatracker.ietf.org/doc/rfc7217/).
 
-## Lambda: Check if any network component is available
+## Lambda
+
+### Check if any network component is available
 
 This function is more useful for developing external components, such as a status indicator.
 
@@ -60,16 +62,17 @@ network:
   id: network_id
 
 button:
-  id: update_now
-  name: "Update now"
-  on_press:
-    then:
-      - if:
-          condition:
-            lambda: |-
-              return id(network_id).is_available();
-          then:
-            - logger.log: "A Network component is available!"
+  - platform: template
+    id: update_now
+    name: "Update now"
+    on_press:
+      then:
+        - if:
+            condition:
+              lambda: |-
+                return id(network_id).is_available();
+            then:
+              - logger.log: "A Network component is available!"
 ```
 
 ## See Also


### PR DESCRIPTION
Added a lambda function to check network component availability.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#11853

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
