### PR TITLE
Hd108 neopixels

### DIFF
--- a/content/changelog/2025.11.0.md
+++ b/content/changelog/2025.11.0.md
@@ -382,7 +382,15 @@ HTTP request actions now pass trigger variables correctly into `on_response` and
 
 - **ESP32 brownout protection**: ESP-IDF now reduces PHY TX power during brownout to prevent boot loops. Can be disabled with `sdkconfig_options: CONFIG_ESP_PHY_REDUCE_TX_POWER: n` if needed. [#11306](https://github.com/esphome/esphome/pull/11306)
 
-- **ESP32-S3 PSRAM**: PSRAM mode is now required when multiple PSRAM modes are available (ESP32-S3 only). Users must explicitly choose PSRAM mode in configuration. [#11470](https://github.com/esphome/esphome/pull/11470)
+- **ESP32 PSRAM**: PSRAM is no longer auto-loaded by components that depend on it (such as `esp32_camera`, `speaker`, and `media_player`). Users must now explicitly add a `psram:` configuration block to their YAML. Additionally, for ESP32-S3, the `mode` option is now required since S3 supports both quad and octal modes. Typically, 2MB PSRAM uses `quad` mode while 8 or 16MB uses `octal` mode—check your module's datasheet. Example configuration:
+
+  ```yaml
+  psram:
+    mode: octal  # Required for ESP32-S3, use 'quad' or 'octal'
+    speed: 80MHz
+  ```
+
+  [#11470](https://github.com/esphome/esphome/pull/11470)
 
 ### Component Behavior Changes
 

--- a/content/components/esp32_camera.md
+++ b/content/components/esp32_camera.md
@@ -10,7 +10,7 @@ params:
 The `esp32_camera` component allows you to use ESP32-based camera boards in ESPHome that
 directly integrate into Home Assistant through the native API.
 
-Requires an {{< docref "/components/i2c" >}} to be set up.
+Requires an {{< docref "/components/i2c" >}} and {{< docref "/components/psram" >}} to be configured.
 
 ```yaml
 # Example configuration entry

--- a/content/components/ethernet.md
+++ b/content/components/ethernet.md
@@ -240,6 +240,20 @@ ethernet:
   power_pin: GPIO5
 ```
 
+**DFRobot Edge101** and **ESP32-DOWD-V3**:
+
+```yaml
+ethernet:
+  type: IP101
+  mdc_pin: GPIO4
+  mdio_pin: GPIO13
+  clk:
+    pin: GPIO0
+    mode: CLK_EXT_IN
+  power_pin: GPIO2
+  phy_addr: 1
+```
+
 **AiThinker ESP32-G Gateway**:
 
 ```yaml

--- a/content/components/light/neopixelbus.md
+++ b/content/components/light/neopixelbus.md
@@ -69,6 +69,7 @@ light:
   - `LPD6803`
   - `LPD8806`
   - `P9813`
+  - `HD108`
 
 - **method** (*Optional*, string): The method used to transmit the data. By default, ESPHome will try to use the best method
   available for this chipset, ESP platform, and the given pin. See [methods](#neopixelbus-methods) for more information.

--- a/content/components/remote_receiver.md
+++ b/content/components/remote_receiver.md
@@ -85,7 +85,7 @@ Multiple remote receivers can be configured as a list of dict definitions within
   glitches from noisy signals. Allowed values are in range `0` to `4294967295us`. Defaults to `50us`.
 
 - **idle** (*Optional*, [Time](/guides/configuration-types#time)): The amount of time that a signal should remain stable/unchanged for it to
-  be considered complete. The maximum allowable value is:
+  be considered complete. Defaults to `10ms`. The maximum allowable value is:
 
   - `65536us` on the `ESP32` and `ESP32-S2` variants
   - `32767us` on all other ESP32 variants

--- a/content/components/wifi.md
+++ b/content/components/wifi.md
@@ -97,12 +97,18 @@ wifi:
   for ESP8266 is 20dB, 20.5dB might cause unexpected restarts.
 
 - **fast_connect** (*Optional*, boolean): If enabled, directly connects to WiFi network without doing a full scan
-  first. This is required for hidden networks and can significantly improve connection times (thus reducing power
-  consumption). Defaults to `off`.
+  first. This can significantly improve connection times (thus reducing power consumption). Defaults to `off`.
   The downside is that this option connects to the first network the ESP sees, even if that network is very far away and
   better ones are available. If multiple networks are configured, the last successfully connected one is tested first.
   In case it fails, all networks are then tested one after the other in their declared order, starting with the first
   one in the list.
+
+  > [!NOTE]
+  > While `fast_connect` skips the initial scan, if the connection attempt fails, ESPHome will still perform a scan
+  > to find available networks. For hidden networks, use `hidden: true` on the network configuration (see
+  > [Connecting to Multiple Networks](#wifi-networks)) to ensure the device always connects without scanning.
+  > Be aware that marking networks as hidden prevents ESPHome from finding the best access point to connect to,
+  > so the device may not connect to the AP with the best signal strength.
 
 - **min_auth_mode** (*Optional*, string): Only on `esp32` and `esp8266`. Sets the minimum WiFi authentication mode
   that the device will accept when connecting to access points. This controls the weakest encryption your device will
@@ -300,10 +306,26 @@ wifi:
 - **hidden** (*Optional*, boolean): Whether this network is hidden. Defaults to false.
   If you add this option you also have to specify ssid.
 
+  > [!TIP]
+  > Set `hidden: true` if your network does not broadcast its SSID. This ensures the device attempts to connect
+  > using hidden network mode without first scanning for visible networks. Note that when connecting to a hidden
+  > network, ESPHome cannot determine which access point has the best signal strength, potentially resulting in
+  > connections to APs with weaker signals when multiple APs share the same SSID.
+
 - **priority** (*Optional*, int): The priority of this network (range: -128 to 127). The network with
   the highest priority is chosen. After each connection failure, the priority is decreased by one.
   If all tracked BSSIDs have identical priorities, they are automatically reset to 0 to start fresh.
   Defaults to `0`.
+
+### Example: Connecting to a Hidden Network
+
+```yaml
+wifi:
+  networks:
+  - ssid: MyHiddenNetwork
+    password: VerySafePassword
+    hidden: true
+```
 
 {{< anchor "eap" >}}
 


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#12263

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
