### PR TITLE
light: document transition_state_publish_interval guidance

### DIFF
--- a/content/components/light/_index.md
+++ b/content/components/light/_index.md
@@ -44,6 +44,14 @@ light:
 - **flash_transition_length** (*Optional*, [Time](/guides/configuration-types#time)): The transition length to use when flash is called.
   Defaults to `0s`.
 
+- **transition_state_publish_interval** (*Optional*, [Time](/guides/configuration-types#time)): How often to publish state updates while a transition or flash is in progress.
+
+  - `0s` (default) – interval publishing is disabled. No extra state updates are scheduled during a transition or flash because of this option. Home Assistant and other consumers typically only see the final result of the transition or flash, not the intermediate progress.
+
+  - Values `>0` – interval publishing is enabled. The starting state is published at the beginning of the transition or flash, intermediate states are published roughly every `transition_state_publish_interval` while it is running, and a final state is published at the end. If the light call includes `save: true`, the stored state is updated when the transition finishes instead of on each intermediate update.
+
+  Shorter intervals create more frequent publishes and therefore more network and CPU load. In testing on ESP8266-class devices, values below about `150ms` rarely produce smoother visible transitions but can generate a large number of API/MQTT updates and push the device toward its CPU limits. For ESP8266-class devices, defaults in the range of `200ms` to `250ms` (around 4–5 Hz) generally provide smooth updates without excessive overhead.
+
 - **initial_state** (*Optional*): The initial state the light should be set to on bootup. This state will be applied
   when the state is **not** restored based on `restore_mode` (below).
 

--- a/content/components/light/_index.md
+++ b/content/components/light/_index.md
@@ -50,7 +50,7 @@ light:
 
   - Values `>0` – interval publishing is enabled. The starting state is published at the beginning of the transition or flash, intermediate states are published roughly every `transition_state_publish_interval` while it is running, and a final state is published at the end. If the light call includes `save: true`, the stored state is updated when the transition finishes instead of on each intermediate update.
 
-  Shorter intervals create more frequent publishes and therefore more network and CPU load. In testing on ESP8266-class devices, values below about `150ms` rarely produce smoother visible transitions but can generate a large number of API/MQTT updates and push the device toward its CPU limits. For ESP8266-class devices, defaults in the range of `200ms` to `250ms` (around 4–5 Hz) generally provide smooth updates without excessive overhead.
+  Shorter intervals create more frequent publishes and therefore more network and CPU load. In testing on ESP8266-class devices, values below about `150ms` rarely produce smoother visible transitions but can generate a large number of API/MQTT updates and push the device toward its CPU limits. For ESP8266-class devices, recommended values in the range of `200ms` to `250ms` (around 4–5 Hz) generally provide smooth updates without excessive overhead.
 
 - **initial_state** (*Optional*): The initial state the light should be set to on bootup. This state will be applied
   when the state is **not** restored based on `restore_mode` (below).


### PR DESCRIPTION
## Description:

Add documentation for the new `transition_state_publish_interval` option on the light component.

This PR:

- Documents the new `transition_state_publish_interval` light configuration option and how `0s` vs `>0` intervals affect when state is published during transitions and flashes.
- Explains that shorter intervals increase API/MQTT traffic and CPU load.
- Provides guidance based on hardware-in-the-loop testing on an ESP8266-class Athom E27 15W (ESP8285) bulb, noting that:
  - Intervals below ~`150ms` rarely produce smoother visible transitions but can generate a large number of publishes and push the device near its CPU limits.
  - Intervals in the `200–250ms` range (≈4–5 Hz) are a good default on ESP8266-class devices, balancing smoothness and overhead.

These documentation changes introduce and describe the new `transition_state_publish_interval` feature added in the linked core ESPHome PR, and provide guidance to help users choose practical values for `transition_state_publish_interval`.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#11968

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
