### PR TITLE
[openthread_info] Fix next

### DIFF
--- a/content/components/text_sensor/openthread_info.md
+++ b/content/components/text_sensor/openthread_info.md
@@ -40,28 +40,28 @@ text_sensor:
 
 - **ip_address** (*Optional*): Expose the off-mesh routable IPv6 address of the Thread device as a text sensor.
   This is the address used for communication outside the Thread mesh network.
-  All options from [Text Sensor](#config-text_sensor).
+  All options from [Text Sensor](/components/text_sensor#config-text_sensor).
 
 - **channel** (*Optional*): Expose the Thread network channel (11-26) as a text sensor.
-  All options from [Text Sensor](#config-text_sensor).
+  All options from [Text Sensor](/components/text_sensor#config-text_sensor).
 
 - **role** (*Optional*): Expose the current device role in the Thread network (Leader, Router, Child, Detached,
-  etc.) as a text sensor. All options from [Text Sensor](#config-text_sensor).
+  etc.) as a text sensor. All options from [Text Sensor](/components/text_sensor#config-text_sensor).
 
 - **rloc16** (*Optional*): Expose the Router Locator (RLOC16) address as a text sensor. This is a 16-bit address
-  used for routing within the Thread network. All options from [Text Sensor](#config-text_sensor).
+  used for routing within the Thread network. All options from [Text Sensor](/components/text_sensor#config-text_sensor).
 
 - **ext_addr** (*Optional*): Expose the IEEE 802.15.4 Extended MAC address as a text sensor.
-  All options from [Text Sensor](#config-text_sensor).
+  All options from [Text Sensor](/components/text_sensor#config-text_sensor).
 
 - **eui64** (*Optional*): Expose the EUI-64 address as a text sensor. This is the unique 64-bit identifier for
-  the device. All options from [Text Sensor](#config-text_sensor).
+  the device. All options from [Text Sensor](/components/text_sensor#config-text_sensor).
 
 - **network_name** (*Optional*): Expose the Thread network name as a text sensor.
-  All options from [Text Sensor](#config-text_sensor).
+  All options from [Text Sensor](/components/text_sensor#config-text_sensor).
 
 - **network_key** (*Optional*): Expose the Thread network key as a text sensor.
-  All options from [Text Sensor](#config-text_sensor).
+  All options from [Text Sensor](/components/text_sensor#config-text_sensor).
 
   > [!WARNING]
   > The `network_key` sensor exposes sensitive security credentials that could allow unauthorized access to your
@@ -69,10 +69,10 @@ text_sensor:
   > implications.
 
 - **pan_id** (*Optional*): Expose the Personal Area Network ID (PAN ID) as a text sensor. This is a 16-bit
-  identifier for the Thread network. All options from [Text Sensor](#config-text_sensor).
+  identifier for the Thread network. All options from [Text Sensor](/components/text_sensor#config-text_sensor).
 
 - **ext_pan_id** (*Optional*): Expose the Extended PAN ID as a text sensor. This is a 64-bit extended identifier
-  for the Thread network. All options from [Text Sensor](#config-text_sensor).
+  for the Thread network. All options from [Text Sensor](/components/text_sensor#config-text_sensor).
 
 ## See Also
 


### PR DESCRIPTION
## Description:

Fix links in openthread_info

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
