### PR TITLE
[es8311] Remove MIN and MAX from mic_gain documentation

### DIFF
--- a/content/components/audio_dac/es8311.md
+++ b/content/components/audio_dac/es8311.md
@@ -27,7 +27,7 @@ audio_dac:
 - **sample_rate** (*Optional*, positive integer): I2S sample rate. Defaults to `16000`.
 - **use_mclk** (*Optional*, bool): Use the MCLK signal to control the clock. Defaults to `True`.
 - **use_microphone** (*Optional*, bool): Configure the codec's ADC to use PDM microphone input instead of analog. Defaults to False.
-- **mic_gain** (*Optional*, enum): The gain applied to the ADC microphones. One of `MIN`, `0DB`, `6DB`, `12DB`, `18DB`, `24DB`, `30DB`, `36DB`, `42DB`, or `MAX`. Defaults to `42DB`.
+- **mic_gain** (*Optional*, enum): The gain applied to the ADC microphones. One of `0DB`, `6DB`, `12DB`, `18DB`, `24DB`, `30DB`, `36DB`, `42DB`. Defaults to `42DB`.
 - **address** (*Optional*, int): The I²C address of the driver. Defaults to `0x18`.
 - **i2c_id** (*Optional*): The ID of the [I²C bus](/components/i2c) the ES8311 is connected to.
 - All other options from [Audio DAC](/components/audio_dac#config-audio_dac).


### PR DESCRIPTION
## Description:

These are sentinel values for enum bounds and should not be used as actual configuration values.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
