### PR TITLE
Add missing information for inkplate

### DIFF
--- a/content/components/display/inkplate.md
+++ b/content/components/display/inkplate.md
@@ -72,6 +72,8 @@ display:
   - `inkplate_10`
   - `inkplate_6_plus`
   - `inkplate_6_v2`
+  - `inkplate_5`
+  - `inkplate_5_v2`
 
 - **greyscale** (*Optional*, boolean): Makes the screen display 3 bit colors. Defaults to `false`
 - **partial_updating** (*Optional*, boolean): Makes the screen update partially, which is faster, but leaves burnin. Defaults to `false`
@@ -138,6 +140,7 @@ esphome:
 
 esp32:
   board: esp-wrover-kit
+  cpu_frequency: 240MHz
 
 logger:
 
@@ -236,6 +239,8 @@ font:
   - file: "Helvetica.ttf"
     id: helvetica_48
     size: 48
+
+psram:
 
 display:
 - platform: inkplate
@@ -398,7 +403,7 @@ display:
   greyscale: true
   partial_updating: false
   update_interval: never
-  model: inkplate_5_v2
+  model: inkplate_5 # or inkplate_5_v2
 
   ckv_pin: 32
   sph_pin: 33


### PR DESCRIPTION
## Description:

Update documentation to clarify compatibility with Inkplate 5.
I have a 5 gen 1, and by reading the documentation, the compatibility wasn't really clear. Indeed it is, so I added a couple of missing bits to clarify that.

Also, adding `psram` and `cpu_frequency` to the complete example since it looks like it wouldn't compile without (error messages are quite clear, but fixing the example seems best).

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
