### PR TITLE
[remote_receiver] Add missing default value for idle config option

### DIFF
--- a/content/components/remote_receiver.md
+++ b/content/components/remote_receiver.md
@@ -85,7 +85,7 @@ Multiple remote receivers can be configured as a list of dict definitions within
   glitches from noisy signals. Allowed values are in range `0` to `4294967295us`. Defaults to `50us`.
 
 - **idle** (*Optional*, [Time](/guides/configuration-types#time)): The amount of time that a signal should remain stable/unchanged for it to
-  be considered complete. The maximum allowable value is:
+  be considered complete. Defaults to `10ms`. The maximum allowable value is:
 
   - `65536us` on the `ESP32` and `ESP32-S2` variants
   - `32767us` on all other ESP32 variants


### PR DESCRIPTION
## Description:

- Document that the `idle` configuration option defaults to `10ms`

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>

