### PR TITLE
ESPNow fixes

### DIFF
--- a/content/components/espnow.md
+++ b/content/components/espnow.md
@@ -10,8 +10,8 @@ params:
 The ESPNow component allows ESPHome to communicate with esp32 devices in a simple and unrestricted way.
 It enables the option to interact with other esp32 devices over the Espressif's ESP-NOW protocol, see
 [documentation](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/network/esp_now.html).
-It can be used with the [Packet Transport Component](/components/packet_transport#packet-transport) to broadcast
-sensor data.
+It can be used with the [Packet Transport Component](/components/packet_transport/espnow) to broadcast
+sensor data, see [ESP-NOW Packet Transport Platform](/components/packet_transport/espnow).
 
 > [!NOTE]
 > Broadcasting data is not recommended, this will also reach devices not controlled by you that use the esp-now protocol.

--- a/content/components/espnow.md
+++ b/content/components/espnow.md
@@ -7,9 +7,11 @@ params:
     image: esp-now.svg
 ---
 
-This component allows ESPHome to communicate with esp32 devices in a simple and unrestricted way.
+The ESPNow component allows ESPHome to communicate with esp32 devices in a simple and unrestricted way.
 It enables the option to interact with other esp32 devices over the Espressif's ESP-NOW protocol, see
-[documentation](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/network/esp_now.html)
+[documentation](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/network/esp_now.html).
+It can be used with the [Packet Transport Component](/components/packet_transport#packet-transport) to broadcast
+sensor data.
 
 > [!NOTE]
 > Broadcasting data is not recommended, this will also reach devices not controlled by you that use the esp-now protocol.

--- a/content/components/espnow.md
+++ b/content/components/espnow.md
@@ -215,3 +215,4 @@ automatically add any peer that data is sent to.
 ## See Also
 
 - {{< apiref "espnow/espnow.h" "espnow/espnow.h" >}}
+- {{< docref "/components/packet_transport/espnow" >}}

--- a/content/components/espnow.md
+++ b/content/components/espnow.md
@@ -10,7 +10,7 @@ params:
 The ESPNow component allows ESPHome to communicate with esp32 devices in a simple and unrestricted way.
 It enables the option to interact with other esp32 devices over the Espressif's ESP-NOW protocol, see
 [documentation](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/network/esp_now.html).
-It can be used with the [Packet Transport Component](/components/packet_transport/espnow) to broadcast
+It can be used with the [Packet Transport Component](/components/packet_transport) to broadcast
 sensor data, see [ESP-NOW Packet Transport Platform](/components/packet_transport/espnow).
 
 > [!NOTE]

--- a/content/components/packet_transport/espnow.md
+++ b/content/components/packet_transport/espnow.md
@@ -9,12 +9,17 @@ params:
 
 {{< anchor "espnow-packet-transport" >}}
 
-The [Packet Transport Component](#packet-transport) platform allows ESPHome nodes to directly communicate with each over a communication channel. The ESP-NOW implementation of the platform uses ESP-NOW as a communication medium. See the [Packet Transport Component](#packet-transport) and {{< docref "/components/espnow" >}} for more information.
+The [Packet Transport Component](#packet-transport) platform allows ESPHome nodes to directly communicate with each
+over a communication channel. The ESP-NOW implementation of the platform uses ESP-NOW as a communication medium.
+See the [Packet Transport Component](#packet-transport) and {{< docref "/components/espnow" >}} for more information.
 
-ESP-NOW provides low-latency, low-power wireless communication between ESP32 devices without requiring a Wi-Fi connection. This makes it ideal for battery-powered sensors or applications where Wi-Fi overhead would impact performance.
+ESP-NOW provides low-latency, low-power wireless communication between ESP32 devices without requiring a Wi-Fi
+connection. This makes it ideal for battery-powered sensors or applications where Wi-Fi overhead would impact
+performance.
 
 > **Note:**  
-> ESP-NOW communication occurs independently of Wi-Fi. Devices can communicate via ESP-NOW even when Wi-Fi is disabled, making it suitable for power-sensitive applications.
+> ESP-NOW communication occurs independently of Wi-Fi. Devices can communicate via ESP-NOW even when Wi-Fi is
+> disabled, making it suitable for power-sensitive applications.
 
 ## Example Configuration
 
@@ -64,10 +69,12 @@ packet_transport:
       - sensor_id
 ```
 
-All devices with the broadcast address (`FF:FF:FF:FF:FF:FF`) registered as a peer will receive the packets. This is useful for hub-and-spoke topologies where multiple devices monitor a single sensor source.
+All devices with the broadcast address (`FF:FF:FF:FF:FF:FF`) registered as a peer will receive the packets.
+This is useful for hub-and-spoke topologies where multiple devices monitor a single sensor source.
 
 > **Warning:**  
-> Using broadcast mode increases ESP-NOW traffic on the radio channel, which may impact performance of other ESP-NOW devices in range. Use specific peer addresses whenever possible to minimize interference.
+> Using broadcast mode increases ESP-NOW traffic on the radio channel, which may impact performance of other
+> ESP-NOW devices in range. Use specific peer addresses whenever possible to minimize interference.
 
 ### Unicast Mode
 
@@ -79,7 +86,8 @@ packet_transport:
       - sensor_id
 ```
 
-Only the specified peer receives the packets. This is more efficient for point-to-point communication and reduces radio channel congestion for neighboring ESP-NOW devices.
+Only the specified peer receives the packets. This is more efficient for point-to-point communication and reduces
+radio channel congestion for neighboring ESP-NOW devices.
 
 ## Simple Example
 
@@ -90,11 +98,11 @@ This example shows two devices exchanging sensor data over ESP-NOW with encrypti
 ```yaml
 espnow:
   peers:
-    - mac_address: "AA:BB:CC:DD:EE:01"  # Device 2
+    - "AA:BB:CC:DD:EE:01"  # Consumer device
 
 packet_transport:
   - platform: espnow
-    peer_address: "AA:BB:CC:DD:EE:01"  # Send to Device 2
+    peer_address: "AA:BB:CC:DD:EE:01"  # Consumer device
     encryption: "MySecretKey123"
     sensors:
       - outdoor_temp
@@ -111,7 +119,7 @@ sensor:
 ```yaml
 espnow:
   peers:
-    - mac_address: "AA:BB:CC:DD:EE:00"  # Device 1
+    - "AA:BB:CC:DD:EE:00"  # Provider device
 
 packet_transport:
   - platform: espnow
@@ -136,7 +144,9 @@ This example shows a central hub receiving sensor data from multiple remote devi
 ```yaml
 espnow:
   peers:
-    - mac_address: "FF:FF:FF:FF:FF:FF"
+    - "AA:BB:CC:DD:EE:01"  # room-sensor-1
+    - "AA:BB:CC:DD:EE:02"  # room-sensor-2
+    - "AA:BB:CC:DD:EE:03"  # outdoor-sensor
 
 packet_transport:
   - platform: espnow
@@ -167,12 +177,9 @@ sensor:
 
 ```yaml
 espnow:
-  peers:
-    - mac_address: "FF:FF:FF:FF:FF:FF"
 
 packet_transport:
   - platform: espnow
-    peer_address: "FF:FF:FF:FF:FF:FF"
     encryption: "HubSecret123"
     sensors:
       - temperature

--- a/content/components/packet_transport/espnow.md
+++ b/content/components/packet_transport/espnow.md
@@ -98,11 +98,11 @@ This example shows two devices exchanging sensor data over ESP-NOW with encrypti
 ```yaml
 espnow:
   peers:
-    - "AA:BB:CC:DD:EE:01"  # Consumer device
+    - "AA:BB:CC:DD:EE:01"  # Consumer mac address
 
 packet_transport:
   - platform: espnow
-    peer_address: "AA:BB:CC:DD:EE:01"  # Consumer device
+    peer_address: "AA:BB:CC:DD:EE:01"  # Consumer mac address
     encryption: "MySecretKey123"
     sensors:
       - outdoor_temp
@@ -119,13 +119,13 @@ sensor:
 ```yaml
 espnow:
   peers:
-    - "AA:BB:CC:DD:EE:00"  # Provider device
+    - "AA:BB:CC:DD:EE:00"  # Provider mac address
 
 packet_transport:
   - platform: espnow
     encryption: "MySecretKey123"
     providers:
-      - name: temp-sensor
+      - name: temp-sensor  # Provider device name
 
 sensor:
   - platform: packet_transport
@@ -144,9 +144,9 @@ This example shows a central hub receiving sensor data from multiple remote devi
 ```yaml
 espnow:
   peers:
-    - "AA:BB:CC:DD:EE:01"  # room-sensor-1
-    - "AA:BB:CC:DD:EE:02"  # room-sensor-2
-    - "AA:BB:CC:DD:EE:03"  # outdoor-sensor
+    - "AA:BB:CC:DD:EE:01"  # room-sensor-1 mac address
+    - "AA:BB:CC:DD:EE:02"  # room-sensor-2 mac address
+    - "AA:BB:CC:DD:EE:03"  # outdoor-sensor mac address
 
 packet_transport:
   - platform: espnow

--- a/content/components/packet_transport/espnow.md
+++ b/content/components/packet_transport/espnow.md
@@ -49,7 +49,7 @@ sensor:
 - **espnow_id** (**Required**, [ID](#config-id)): The esp-now ID to use for transport.
 - **peer_address** (*Optional*, MAC Address): MAC address to send packets to. This can be either a specific
   peer address for point-to-point communication, or the broadcast address. Default FF:FF:FF:FF:FF:FF
-- All other options from the [Packet Transport Component](#packet-transport)
+- All other options from the [Packet Transport Component](/components/packet_transport)
 
 > **Note:**  
 > Peers must be registered with the {{< docref "/components/espnow" >}} component before
@@ -192,7 +192,7 @@ sensor:
 
 ## See Also
 
-- [Packet Transport Component](#packet-transport)
+- [Packet Transport Component](/components/packet_transport)
 - {{< docref "/components/espnow" >}}
 - {{< docref "/components/binary_sensor/packet_transport" >}}
 - {{< docref "/components/sensor/packet_transport" >}}


### PR DESCRIPTION
## Description:

ESPNow fixes:
- add a link to espnow packet transport from the main espnow docs
- peers do not start with `mac_address`
- adding `FF:FF:FF:FF:FF:FF` as a  peer does nothing
- fix line lengths

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
