### PR TITLE
[mipi_rgb] Clarify use of transform

### DIFF
--- a/content/components/display/mipi_rgb.md
+++ b/content/components/display/mipi_rgb.md
@@ -134,9 +134,11 @@ Displays needing a custom init sequence require an SPI bus to be configured, plu
   `16bit` (default) or `18bit`.
 - **invert_colors** (*Optional*): Inverts the display colors, (white becomes black.) Defaults to false.
 - **color_order** (*Optional*): Should be one of `bgr` (default) or `rgb`.
-- **transform** (*Optional*): Transform the display presentation using hardware. All defaults are `false`.
-  This option should not be used with `rotation`. For the `CUSTOM` model, use `transform: disabled`
-  if the display does not support it, which will prevent a `rotation` being translated to a hardware transform.
+- **transform** (*Optional*): Transform the display presentation using hardware.
+  This is typically used only to correct for displays that have x or y drivers wired backwards. To rotate the
+  display the `rotation` option is preferred - it will automatically use hardware transform if possible.
+  The default values for the `mirror_x` and `mirror_y` options are model dependent.
+  For the `CUSTOM` model, use of `transform: disabled` will prevent a `rotation` being translated to a hardware transform.
 
   - **mirror_x** (*Optional*, boolean): If true, mirror the x-axis.
   - **mirror_y** (*Optional*, boolean): If true, mirror the y-axis.


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes https://discord.com/channels/429907082951524364/1440775570219598006

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
