### PR TITLE
[lvgl] Fix LVGL horizontal and vertical equivalent layout config

### DIFF
--- a/content/components/lvgl/layouts.md
+++ b/content/components/lvgl/layouts.md
@@ -38,7 +38,7 @@ The configuration `layout: horizontal` is a shorthand for a flex layout:
     flex_flow: row
     flex_align_main: space_evenly
     flex_align_track: center
-    flex_align_cross: stretch
+    flex_align_cross: center
 ```
 
 ### Vertical Layout
@@ -51,7 +51,7 @@ The configuration `layout: vertical` is a shorthand for a flex layout:
     flex_flow: column
     flex_align_main: space_evenly
     flex_align_track: center
-    flex_align_cross: stretch
+    flex_align_cross: center
 ```
 
 ### Flex


### PR DESCRIPTION
## Description:

While debugging some LVGL layouts on my device, I noticed that the docs have an incorrect equivalent configuration for the horizontal and vertical layout shorthand.

I suspect that what is in the docs is probably what was _intended_ -- it is what I expected when I used `layout: horizontal` and `layout: vertical` but as it stands the docs do not match the current implementation:

https://github.com/esphome/esphome/blob/a7a5a0b9a23a048a63b8e40621f39c411b9db8c4/esphome/components/lvgl/layout.py#L58-L63

I'm also happy to update the layout in `esphome/esphome` to match the docs if that is actually what was intended.

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
