### PR TITLE
Fix media and oi.esphome.io links

### DIFF
--- a/content/components/image.md
+++ b/content/components/image.md
@@ -36,7 +36,7 @@ image:
     type: rgb565
     resize: 200x162
   images:
-    - file: https://esphome.io/images/logo.png
+    - file: https://media.esphome.io/logo/logo.png
       id: esphome_logo
 ```
 

--- a/content/components/web_server.md
+++ b/content/components/web_server.md
@@ -30,14 +30,14 @@ web_server:
 
 - **port** (*Optional*, int): The port the web server should open its socket on.
 - **css_url** (*Optional*, url): The URL that should be used for the CSS stylesheet. Defaults
-  to <https://esphome.io/_static/webserver-v1.min.css> (updates will go to `v2`, `v3`, etc). Can be set to empty string.
+  to <https://oi.esphome.io/v1/webserver-v1.min.css> (updates will go to `v2`, `v3`, etc). Can be set to empty string.
 
 - **css_include** (*Optional*, local file): Path to local file to be included in web server index page.
   Contents of this file will be served as `/0.css` and used as CSS stylesheet by internal webserver.
   Useful when building device without internet access, where you want to use built-in AP and webserver.
 
 - **js_url** (*Optional*, url): The URL that should be used for the JS script. Defaults
-  to <https://esphome.io/_static/webserver-v1.min.js>. Can be set to empty string.
+  to <https://oi.esphome.io/v1/webserver-v1.min.js>. Can be set to empty string.
 
 - **js_include** (*Optional*, local file): Path to local file to be included in web server index page.
   Contents of this file will be served as `/0.js` and used as JS script by internal webserver.
@@ -80,7 +80,7 @@ web_server:
   `sorting_weight` will be displayed first. Defaults to `50`
 
 To conserve flash size, the CSS and JS files used on the root page to show a simple user
-interface are hosted by esphome.io. If you want to use your own service, use the
+interface are externally hosted at oi.esphome.io. If you want to use your own service, use the
 `css_url` and `js_url` options in your configuration.
 
 > [!NOTE]

--- a/content/cookbook/lvgl.md
+++ b/content/cookbook/lvgl.md
@@ -1223,7 +1223,7 @@ esphome:
     - lvgl.widget.hide: boot_screen
 
 image:
-  - file: https://esphome.io/favicon.ico
+  - file: https://media.esphome.io/logo/logo.png
     id: boot_logo
     resize: 200x200
     type: RGB565


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
