### PR TITLE
[wifi][esp32_improv] Update default timeouts to 90s

### DIFF
--- a/content/components/esp32_improv.md
+++ b/content/components/esp32_improv.md
@@ -39,7 +39,7 @@ esp32_improv:
 - **status_indicator** (*Optional*, [ID](/guides/configuration-types#id)): An {{< docref "output/index" "output" >}} to display feedback to the user.
 - **identify_duration** (*Optional*, [Time](/guides/configuration-types#time)): The amount of time to identify for. Defaults to `10s`.
 - **wifi_timeout** (*Optional*, [Time](/guides/configuration-types#time)): The amount of time to wait before starting the Improv service
-  after Wi-Fi is no longer connected. Defaults to `1min`.
+  after Wi-Fi is no longer connected. Defaults to `90s`.
 - **next_url** (*Optional*, string): The URL to open after provisioning is complete. Defaults to
   `https://my.home-assistant.io/redirect/config_flow_start?domain=esphome`.
 

--- a/content/components/wifi.md
+++ b/content/components/wifi.md
@@ -79,7 +79,7 @@ wifi:
 
   - **ap_timeout** (*Optional*, [Time](/guides/configuration-types#time)): The time after which to enable the
     configured fallback hotspot. Can be disabled by setting this to `0s`, which requires manually starting the AP by
-    other means (eg: from a button press). Defaults to `1min`.
+    other means (eg: from a button press). Defaults to `2min`.
 
 - **domain** (*Optional*, string): Set the domain of the node hostname used for uploading.
   For example, if it's set to `.local`, all uploads will be sent to `<HOSTNAME>.local`.

--- a/content/components/wifi.md
+++ b/content/components/wifi.md
@@ -79,7 +79,7 @@ wifi:
 
   - **ap_timeout** (*Optional*, [Time](/guides/configuration-types#time)): The time after which to enable the
     configured fallback hotspot. Can be disabled by setting this to `0s`, which requires manually starting the AP by
-    other means (eg: from a button press). Defaults to `2min`.
+    other means (eg: from a button press). Defaults to `90s`.
 
 - **domain** (*Optional*, string): Set the domain of the node hostname used for uploading.
   For example, if it's set to `.local`, all uploads will be sent to `<HOSTNAME>.local`.


### PR DESCRIPTION
## Description:

Updates WiFi and ESP32 Improv documentation to reflect the new default timeout values:
- WiFi `ap_timeout`: changed from `1min` to `90s`
- ESP32 Improv `wifi_timeout`: changed from `1min` to `90s`

These changes align both timeout defaults and ensure WiFi has sufficient time to try all BSSIDs during initial connection before starting the fallback AP or Improv provisioning. Since WiFi scanning is skipped once the AP is active (to avoid disrupting the AP), it's important to exhaust all connection options before falling back to AP mode.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#11965

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
