### PR TITLE
2025.11.0b4

### DIFF
--- a/content/changelog/2025.11.0.md
+++ b/content/changelog/2025.11.0.md
@@ -648,6 +648,14 @@ The 2025.11 release blog posts include comprehensive migration examples for comm
 - [web_server.ota] Merge multiple instances to prevent undefined behavior [esphome#11905](https://github.com/esphome/esphome/pull/11905) by [@bdraco](https://github.com/bdraco)
 - [web_server_idf] Fix lwIP assertion crash by shutting down sockets on connection close [esphome#11937](https://github.com/esphome/esphome/pull/11937) by [@bdraco](https://github.com/bdraco)
 - [uart] Setup uart pins only if flags are set [esphome#11914](https://github.com/esphome/esphome/pull/11914) by [@asergunov](https://github.com/asergunov)
+- [captive_portal] Warn when enabled without WiFi AP configured [esphome#11856](https://github.com/esphome/esphome/pull/11856) by [@bdraco](https://github.com/bdraco)
+- [core] Add support for setting environment variables [esphome#11953](https://github.com/esphome/esphome/pull/11953) by [@swoboda1337](https://github.com/swoboda1337) (new-feature)
+- [mipi_rgb] GUITION-4848S040 colors and orientation fix [esphome#11709](https://github.com/esphome/esphome/pull/11709) by [@strange-v](https://github.com/strange-v)
+- [lvgl] Apply scale to spinbox value [esphome#11946](https://github.com/esphome/esphome/pull/11946) by [@clydebarrow](https://github.com/clydebarrow)
+- [esp32] Fix Arduino build on some ESP32 S2 boards [esphome#11972](https://github.com/esphome/esphome/pull/11972) by [@swoboda1337](https://github.com/swoboda1337)
+- [scheduler] Add defensive nullptr checks and explicit locking requirements [esphome#11974](https://github.com/esphome/esphome/pull/11974) by [@bdraco](https://github.com/bdraco)
+- [sfa30] Fix negative temperature values [esphome#11973](https://github.com/esphome/esphome/pull/11973) by [@swoboda1337](https://github.com/swoboda1337)
+- [wifi] Fix captive portal unusable when WiFi credentials are wrong [esphome#11965](https://github.com/esphome/esphome/pull/11965) by [@bdraco](https://github.com/bdraco)
 
 ### All changes
 

--- a/content/components/esp32_improv.md
+++ b/content/components/esp32_improv.md
@@ -39,7 +39,7 @@ esp32_improv:
 - **status_indicator** (*Optional*, [ID](/guides/configuration-types#id)): An {{< docref "output/index" "output" >}} to display feedback to the user.
 - **identify_duration** (*Optional*, [Time](/guides/configuration-types#time)): The amount of time to identify for. Defaults to `10s`.
 - **wifi_timeout** (*Optional*, [Time](/guides/configuration-types#time)): The amount of time to wait before starting the Improv service
-  after Wi-Fi is no longer connected. Defaults to `1min`.
+  after Wi-Fi is no longer connected. Defaults to `90s`.
 - **next_url** (*Optional*, string): The URL to open after provisioning is complete. Defaults to
   `https://my.home-assistant.io/redirect/config_flow_start?domain=esphome`.
 

--- a/content/components/wifi.md
+++ b/content/components/wifi.md
@@ -79,7 +79,7 @@ wifi:
 
   - **ap_timeout** (*Optional*, [Time](/guides/configuration-types#time)): The time after which to enable the
     configured fallback hotspot. Can be disabled by setting this to `0s`, which requires manually starting the AP by
-    other means (eg: from a button press). Defaults to `1min`.
+    other means (eg: from a button press). Defaults to `90s`.
 
 - **domain** (*Optional*, string): Set the domain of the node hostname used for uploading.
   For example, if it's set to `.local`, all uploads will be sent to `<HOSTNAME>.local`.

--- a/content/guides/supporters.md
+++ b/content/guides/supporters.md
@@ -898,6 +898,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Arjan Filius (@iafilius)](https://github.com/iafilius)
 - [Iago Veiga (@iago-veiga)](https://github.com/iago-veiga)
 - [Iain Hay (@IainPHay)](https://github.com/IainPHay)
+- [Ralph Thomas (@iamralpht)](https://github.com/iamralpht)
 - [Ian-Blockmans (@Ian-Blockmans)](https://github.com/Ian-Blockmans)
 - [Adrián Panella (@ianchi)](https://github.com/ianchi)
 - [Ian Anderson (@ianderso)](https://github.com/ianderso)
@@ -2272,4 +2273,4 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Christian Zufferey (@zuzu59)](https://github.com/zuzu59)
 - [Zynth-dev (@Zynth-dev)](https://github.com/Zynth-dev)
 
-*This page was last updated November 17, 2025.*
+*This page was last updated November 19, 2025.*

--- a/data/version.yaml
+++ b/data/version.yaml
@@ -1,2 +1,2 @@
-release: 2025.11.0b3
+release: 2025.11.0b4
 version: '2025.11'


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- Fix API docs url redirect [docs#5632](https://github.com/esphome/esphome-docs/pull/5632)
- Update usb_uart.md [docs#5633](https://github.com/esphome/esphome-docs/pull/5633)
- [lvgl] Update examples with selected_digit for spinbox [docs#5630](https://github.com/esphome/esphome-docs/pull/5630)
- Bump actions/checkout from 5.0.0 to 5.0.1 [docs#5638](https://github.com/esphome/esphome-docs/pull/5638)
- [nrf52] minimum examples [docs#5493](https://github.com/esphome/esphome-docs/pull/5493)
- [wifi][esp32_improv] Update default timeouts to 90s [docs#5639](https://github.com/esphome/esphome-docs/pull/5639)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
