### PR TITLE
[wifi] Add clarification to note regarding `disable` action

### DIFF
--- a/content/components/wifi.md
+++ b/content/components/wifi.md
@@ -327,8 +327,8 @@ on_...:
 ```
 
 > [!NOTE]
-> Be mindful of the reboot timeouts set for both the API component and WiFi component if you disable WiFi. If WiFi
-> remains off for longer than the duration of either timeout, the device will reboot!
+> Be mindful of the reboot timeouts set for both the [API component](https://esphome.io/components/api/) and the [WiFi component](https://esphome.io/components/wifi/) if you disable WiFi.
+> If WiFi remains off for longer than the duration of either timeout, the device will reboot!
 
 {{< anchor "wifi-on_enable" >}}
 

--- a/content/components/wifi.md
+++ b/content/components/wifi.md
@@ -327,7 +327,7 @@ on_...:
 ```
 
 > [!NOTE]
-> Be mindful of the reboot timeouts set for both the [API component](https://esphome.io/components/api/) and the [WiFi component](https://esphome.io/components/wifi/) if you disable WiFi.
+> Be mindful of the reboot timeouts set for both the [API component](/components/api/) and the [WiFi component](/components/wifi/#configuration-variables) if you disable WiFi.
 > If WiFi remains off for longer than the duration of either timeout, the device will reboot!
 
 {{< anchor "wifi-on_enable" >}}

--- a/content/components/wifi.md
+++ b/content/components/wifi.md
@@ -327,7 +327,8 @@ on_...:
 ```
 
 > [!NOTE]
-> If you disable WiFi, you must enable WiFi again before the API timeout is reached or the device will reboot. You can disable the API timeout to avoid this limitation.
+> Be mindful of the reboot timeouts set for both the API component and WiFi component if you disable WiFi. If WiFi
+> remains off for longer than the duration of either timeout, the device will reboot!
 
 {{< anchor "wifi-on_enable" >}}
 

--- a/content/components/wifi.md
+++ b/content/components/wifi.md
@@ -327,8 +327,9 @@ on_...:
 ```
 
 > [!NOTE]
-> Be mindful of the reboot timeouts set for both the [API component](/components/api/) and the [WiFi component](/components/wifi/#configuration-variables) if you disable WiFi.
-> If WiFi remains off for longer than the duration of either timeout, the device will reboot!
+> Be mindful of the reboot timeouts set for both the [API component](/components/api/) and the
+> [WiFi component](#configuration-variables) if you disable WiFi. If WiFi remains off for longer than the duration of
+>  either timeout, the device will reboot!
 
 {{< anchor "wifi-on_enable" >}}
 

--- a/content/components/wifi.md
+++ b/content/components/wifi.md
@@ -329,7 +329,7 @@ on_...:
 > [!NOTE]
 > Be mindful of the reboot timeouts set for both the [API component](/components/api/) and the
 > [WiFi component](#configuration-variables) if you disable WiFi. If WiFi remains off for longer than the duration of
->  either timeout, the device will reboot!
+> either timeout, the device will reboot!
 
 {{< anchor "wifi-on_enable" >}}
 

--- a/content/components/wifi.md
+++ b/content/components/wifi.md
@@ -327,7 +327,7 @@ on_...:
 ```
 
 > [!NOTE]
-> Be aware that if you disable WiFi, the API timeout will need to be disabled otherwise the device will reboot.
+> If you disable WiFi, you must enable WiFi again before the API timeout is reached or the device will reboot. You can disable the API timeout to avoid this limitation.
 
 {{< anchor "wifi-on_enable" >}}
 


### PR DESCRIPTION
Updates note to be more clear on the limitations imposed by the api timeout when disabling the wifi component.

Clarified note about disabling WiFi and API timeout limitations.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
