### PR TITLE
[packages] clarify package inclusion methods

### DIFF
--- a/content/components/packages.md
+++ b/content/components/packages.md
@@ -23,9 +23,12 @@ merged by concatenation. All other configuration values are replaced with the la
 
 ESPHome uses `!include` to "bring in" packages from other files; this feature is described in [!include](/guides/yaml#yaml-include).
 
-The `packages:` key may have a value that is a list of valid package references, or a mapping of keys to package references.
-When a mapping is used, the keys are for reference only and have no significance in themselves.
-Where only a single package reference is required, it may be used directly rather than in a list.
+The `packages:` key may have a value that is:
+
+- A list of valid package references
+- A mapping of keys to package references. When a mapping is used, the keys are for reference only and have no significance in themselves.
+- A single package reference, which may be used directly rather than in a list.
+
 Examples of all formats are shown below.
 
 ## Local Packages

--- a/content/components/packages.md
+++ b/content/components/packages.md
@@ -27,7 +27,6 @@ The `packages:` key may have a value that is:
 
 - A list of valid package references
 - A mapping of keys to package references. When a mapping is used, the keys are for reference only and have no significance in themselves.
-- A single package reference, which may be used directly rather than in a list.
 
 Examples of all formats are shown below.
 
@@ -189,8 +188,8 @@ sensor:
 ```
 
 ```yaml
-# only one package is included here, no need for a list
-packages: !include common.yaml
+packages:
+  - !include common.yaml
 
 sensor:
   - id: !extend uptime_sensor
@@ -258,7 +257,8 @@ the ID of the entry to modify.
 For example, to remove a common uptime sensor that is shared between configurations:
 
 ```yaml
-packages: !include common.yaml  # see above
+packages:
+  - !include common.yaml  # see above
 
 sensor:
   - id: !remove uptime_sensor
@@ -280,7 +280,8 @@ lvgl:
 To remove captive portal for a specific device:
 
 ```yaml
-packages: !include common.yaml  # see above
+packages:
+  - !include common.yaml  # see above
 
 captive_portal: !remove
 ```


### PR DESCRIPTION
## Description:

Just so that it is not overlooked by readers, including myself, I made more visually clear the ways a package may be included in a configuration.

**Related issue (if applicable):** 

esphome/esphome#12107

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
