### PR TITLE
Update Bluetooth Proxy buy links for GL-S10 and LilyGO T-ETH-POE

### DIFF
--- a/themes/esphome-theme/layouts/_default/projects.html
+++ b/themes/esphome-theme/layouts/_default/projects.html
@@ -437,8 +437,14 @@
     <ul>
       <li>
         <a
-          href="https://store.gl-inet.com/collections/iot-gateway/products/gl-s10-bluetooth-iot-gateway"
+          href="https://store.gl-inet.com/products/gl-s10-ble-iot-gateway?variant=39514685112414"
           >GL.iNet Shop</a
+        >
+      </li>
+      <li>
+        <a
+          href="https://www.aliexpress.us/item/3256803802198078.html"
+          >AliExpress - ESPHome pre-flashed</a
         >
       </li>
     </ul>
@@ -555,6 +561,12 @@
     </p>
     <p>Buy</p>
     <ul>
+      <li>
+        <a
+          href="https://lilygo.cc/en-us/products/t-internet-poe?variant=52074812965045"
+          >LilyGO Store</a
+        >
+      </li>
       <li>
         <a
           href="https://www.aliexpress.com/item/2255800936677694.html?pdp_ext_f=%7B%22sku_id%22%3A%2210000014557692201%22%7D"


### PR DESCRIPTION
## Description:

Update and add buy links for Bluetooth Proxy devices in the web installer:

- **GL.iNet GL-S10**: Update store link to working URL and add AliExpress pre-flashed option
- **LilyGO T-ETH-POE**: Add official LilyGO Store link

### Changes:
1. Fixed GL.iNet Shop link (old URL was broken)
2. Added AliExpress link for ESPHome pre-flashed GL-S10 units
3. Added LilyGO Store as primary buy option for T-ETH-POE board

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** N/A

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
