### PR TITLE
Link blog post for network::get_use_address() migration in 2025.11.0 changelog

### DIFF
--- a/content/changelog/2025.11.0.md
+++ b/content/changelog/2025.11.0.md
@@ -487,9 +487,11 @@ See the [Event Entity Class: Memory Optimizations](https://developers.esphome.io
 
 ### Network Components
 
+See the [Network get_use_address() Optimization](https://developers.esphome.io/blog/2025/11/20/network-use-address-optimization/) blog post for migration details.
+
 - **WiFi scan results**: External components that access WiFi scan results after connection must call `wifi.request_wifi_scan_results()` in their `to_code()` function to prevent cleanup. [#11205](https://github.com/esphome/esphome/pull/11205)
 
-- **use_address**: Changed from `const std::string &` to `const char *` in WiFi, Ethernet, and OpenThread components. Update external components calling `get_use_address()` or `set_use_address()`. [#11707](https://github.com/esphome/esphome/pull/11707)
+- **use_address**: Changed from `const std::string &` to `const char *` in WiFi, Ethernet, and OpenThread components. Remove `.c_str()` calls when using `get_use_address()`. [#11707](https://github.com/esphome/esphome/pull/11707)
 
 ### Other Components
 


### PR DESCRIPTION
dev pr https://github.com/esphome/developers.esphome.io/pull/78

## Description:

Updates the 2025.11.0 changelog to reference the new blog post documenting the `network::get_use_address()` breaking change migration. The blog post provides comprehensive examples for external component authors including version compatibility patterns and real-world usage.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

N/A

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
