### PR TITLE
[psram] Fix breaking change for psram missing key info

### DIFF
--- a/content/changelog/2025.11.0.md
+++ b/content/changelog/2025.11.0.md
@@ -382,7 +382,15 @@ HTTP request actions now pass trigger variables correctly into `on_response` and
 
 - **ESP32 brownout protection**: ESP-IDF now reduces PHY TX power during brownout to prevent boot loops. Can be disabled with `sdkconfig_options: CONFIG_ESP_PHY_REDUCE_TX_POWER: n` if needed. [#11306](https://github.com/esphome/esphome/pull/11306)
 
-- **ESP32-S3 PSRAM**: PSRAM mode is now required when multiple PSRAM modes are available (ESP32-S3 only). Users must explicitly choose PSRAM mode in configuration. [#11470](https://github.com/esphome/esphome/pull/11470)
+- **ESP32 PSRAM**: PSRAM is no longer auto-loaded by components that depend on it (such as `esp32_camera`, `speaker`, and `media_player`). Users must now explicitly add a `psram:` configuration block to their YAML. Additionally, for ESP32-S3, the `mode` option is now required since S3 supports both quad and octal modes. Typically, 2MB PSRAM uses `quad` mode while 8 or 16MB uses `octal` mode—check your module's datasheet. Example configuration:
+
+  ```yaml
+  psram:
+    mode: octal  # Required for ESP32-S3, use 'quad' or 'octal'
+    speed: 80MHz
+  ```
+
+  [#11470](https://github.com/esphome/esphome/pull/11470)
 
 ### Component Behavior Changes
 


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
