### PR TITLE
[cst816] Add CST836 and CST816D to supported chips list

### DIFF
--- a/content/components/touchscreen/cst816.md
+++ b/content/components/touchscreen/cst816.md
@@ -10,8 +10,7 @@ params:
 The `cst816` touchscreen platform allows using the touch screen controllers based on the CST816 series of chips with ESPHome.
 The [I²C](/components/i2c) is required to be set up in your configuration for this touchscreen to work.
 
-This controller is used in the Lilygo T-Display S3 AMOLED. The component should work with CST816T, CST816S, CST820, CST826 and CST716
-controller chips.
+This controller is used in the Lilygo T-Display S3 AMOLED. The component should work with CST716, CST816D, CST816S, CST816T, CST820, CST826, and CST836 controller chips.
 
 {{< img src="cst816.jpg" alt="Image" caption="cst816t touchscreen on T-Display S3 AMOLED" width="50.0%" class="align-center" >}}
 

--- a/content/components/touchscreen/cst816.md
+++ b/content/components/touchscreen/cst816.md
@@ -10,7 +10,8 @@ params:
 The `cst816` touchscreen platform allows using the touch screen controllers based on the CST816 series of chips with ESPHome.
 The [I²C](/components/i2c) is required to be set up in your configuration for this touchscreen to work.
 
-This controller is used in the Lilygo T-Display S3 AMOLED. The component should work with CST716, CST816D, CST816S, CST816T, CST820, CST826, and CST836 controller chips.
+This controller is used in the Lilygo T-Display S3 AMOLED. The component should work with CST716, CST816D, CST816S,
+CST816T, CST820, CST826, and CST836 controller chips.
 
 {{< img src="cst816.jpg" alt="Image" caption="cst816t touchscreen on T-Display S3 AMOLED" width="50.0%" class="align-center" >}}
 


### PR DESCRIPTION
## Description:

Add cst836 docs

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#12260

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
