### PR TITLE
fix: Unintuitive config documentations for ES8311

### DIFF
--- a/content/components/audio_dac/es8311.md
+++ b/content/components/audio_dac/es8311.md
@@ -26,8 +26,8 @@ audio_dac:
 - **bits_per_sample** (*Optional*, enum): The bit depth of the audio samples. One of `16bit`, `24bit`, or `32bit`. Defaults to `16bit`.
 - **sample_rate** (*Optional*, positive integer): I2S sample rate. Defaults to `16000`.
 - **use_mclk** (*Optional*, bool): Use the MCLK signal to control the clock. Defaults to `True`.
-- **use_microphone** (*Optional*, bool): Configure the codec's ADC for microphone input. Defaults to `False`.
-- **mic_gain** (*Optional*, enum): The gain applied to the ADC microphones. One of `MIN`, `0DB`, `6DB`, `12DB`, `18DB`, `24DB`, `30DB`, `36DB`, `42DB`, or `MAX`. Defaults to `42DB`.
+- **use_microphone** (*Optional*, bool): Configure the codec's ADC for microphone input to use PDM instead of analog input. Defaults to `False`.
+- **mic_gain** (*Optional*, enum): The gain applied to the ADC microphones. One of `0DB`, `6DB`, `12DB`, `18DB`, `24DB`, `30DB`, `36DB` or `42DB`. Defaults to `42DB`.
 - **address** (*Optional*, int): The I²C address of the driver. Defaults to `0x18`.
 - **i2c_id** (*Optional*): The ID of the [I²C bus](/components/i2c) the ES8311 is connected to.
 - All other options from [Audio DAC](/components/audio_dac#config-audio_dac).

--- a/content/components/audio_dac/es8311.md
+++ b/content/components/audio_dac/es8311.md
@@ -26,8 +26,8 @@ audio_dac:
 - **bits_per_sample** (*Optional*, enum): The bit depth of the audio samples. One of `16bit`, `24bit`, or `32bit`. Defaults to `16bit`.
 - **sample_rate** (*Optional*, positive integer): I2S sample rate. Defaults to `16000`.
 - **use_mclk** (*Optional*, bool): Use the MCLK signal to control the clock. Defaults to `True`.
-- **use_microphone** (*Optional*, bool): Configure the codec's ADC for microphone input to use PDM instead of analog input. Defaults to `False`.
-- **mic_gain** (*Optional*, enum): The gain applied to the ADC microphones. One of `0DB`, `6DB`, `12DB`, `18DB`, `24DB`, `30DB`, `36DB` or `42DB`. Defaults to `42DB`.
+- **use_microphone** (*Optional*, bool): Configure the codec's ADC to use PDM microphone input instead of analog. Defaults to False.
+- **mic_gain** (*Optional*, enum): The gain applied to the ADC microphones. One of `MIN`, `0DB`, `6DB`, `12DB`, `18DB`, `24DB`, `30DB`, `36DB`, `42DB`, or `MAX`. Defaults to `42DB`.
 - **address** (*Optional*, int): The I²C address of the driver. Defaults to `0x18`.
 - **i2c_id** (*Optional*): The ID of the [I²C bus](/components/i2c) the ES8311 is connected to.
 - All other options from [Audio DAC](/components/audio_dac#config-audio_dac).


### PR DESCRIPTION
## Description:

This documentation updates the valid values for `mic_gain` option and the real use of the `use_microphone` option. Ideally the latter should also have its name changed but that would be a breaking change.

**Related issue (if applicable):** fixes #5140

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
