### PR TITLE
Fix example state logging for binary sensor values

### DIFF
--- a/content/components/binary_sensor/_index.md
+++ b/content/components/binary_sensor/_index.md
@@ -322,10 +322,10 @@ binary_sensor:
       then:
       - logger.log:
           format: "Old state was %s"
-          args: ['x_previous.has_value() ? ONOFF(x_previous) : "Unknown"']
+          args: ['x_previous.has_value() ? ONOFF(x_previous.value()) : "Unknown"']
       - logger.log:
           format: "New state is %s"
-          args: ['x.has_value() ? ONOFF(x) : "Unknown"']
+          args: ['x.has_value() ? ONOFF(x.value()) : "Unknown"']
 ```
 
 Configuration variables: See [Automation](/automations).


### PR DESCRIPTION


## Description:

Fix exemple state logging for binary sensor values because the conversion from optional<bool> to bool return always true, it is needed to call the value member.

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

