### PR TITLE
[esp32] Add ESP32-C61 documentation

### DIFF
--- a/content/components/canbus/esp32_can.md
+++ b/content/components/canbus/esp32_can.md
@@ -39,28 +39,28 @@ canbus:
 
 The following table lists the bit rates supported by the component for ESP32 variants:
 
-| bit_rate          | ESP32 | ESP32-C3 | ESP32-C6 | ESP32-H2 | ESP32-S2 | ESP32-S3 |
-| ----------------- | ----- | -------- | -------- | -------- | -------- | -------- |
-| 1KBPS             |       | x        | x        | x        | x        | x        |
-| 5KBPS             |       | x        | x        | x        | x        | x        |
-| 10KBPS | | x | x | x | x | x |
-| 12K5BPS | | x | x | x | x | x |
-| 16KBPS | | x | x | x | x | x |
-| 20KBPS | | x | x | x | x | x |
-| 25KBPS | x | x | x | x | x | x |
-| 31K25BPS | | | | | | |
-| 33KBPS | | | | | | |
-| 40KBPS | | | | | | |
-| 50KBPS | x | x | x | x | x | x |
-| 80KBPS | | | | | | |
-| 83K38BPS | | | | | | |
-| 95KBPS | | | | | | |
-| 100KBPS | x | x | x | x | x | x |
-| 125KBPS (Default) | x | x | x | x | x | x |
-| 250KBPS | x | x | x | x | x | x |
-| 500KBPS | x | x | x | x | x | x |
-| 800KBPS | x | x | x | x | x | x |
-| 1000KBPS | x | x | x | x | x | x |
+| bit_rate          | ESP32 | ESP32-C3 | ESP32-C6 | ESP32-C61 | ESP32-H2 | ESP32-S2 | ESP32-S3 |
+| ----------------- | ----- | -------- | -------- | --------- | -------- | -------- | -------- |
+| 1KBPS             |       | x        | x        | x         | x        | x        | x        |
+| 5KBPS             |       | x        | x        | x         | x        | x        | x        |
+| 10KBPS | | x | x | x | x | x | x |
+| 12K5BPS | | x | x | x | x | x | x |
+| 16KBPS | | x | x | x | x | x | x |
+| 20KBPS | | x | x | x | x | x | x |
+| 25KBPS | x | x | x | x | x | x | x |
+| 31K25BPS | | | | | | | |
+| 33KBPS | | | | | | | |
+| 40KBPS | | | | | | | |
+| 50KBPS | x | x | x | x | x | x | x |
+| 80KBPS | | | | | | | |
+| 83K38BPS | | | | | | | |
+| 95KBPS | | | | | | | |
+| 100KBPS | x | x | x | x | x | x | x |
+| 125KBPS (Default) | x | x | x | x | x | x | x |
+| 250KBPS | x | x | x | x | x | x | x |
+| 500KBPS | x | x | x | x | x | x | x |
+| 800KBPS | x | x | x | x | x | x | x |
+| 1000KBPS | x | x | x | x | x | x | x |
 
 ## Wiring options
 

--- a/content/components/deep_sleep.md
+++ b/content/components/deep_sleep.md
@@ -67,7 +67,7 @@ Advanced features:
 
   - **pins** (**Required**, list of pin numbers): The pins to wake up on.
   - **mode** (**Required**): The mode to use for the wakeup source. Must be one of:
-    - `ANY_LOW`: wake up when any selected pin is LOW (ESP32‑S2/S3/C6/H2 only)
+    - `ANY_LOW`: wake up when any selected pin is LOW (ESP32‑S2/S3/C6/C61/H2 only)
     - `ALL_LOW`: wake up when all selected pins are LOW (ESP32 only)
     - `ANY_HIGH`: wake up when any selected pin is HIGH
 

--- a/content/components/esp32.md
+++ b/content/components/esp32.md
@@ -18,7 +18,7 @@ esp32:
 ## Configuration variables
 
 - **variant** (*Optional*, string): The ESP32 mcu/chip to use for this device configuration. One of `esp32`,
-  `esp32s2`, `esp32s3`, `esp32c2`, `esp32c3`, `esp32c5`, `esp32c6`, `esp32h2` or `esp32p4`.
+  `esp32s2`, `esp32s3`, `esp32c2`, `esp32c3`, `esp32c5`, `esp32c6`, `esp32c61`, `esp32h2` or `esp32p4`.
   This must match the hardware in use, or it will fail to flash.
 
 - **board** (*Optional*, string): The PlatformIO board ID that should be used. Choose the appropriate board from
@@ -64,7 +64,7 @@ esp32:
 
 ### ESP-IDF Framework
 
-ESP-IDF is Espressif's native development framework. It is required for ESP32-C2, ESP32-C5, ESP32-C6,
+ESP-IDF is Espressif's native development framework. It is required for ESP32-C2, ESP32-C5, ESP32-C6, ESP32-C61,
 ESP32-H2, and ESP32-P4 variants, as these are not supported by the Arduino framework. It is recommended for
 all ESP32 chips when possible. See the {{< docref "/guides/esp32_arduino_to_idf" "migration guide" >}} for help transitioning from Arduino.
 
@@ -78,7 +78,7 @@ esp32:
 
 ### Configuration variables
 
-- **type** (*Optional*, string): The framework type, either `esp-idf` or `arduino`. Defaults to `arduino` for ESP32 (classic), ESP32-C3, ESP32-S2, and ESP32-S3. Defaults to `esp-idf` for ESP32-C2, ESP32-C5, ESP32-C6, ESP32-H2, and ESP32-P4 (Arduino is not supported on these variants)
+- **type** (*Optional*, string): The framework type, either `esp-idf` or `arduino`. Defaults to `arduino` for ESP32 (classic), ESP32-C3, ESP32-S2, and ESP32-S3. Defaults to `esp-idf` for ESP32-C2, ESP32-C5, ESP32-C6, ESP32-C61, ESP32-H2, and ESP32-P4 (Arduino is not supported on these variants)
 
 - **version** (*Optional*, string): The base framework version number to use, from
   [ESP32 ESP-IDF releases](https://github.com/espressif/esp-idf/releases) or

--- a/content/components/light/esp32_rmt_led_strip.md
+++ b/content/components/light/esp32_rmt_led_strip.md
@@ -61,6 +61,7 @@ light:
 | ESP32-C3      | 96 symbols       | 48 symbols |
 | ESP32-C5 | 96 symbols | 48 symbols |
 | ESP32-C6 | 96 symbols | 48 symbols |
+| ESP32-C61 | 96 symbols | 48 symbols |
 | ESP32-H2 | 96 symbols | 48 symbols |
 | ESP32-P4 | 192 symbols | 48 symbols |
 | ESP32-S2 | 256 symbols | 64 symbols |

--- a/content/components/logger.md
+++ b/content/components/logger.md
@@ -91,6 +91,7 @@ so if you use any other configuration you will not get log messages over the on-
 | ESP32-C3 | TX: 21, RX: 20 | N/A | Undefined | N/A | N/A | 18/19 |
 | ESP32-C5 | TX: 10, RX: 11 | N/A | Undefined | N/A | N/A | 13/14 |
 | ESP32-C6 | TX: 16, RX: 17 | N/A | Undefined | N/A | N/A | 12/13 |
+| ESP32-C61 | TX: 5, RX: 4 | N/A | Undefined | N/A | N/A | 12/13 |
 | ESP32-P4 | TX: 37, RX: 38 | N/A | TX: 10, RX: 11 | N/A | N/A | 24/25 |
 | ESP32-S2 | TX: 43, RX: 44 | N/A | TX: 17, RX: 18 | N/A | 19/20 | N/A |
 | ESP32-S3 | TX: 43, RX: 44 | N/A | TX: 17, RX: 18 | Undefined | 19/20 | 19/20 |
@@ -114,6 +115,7 @@ the original ESP32 or ESP8266) continue to use USB-to-serial bridge ICs for comm
 | ESP32-C3 | `USB_SERIAL_JTAG` |
 | ESP32-C5 | `USB_SERIAL_JTAG` |
 | ESP32-C6 | `USB_SERIAL_JTAG` |
+| ESP32-C61 | `USB_SERIAL_JTAG` |
 | ESP32-P4 | `USB_SERIAL_JTAG` |
 | ESP32-S2 | `USB_CDC`         |
 | ESP32-S3 | `USB_SERIAL_JTAG` |

--- a/content/components/remote_receiver.md
+++ b/content/components/remote_receiver.md
@@ -110,6 +110,7 @@ Multiple remote receivers can be configured as a list of dict definitions within
 | ESP32-C3      | 96 symbols       | 48 symbols |
 | ESP32-C5      | 96 symbols       | 48 symbols |
 | ESP32-C6      | 96 symbols       | 48 symbols |
+| ESP32-C61     | 96 symbols       | 48 symbols |
 | ESP32-H2      | 96 symbols       | 48 symbols |
 | ESP32-P4      | 192 symbols      | 48 symbols |
 | ESP32-S2      | 256 symbols      | 64 symbols |

--- a/content/components/remote_transmitter.md
+++ b/content/components/remote_transmitter.md
@@ -51,6 +51,7 @@ remote_transmitter:
 | ESP32-C3      | 96 symbols       | 48 symbols |
 | ESP32-C5 | 96 symbols | 48 symbols |
 | ESP32-C6 | 96 symbols | 48 symbols |
+| ESP32-C61 | 96 symbols | 48 symbols |
 | ESP32-H2 | 96 symbols | 48 symbols |
 | ESP32-P4 | 192 symbols | 48 symbols |
 | ESP32-S2 | 256 symbols | 64 symbols |

--- a/content/components/sensor/adc.md
+++ b/content/components/sensor/adc.md
@@ -86,6 +86,7 @@ To simplify this, we provide the setting `attenuation: auto` for an automatic/se
 | ESP32-C3 | GPIO0 - GPIO4 | GPIO5 |
 | ESP32-C5 | GPIO1 - GPIO6 | no `ADC2`                                             |
 | ESP32-C6 | GPIO0 - GPIO6 | no `ADC2`                                             |
+| ESP32-C61 | GPIO1, GPIO3 - GPIO5 | no `ADC2`                                      |
 | ESP32-H2 | GPIO1 - GPIO5 | no `ADC2`                                             |
 | ESP32-S2 | GPIO1 - GPIO10 | GPIO11 - GPIO20 |
 | ESP32-S3 | GPIO1 - GPIO10 | GPIO11 - GPIO20 |
@@ -94,7 +95,7 @@ To simplify this, we provide the setting `attenuation: auto` for an automatic/se
 Different ESP32 variants use different ADC calibration methods:
 
 - Original ESP32 (non-variant) & ESP32-S2: Use line-fitting calibration
-- ESP32-C3, ESP32-C5, ESP32-C6, ESP32-H2, ESP32-S3 & ESP32-P4: Use curve-fitting calibration
+- ESP32-C3, ESP32-C5, ESP32-C6, ESP32-C61, ESP32-H2, ESP32-S3 & ESP32-P4: Use curve-fitting calibration
 
 This is handled automatically by the code, but it's worth noting if you're debugging ADC readings or need to understand the calibration process.
 


### PR DESCRIPTION
## Description:

Add esp32 c61 docs

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#12285

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
