### PR TITLE
2025.11.1

### DIFF
--- a/content/changelog/2025.11.0.md
+++ b/content/changelog/2025.11.0.md
@@ -518,6 +518,25 @@ The 2025.11 release blog posts include comprehensive migration examples for comm
 
 <!-- markdownlint-disable MD013 -->
 
+## Release 2025.11.1 - November 24
+
+<details>
+<summary></summary>
+
+- [graph] Fix legend border [esphome#12000](https://github.com/esphome/esphome/pull/12000) by [@swoboda1337](https://github.com/swoboda1337)
+- [network] Fix IPAddress constructor causing comparison failures and garbage output [esphome#12005](https://github.com/esphome/esphome/pull/12005) by [@bdraco](https://github.com/bdraco)
+- [ltr501][ltr_als_ps] Rename enum to avoid collision with lwip defines [esphome#12017](https://github.com/esphome/esphome/pull/12017) by [@swoboda1337](https://github.com/swoboda1337)
+- [cst816][packet_transport][udp][wake_on_lan] Fix error messages [esphome#12019](https://github.com/esphome/esphome/pull/12019) by [@swoboda1337](https://github.com/swoboda1337)
+- [jsn_sr04t] Fix model AJ_SR04M [esphome#11992](https://github.com/esphome/esphome/pull/11992) by [@swoboda1337](https://github.com/swoboda1337)
+- [cst816][http_request] Fix status_set_error() dangling pointer bugs [esphome#12033](https://github.com/esphome/esphome/pull/12033) by [@bdraco](https://github.com/bdraco)
+- [esp32] Fix C2 builds [esphome#12050](https://github.com/esphome/esphome/pull/12050) by [@swoboda1337](https://github.com/swoboda1337)
+- [core] Add support for passing yaml files to clean-all [esphome#12039](https://github.com/esphome/esphome/pull/12039) by [@swoboda1337](https://github.com/swoboda1337)
+- [script][wait_until] Fix FIFO ordering and reentrancy bugs [esphome#12049](https://github.com/esphome/esphome/pull/12049) by [@bdraco](https://github.com/bdraco)
+- [esp_ldo,mipi_dsi,mipi_rgb] Fix dangling pointer bugs in mark_failed() [esphome#12077](https://github.com/esphome/esphome/pull/12077) by [@bdraco](https://github.com/bdraco)
+- [online_image] Fix some large PNGs causing watchdog timeout [esphome#12025](https://github.com/esphome/esphome/pull/12025) by [@jesserockz](https://github.com/jesserockz)
+
+</details>
+
 ## Full list of changes
 
 ### New Features

--- a/content/components/esphome.md
+++ b/content/components/esphome.md
@@ -52,6 +52,9 @@ Advanced options:
 - **platformio_options** (*Optional*, mapping): Additional options to pass over to PlatformIO in the
   platformio.ini file. See [`platformio_options`](#esphome-platformio_options).
 
+- **environment_variables** (*Optional*, mapping): Environment variables to set during the build process.
+  See [`environment_variables`](#esphome-environment_variables).
+
 - **includes** (*Optional*, list of files): A list of C/C++ files to include in the (auto-generated) `main` file.
   The paths in this list are relative to the directory where the YAML configuration file is located or `<...>` includes.
   See [`includes`](#esphome-includes).
@@ -191,6 +194,27 @@ esphome:
     upload_speed: 115200
     board_build.f_flash: 80000000L
 ```
+
+{{< anchor "esphome-environment_variables" >}}
+
+## `environment_variables`
+
+With the `environment_variables` option, you can set environment variables that will be available during the
+compilation process. This is useful when you need to pass configuration to build scripts, custom libraries,
+or PlatformIO build environments.
+
+```yaml
+# Example configuration entry
+esphome:
+  # ...
+  environment_variables:
+    HTTP_PROXY: "http://user:pass@10.10.1.10:3128/"
+    PLATFORMIO_SETTING_ENABLE_PROXY_STRICT_SSL: "false"
+```
+
+> [!NOTE]
+> Environment variables set here are only available during the build process. They do not affect
+> the runtime behavior of your device.
 
 {{< anchor "esphome-includes" >}}
 

--- a/content/guides/supporters.md
+++ b/content/guides/supporters.md
@@ -109,6 +109,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [alva (@alva-seal)](https://github.com/alva-seal)
 - [Amaery (@Amaery)](https://github.com/Amaery)
 - [Andreas Mandel (@amandel)](https://github.com/amandel)
+- [Aman kumar (@amankrokx)](https://github.com/amankrokx)
 - [Andrew McFague (@amcfague)](https://github.com/amcfague)
 - [Amish Vishwakarma (@amishv)](https://github.com/amishv)
 - [Amit Keret (@amitkeret)](https://github.com/amitkeret)
@@ -1077,6 +1078,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Jaakko Paju (@jpaju)](https://github.com/jpaju)
 - [Javier Peletier (@jpeletier)](https://github.com/jpeletier)
 - [Jan Rieger (@jrieger)](https://github.com/jrieger)
+- [Joseph Spiros (@jspiros)](https://github.com/jspiros)
 - [jsuanet (@jsuanet)](https://github.com/jsuanet)
 - [James Szalay (@jtszalay)](https://github.com/jtszalay)
 - [Juan Antonio Aldea (@JuantAldea)](https://github.com/JuantAldea)
@@ -2273,4 +2275,4 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Christian Zufferey (@zuzu59)](https://github.com/zuzu59)
 - [Zynth-dev (@Zynth-dev)](https://github.com/Zynth-dev)
 
-*This page was last updated November 19, 2025.*
+*This page was last updated November 24, 2025.*

--- a/data/version.yaml
+++ b/data/version.yaml
@@ -1,2 +1,2 @@
-release: 2025.11.0
+release: 2025.11.1
 version: '2025.11'


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- [core] Add support for setting environment variables [docs#5635](https://github.com/esphome/esphome-docs/pull/5635)
- Fix Typos / Duplicated Text [docs#5655](https://github.com/esphome/esphome-docs/pull/5655)
- Link blog post for network::get_use_address() migration in 2025.11.0 changelog [docs#5654](https://github.com/esphome/esphome-docs/pull/5654)
- [climate] Document public accessor methods for custom modes in 2025.11.0 release [docs#5653](https://github.com/esphome/esphome-docs/pull/5653)
- [changelog] Fix blog post links in 2025.11.0 changelog [docs#5656](https://github.com/esphome/esphome-docs/pull/5656)
- [mipi_rgb] Clarify use of transform [docs#5649](https://github.com/esphome/esphome-docs/pull/5649)
- ESPNow fixes [docs#5658](https://github.com/esphome/esphome-docs/pull/5658)
- [lvgl] Enhance 'indicator' styling options description [docs#5661](https://github.com/esphome/esphome-docs/pull/5661)
- Update board link in esp32 component docs [docs#5662](https://github.com/esphome/esphome-docs/pull/5662)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
