### PR TITLE
[gree] `turbo`, `light`, `health`, `xfan` switches for supported models

### DIFF
--- a/content/components/climate/climate_ir.md
+++ b/content/components/climate/climate_ir.md
@@ -142,7 +142,7 @@ The Daikin ARC remotes (`daikin_arc` climate, `daikin_arc417`, `daikin_arc480` p
   - `yag`
 
 ```yaml
-# Example configuration entry
+# Example configuration entry for climate only
 climate:
   - platform: gree
     name: "AC"
@@ -150,16 +150,17 @@ climate:
     sensor: room_temperature
     model: yan
 ```
-`yan`, `yaa`, `yac` and `yac1fb9` model, support a couple of additional features which can be controlled with switches:
 
-  - **gree_id** (**Required**, [ID](/guides/configuration-types#id)): Specify the ID of the `gree` climate to which these swicthes should belong.
-  - **light** (*Optional*, [Switch](/components/switch#config-switch)): To turn off indoor unit display/LED at night for complete room darkness.
-  - **turbo** (*Optional*, [Switch](/components/switch#config-switch)): For maximum fan speed and fastest results.
-  - **health** (*Optional*, [Switch](/components/switch#config-switch)): Removal of dust and germs from the environment by ionizing the air flowing through the blades.
-  - **xfan** (*Optional*, [Switch](/components/switch#config-switch)): Prevention of excess moisture in the machine that cause mold, mildew, and unpleasant odors. Indoor fan will keep running for short period after turning turn off the AC, to dry the blades.
+Models `yan`, `yaa`, `yac` and `yac1fb9` support a couple of additional features which can be controlled with switches:
+
+- **gree_id** (**Required**, [ID](/guides/configuration-types#id)): Specify the ID of the `gree` climate to which these swicthes should belong.
+- **light** (*Optional*, [Switch](/components/switch#config-switch)): To turn off indoor unit display/LED at night for complete room darkness.
+- **turbo** (*Optional*, [Switch](/components/switch#config-switch)): For maximum fan speed and fastest results.
+- **health** (*Optional*, [Switch](/components/switch#config-switch)): Removal of dust and germs from the environment by ionizing the air flowing through the blades.
+- **xfan** (*Optional*, [Switch](/components/switch#config-switch)): Prevention of excess moisture in the machine that cause mold, mildew, and unpleasant odors. Indoor fan will keep running for short period after turning turn off the AC, to dry the blades.
 
 ```yaml
-# Example configuration entry
+# Example configuration entry for switches of the climate
 switch:
   - platform: gree
     gree_id: my_gree_ac

--- a/content/components/climate/climate_ir.md
+++ b/content/components/climate/climate_ir.md
@@ -131,7 +131,7 @@ The Daikin ARC remotes (`daikin_arc` climate, `daikin_arc417`, `daikin_arc480` p
 
 ### `gree`
 
-- **model** (**Required**, string): GREE has a few different protocols depending on model. One of these will work for you.
+- **model** (**Required**, string): GREE has a few different protocols depending on model. One of these will likely work for you:
 
   - `generic`
   - `yan`
@@ -146,8 +146,31 @@ The Daikin ARC remotes (`daikin_arc` climate, `daikin_arc417`, `daikin_arc480` p
 climate:
   - platform: gree
     name: "AC"
+    id: my_gree_ac
     sensor: room_temperature
     model: yan
+```
+`yan`, `yaa`, `yac` and `yac1fb9` model, support a couple of additional features which can be controlled with switches:
+
+  - **gree_id** (**Required**, [ID](/guides/configuration-types#id)): Specify the ID of the `gree` climate to which these swicthes should belong.
+  - **light** (*Optional*, [Switch](/components/switch#config-switch)): To turn off indoor unit display/LED at night for complete room darkness.
+  - **turbo** (*Optional*, [Switch](/components/switch#config-switch)): For maximum fan speed and fastest results.
+  - **health** (*Optional*, [Switch](/components/switch#config-switch)): Removal of dust and germs from the environment by ionizing the air flowing through the blades.
+  - **xfan** (*Optional*, [Switch](/components/switch#config-switch)): Prevention of excess moisture in the machine that cause mold, mildew, and unpleasant odors. Indoor fan will keep running for short period after turning turn off the AC, to dry the blades.
+
+```yaml
+# Example configuration entry
+switch:
+  - platform: gree
+    gree_id: my_gree_ac
+    light:
+      name: "AC Lights"
+    turbo:
+      name: "AC Turbo"
+    health:
+      name: "AC Health"
+    xfan:
+      name: "AC X-Fan"
 ```
 
 {{< anchor "midea_ir" >}}


### PR DESCRIPTION
## Description:

doc for https://github.com/esphome/esphome/pull/12160

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#12160

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
