### PR TITLE
Adding documentation for idle mode for SPS30 sensor

### DIFF
--- a/content/components/sensor/sps30.md
+++ b/content/components/sensor/sps30.md
@@ -50,6 +50,7 @@ sensor:
       id: "pm_size"
     address: 0x69
     update_interval: 10s
+    idle_interval: 5min
 ```
 
 ## Configuration variables
@@ -102,6 +103,8 @@ sensor:
 - **update_interval** (*Optional*, [Time](/guides/configuration-types#time)): The interval to check the
   sensor. Defaults to `60s`.
 
+- **idle_interval** (*Optional*, [Time](/guides/configuration-types#time)): If specified, will put the sensor into an idle mode between readings for the specified amount of time.
+
 ## Wiring
 
 The sensor has a 5 pin JST ZHR type connector, with a 1.5mm pitch. ([Matching connector housing](https://octopart.com/zhr-5-jst-279203), [datasheet](http://www.farnell.com/datasheets/1393424.pdf))
@@ -146,6 +149,39 @@ sensor:
 ```
 
 Sensirion recommends cleaning at least once per week.
+
+## Idle Operation Mode
+
+The SPS30 sensor can go into an idle operation mode where most internal electronics are switched off, including the fan and laser.  This greatly reduces power consumption as well
+as can prolong the life of the sensor.
+
+Specifying an `idle_interval` configuration parameter will automatically stop the sensor for that interval, wake it when it is time, allow the sensor to warm up, and take a reading
+before putting it back into idle state.
+
+The start and stop actions below allow users to manually take the sensor in and out of idle mode.  Note that after the sensor is started, it does have a warm-up period of 30 seconds
+prior to outputting measurements.
+
+See [low power documentation](https://sensirion.com/media/documents/188A2C3C/6166F165/Sensirion_Particulate_Matter_AppNotes_SPS30_Low_Power_Operation_D1.pdf) for more information.
+
+### Start Measurement Action
+
+This [action](/automations/actions#all-actions) manually puts the sensor into measurement mode.
+
+```yaml
+    on_...:
+      then:
+        - sps30.start_measurement: my_sps30
+```
+
+### Stop Measurement Action
+
+This [action](/automations/actions#all-actions) manually puts the sensor into sleep mode.
+
+```yaml
+    on_...:
+      then:
+        - sps30.stop_measurement: my_sps30
+```
 
 ## See Also
 


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes https://github.com/esphome/feature-requests/issues/2133

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#12255
- 
## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
