### PR TITLE
Update networking instructions for ESPHome

### DIFF
--- a/src/content/docs/guides/faq.mdx
+++ b/src/content/docs/guides/faq.mdx
@@ -516,7 +516,7 @@ services:
 
 <span id="docker-reference-notes"></span>
 
-> > [!NOTE]
+> [!NOTE]
 > By default, ESPHome uses mDNS to resolve device IPs on the network; this is used to determine online/offline state
 > in the [ESPHome Device Builder](/guides/getting_started_hassio#installing-esphome-device-builder). In order for this feature to work, you
 > must either use Docker's [host](https://docs.docker.com/network/drivers/host/) networking mode or create [macvlan](https://docs.docker.com/engine/network/drivers/macvlan/)/[ipvlan](https://docs.docker.com/engine/network/drivers/ipvlan/) networks.

--- a/src/content/docs/guides/faq.mdx
+++ b/src/content/docs/guides/faq.mdx
@@ -516,15 +516,19 @@ services:
 
 <span id="docker-reference-notes"></span>
 
-> [!NOTE]
+> > [!NOTE]
 > By default, ESPHome uses mDNS to resolve device IPs on the network; this is used to determine online/offline state
 > in the [ESPHome Device Builder](/guides/getting_started_hassio#installing-esphome-device-builder). In order for this feature to work, you
-> must use Docker's host networking mode.
+> must either use Docker's [host](https://docs.docker.com/network/drivers/host/) networking mode or create [macvlan](https://docs.docker.com/engine/network/drivers/macvlan/)/[ipvlan](https://docs.docker.com/engine/network/drivers/ipvlan/) networks.
 >
-> The [host networking driver](https://docs.docker.com/network/drivers/host/) only works on Linux hosts; it is
+> The [host networking driver](https://docs.docker.com/engine/network/drivers/host/) only works on Linux hosts; it is
 > available on Docker Desktop version 4.29 and later.
 >
-> If you don't want to use the host networking driver, you have to use an alternate method as described below.
+> When working with multiple network interfaces, you can specify which interface the dashboard should bind to by setting the environment
+> variable `DASHBOARD_LISTENING_NETWORK_INTERFACE`. This is particularly useful when using a reverse proxy: the dashboard can be exposed
+> through the reverse proxy on one network while managing devices on another.
+>
+> If you cannot use docker any of those networking based solutions, you have to use an alternate method as described below.
 >
 > Note that mDNS might not work if your Home Assistant server and your ESPHome nodes are on different subnets
 > and/or VLANs. If your router supports Avahi, you can configure mDNS to work across different subnets.

--- a/src/content/docs/guides/getting_started_command_line.mdx
+++ b/src/content/docs/guides/getting_started_command_line.mdx
@@ -42,6 +42,14 @@ services:
       - USERNAME=test
       - PASSWORD=ChangeMe
 ```
+Docker specific environment variables:
+
+| Name | Default value | Description |
+|-----|------|------|
+| DASHBOARD_LISTENING_NETWORK_INTERFACE | `not set` | Network interface the dashboard listens on. This is mainly useful for advanced networking setups, such as when exposing the dashboard through a reverse proxy while the container is attached to a [macvlan](https://docs.docker.com/engine/network/drivers/macvlan/) or [ipvlan](https://docs.docker.com/engine/network/drivers/ipvlan/) network.)|
+
+In addition to the variables listed above, all other supported [ESPHome environment variables](https://github.com/esphome/feature-requests/issues/2759) can also be defined at the container level.
+
 
 > [!NOTE]
 > If you are using NFS share to back your container's config volume, you may


### PR DESCRIPTION
## Description:
Document the new env variable that allow to specify a listening network interface for the dashboard

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- https://github.com/esphome/esphome/pull/11876

## Checklist:

  - [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  

I did purposely not prefix the env var with `esphome` like the other - as this one does not alter the behavior or esphome itself. It only affects the way the docket init script instantiate `esphome`. I can totally rename if you have a better idea