### PR TITLE
Add AQI documentation for pmsx003 sensor, improve AQI documentation in general

### DIFF
--- a/content/components/sensor/hm3301.md
+++ b/content/components/sensor/hm3301.md
@@ -69,10 +69,10 @@ Both calculation types take the PM2.5 and PM10 values and return the higher
 | Index | Level | Health Implications |
 |-------|-------|---------------------|
 | 0-50 | Good | Air quality is satisfactory |
-| 51-100 | Moderate | Acceptable; some pollutants may be a concern for sensitive individuals |
-| 101-150 | Unhealthy for Sensitive Groups | Members of sensitive groups may experience health effects |
+| 51-100 | Moderate | Some pollutants may be a concern for sensitive individuals |
+| 101-150 | Unhealthy for Sensitive Groups | Sensitive groups may experience health effects |
 | 151-200 | Unhealthy | Everyone may begin to experience health effects |
-| 201-300 | Very Unhealthy | Health alert: everyone may experience more serious health effects |
+| 201-300 | Very Unhealthy | Everyone may experience more serious health effects |
 | 301-500 | Hazardous | Health warnings of emergency conditions |
 
 ### CAQI Scale (European)

--- a/content/components/sensor/hm3301.md
+++ b/content/components/sensor/hm3301.md
@@ -49,13 +49,39 @@ sensor:
   - **calculation_type** (**Required**): One of: `AQI` or `CAQI`.
   - All other options from [Sensor](/components/sensor).
 
-## Air Quality Sensor
+## Air Quality Index
 
-There is a sensor which calculates quality of air based on PM 2.5 and PM 10.0 values.
-There are two implementations:
+The AQI (Air Quality Index) sensor calculates an air quality index value based on the PM2.5 and PM10 particulate matter concentrations. This provides a single number that indicates overall air quality and associated health concerns.
 
-- AQI: USA air quality standard
-- CAQI: Europe air quality standard
+Two calculation standards are supported:
+
+- **AQI** (US EPA Air Quality Index): The standard used in the United States, Canada, and parts of Asia. Scale of 0-500+.
+- **CAQI** (Common Air Quality Index): The European standard. Scale of 0-400.
+
+Both calculation types take the PM2.5 and PM10 values and return the higher (more conservative) of the two calculated index values.
+
+### AQI Scale (US EPA)
+
+| Index | Level | Health Implications |
+|-------|-------|---------------------|
+| 0-50 | Good | Air quality is satisfactory |
+| 51-100 | Moderate | Acceptable; some pollutants may be a concern for sensitive individuals |
+| 101-150 | Unhealthy for Sensitive Groups | Members of sensitive groups may experience health effects |
+| 151-200 | Unhealthy | Everyone may begin to experience health effects |
+| 201-300 | Very Unhealthy | Health alert: everyone may experience more serious health effects |
+| 301-500 | Hazardous | Health warnings of emergency conditions |
+
+### CAQI Scale (European)
+
+| Index | Level | Health Implications |
+|-------|-------|---------------------|
+| 0-25 | Very Low | Air quality is excellent |
+| 26-50 | Low | Air quality is good |
+| 51-75 | Medium | Air quality is fair |
+| 76-100 | High | Air quality is poor |
+| 101-400 | Very High | Air quality is very poor |
+
+### Configuration Example
 
 ```yaml
 sensor:
@@ -65,8 +91,13 @@ sensor:
     pm_10_0:
       name: "PM10.0"
     aqi:
-      name: "AQI"
-      calculation_type: "CAQI"
+      name: "Air Quality Index"
+      calculation_type: "CAQI"  # or "AQI" for US EPA standard
+      # Optional: Apply filters for smoother values
+      filters:
+        - sliding_window_moving_average:
+            window_size: 10
+            send_every: 1
 ```
 
 ## See Also

--- a/content/components/sensor/hm3301.md
+++ b/content/components/sensor/hm3301.md
@@ -51,14 +51,18 @@ sensor:
 
 ## Air Quality Index
 
-The AQI (Air Quality Index) sensor calculates an air quality index value based on the PM2.5 and PM10 particulate matter concentrations. This provides a single number that indicates overall air quality and associated health concerns.
+The AQI (Air Quality Index) sensor calculates an air quality index value based on the
+PM2.5 and PM10 particulate matter concentrations. This provides a single number that
+indicates overall air quality and associated health concerns.
 
 Two calculation standards are supported:
 
-- **AQI** (US EPA Air Quality Index): The standard used in the United States, Canada, and parts of Asia. Scale of 0-500+.
+- **AQI** (US EPA Air Quality Index): The standard used in the United States, Canada,
+  and parts of Asia. Scale of 0-500+.
 - **CAQI** (Common Air Quality Index): The European standard. Scale of 0-400.
 
-Both calculation types take the PM2.5 and PM10 values and return the higher (more conservative) of the two calculated index values.
+Both calculation types take the PM2.5 and PM10 values and return the higher
+(more conservative) of the two calculated index values.
 
 ### AQI Scale (US EPA)
 

--- a/content/components/sensor/pmsx003.md
+++ b/content/components/sensor/pmsx003.md
@@ -41,6 +41,9 @@ sensor:
       name: "Particulate Matter <2.5µm Concentration"
     pm_10_0:
       name: "Particulate Matter <10.0µm Concentration"
+    aqi:
+      name: "Air Quality Index"
+      calculation_type: "AQI"
 ```
 
 ## Configuration variables
@@ -90,11 +93,68 @@ sensor:
 - **formaldehyde** (*Optional*): Use the formaldehyde (HCHO) concentration in µg per cubic meter for the `PMS5003S` and `PMS5003ST` type sensors.
   All options from [Sensor](/components/sensor).
 
+- **aqi** (*Optional*): Air Quality Index sensor. Requires both `pm_2_5` and `pm_10_0` sensors to be configured. See [Air Quality Index](#air-quality-index) below.
+
+  - **calculation_type** (**Required**): The AQI calculation standard to use. One of: `AQI` (US EPA) or `CAQI` (European).
+  - All other options from [Sensor](/components/sensor).
+
 - **update_interval** (*Optional*): Amount of time to wait between generating measurements. If this is longer than 30
   seconds, and if `tx_pin` is set in the UART configuration, the fan will be spun down between measurements. Default to `0s` (forward data as it's coming in from the sensor).
 
 - **uart_id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID of the [UART Component](/components/uart) if you want
   to use multiple UART buses.
+
+## Air Quality Index
+
+The AQI (Air Quality Index) sensor calculates an air quality index value based on the PM2.5 and PM10 particulate matter concentrations. This provides a single number that indicates overall air quality and associated health concerns.
+
+Two calculation standards are supported:
+
+- **AQI** (US EPA Air Quality Index): The standard used in the United States, Canada, and parts of Asia. Scale of 0-500+.
+- **CAQI** (Common Air Quality Index): The European standard. Scale of 0-400.
+
+Both calculation types take the PM2.5 and PM10 values and return the higher (more conservative) of the two calculated index values.
+
+### AQI Scale (US EPA)
+
+| Index | Level | Health Implications |
+|-------|-------|---------------------|
+| 0-50 | Good | Air quality is satisfactory |
+| 51-100 | Moderate | Acceptable; some pollutants may be a concern for sensitive individuals |
+| 101-150 | Unhealthy for Sensitive Groups | Members of sensitive groups may experience health effects |
+| 151-200 | Unhealthy | Everyone may begin to experience health effects |
+| 201-300 | Very Unhealthy | Health alert: everyone may experience more serious health effects |
+| 301-500 | Hazardous | Health warnings of emergency conditions |
+
+### CAQI Scale (European)
+
+| Index | Level | Health Implications |
+|-------|-------|---------------------|
+| 0-25 | Very Low | Air quality is excellent |
+| 26-50 | Low | Air quality is good |
+| 51-75 | Medium | Air quality is fair |
+| 76-100 | High | Air quality is poor |
+| 101-400 | Very High | Air quality is very poor |
+
+### Configuration Example
+
+```yaml
+sensor:
+  - platform: pmsx003
+    type: PMSX003
+    pm_2_5:
+      name: "PM2.5"
+    pm_10_0:
+      name: "PM10"
+    aqi:
+      name: "Air Quality Index"
+      calculation_type: "AQI"  # or "CAQI" for European standard
+      # Optional: Apply filters for smoother values
+      filters:
+        - sliding_window_moving_average:
+            window_size: 15
+            send_every: 1
+```
 
 ## See Also
 

--- a/content/components/sensor/pmsx003.md
+++ b/content/components/sensor/pmsx003.md
@@ -126,10 +126,10 @@ Both calculation types take the PM2.5 and PM10 values and return the higher
 | Index | Level | Health Implications |
 |-------|-------|---------------------|
 | 0-50 | Good | Air quality is satisfactory |
-| 51-100 | Moderate | Acceptable; some pollutants may be a concern for sensitive individuals |
-| 101-150 | Unhealthy for Sensitive Groups | Members of sensitive groups may experience health effects |
+| 51-100 | Moderate | Some pollutants may be a concern for sensitive individuals |
+| 101-150 | Unhealthy for Sensitive Groups | Sensitive groups may experience health effects |
 | 151-200 | Unhealthy | Everyone may begin to experience health effects |
-| 201-300 | Very Unhealthy | Health alert: everyone may experience more serious health effects |
+| 201-300 | Very Unhealthy | Everyone may experience more serious health effects |
 | 301-500 | Hazardous | Health warnings of emergency conditions |
 
 ### CAQI Scale (European)

--- a/content/components/sensor/pmsx003.md
+++ b/content/components/sensor/pmsx003.md
@@ -93,9 +93,11 @@ sensor:
 - **formaldehyde** (*Optional*): Use the formaldehyde (HCHO) concentration in µg per cubic meter for the `PMS5003S` and `PMS5003ST` type sensors.
   All options from [Sensor](/components/sensor).
 
-- **aqi** (*Optional*): Air Quality Index sensor. Requires both `pm_2_5` and `pm_10_0` sensors to be configured. See [Air Quality Index](#air-quality-index) below.
+- **aqi** (*Optional*): Air Quality Index sensor. Requires both `pm_2_5` and `pm_10_0`
+  sensors to be configured. See [Air Quality Index](#air-quality-index) below.
 
-  - **calculation_type** (**Required**): The AQI calculation standard to use. One of: `AQI` (US EPA) or `CAQI` (European).
+  - **calculation_type** (**Required**): The AQI calculation standard to use.
+    One of: `AQI` (US EPA) or `CAQI` (European).
   - All other options from [Sensor](/components/sensor).
 
 - **update_interval** (*Optional*): Amount of time to wait between generating measurements. If this is longer than 30
@@ -106,14 +108,18 @@ sensor:
 
 ## Air Quality Index
 
-The AQI (Air Quality Index) sensor calculates an air quality index value based on the PM2.5 and PM10 particulate matter concentrations. This provides a single number that indicates overall air quality and associated health concerns.
+The AQI (Air Quality Index) sensor calculates an air quality index value based on the
+PM2.5 and PM10 particulate matter concentrations. This provides a single number that
+indicates overall air quality and associated health concerns.
 
 Two calculation standards are supported:
 
-- **AQI** (US EPA Air Quality Index): The standard used in the United States, Canada, and parts of Asia. Scale of 0-500+.
+- **AQI** (US EPA Air Quality Index): The standard used in the United States, Canada,
+  and parts of Asia. Scale of 0-500+.
 - **CAQI** (Common Air Quality Index): The European standard. Scale of 0-400.
 
-Both calculation types take the PM2.5 and PM10 values and return the higher (more conservative) of the two calculated index values.
+Both calculation types take the PM2.5 and PM10 values and return the higher
+(more conservative) of the two calculated index values.
 
 ### AQI Scale (US EPA)
 


### PR DESCRIPTION
##  Description:

  Adds Air Quality Index (AQI) documentation for the pmsx003 particulate matter sensor and enhances the existing hm3301 AQI documentation.

##  Changes:
  - Added AQI configuration option to pmsx003 sensor documentation
  - Added detailed "Air Quality Index" section explaining AQI vs CAQI calculation standards
  - Enhanced hm3301 AQI documentation with health implication tables
  - Documented both AQI (US EPA, 0-500 scale) and CAQI (European, 0-400 scale) standards
  - Added configuration examples showing AQI setup with optional filtering
  - Included health implication reference tables for both standards

##  Related issue (if applicable): N/A

##  Pull request in https://github.com/esphome/esphome with YAML changes (if applicable): 
  - esphome/esphome#12203
