### PR TITLE
2025.11.3

### DIFF
--- a/content/changelog/2025.11.0.md
+++ b/content/changelog/2025.11.0.md
@@ -526,6 +526,25 @@ The 2025.11 release blog posts include comprehensive migration examples for comm
 
 <!-- markdownlint-disable MD013 -->
 
+## Release 2025.11.3 - December 3
+
+<details>
+<summary></summary>
+
+- [build] Don't clear pio cache unless requested [esphome#11966](https://github.com/esphome/esphome/pull/11966) by [@clydebarrow](https://github.com/clydebarrow)
+- [usb_uart] Wake main loop immediately when USB data arrives [esphome#12148](https://github.com/esphome/esphome/pull/12148) by [@bdraco](https://github.com/bdraco)
+- [espnow] Initialize LwIP stack when running without WiFi component [esphome#12169](https://github.com/esphome/esphome/pull/12169) by [@bdraco](https://github.com/bdraco)
+- [helpers] Add conversion from FixedVector to std::vector [esphome#12179](https://github.com/esphome/esphome/pull/12179) by [@clydebarrow](https://github.com/clydebarrow)
+- [hlk_fm22x] Fix Action::play method signatures [esphome#12192](https://github.com/esphome/esphome/pull/12192) by [@bdraco](https://github.com/bdraco)
+- [mopeka_pro_check] Fix negative temperatures [esphome#12198](https://github.com/esphome/esphome/pull/12198) by [@swoboda1337](https://github.com/swoboda1337)
+- [ade7953] Apply voltage_gain setting to both channels [esphome#12180](https://github.com/esphome/esphome/pull/12180) by [@dlitz](https://github.com/dlitz)
+- [core] Fix clean all on windows [esphome#12217](https://github.com/esphome/esphome/pull/12217) by [@swoboda1337](https://github.com/swoboda1337)
+- [rtl87xx] Fix AsyncTCP compilation by upgrading FreeRTOS to 8.2.3 [esphome#12230](https://github.com/esphome/esphome/pull/12230) by [@swoboda1337](https://github.com/swoboda1337)
+- [analog_threshold] Fix oscillation when using invert filter [esphome#12251](https://github.com/esphome/esphome/pull/12251) by [@swoboda1337](https://github.com/swoboda1337)
+- [rtl87xx] Fix FreeRTOS version for RTL8720C boards [esphome#12261](https://github.com/esphome/esphome/pull/12261) by [@swoboda1337](https://github.com/swoboda1337)
+
+</details>
+
 ## Release 2025.11.2 - November 27
 
 <details>

--- a/content/guides/supporters.md
+++ b/content/guides/supporters.md
@@ -229,6 +229,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Pierre (@bemble)](https://github.com/bemble)
 - [Ben-Schwabe (@Ben-Schwabe)](https://github.com/Ben-Schwabe)
 - [Benas09 (@Benas09)](https://github.com/Benas09)
+- [Benjamin Choy (@bench2012)](https://github.com/bench2012)
 - [Ben Kristinsson (@benediktkr)](https://github.com/benediktkr)
 - [Ben Hoff (@benhoff)](https://github.com/benhoff)
 - [Benoît Leforestier (@Benichou34)](https://github.com/Benichou34)
@@ -562,6 +563,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [djwlindenaar (@djwlindenaar)](https://github.com/djwlindenaar)
 - [Marcos Pérez Ferro (@djwmarcx)](https://github.com/djwmarcx)
 - [Dmitry Ketov (@dketov)](https://github.com/dketov)
+- [Darsey Litzenberger (@dlitz)](https://github.com/dlitz)
 - [Dan Mannock (@dmannock)](https://github.com/dmannock)
 - [Dmitriy Lopatko (@dmitriy5181)](https://github.com/dmitriy5181)
 - [dmkif (@dmkif)](https://github.com/dmkif)
@@ -960,6 +962,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Jonathan Kollasch (@jakllsch)](https://github.com/jakllsch)
 - [Jakob Reiter (@jakommo)](https://github.com/jakommo)
 - [jakub-medrzak (@jakub-medrzak)](https://github.com/jakub-medrzak)
+- [Jakub Čermák (@jakubcermak)](https://github.com/jakubcermak)
 - [James Braid (@jamesbraid)](https://github.com/jamesbraid)
 - [James Duke (@jamesduke)](https://github.com/jamesduke)
 - [James Gao (@jamesgao)](https://github.com/jamesgao)
@@ -2276,4 +2279,4 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Christian Zufferey (@zuzu59)](https://github.com/zuzu59)
 - [Zynth-dev (@Zynth-dev)](https://github.com/Zynth-dev)
 
-*This page was last updated November 27, 2025.*
+*This page was last updated December 3, 2025.*

--- a/data/version.yaml
+++ b/data/version.yaml
@@ -1,2 +1,2 @@
-release: 2025.11.2
+release: 2025.11.3
 version: '2025.11'


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- [wifi] Clarify fast_connect behavior and add hidden network documentation [docs#5682](https://github.com/esphome/esphome-docs/pull/5682)
- Add DFRobot Edge101 Ethernet configuration example [docs#5686](https://github.com/esphome/esphome-docs/pull/5686)
- [remote_receiver] Add missing default value for idle config option [docs#5700](https://github.com/esphome/esphome-docs/pull/5700)
- [psram] Fix breaking change for psram missing key info [docs#5707](https://github.com/esphome/esphome-docs/pull/5707)
- Add PSRAM requirement note to ESP32 Camera Component [docs#5710](https://github.com/esphome/esphome-docs/pull/5710)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
