### PR TITLE
M5core2 display

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@
 
 <a href="https://esphome.io/">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://esphome.io/images/logo-docs-on-dark.svg">
-    <img src="https://esphome.io/images/logo-docs.svg" alt="ESPHome Logo">
+    <source media="(prefers-color-scheme: dark)" srcset="https://media.esphome.io/logo/logo-text-on-dark.svg">
+    <img src="https://media.esphome.io/logo/logo-text-on-light.svg" alt="ESPHome Logo">
   </picture>
 </a>
 

--- a/content/components/display/mipi_spi.md
+++ b/content/components/display/mipi_spi.md
@@ -62,6 +62,7 @@ using an octal SPI bus, so references here to parallel and octal SPI are equival
 | ADAFRUIT-S2-TFT-FEATHER              | Adafruit     | <https://www.adafruit.com/product/6312>                           |
 | ADAFRUIT-FUNHOUSE                    | Adafruit     | <https://www.adafruit.com/product/4985>                           |
 | M5CORE                               | M5Stack | <https://docs.m5stack.com/en/core/BASIC%20v2.6> |
+| M5CORE2                              | M5Stack | <https://docs.m5stack.com/en/core/core2> |
 | S3BOX                                | Espressif | <https://www.espressif.com/en/products/devkits/esp32-s3-box> |
 | S3BOXLITE                            | Espressif | <https://www.espressif.com/en/products/devkits/esp32-s3-box-lite> |
 | WAVESHARE-4-TFT                      | Waveshare | <https://www.waveshare.com/4inch-tft-touch-shield.htm> |

--- a/themes/esphome-theme/layouts/_default/projects.html
+++ b/themes/esphome-theme/layouts/_default/projects.html
@@ -437,8 +437,14 @@
     <ul>
       <li>
         <a
-          href="https://store.gl-inet.com/collections/iot-gateway/products/gl-s10-bluetooth-iot-gateway"
+          href="https://store.gl-inet.com/products/gl-s10-ble-iot-gateway?variant=39514685112414"
           >GL.iNet Shop</a
+        >
+      </li>
+      <li>
+        <a
+          href="https://www.aliexpress.us/item/3256803802198078.html"
+          >AliExpress - ESPHome pre-flashed</a
         >
       </li>
     </ul>
@@ -555,6 +561,12 @@
     </p>
     <p>Buy</p>
     <ul>
+      <li>
+        <a
+          href="https://lilygo.cc/en-us/products/t-internet-poe?variant=52074812965045"
+          >LilyGO Store</a
+        >
+      </li>
       <li>
         <a
           href="https://www.aliexpress.com/item/2255800936677694.html?pdp_ext_f=%7B%22sku_id%22%3A%2210000014557692201%22%7D"


### PR DESCRIPTION
## Description:
Add M5CORE2 entry to MIPI SPI documentation

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#12301

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
