### PR TITLE
[lvgl] Update examples with selected_digit for spinbox

### DIFF
--- a/content/components/lvgl/widgets.md
+++ b/content/components/lvgl/widgets.md
@@ -1538,9 +1538,6 @@ The `slider` can be also integrated as {{< docref "/components/number/lvgl" "Num
 
 See [Light brightness slider](/cookbook/lvgl#lvgl-cookbook-bright) and [Media player volume slider](/cookbook/lvgl#lvgl-cookbook-volume) for examples which demonstrate how to use a slider to control entities in Home Assistant.
 
-{{< anchor "lvgl-widget-canvas" >}}
-{{< anchor "lvgl-widget-spinbox" >}}
-
 ## `spinbox`
 
 The spinbox contains a numeric value (as text) which can be increased or decreased through actions. You can, for example, use buttons labeled with plus and minus to call actions which increase or decrease the value as required.
@@ -1589,7 +1586,7 @@ The spinbox contains a numeric value (as text) which can be increased or decreas
     text_align: center
     range_from: -10
     range_to: 40
-    step: 0.5
+    selected_digit: 2
     digits: 3
     decimal_places: 1
 

--- a/content/components/lvgl/widgets.md
+++ b/content/components/lvgl/widgets.md
@@ -1538,6 +1538,8 @@ The `slider` can be also integrated as {{< docref "/components/number/lvgl" "Num
 
 See [Light brightness slider](/cookbook/lvgl#lvgl-cookbook-bright) and [Media player volume slider](/cookbook/lvgl#lvgl-cookbook-volume) for examples which demonstrate how to use a slider to control entities in Home Assistant.
 
+{{< anchor "lvgl-widget-spinbox" >}}
+
 ## `spinbox`
 
 The spinbox contains a numeric value (as text) which can be increased or decreased through actions. You can, for example, use buttons labeled with plus and minus to call actions which increase or decrease the value as required.

--- a/content/cookbook/lvgl.md
+++ b/content/cookbook/lvgl.md
@@ -523,7 +523,7 @@ lvgl:
                     width: 50
                     range_from: 15
                     range_to: 35
-                    step: 0.5
+                    selected_digit: 0
                     rollover: false
                     digits: 3
                     decimal_places: 1
@@ -2229,7 +2229,7 @@ number:
     restore_value: true
     min_value: 10
     max_value: 180
-    step: 5
+    selected_digit: 1
     mode: box
 ```
 

--- a/content/cookbook/lvgl.md
+++ b/content/cookbook/lvgl.md
@@ -2229,7 +2229,7 @@ number:
     restore_value: true
     min_value: 10
     max_value: 180
-    selected_digit: 1
+    step: 5
     mode: box
 ```
 


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes https://github.com/esphome/esphome-docs/issues/5495

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
