### PR TITLE
[changelog] Fix blog post links in 2025.11.0 changelog

### DIFF
--- a/content/changelog/2025.11.0.md
+++ b/content/changelog/2025.11.0.md
@@ -429,7 +429,7 @@ The following changes affect external component developers. Standard YAML config
 
 ## Core Framework Changes
 
-- **Action/Trigger Framework**: All action/trigger/condition method signatures changed to use const references (`const Ts&... x`) instead of pass-by-value (`Ts... x`). See the [Action Framework Performance Optimization](https://developers.esphome.io/blog/2025/11/action-framework-performance-optimization.html) blog post for migration details. [#11704](https://github.com/esphome/esphome/pull/11704)
+- **Action/Trigger Framework**: All action/trigger/condition method signatures changed to use const references (`const Ts&... x`) instead of pass-by-value (`Ts... x`). See the [Action Framework Performance Optimization](https://developers.esphome.io/blog/2025/11/06/action-framework-performance-optimization/) blog post for migration details. [#11704](https://github.com/esphome/esphome/pull/11704)
 
 - **Controller API**: Controllers now use global registry pattern. Method signatures changed to remove unused state parameters (e.g., `on_sensor_update(sensor::Sensor *obj)` instead of `on_sensor_update(sensor::Sensor *obj, float state)`). External controller implementations extremely rare. [#11772](https://github.com/esphome/esphome/pull/11772)
 
@@ -443,7 +443,7 @@ The following changes affect external component developers. Standard YAML config
 
 ### Climate
 
-See the [Climate Entity Class: FiniteSetMask and Flash Storage Optimizations](https://developers.esphome.io/blog/2025/11/climate-entity-class-memory-optimizations.html) blog post for migration details.
+See the [Climate Entity Class: FiniteSetMask and Flash Storage Optimizations](https://developers.esphome.io/blog/2025/11/07/climate-entity-class-finitesetmask-and-flash-storage-optimizations/) blog post for migration details.
 
 - **Custom modes storage**: Changed from `std::set<std::string>` to `FiniteSetMask` for supported modes, and from `std::vector<std::string>` to `std::vector<const char *>` for custom fan modes and presets. [#11466](https://github.com/esphome/esphome/pull/11466), [#11621](https://github.com/esphome/esphome/pull/11621)
 
@@ -453,7 +453,7 @@ See the [Climate Entity Class: FiniteSetMask and Flash Storage Optimizations](ht
 
 ### Light
 
-See the [Light Entity Class: Memory Optimizations](https://developers.esphome.io/blog/2025/11/light-entity-class-memory-optimizations.html) blog post for migration details.
+See the [Light Entity Class: Memory Optimizations](https://developers.esphome.io/blog/2025/11/07/light-entity-class-memory-optimizations/) blog post for migration details.
 
 - **Color modes**: Replaced `std::set<ColorMode>` with `ColorModeMask` bitmask class. [#11348](https://github.com/esphome/esphome/pull/11348)
 
@@ -463,7 +463,7 @@ See the [Light Entity Class: Memory Optimizations](https://developers.esphome.io
 
 ### Fan
 
-See the [Fan Entity Class: Preset Mode Flash Storage and Order Preservation](https://developers.esphome.io/blog/2025/11/fan-entity-class-memory-optimizations.html) blog post for migration details.
+See the [Fan Entity Class: Preset Mode Flash Storage and Order Preservation](https://developers.esphome.io/blog/2025/11/07/fan-entity-class-preset-mode-flash-storage-and-order-preservation/) blog post for migration details.
 
 - **Preset modes**: Changed from `std::set<std::string>` to `std::vector<const char *>`. The `.preset_mode` public member has been removed - use `get_preset_mode()` for reading and `set_preset_mode_()` for writing in derived classes. [#11483](https://github.com/esphome/esphome/pull/11483), [#11632](https://github.com/esphome/esphome/pull/11632)
 
@@ -471,7 +471,7 @@ See the [Fan Entity Class: Preset Mode Flash Storage and Order Preservation](htt
 
 ### Select
 
-See the [Select Entity Class: Index-Based Operations and Flash Storage](https://developers.esphome.io/blog/2025/11/select-entity-class-memory-optimizations.html) blog post for migration details.
+See the [Select Entity Class: Index-Based Operations and Flash Storage](https://developers.esphome.io/blog/2025/11/07/select-entity-class-index-based-operations-and-flash-storage/) blog post for migration details.
 
 - **Options storage**: Changed from `std::vector<std::string>` to `FixedVector<const char *>`. [#11514](https://github.com/esphome/esphome/pull/11514)
 
@@ -481,7 +481,7 @@ See the [Select Entity Class: Index-Based Operations and Flash Storage](https://
 
 ### Event
 
-See the [Event Entity Class: Memory Optimizations](https://developers.esphome.io/blog/2025/11/event-entity-class-memory-optimizations.html) blog post for migration details.
+See the [Event Entity Class: Memory Optimizations](https://developers.esphome.io/blog/2025/11/07/event-entity-class-memory-optimizations/) blog post for migration details.
 
 - **Event types storage**: Changed from `FixedVector<std::string>` to `FixedVector<const char *>`. The `last_event_type` field is now private - use `get_last_event_type()` getter instead. [#11463](https://github.com/esphome/esphome/pull/11463), [#11767](https://github.com/esphome/esphome/pull/11767)
 


### PR DESCRIPTION
## Description:

Fix incorrect blog post links in the 2025.11.0 changelog. All six blog post URLs were using the wrong format (`.html` extensions and missing date paths) and have been corrected to use the proper directory-style format with full date paths.

**Changed URLs:**
- Action Framework: `2025/11/action-framework-performance-optimization.html` → `2025/11/06/action-framework-performance-optimization/`
- Climate Entity: `2025/11/climate-entity-class-memory-optimizations.html` → `2025/11/07/climate-entity-class-finitesetmask-and-flash-storage-optimizations/`
- Light Entity: `2025/11/light-entity-class-memory-optimizations.html` → `2025/11/07/light-entity-class-memory-optimizations/`
- Fan Entity: `2025/11/fan-entity-class-memory-optimizations.html` → `2025/11/07/fan-entity-class-preset-mode-flash-storage-and-order-preservation/`
- Select Entity: `2025/11/select-entity-class-memory-optimizations.html` → `2025/11/07/select-entity-class-index-based-operations-and-flash-storage/`
- Event Entity: `2025/11/event-entity-class-memory-optimizations.html` → `2025/11/07/event-entity-class-memory-optimizations/`

All URLs have been verified to load correctly.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** N/A

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
