### PR TITLE
Add Waveshare 4.2inch (G) to supported waveshare displays

### DIFF
--- a/content/components/display/waveshare_epaper.md
+++ b/content/components/display/waveshare_epaper.md
@@ -108,6 +108,7 @@ lambda: |-
   - `2.90in-bV3` - B/W rendering only
   - `4.20in`
   - `4.20in-bV2` - B/W rendering only
+  - `4.20in-gv2` - 4.2in 4-color display (black, white, yellow, red)
   - `gdey042t81` - GoodDisplay GDEY042T81 4.2" B/W
   - `4.20in-bV2-bwr` - BWR rendering enabled (uses double the amount of RAM for the display buffer as B/W rendering)
   - `5.83in`


### PR DESCRIPTION
## Description:
Add Waveshare 3.7inch (G) to supported the the displays supported by the waveshare_epaper component.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#12211

## Checklist:

  - [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.


