### PR TITLE
[psram] C5 docs

### DIFF
--- a/content/components/psram.md
+++ b/content/components/psram.md
@@ -23,7 +23,7 @@ psram:
 ## Configuration variables
 
 - **mode** (*Optional*): Defines the operating mode the PSRAM should utilize. One of `quad`, `octal` or `hex`.
-  Defaults to `quad` for ESP32, ESP32-S2, ESP32-C5 and `hex` for ESP32-P4. ESP32-S3 has no default and *requires* this option to be set.
+  Defaults to `quad` for ESP32, ESP32-C5, ESP32-S2 and `hex` for ESP32-P4. ESP32-S3 has no default and *requires* this option to be set.
   See notes below.
 - **speed** (*Optional*, int): The speed at which the PSRAM should operate. One of `40MHz` (default), `80MHz` or `120MHz`.
 - **enable_ecc** (*Optional*, bool): For octal mode, enable ECC (Error Correction Code) for the PSRAM (default is off.)
@@ -39,7 +39,7 @@ psram:
 
 ## Modes
 
-The ESP32, ESP32-S2 and ESP32-C5 PSRAM is only available in `quad` mode, and ESP32-P4 only supports `hex` mode. These are the defaults
+The ESP32, ESP32-C5 and ESP32-S2 PSRAM is only available in `quad` mode, and ESP32-P4 only supports `hex` mode. These are the defaults
 when using those variants. For ESP32-S3, the `mode` option is required and must be set to `quad` or `octal`.
 Typically on ESP32-S3 modules, a 2MB PSRAM will use quad mode, while 8 or 16MB will use octal mode, but check
 the datasheet for the module you are using to be sure.

--- a/content/components/psram.md
+++ b/content/components/psram.md
@@ -23,7 +23,7 @@ psram:
 ## Configuration variables
 
 - **mode** (*Optional*): Defines the operating mode the PSRAM should utilize. One of `quad`, `octal` or `hex`.
-  Defaults to `quad` for ESP32, ESP32-C5 and `hex` for ESP32-P4. ESP32-S3 has no default and *requires* this option to be set.
+  Defaults to `quad` for ESP32, ESP32-S2, ESP32-C5 and `hex` for ESP32-P4. ESP32-S3 has no default and *requires* this option to be set.
   See notes below.
 - **speed** (*Optional*, int): The speed at which the PSRAM should operate. One of `40MHz` (default), `80MHz` or `120MHz`.
 - **enable_ecc** (*Optional*, bool): For octal mode, enable ECC (Error Correction Code) for the PSRAM (default is off.)
@@ -39,7 +39,7 @@ psram:
 
 ## Modes
 
-The ESP32 and ESP32-C5 PSRAM is only available in `quad` mode, and ESP32-P4 only supports `hex` mode. These are the defaults
+The ESP32, ESP32-S2 and ESP32-C5 PSRAM is only available in `quad` mode, and ESP32-P4 only supports `hex` mode. These are the defaults
 when using those variants. For ESP32-S3, the `mode` option is required and must be set to `quad` or `octal`.
 Typically on ESP32-S3 modules, a 2MB PSRAM will use quad mode, while 8 or 16MB will use octal mode, but check
 the datasheet for the module you are using to be sure.

--- a/content/components/psram.md
+++ b/content/components/psram.md
@@ -23,7 +23,7 @@ psram:
 ## Configuration variables
 
 - **mode** (*Optional*): Defines the operating mode the PSRAM should utilize. One of `quad`, `octal` or `hex`.
-  Defaults to `quad` for ESP32 and `hex` for ESP32-P4. ESP32-S3 has no default and *requires* this option to be set.
+  Defaults to `quad` for ESP32, ESP32-C5 and `hex` for ESP32-P4. ESP32-S3 has no default and *requires* this option to be set.
   See notes below.
 - **speed** (*Optional*, int): The speed at which the PSRAM should operate. One of `40MHz` (default), `80MHz` or `120MHz`.
 - **enable_ecc** (*Optional*, bool): For octal mode, enable ECC (Error Correction Code) for the PSRAM (default is off.)
@@ -39,7 +39,7 @@ psram:
 
 ## Modes
 
-The ESP32 PSRAM is only available in `quad` mode, and ESP32-P4 only supports `hex` mode. These are the defaults
+The ESP32 and ESP32-C5 PSRAM is only available in `quad` mode, and ESP32-P4 only supports `hex` mode. These are the defaults
 when using those variants. For ESP32-S3, the `mode` option is required and must be set to `quad` or `octal`.
 Typically on ESP32-S3 modules, a 2MB PSRAM will use quad mode, while 8 or 16MB will use octal mode, but check
 the datasheet for the module you are using to be sure.


### PR DESCRIPTION
## Description:

Psram esp32c5 docs

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#12215

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
