### PR TITLE
2025.11.4

### DIFF
--- a/content/changelog/2025.11.0.md
+++ b/content/changelog/2025.11.0.md
@@ -526,6 +526,21 @@ The 2025.11 release blog posts include comprehensive migration examples for comm
 
 <!-- markdownlint-disable MD013 -->
 
+## Release 2025.11.4 - December 4
+
+<details>
+<summary></summary>
+
+- [esp32] Add build flag to suppress noexecstack message [esphome#12272](https://github.com/esphome/esphome/pull/12272) by [@clydebarrow](https://github.com/clydebarrow)
+- [ld2420] Add missing USE_SELECT ifdefs [esphome#12275](https://github.com/esphome/esphome/pull/12275) by [@swoboda1337](https://github.com/swoboda1337)
+- [config] Provide path for `has_at_most_one_of` messages [esphome#12277](https://github.com/esphome/esphome/pull/12277) by [@clydebarrow](https://github.com/clydebarrow)
+- [es8311] Remove MIN and MAX from mic_gain enum options [esphome#12281](https://github.com/esphome/esphome/pull/12281) by [@swoboda1337](https://github.com/swoboda1337)
+- [esp32_hosted] Fix build and bump IDF component version to 2.7.0 [esphome#12282](https://github.com/esphome/esphome/pull/12282) by [@swoboda1337](https://github.com/swoboda1337)
+- [CI] Trigger generic version notifier job on release [esphome#12292](https://github.com/esphome/esphome/pull/12292) by [@jesserockz](https://github.com/jesserockz)
+- [scheduler] Fix use-after-free when cancelling timeouts from non-main-loop threads [esphome#12288](https://github.com/esphome/esphome/pull/12288) by [@bdraco](https://github.com/bdraco)
+
+</details>
+
 ## Release 2025.11.3 - December 3
 
 <details>

--- a/content/components/touchscreen/cst816.md
+++ b/content/components/touchscreen/cst816.md
@@ -10,8 +10,8 @@ params:
 The `cst816` touchscreen platform allows using the touch screen controllers based on the CST816 series of chips with ESPHome.
 The [I²C](/components/i2c) is required to be set up in your configuration for this touchscreen to work.
 
-This controller is used in the Lilygo T-Display S3 AMOLED. The component should work with CST816T, CST816S, CST820, CST826 and CST716
-controller chips.
+This controller is used in the Lilygo T-Display S3 AMOLED. The component should work with CST716, CST816D, CST816S,
+CST816T, CST820, CST826, and CST836 controller chips.
 
 {{< img src="cst816.jpg" alt="Image" caption="cst816t touchscreen on T-Display S3 AMOLED" width="50.0%" class="align-center" >}}
 

--- a/content/guides/supporters.md
+++ b/content/guides/supporters.md
@@ -281,6 +281,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Bob Kersten (@bobkersten)](https://github.com/bobkersten)
 - [Bodmer (@Bodmer)](https://github.com/Bodmer)
 - [Anthony Todd (@bohregard)](https://github.com/bohregard)
+- [Bohrium332 (@Bohrium332)](https://github.com/Bohrium332)
 - [Bomaker (@Bomaker)](https://github.com/Bomaker)
 - [Mauricio Bonani (@bonanitech)](https://github.com/bonanitech)
 - [Casey Olson (@bookcasey)](https://github.com/bookcasey)
@@ -617,6 +618,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [dyarkovoy (@dyarkovoy)](https://github.com/dyarkovoy)
 - [Janez Troha (@dz0ny)](https://github.com/dz0ny)
 - [Dimitris Zervas (@dzervas)](https://github.com/dzervas)
+- [Dziban303 (@dziban303)](https://github.com/dziban303)
 - [dziobson (@dziobson)](https://github.com/dziobson)
 - [Dan Jackson (@e28eta)](https://github.com/e28eta)
 - [Ettore Beltrame (@E440QF)](https://github.com/E440QF)
@@ -671,6 +673,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [ervede (@ervede)](https://github.com/ervede)
 - [escoand (@escoand)](https://github.com/escoand)
 - [Eric Severance (@esev)](https://github.com/esev)
+- [esphome[bot] (@esphome[bot])](https://github.com/esphome[bot])
 - [esphomebot (@esphomebot)](https://github.com/esphomebot)
 - [espressif2022 (@espressif2022)](https://github.com/espressif2022)
 - [Daniel Dunn (@EternityForest)](https://github.com/EternityForest)
@@ -909,6 +912,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Jan Pobořil (@iBobik)](https://github.com/iBobik)
 - [icarome (@icarome)](https://github.com/icarome)
 - [icefest (@icefest)](https://github.com/icefest)
+- [Igor Cicimov (@icicimov)](https://github.com/icicimov)
 - [ChenHsingYu (@idreamshen)](https://github.com/idreamshen)
 - [igg (@igg)](https://github.com/igg)
 - [Ignacio Hernandez-Ros (@IgnacioHR)](https://github.com/IgnacioHR)
@@ -1384,6 +1388,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [mhentschke (@mhentschke)](https://github.com/mhentschke)
 - [Marcel Hetzendorfer (@mhetzi)](https://github.com/mhetzi)
 - [M Hightower (@mhightower83)](https://github.com/mhightower83)
+- [Michael (@mib1185)](https://github.com/mib1185)
 - [Jörg Thalheim (@Mic92)](https://github.com/Mic92)
 - [Michaël Arnauts (@michaelarnauts)](https://github.com/michaelarnauts)
 - [michaelmeller (@michaelmeller)](https://github.com/michaelmeller)
@@ -2279,4 +2284,4 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Christian Zufferey (@zuzu59)](https://github.com/zuzu59)
 - [Zynth-dev (@Zynth-dev)](https://github.com/Zynth-dev)
 
-*This page was last updated December 3, 2025.*
+*This page was last updated December 4, 2025.*

--- a/data/version.yaml
+++ b/data/version.yaml
@@ -1,2 +1,2 @@
-release: 2025.11.3
+release: 2025.11.4
 version: '2025.11'


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- [cst816] Add CST836 and CST816D to supported chips list [docs#5718](https://github.com/esphome/esphome-docs/pull/5718)
- Add missing information for inkplate [docs#5696](https://github.com/esphome/esphome-docs/pull/5696)
- Fix inconsistencies between documentation and code. [docs#5695](https://github.com/esphome/esphome-docs/pull/5695)
- Bump actions/stale from 10.1.0 to 10.1.1 [docs#5720](https://github.com/esphome/esphome-docs/pull/5720)
- fix: Unintuitive config documentations for ES8311 [docs#5691](https://github.com/esphome/esphome-docs/pull/5691)
- Update mcp230xx.md  - update datasheets to current versions and links to HTTPS [docs#5581](https://github.com/esphome/esphome-docs/pull/5581)
- Add warning about sensor membrane tampering [docs#5496](https://github.com/esphome/esphome-docs/pull/5496)
- Add Seeed Studio XIAO ESP32-S3 PoE to Bluetooth Proxy device list [docs#5540](https://github.com/esphome/esphome-docs/pull/5540)
- [cookbook] Fix power_meter action and sensor ID references [docs#5721](https://github.com/esphome/esphome-docs/pull/5721)
- Added the link to the PAJ7620 Gesture Sensor [docs#5722](https://github.com/esphome/esphome-docs/pull/5722)
- Clarify address configuration for BMI160 sensor [docs#5717](https://github.com/esphome/esphome-docs/pull/5717)
- [es8311] Remove MIN and MAX from mic_gain documentation [docs#5723](https://github.com/esphome/esphome-docs/pull/5723)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
