### PR TITLE
Add PSRAM requirement note to ESP32 Camera Component

### DIFF
--- a/content/components/esp32_camera.md
+++ b/content/components/esp32_camera.md
@@ -10,7 +10,7 @@ params:
 The `esp32_camera` component allows you to use ESP32-based camera boards in ESPHome that
 directly integrate into Home Assistant through the native API.
 
-Requires an {{< docref "/components/i2c" >}} to be set up.
+Requires an {{< docref "/components/i2c" >}} and {{< docref "/components/psram" >}} to be set up.
 
 ```yaml
 # Example configuration entry

--- a/content/components/esp32_camera.md
+++ b/content/components/esp32_camera.md
@@ -10,7 +10,7 @@ params:
 The `esp32_camera` component allows you to use ESP32-based camera boards in ESPHome that
 directly integrate into Home Assistant through the native API.
 
-Requires an {{< docref "/components/i2c" >}} and {{< docref "/components/psram" >}} to be set up.
+Requires an {{< docref "/components/i2c" >}} and {{< docref "/components/psram" >}} to be configured.
 
 ```yaml
 # Example configuration entry


### PR DESCRIPTION
## Description:

Since PSRAM now needs to be explicitly added, it should be noted as a requirement (and linked to).

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
