### PR TITLE
[cookbook] Fix power_meter action and sensor ID references

### DIFF
--- a/content/cookbook/power_meter.md
+++ b/content/cookbook/power_meter.md
@@ -130,7 +130,7 @@ api:
       variables:
         new_total: int
       then:
-        - pulse_counter.set_total_pulses:
+        - pulse_meter.set_total_pulses:
             id: sensor_pulse_meter
             value: !lambda 'return new_total * 1000;'
 ```
@@ -146,7 +146,7 @@ sensor:
   - platform: total_daily_energy
     name: 'Total Daily Energy'
     id: sensor_total_daily_energy
-    power_id: sensor_energy_pulse_meter
+    power_id: sensor_pulse_meter
     unit_of_measurement: 'kWh'
     state_class: total_increasing
     device_class: energy


### PR DESCRIPTION
## Description:

Changes to content/cookbook/power_meter.md:

1. Line 133: Changed pulse_counter.set_total_pulses → pulse_meter.set_total_pulses
  - The cookbook uses pulse_meter sensor, so it needs the matching action
2. Line 149: Changed power_id: sensor_energy_pulse_meter → power_id: sensor_pulse_meter
  - Fixes reference to match the sensor ID defined on line 42

Fixes: esphome/esphome-docs#5543

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
