### PR TITLE
[core] Add support for setting environment variables

### DIFF
--- a/content/components/esphome.md
+++ b/content/components/esphome.md
@@ -52,6 +52,9 @@ Advanced options:
 - **platformio_options** (*Optional*, mapping): Additional options to pass over to PlatformIO in the
   platformio.ini file. See [`platformio_options`](#esphome-platformio_options).
 
+- **environment_variables** (*Optional*, mapping): Environment variables to set during the build process.
+  See [`environment_variables`](#esphome-environment_variables).
+
 - **includes** (*Optional*, list of files): A list of C/C++ files to include in the (auto-generated) `main` file.
   The paths in this list are relative to the directory where the YAML configuration file is located or `<...>` includes.
   See [`includes`](#esphome-includes).
@@ -191,6 +194,27 @@ esphome:
     upload_speed: 115200
     board_build.f_flash: 80000000L
 ```
+
+{{< anchor "esphome-environment_variables" >}}
+
+## `environment_variables`
+
+With the `environment_variables` option, you can set environment variables that will be available during the
+compilation process. This is useful when you need to pass configuration to build scripts, custom libraries,
+or PlatformIO build environments.
+
+```yaml
+# Example configuration entry
+esphome:
+  # ...
+  environment_variables:
+    HTTP_PROXY: "HTTP_PROXY=http://user:pass@10.10.1.10:3128/"
+    PLATFORMIO_SETTING_ENABLE_PROXY_STRICT_SSL: "false"
+```
+
+> [!NOTE]
+> Environment variables set here are only available during the build process. They do not affect
+> the runtime behavior of your device.
 
 {{< anchor "esphome-includes" >}}
 

--- a/content/components/esphome.md
+++ b/content/components/esphome.md
@@ -208,7 +208,7 @@ or PlatformIO build environments.
 esphome:
   # ...
   environment_variables:
-    HTTP_PROXY: "HTTP_PROXY=http://user:pass@10.10.1.10:3128/"
+    HTTP_PROXY: "http://user:pass@10.10.1.10:3128/"
     PLATFORMIO_SETTING_ENABLE_PROXY_STRICT_SSL: "false"
 ```
 


### PR DESCRIPTION
## Description:

See https://github.com/esphome/esphome/issues/11735 and https://github.com/esphome/esphome/issues/10877: 
"Unfortunately, due to regional Internet restrictions, it is not always possible to download libraries from registry.platformio. Platfomio supports proxy server configuration using environment variables. But in the case of the addon, this is quite problematic."

See https://docs.platformio.org/en/latest/core/installation/proxy-configuration.html

Adding a generic way to set environment variables seems to be the most flexible solution:
```yaml
# Example configuration entry
esphome:
  # ...
  environment_variables:
    HTTP_PROXY: "http://user:pass@10.10.1.10:3128/"
    PLATFORMIO_SETTING_ENABLE_PROXY_STRICT_SSL: "false"
```

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#11953

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
