### PR TITLE
[display] Document new display.sleep / display.wakeup actions

### DIFF
--- a/content/components/display/_index.md
+++ b/content/components/display/_index.md
@@ -481,6 +481,39 @@ RGB displays use red, green, and blue, while grayscale displays may use white.
 
 {{< anchor "display-pages" >}}
 
+{{< anchor "display-power-save-mode" >}}
+
+### Display power save mode
+
+On many displays you can partially turn off the display to save a significant amount of power and avoid wearing it out by having it enter sleep mode. Note that
+not all display components support sleeping mode or have it implemented yet. Check the corresponding display component documentation.
+
+**display.sleep**: Puts the display on power saving mode.
+
+```yaml
+lvgl:
+  on_idle:
+    timeout: 30s
+    then:
+      - light.turn_off: display_backlight
+      - lvgl.pause:
+      - delay: 5s # wait for display backlight to fade out for a nice effect
+      - display.sleep: my_display
+```
+
+**display.wakeup**: Wakes up the display from power saving mode
+
+```yaml
+touchscreen:
+  - on_release:
+      - if:
+          condition:
+            - lvgl.is_paused:
+          then:
+            - light.turn_on: display_backlight
+            - display.wakeup: my_display
+```
+
 ### Display Pages
 
 Certain display types also allow you to show "pages". With pages you can create drawing lambdas

--- a/content/components/display/epaper_spi.md
+++ b/content/components/display/epaper_spi.md
@@ -61,6 +61,10 @@ but can be overridden if needed.
   to use multiple SPI buses.
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID used for code generation.
 
+## Sleep/Wakeup support
+
+[Sleep / Wakeup actions](/components/display#display-power-save-mode) (`display.sleep` / `display.wakeup`) not implemented yet for this display component.
+
 ## See Also
 
 - {{< docref "index/" >}}

--- a/content/components/display/ili9xxx.md
+++ b/content/components/display/ili9xxx.md
@@ -281,6 +281,10 @@ display:
     invert_colors: true
 ```
 
+## Sleep/Wakeup support
+
+[Sleep / Wakeup actions](/components/display#display-power-save-mode) (`display.sleep` / `display.wakeup`) not implemented yet for this display component.
+
 ## See Also
 
 - {{< docref "index/" >}}

--- a/content/components/display/inkplate.md
+++ b/content/components/display/inkplate.md
@@ -515,6 +515,10 @@ display:
       number: 5
 ```
 
+### Sleep/Wakeup support
+
+[Sleep / Wakeup actions](/components/display#display-power-save-mode) (`display.sleep` / `display.wakeup`) not implemented yet for this display component.
+
 ### See Also
 
 - {{< docref "index/" >}}

--- a/content/components/display/lcd_display.md
+++ b/content/components/display/lcd_display.md
@@ -243,6 +243,10 @@ binary_sensor:
             id(mydisplay).no_backlight();
 ```
 
+## Sleep/Wakeup support
+
+[Sleep / Wakeup actions](/components/display#display-power-save-mode) (`display.sleep` / `display.wakeup`) not implemented yet for this display component.
+
 ## See Also
 
 - {{< docref "index/" >}}

--- a/content/components/display/max7219.md
+++ b/content/components/display/max7219.md
@@ -178,6 +178,10 @@ Please see [Formatted Text](/components/display#display-printf) for a quick intr
 > [Creative Commons BY-SA 3.0](https://creativecommons.org/licenses/by-sa/3.0/deed.de) and modified
 > for this documentation.
 
+## Sleep/Wakeup support
+
+[Sleep / Wakeup actions](/components/display#display-power-save-mode) (`display.sleep` / `display.wakeup`) not implemented yet for this display component.
+
 ## See Also
 
 - {{< docref "index/" >}}

--- a/content/components/display/max7219digit.md
+++ b/content/components/display/max7219digit.md
@@ -235,6 +235,10 @@ display a single character. So not very space efficient. The format of the comma
 Please see [Formatted Text](/components/display#display-printf) for a quick introduction into the `printf` formatting rules and
 [Displaying Time](/components/display#display-strftime) for an introduction into the `strftime` time formatting.
 
+## Sleep/Wakeup support
+
+[Sleep / Wakeup actions](/components/display#display-power-save-mode) (`display.sleep` / `display.wakeup`) not implemented yet for this display component.
+
 ## See Also
 
 - {{< docref "index/" >}}

--- a/content/components/display/mipi_dsi.md
+++ b/content/components/display/mipi_dsi.md
@@ -148,6 +148,10 @@ be able to be dimmed using a {{< docref "/components/light/monochromatic" >}} wi
 
 A touchscreen, if present, must be configured separately. See the {{< docref "/components/touchscreen" >}} documentation for more information.
 
+## Sleep/Wakeup support
+
+[Sleep / Wakeup actions](/components/display#display-power-save-mode) (`display.sleep` / `display.wakeup`) not implemented yet for this display component.
+
 ## See Also
 
 - {{< docref "index/" >}}

--- a/content/components/display/mipi_rgb.md
+++ b/content/components/display/mipi_rgb.md
@@ -221,6 +221,10 @@ display:
 
 ```
 
+## Sleep/Wakeup support
+
+[Sleep / Wakeup actions](/components/display#display-power-save-mode) (`display.sleep` / `display.wakeup`) are supported for this display type.
+
 ## See Also
 
 - {{< docref "index/" >}}

--- a/content/components/display/mipi_spi.md
+++ b/content/components/display/mipi_spi.md
@@ -219,7 +219,7 @@ A touchscreen, if present, must be configured separately. See the {{< docref "/c
 
 ## Sleep/Wakeup support
 
-[Sleep / Wakeup actions](/components/display#display-power-save-mode) (`display.sleep` / `display.wakeup`) not implemented yet for this display component.
+[Sleep / Wakeup actions](/components/display#display-power-save-mode) (`display.sleep` / `display.wakeup`) are supported for this display type.
 
 ## See Also
 

--- a/content/components/display/mipi_spi.md
+++ b/content/components/display/mipi_spi.md
@@ -217,6 +217,10 @@ their brightness can be set using the `brightness` option. This may also be cont
 
 A touchscreen, if present, must be configured separately. See the {{< docref "/components/touchscreen" >}} documentation for more information.
 
+## Sleep/Wakeup support
+
+[Sleep / Wakeup actions](/components/display#display-power-save-mode) (`display.sleep` / `display.wakeup`) not implemented yet for this display component.
+
 ## See Also
 
 - {{< docref "index/" >}}

--- a/content/components/display/nextion.md
+++ b/content/components/display/nextion.md
@@ -432,6 +432,10 @@ the example below illustrates:
 Note that the first one requires a custom protocol to be included in the Nextion display's HMI code/configuration. See
 the individual components (linked below) for more detail.
 
+## Sleep/Wakeup support
+
+[Sleep / Wakeup actions](/components/display#display-power-save-mode) (`display.sleep` / `display.wakeup`) not implemented yet for this display component.
+
 ## See Also
 
 - {{< docref "index/" >}}

--- a/content/components/display/pcd8544.md
+++ b/content/components/display/pcd8544.md
@@ -57,6 +57,10 @@ To use a backlight LIGHT pin needs to be connected to ground. If connected to GP
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID used for code generation.
 - **contrast** (*Optional*, int): Set screen contrast (0-255). Defaults to `0x7f`.
 
+## Sleep/Wakeup support
+
+[Sleep / Wakeup actions](/components/display#display-power-save-mode) (`display.sleep` / `display.wakeup`) not implemented yet for this display component.
+
 ## See Also
 
 - {{< docref "index/" >}}

--- a/content/components/display/pvvx_mithermometer.md
+++ b/content/components/display/pvvx_mithermometer.md
@@ -212,6 +212,10 @@ display:
   time_id: homeassistant_time
 ```
 
+## Sleep/Wakeup support
+
+[Sleep / Wakeup actions](/components/display#display-power-save-mode) (`display.sleep` / `display.wakeup`) not implemented yet for this display component.
+
 ## See Also
 
 - {{< docref "index/" >}}

--- a/content/components/display/qspi_dbi.md
+++ b/content/components/display/qspi_dbi.md
@@ -221,7 +221,7 @@ touchscreen:
 
 ## Sleep/Wakeup support
 
-[Sleep / Wakeup actions](/components/display#display-power-save-mode) (`display.sleep` / `display.wakeup`) are supported for this display type.
+[Sleep / Wakeup actions](/components/display#display-power-save-mode) (`display.sleep` / `display.wakeup`) are not supported for this display type since it is deprecated. Move to {{< docref "mipi_spi" >}} for support
 
 ## See Also
 

--- a/content/components/display/qspi_dbi.md
+++ b/content/components/display/qspi_dbi.md
@@ -219,6 +219,10 @@ touchscreen:
     mirror_y: true
 ```
 
+## Sleep/Wakeup support
+
+[Sleep / Wakeup actions](/components/display#display-power-save-mode) (`display.sleep` / `display.wakeup`) are supported for this display type.
+
 ## See Also
 
 - {{< docref "index/" >}}

--- a/content/components/display/rpi_dpi_rgb.md
+++ b/content/components/display/rpi_dpi_rgb.md
@@ -198,6 +198,10 @@ display:
         - 1         #b5
 ```
 
+## Sleep/Wakeup support
+
+[Sleep / Wakeup actions](/components/display#display-power-save-mode) (`display.sleep` / `display.wakeup`) not implemented yet for this display component.
+
 ## See Also
 
 - {{< docref "index/" >}}

--- a/content/components/display/sdl.md
+++ b/content/components/display/sdl.md
@@ -95,6 +95,11 @@ Linux instructions above. See <https://learn.microsoft.com/en-us/windows/wsl/ins
 
 The `esphome run yourfile.yaml` command will compile and automatically run the build file on the `host` platform.
 
+## Sleep/Wakeup support
+
+[Sleep / Wakeup actions](/components/display#display-power-save-mode) (`display.sleep` / `display.wakeup`) not implemented for this display component
+since it is more intended for design/testing.
+
 ## See Also
 
 - [SDL touchscreen](/components/touchscreen/sdl#sdl_touchscreen)

--- a/content/components/display/ssd1306.md
+++ b/content/components/display/ssd1306.md
@@ -163,6 +163,10 @@ display:
 
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID used for code generation.
 
+## Sleep/Wakeup support
+
+[Sleep / Wakeup actions](/components/display#display-power-save-mode) (`display.sleep` / `display.wakeup`) not implemented yet for this display component.
+
 ## See Also
 
 - {{< docref "index/" >}}

--- a/content/components/display/ssd1322.md
+++ b/content/components/display/ssd1322.md
@@ -53,6 +53,10 @@ display:
 - **pages** (*Optional*, list): Show pages instead of a single lambda. See [Display Pages](/components/display#display-pages).
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID used for code generation.
 
+## Sleep/Wakeup support
+
+[Sleep / Wakeup actions](/components/display#display-power-save-mode) (`display.sleep` / `display.wakeup`) not implemented yet for this display component.
+
 ## See Also
 
 - {{< docref "index/" >}}

--- a/content/components/display/ssd1325.md
+++ b/content/components/display/ssd1325.md
@@ -137,6 +137,10 @@ display:
 The last argument of the `Color` constructor is the intensity of the white element; it is a percentage
 (value of range 0 to 1). It may be defined by another variable so it is adjustable in code.
 
+## Sleep/Wakeup support
+
+[Sleep / Wakeup actions](/components/display#display-power-save-mode) (`display.sleep` / `display.wakeup`) not implemented yet for this display component.
+
 ## See Also
 
 - {{< docref "index/" >}}

--- a/content/components/display/ssd1327.md
+++ b/content/components/display/ssd1327.md
@@ -190,6 +190,10 @@ display:
 The last argument of the `Color` constructor is the intensity of the white element; it is a percentage
 (value of range 0 to 1). It may be defined by another variable so it is adjustable in code.
 
+## Sleep/Wakeup support
+
+[Sleep / Wakeup actions](/components/display#display-power-save-mode) (`display.sleep` / `display.wakeup`) not implemented yet for this display component.
+
 ## See Also
 
 - {{< docref "index/" >}}

--- a/content/components/display/ssd1331.md
+++ b/content/components/display/ssd1331.md
@@ -87,6 +87,10 @@ display:
       it.image(0, 0, id(my_image));
 ```
 
+## Sleep/Wakeup support
+
+[Sleep / Wakeup actions](/components/display#display-power-save-mode) (`display.sleep` / `display.wakeup`) not implemented yet for this display component.
+
 ## See Also
 
 - {{< docref "index/" >}}

--- a/content/components/display/ssd1351.md
+++ b/content/components/display/ssd1351.md
@@ -93,6 +93,10 @@ display:
       it.image(0, 0, id(my_image));
 ```
 
+## Sleep/Wakeup support
+
+[Sleep / Wakeup actions](/components/display#display-power-save-mode) (`display.sleep` / `display.wakeup`) not implemented yet for this display component.
+
 ## See Also
 
 - {{< docref "index/" >}}

--- a/content/components/display/st7567.md
+++ b/content/components/display/st7567.md
@@ -164,6 +164,10 @@ display:
       it.print(0, 0, id(my_font), "Hello World!");
 ```
 
+## Sleep/Wakeup support
+
+[Sleep / Wakeup actions](/components/display#display-power-save-mode) (`display.sleep` / `display.wakeup`) not implemented yet for this display component.
+
 ## See Also
 
 - {{< docref "index/" >}}

--- a/content/components/display/st7701s.md
+++ b/content/components/display/st7701s.md
@@ -180,7 +180,7 @@ display:
 
 ## Sleep/Wakeup support
 
-[Sleep / Wakeup actions](/components/display#display-power-save-mode) (`display.sleep` / `display.wakeup`) are supported for this display component.
+[Sleep / Wakeup actions](/components/display#display-power-save-mode) (`display.sleep` / `display.wakeup`) are not supported for this display component since it is deprecated. Migrate to {{< docref "mipi_rgb" >}} for support.
 
 ## See Also
 

--- a/content/components/display/st7701s.md
+++ b/content/components/display/st7701s.md
@@ -178,6 +178,10 @@ display:
       it.print(0, 0, id(my_font), id(my_red), TextAlign::TOP_LEFT, "Hello World!");
 ```
 
+## Sleep/Wakeup support
+
+[Sleep / Wakeup actions](/components/display#display-power-save-mode) (`display.sleep` / `display.wakeup`) are supported for this display component.
+
 ## See Also
 
 - {{< docref "index/" >}}

--- a/content/components/display/st7735.md
+++ b/content/components/display/st7735.md
@@ -79,6 +79,10 @@ display:
 - INITR_18BLACKTAB
 - INITR_18REDTAB
 
+## Sleep/Wakeup support
+
+[Sleep / Wakeup actions](/components/display#display-power-save-mode) (`display.sleep` / `display.wakeup`) not implemented yet for this display component.
+
 ## See Also
 
 - [SPI Bus](/components/spi)

--- a/content/components/display/st7789v.md
+++ b/content/components/display/st7789v.md
@@ -295,6 +295,10 @@ display:
       }
 ```
 
+## Sleep/Wakeup support
+
+[Sleep / Wakeup actions](/components/display#display-power-save-mode) (`display.sleep` / `display.wakeup`) not implemented yet for this display component.
+
 ## See Also
 
 - {{< docref "index/" >}}

--- a/content/components/display/st7920.md
+++ b/content/components/display/st7920.md
@@ -52,6 +52,10 @@ display:
 - **pages** (*Optional*, list): Show pages instead of a single lambda. See [Display Pages](/components/display#display-pages).
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID used for code generation.
 
+## Sleep/Wakeup support
+
+[Sleep / Wakeup actions](/components/display#display-power-save-mode) (`display.sleep` / `display.wakeup`) not implemented yet for this display component.
+
 ## See Also
 
 - {{< docref "index/" >}}

--- a/content/components/display/tm1621.md
+++ b/content/components/display/tm1621.md
@@ -80,6 +80,10 @@ Also we have five function to display or not some unites:
 - V on the first line and A on the second line : `display_voltage(bool)`
 - kW/h on the first line and W on the second line : `display_kwh(bool)`
 
+## Sleep/Wakeup support
+
+[Sleep / Wakeup actions](/components/display#display-power-save-mode) (`display.sleep` / `display.wakeup`) not implemented yet for this display component.
+
 ## See Also
 
 - {{< docref "index/" >}}

--- a/content/components/display/tm1637.md
+++ b/content/components/display/tm1637.md
@@ -179,6 +179,10 @@ The last displays Dio pin shares the Clk pin of the first display.
 
 {{< img src="tm1637_3plus_devices.png" alt="Image" caption="Three TM1637 displays on 3 control lines" width="50.0%" class="align-center" >}}
 
+## Sleep/Wakeup support
+
+[Sleep / Wakeup actions](/components/display#display-power-save-mode) (`display.sleep` / `display.wakeup`) not implemented yet for this display component.
+
 ## See Also
 
 - {{< docref "index/" >}}

--- a/content/components/display/tm1638.md
+++ b/content/components/display/tm1638.md
@@ -167,6 +167,10 @@ binary_sensor:
         - output.turn_off: TM1638Led2
 ```
 
+## Sleep/Wakeup support
+
+[Sleep / Wakeup actions](/components/display#display-power-save-mode) (`display.sleep` / `display.wakeup`) not implemented yet for this display component.
+
 ## See Also
 
 - {{< docref "index/" >}}

--- a/content/components/display/waveshare_epaper.md
+++ b/content/components/display/waveshare_epaper.md
@@ -159,6 +159,10 @@ lambda: |-
 
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID used for code generation.
 
+## Sleep/Wakeup support
+
+[Sleep / Wakeup actions](/components/display#display-power-save-mode) (`display.sleep` / `display.wakeup`) not implemented yet for this display component.
+
 ## See Also
 
 - {{< docref "index/" >}}


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
