### PR TITLE
[mipi_spi] Add JC4827W543 mipi_spi display

### DIFF
--- a/content/components/display/mipi_spi.md
+++ b/content/components/display/mipi_spi.md
@@ -73,6 +73,7 @@ using an octal SPI bus, so references here to parallel and octal SPI are equival
 | JC3248W535                           | Guition | <https://www.aliexpress.com/item/1005007566332450.html> |
 | JC3636W518                           | Guition | <https://www.aliexpress.com/item/1005007890666293.html> |
 | JC3636W518V2                         | Guition | <https://www.aliexpress.com/item/1005007890666293.html> |
+| JC4827W543                           | Guition | <https://www.aliexpress.com/item/1005006729377800.html> |
 | LANBON-L8                            | Lanbon | <https://www.lanbon.cn/product/lanbon-l8> |
 | T4-S3                                | Lilygo | <https://www.lilygo.cc/products/t4-s3> |
 | T-EMBED                              | Lilygo | <https://www.lilygo.cc/products/t-embed> |


### PR DESCRIPTION
## Description:

Document JC4827W543 as a board you can use with mipi_spi

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#12034

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

