### PR TITLE
[esp32] Improve IDF component support

### DIFF
--- a/content/components/esp32.md
+++ b/content/components/esp32.md
@@ -231,15 +231,39 @@ esp32:
 
 The `components` option allows you to include IDF components. These components will then be compiled into the resulting
 firmware and may be used by [lambdas](/automations/templates#config-lambda). The most common usage of this option is to include third-party
-components that are available in the [ESP Component Registry](https://components.espressif.com/). They can be added by
-listing their name under this option. It is also possible to use specific versions, or to fetch components from a file or
-git repository.
+components that are available in the [ESP Component Registry](https://components.espressif.com/).
+
+### Simple
+
+For components from the ESP Component Registry, you can use the shorthand syntax `owner/component^version`:
+
+```yaml
+esp32:
+  framework:
+    components:
+      - espressif/esp_hosted^2.6.1
+```
+
+### Advanced
+
+For more complex configurations (custom git repositories, local paths, etc.), use the advanced syntax:
+
+```yaml
+esp32:
+  framework:
+    components:
+      - name: my_custom_component
+        source: https://github.com/user/component.git
+        ref: main
+        path: components/custom
+```
+
+#### Configuration Variables
 
 - **name** (*Required*, string): Name of the component e.g. `espressif/esp_hosted`.
 - **ref** (*Optional*, string): Component registry version or a git ref.
 - **source** (*Optional*, string): The git repository to use for the component. This can be used for a
   custom or patched version of the component.
-
 - **path** (*Optional*, string): The path of the component in the git repository or a local path to the
   component if `source` is not set.
 


### PR DESCRIPTION
## Description:

Improve IDF component support:
- Add shorthand support, ie `espressif/esp_hosted^2.6.6`
- Allow yaml to overwrite versions defined in the code

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#12127

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
