### PR TITLE
[adc] Fix ESP32 attenuation max value from 12db to 11db

### DIFF
--- a/content/components/sensor/adc.md
+++ b/content/components/sensor/adc.md
@@ -66,7 +66,7 @@ sensor:
 ## ESP32 Attenuation
 
 On the ESP32 the voltage measured with the ADC caps out at ~1.1V by default as the sensing range (attenuation of the ADC) is set to `0db` by default.
-Measuring higher voltages requires setting `attenuation` to one of the following values: `0db`, `2.5db`, `6db`, `12db`.
+Measuring higher voltages requires setting `attenuation` to one of the following values: `0db`, `2.5db`, `6db`, `11db`.
 There's more information [at the manufacturer's website](https://docs.espressif.com/projects/esp-idf/en/v4.4.7/esp32/api-reference/peripherals/adc.html#_CPPv425adc1_config_channel_atten14adc1_channel_t11adc_atten_t).
 
 To simplify this, we provide the setting `attenuation: auto` for an automatic/seamless transition among scales. [Our implementation](https://github.com/esphome/esphome/blob/dev/esphome/components/adc/adc_sensor_esp32.cpp) combines all available ranges to allow the best resolution without having to compromise on a specific attenuation.
@@ -115,7 +115,7 @@ filters:
   - multiply: 0.00026862 # 1.1/4095, for attenuation 0db
   - multiply: 0.00036630 # 1.5/4095, for attenuation 2.5db
   - multiply: 0.00053724 # 2.2/4095, for attenuation 6db
-  - multiply: 0.00095238 # 3.9/4095, for attenuation 12db
+  - multiply: 0.00095238 # 3.9/4095, for attenuation 11db
   # your existing filters would go here
 ```
 


### PR DESCRIPTION
## Summary
- Fix the documented ESP32 ADC attenuation max value from `12db` to `11db` per [Espressif documentation](https://docs.espressif.com/projects/esp-idf/en/v4.4.7/esp32/api-reference/peripherals/adc.html#_CPPv425adc1_config_channel_atten14adc1_channel_t11adc_atten_t)

Closes #5699

## Test plan
- [x] Verify the documentation renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)