### PR TITLE
Update docs for ESP32-C5, C61, and P4 variant support

### DIFF
--- a/content/components/canbus/esp32_can.md
+++ b/content/components/canbus/esp32_can.md
@@ -39,28 +39,33 @@ canbus:
 
 The following table lists the bit rates supported by the component for ESP32 variants:
 
-| bit_rate          | ESP32 | ESP32-C3 | ESP32-C6 | ESP32-C61 | ESP32-H2 | ESP32-S2 | ESP32-S3 |
-| ----------------- | ----- | -------- | -------- | --------- | -------- | -------- | -------- |
-| 1KBPS             |       | x        | x        | x         | x        | x        | x        |
-| 5KBPS             |       | x        | x        | x         | x        | x        | x        |
-| 10KBPS | | x | x | x | x | x | x |
-| 12K5BPS | | x | x | x | x | x | x |
-| 16KBPS | | x | x | x | x | x | x |
-| 20KBPS | | x | x | x | x | x | x |
-| 25KBPS | x | x | x | x | x | x | x |
-| 31K25BPS | | | | | | | |
-| 33KBPS | | | | | | | |
-| 40KBPS | | | | | | | |
-| 50KBPS | x | x | x | x | x | x | x |
-| 80KBPS | | | | | | | |
-| 83K38BPS | | | | | | | |
-| 95KBPS | | | | | | | |
-| 100KBPS | x | x | x | x | x | x | x |
-| 125KBPS (Default) | x | x | x | x | x | x | x |
-| 250KBPS | x | x | x | x | x | x | x |
-| 500KBPS | x | x | x | x | x | x | x |
-| 800KBPS | x | x | x | x | x | x | x |
-| 1000KBPS | x | x | x | x | x | x | x |
+| bit_rate          | ESP32 | Other variants* |
+| ----------------- | ----- | --------------- |
+| 1KBPS             |       | x               |
+| 5KBPS             |       | x               |
+| 10KBPS            |       | x               |
+| 12K5BPS           |       | x               |
+| 16KBPS            |       | x               |
+| 20KBPS            |       | x               |
+| 25KBPS            | x     | x               |
+| 31K25BPS          |       |                 |
+| 33KBPS            |       |                 |
+| 40KBPS            |       |                 |
+| 50KBPS            | x     | x               |
+| 80KBPS            |       |                 |
+| 83K3BPS           |       |                 |
+| 95KBPS            |       |                 |
+| 100KBPS           | x     | x               |
+| 125KBPS (Default) | x     | x               |
+| 250KBPS           | x     | x               |
+| 500KBPS           | x     | x               |
+| 800KBPS           | x     | x               |
+| 1000KBPS          | x     | x               |
+
+\* Other variants: ESP32-C3, ESP32-C5, ESP32-C6, ESP32-C61, ESP32-H2, ESP32-P4, ESP32-S2, ESP32-S3
+
+> [!NOTE]
+> ESP32-C2 does not have TWAI/CAN hardware and is not supported.
 
 ## Wiring options
 

--- a/content/components/canbus/esp32_can.md
+++ b/content/components/canbus/esp32_can.md
@@ -62,7 +62,7 @@ The following table lists the bit rates supported by the component for ESP32 var
 | 800KBPS           | x     | x               |
 | 1000KBPS          | x     | x               |
 
-\* Other variants: ESP32-C3, ESP32-C5, ESP32-C6, ESP32-C61, ESP32-H2, ESP32-P4, ESP32-S2, ESP32-S3
+Other variants: ESP32-C3, ESP32-C5, ESP32-C6, ESP32-C61, ESP32-H2, ESP32-P4, ESP32-S2, ESP32-S3
 
 > [!NOTE]
 > ESP32-C2 does not have TWAI/CAN hardware and is not supported.

--- a/content/components/deep_sleep.md
+++ b/content/components/deep_sleep.md
@@ -67,7 +67,7 @@ Advanced features:
 
   - **pins** (**Required**, list of pin numbers): The pins to wake up on.
   - **mode** (**Required**): The mode to use for the wakeup source. Must be one of:
-    - `ANY_LOW`: wake up when any selected pin is LOW (ESP32‑S2/S3/C6/C61/H2 only)
+    - `ANY_LOW`: wake up when any selected pin is LOW (ESP32‑C5/C6/C61/H2/P4/S2/S3 only)
     - `ALL_LOW`: wake up when all selected pins are LOW (ESP32 only)
     - `ANY_HIGH`: wake up when any selected pin is HIGH
 

--- a/content/components/openthread.md
+++ b/content/components/openthread.md
@@ -18,7 +18,7 @@ This component allows ESPHome nodes to communicate with Home Assistant over a Th
 
 ## Usage
 
-This component requires an ESP32 (ESP32-C6 or ESP32-H2 because they have Thread radio chip) and the use of
+This component requires an ESP32 (ESP32-C5, ESP32-C6, or ESP32-H2 because they have Thread radio chip) and the use of
 ESP-IDF.
 
 ```yaml


### PR DESCRIPTION
## Description:

 Changes:
  - esp32_can.md: Add ESP32-C5, ESP32-C61, and ESP32-P4 columns to bit_rate support table
  - deep_sleep.md: Update ANY_LOW wakeup mode description to include C5, C61, and P4 variants
  - openthread.md: Add ESP32-C5 to list of supported variants (has IEEE 802.15.4 radio)
 
**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#12305

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
