### PR TITLE
[climate] Document public accessor methods for custom modes in 2025.11.0 release

### DIFF
--- a/content/changelog/2025.11.0.md
+++ b/content/changelog/2025.11.0.md
@@ -419,6 +419,12 @@ Users who access component members directly in YAML lambdas may need updates:
 - **Fan**: Change `id(my_fan).preset_mode` to `id(my_fan).get_preset_mode()`. [#11632](https://github.com/esphome/esphome/pull/11632)
 
 - **Event**: Change `id(my_event).last_event_type` to `id(my_event).get_last_event_type()`. [#11767](https://github.com/esphome/esphome/pull/11767)
+
+- **Climate**: Custom mode members are now private. Change direct access to public accessor methods:
+  - Check if active: `id(my_climate).custom_fan_mode.has_value()` → `id(my_climate).has_custom_fan_mode()`, `id(my_climate).custom_preset.has_value()` → `id(my_climate).has_custom_preset()`
+  - Get value: `id(my_climate).custom_fan_mode.value()` → `id(my_climate).get_custom_fan_mode()`, `id(my_climate).custom_preset.value()` → `id(my_climate).get_custom_preset()`
+
+  [#11621](https://github.com/esphome/esphome/pull/11621)
 <!-- BREAKING_CHANGES_USERS_END -->
 
 ### Breaking Changes for Developers
@@ -447,7 +453,7 @@ See the [Climate Entity Class: FiniteSetMask and Flash Storage Optimizations](ht
 
 - **Custom modes storage**: Changed from `std::set<std::string>` to `FiniteSetMask` for supported modes, and from `std::vector<std::string>` to `std::vector<const char *>` for custom fan modes and presets. [#11466](https://github.com/esphome/esphome/pull/11466), [#11621](https://github.com/esphome/esphome/pull/11621)
 
-- **Member access**: Climate device members (`custom_fan_mode_`, `custom_preset_`) are now private. Use protected setter methods (`set_custom_fan_mode_()`, `set_custom_preset_()`) in derived classes. [#11621](https://github.com/esphome/esphome/pull/11621)
+- **Member access**: Climate device members (`custom_fan_mode_`, `custom_preset_`) are now private. Use protected setter methods (`set_custom_fan_mode_()`, `set_custom_preset_()`) in derived classes. Use public accessor methods to read values: `has_custom_fan_mode()`, `get_custom_fan_mode()`, `has_custom_preset()`, `get_custom_preset()`. [#11621](https://github.com/esphome/esphome/pull/11621)
 
 - **Deprecated methods**: Removed methods deprecated in 1.20 (July 2021). [#11388](https://github.com/esphome/esphome/pull/11388)
 

--- a/content/components/climate/_index.md
+++ b/content/components/climate/_index.md
@@ -234,17 +234,41 @@ advanced stuff.
     id(my_climate).target_humidity
     // Fan mode, type: FanMode (enum)
     id(my_climate).fan_mode
-    // Custom Fan mode, type: string
-    id(my_climate).custom_fan_mode
     // Swing mode, type: SwingMode (enum)
     id(my_climate).swing_mode
     // Current action (currentl on idle, cooling, heating, etc.), ClimateAction (enum)
     id(my_climate).action
     // Preset, type: Preset (enum)
     id(my_climate).preset
-    // Custom Preset, type: string
-    id(my_climate).custom_preset
 ```
+
+- Custom mode accessor methods:
+
+```cpp
+    // Check if custom fan mode is active, type: bool
+    id(my_climate).has_custom_fan_mode()
+    // Get custom fan mode (read-only), type: const char*
+    id(my_climate).get_custom_fan_mode()
+    // Check if custom preset is active, type: bool
+    id(my_climate).has_custom_preset()
+    // Get custom preset (read-only), type: const char*
+    id(my_climate).get_custom_preset()
+```
+
+> [!WARNING]
+> Always check if a custom mode is active before accessing it. Calling `get_custom_fan_mode()` or `get_custom_preset()` when no custom mode is set will return `nullptr`, which can cause crashes if dereferenced.
+>
+> ```cpp
+> // Correct - check before accessing
+> if (id(my_climate).has_custom_fan_mode()) {
+>   const char* mode = id(my_climate).get_custom_fan_mode();
+>   // Now safe to use mode
+> }
+>
+> // Wrong - may crash if no custom mode is set
+> const char* mode = id(my_climate).get_custom_fan_mode();
+> ESP_LOGD("tag", "Mode: %s", mode);  // Crashes if mode is nullptr
+> ```
 
 - `.make_call`  : Control the climate device
 


### PR DESCRIPTION
## Description:

This PR adds missing documentation for the Climate entity's public accessor methods (`has_custom_fan_mode()`, `get_custom_fan_mode()`, `has_custom_preset()`, `get_custom_preset()`) that were introduced in PR #11621.

### Changes Made:

1. **Release Notes (2025.11.0.md) - YAML Lambda Changes Section**
   - Added Climate to the user-facing breaking changes with before/after migration examples
   - Shows migration from `custom_fan_mode.has_value()`/`custom_fan_mode.value()` to the new accessor methods

2. **Release Notes - Breaking Changes for Developers Section**
   - Updated the Climate member access bullet point to mention the public accessor methods alongside the protected setters

3. **Climate Entity Documentation (`content/components/climate/_index.md`)**
   - Removed deprecated direct member access examples for `custom_fan_mode` and `custom_preset` from the attributes list
   - Added new "Custom mode accessor methods" section documenting all four public accessor methods
   - Added prominent warning about nullptr safety when using the getter methods without checking first

### Technical Details:

The changes document the API transition from:
- **Old**: `optional<std::string> custom_fan_mode` (public member, direct access)
- **New**: `const char* custom_fan_mode_` (private member, accessor methods)

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- PR#11621 (not linked because the bot kept complaining)

## Checklist:

  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook. *(N/A - updating existing documentation)*
