### PR TITLE
Add waveshare 7.50in-hd

### DIFF
--- a/content/components/display/waveshare_epaper.md
+++ b/content/components/display/waveshare_epaper.md
@@ -122,6 +122,7 @@ lambda: |-
   - `7.50inV2` - Can't use with an ESP8266 as it runs out of RAM
   - `7.50inV2alt` (alternative version to the above `7.50inV2`  )
   - `7.50inV2p` - Support for partial refresh and fast refresh (Only suitable for `7.50inV2` models manufactured after September 2023)
+  - `7.50in-hd` - Can't use with an ESP8266 as it runs out of RAM, B/W rendering only
   - `7.50in-hd-b` - Can't use with an ESP8266 as it runs out of RAM
   - `gdey029t94` - GooDisplay GDEY029t94, as used in the monochrome 2.9inch display from seeedstudio
   - `gdew029t5` - GooDisplay GDEW029T5, as used on the AdaFruit MagTag and Pimoroni Badger


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#12206

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
