### PR TITLE
[cc1101] Add missing details

### DIFF
--- a/content/components/cc1101.md
+++ b/content/components/cc1101.md
@@ -24,7 +24,7 @@ ESPHome via the [SPI Bus](/components/spi) and integrates with the
 # Minimal Example
 cc1101:
   cs_pin: GPIOXX
-  frequency: 433920
+  frequency: 433.92MHz
 ```
 
 ## Configuration Variables
@@ -36,8 +36,8 @@ cc1101:
 
 ### General Settings
 
-- **frequency** (*Optional*, float): The operating frequency in kHz.
-  Range: `300000` to `928000`. Defaults to `433920` (433.92 MHz).
+- **frequency** (*Optional*, frequency): The operating frequency.
+  Range: `300MHz` to `928MHz`. Defaults to `433.92MHz`.
 - **output_power** (*Optional*, float): The transmission power in dBm.
   Range: `-30` to `11`. Defaults to `10`.
 - **modulation_type** (*Optional*, enum): The modulation format.
@@ -50,16 +50,16 @@ cc1101:
 
 ### Tuner Settings
 
-- **filter_bandwidth** (*Optional*, float): The receive filter bandwidth in kHz.
-  Range: `58` to `812`. Defaults to `203`.
-- **fsk_deviation** (*Optional*, float): Frequency deviation for FSK/GFSK modulation in kHz.
-  Range: `1.5` to `381`.
+- **filter_bandwidth** (*Optional*, frequency): The receive filter bandwidth.
+  Range: `58kHz` to `812kHz`. Defaults to `203kHz`.
+- **fsk_deviation** (*Optional*, frequency): Frequency deviation for FSK/GFSK modulation.
+  Range: `1.5kHz` to `381kHz`.
 - **msk_deviation** (*Optional*, int): Deviation index for MSK modulation. Range: `1` to `8`.
 - **channel** (*Optional*, int): Channel number (added to base frequency). Defaults to `0`.
-- **channel_spacing** (*Optional*, float): Spacing between channels in kHz.
-  Range: `25` to `405`. Defaults to `200`.
-- **if_frequency** (*Optional*, float): Intermediate Frequency in kHz.
-  Range: `25` to `788`. Defaults to `153`.
+- **channel_spacing** (*Optional*, frequency): Spacing between channels.
+  Range: `25kHz` to `405kHz`. Defaults to `200kHz`.
+- **if_frequency** (*Optional*, frequency): Intermediate Frequency.
+  Range: `25kHz` to `788kHz`. Defaults to `153kHz`.
 - **pktlen** (*Optional*, int): Packet length configuration. Sets the expected packet size for
   fixed-length packet mode. Range: `1` to `255`. Not typically needed for OOK/ASK modulation.
 

--- a/content/components/cc1101.md
+++ b/content/components/cc1101.md
@@ -24,7 +24,7 @@ ESPHome via the [SPI Bus](/components/spi) and integrates with the
 # Minimal Example
 cc1101:
   cs_pin: GPIOXX
-  frequency: 433.92MHz
+  frequency: 433920
 ```
 
 ## Configuration Variables
@@ -36,8 +36,8 @@ cc1101:
 
 ### General Settings
 
-- **frequency** (*Optional*, frequency): The operating frequency.
-  Range: `300MHz` to `928MHz`. Defaults to `433.92MHz`.
+- **frequency** (*Optional*, float): The operating frequency in kHz.
+  Range: `300000` to `928000`. Defaults to `433920` (433.92 MHz).
 - **output_power** (*Optional*, float): The transmission power in dBm.
   Range: `-30` to `11`. Defaults to `10`.
 - **modulation_type** (*Optional*, enum): The modulation format.
@@ -50,12 +50,16 @@ cc1101:
 
 ### Tuner Settings
 
-- **filter_bandwidth** (*Optional*, frequency): The receive filter bandwidth.
-  Range: `58kHz` to `812kHz`. Defaults to `203kHz`.
-- **fsk_deviation** (*Optional*, frequency): Frequency deviation for FSK/GFSK modulation.
+- **filter_bandwidth** (*Optional*, float): The receive filter bandwidth in kHz.
+  Range: `58` to `812`. Defaults to `203`.
+- **fsk_deviation** (*Optional*, float): Frequency deviation for FSK/GFSK modulation in kHz.
+  Range: `1.5` to `381`.
+- **msk_deviation** (*Optional*, int): Deviation index for MSK modulation. Range: `1` to `8`.
 - **channel** (*Optional*, int): Channel number (added to base frequency). Defaults to `0`.
-- **channel_spacing** (*Optional*, frequency): Spacing between channels. Defaults to `200kHz`.
-- **if_frequency** (*Optional*, frequency): Intermediate Frequency. Defaults to `153kHz`.
+- **channel_spacing** (*Optional*, float): Spacing between channels in kHz.
+  Range: `25` to `405`. Defaults to `200`.
+- **if_frequency** (*Optional*, float): Intermediate Frequency in kHz.
+  Range: `25` to `788`. Defaults to `153`.
 - **pktlen** (*Optional*, int): Packet length configuration. Sets the expected packet size for
   fixed-length packet mode. Range: `1` to `255`. Not typically needed for OOK/ASK modulation.
 


### PR DESCRIPTION
## Description:

Add missing details
  
**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#12313

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
