### PR TITLE
Improve readability of Log Levels

### DIFF
--- a/content/components/logger.md
+++ b/content/components/logger.md
@@ -126,42 +126,15 @@ the original ESP32 or ESP8266) continue to use USB-to-serial bridge ICs for comm
 
 Possible log levels are (sorted by severity):
 
-- `NONE`
-
-- No messages are logged.
-
-- `ERROR`
-
-- With this log level, only errors are logged. Errors are issues that prevent the ESP from working
-
-    correctly. Color: red
-
-- `WARN`
-
-- With this log level, warnings and errors are logged. Warnings are issues like invalid readings from
-
-    sensors that ESPHome can recover from. Color: yellow
-
-- `INFO`
-
-- With this log level, everything up to info messages are logged; so errors, warnings and info. Color: green
-
-- `DEBUG` (**Default**)
-
-- Everything up to this log level is logged. Debug messages include the current readings from a sensor
-
-    and status messages. Color: cyan
-
-- `VERBOSE`
-
-- Like debug, but a few more messages that are usually deemed to be spam are also included. Color: grey
-
-- `VERY_VERBOSE`
-
-- All internal messages are logged. Including all the data flowing through data buses like
-
-    I²C, SPI or UART. Warning: May cause the device to slow down and have trouble staying
-    connecting due to amount of generated messages. Color: white
+| Level          | Colour |           |
+| -------------- | ------ | --------- |
+| `NONE`         |        | No messages are logged. |
+| `ERROR`        | Red    | Only errors are logged. Errors are issues that prevent the ESP from working correctly. |
+| `WARN`         | Yellow | Warnings and errors are logged. Warnings are issues like invalid readings from sensors that ESPHome can recover from. |
+| `INFO`         | Green  | Everything up to info messages are logged; so errors, warnings and info. |
+| `DEBUG`        | Cyan   | **Default** - Everything up to this log level is logged. Debug messages include the current readings from a sensor and status messages. |
+| `VERBOSE`      | Grey   | Like debug, but a few more messages that are usually deemed to be spam are also included. |
+| `VERY_VERBOSE` | White  | All internal messages are logged. Including all the data flowing through data buses like I²C, SPI or UART.<br>Warning: May cause the device to slow down and have trouble staying connecting due to amount of generated messages. |
 
 {{< anchor "logger-manual_tag_specific_levels" >}}
 

--- a/content/components/logger.md
+++ b/content/components/logger.md
@@ -126,19 +126,18 @@ the original ESP32 or ESP8266) continue to use USB-to-serial bridge ICs for comm
 
 Possible log levels are (sorted by severity):
 
-| Level          | Color  | Description |
-| -------------- | ------ | ----------- |
-| `NONE`         |        | No messages are logged. |
-| `ERROR`        | Red    | Only errors are logged. Errors prevent the ESP from working correctly. |
-| `WARN`         | Yellow | Warnings and errors. Warnings are recoverable issues like invalid sensor readings. |
-| `INFO`         | Green  | Errors, warnings and info messages are logged. |
-| `DEBUG`        | Cyan   | **Default** - Everything up to debug level. Includes sensor readings and status messages. |
-| `VERBOSE`      | Gray   | Like debug, but includes additional messages usually deemed to be spam. |
-| `VERY_VERBOSE` | White  | All internal messages including data flowing through I²C, SPI and UART buses. |
+| Level              | Color  | Description |
+| ------------------ | ------ | ----------- |
+| `NONE`             |        | No messages are logged. |
+| `ERROR`            | Red    | Only errors are logged. Errors prevent the ESP from working correctly. |
+| `WARN`             | Yellow | Warnings and errors. Warnings are recoverable issues like invalid sensor readings. |
+| `INFO`             | Green  | Errors, warnings and info messages are logged. |
+| `DEBUG` (default)  | Cyan   | Everything up to debug. Includes sensor readings and status messages. |
+| `VERBOSE`          | Gray   | Like debug, but includes additional messages usually deemed to be spam. |
+| `VERY_VERBOSE`     | White  | All internal messages including data flowing through I²C, SPI and UART buses. |
 
 > [!WARNING]
-> `VERY_VERBOSE` may cause the device to slow down and have trouble staying connected
-> due to the amount of generated messages.
+> Using `VERY_VERBOSE` can significantly impact device performance and may cause connection instability.
 
 {{< anchor "logger-manual_tag_specific_levels" >}}
 

--- a/content/components/logger.md
+++ b/content/components/logger.md
@@ -126,8 +126,8 @@ the original ESP32 or ESP8266) continue to use USB-to-serial bridge ICs for comm
 
 Possible log levels are (sorted by severity):
 
-| Level          | Colour |           |
-| -------------- | ------ | --------- |
+| Level          | Colour | Description |
+| -------------- | ------ | ----------- |
 | `NONE`         |        | No messages are logged. |
 | `ERROR`        | Red    | Only errors are logged. Errors are issues that prevent the ESP from working correctly. |
 | `WARN`         | Yellow | Warnings and errors are logged. Warnings are issues like invalid readings from sensors that ESPHome can recover from. |

--- a/content/components/logger.md
+++ b/content/components/logger.md
@@ -134,7 +134,7 @@ Possible log levels are (sorted by severity):
 | `INFO`         | Green  | Everything up to info messages are logged; so errors, warnings and info. |
 | `DEBUG`        | Cyan   | **Default** - Everything up to this log level is logged. Debug messages include the current readings from a sensor and status messages. |
 | `VERBOSE`      | Grey   | Like debug, but a few more messages that are usually deemed to be spam are also included. |
-| `VERY_VERBOSE` | White  | All internal messages are logged. Including all the data flowing through data buses like I²C, SPI or UART.<br>Warning: May cause the device to slow down and have trouble staying connecting due to amount of generated messages. |
+| `VERY_VERBOSE` | White  | All internal messages are logged. Including all the data flowing through data buses like I²C, SPI or UART. Warning: May cause the device to slow down and have trouble staying connecting due to amount of generated messages. |
 
 {{< anchor "logger-manual_tag_specific_levels" >}}
 

--- a/content/components/logger.md
+++ b/content/components/logger.md
@@ -126,15 +126,19 @@ the original ESP32 or ESP8266) continue to use USB-to-serial bridge ICs for comm
 
 Possible log levels are (sorted by severity):
 
-| Level          | Colour | Description |
+| Level          | Color  | Description |
 | -------------- | ------ | ----------- |
 | `NONE`         |        | No messages are logged. |
-| `ERROR`        | Red    | Only errors are logged. Errors are issues that prevent the ESP from working correctly. |
-| `WARN`         | Yellow | Warnings and errors are logged. Warnings are issues like invalid readings from sensors that ESPHome can recover from. |
-| `INFO`         | Green  | Everything up to info messages are logged; so errors, warnings and info. |
-| `DEBUG`        | Cyan   | **Default** - Everything up to this log level is logged. Debug messages include the current readings from a sensor and status messages. |
-| `VERBOSE`      | Grey   | Like debug, but a few more messages that are usually deemed to be spam are also included. |
-| `VERY_VERBOSE` | White  | All internal messages are logged. Including all the data flowing through data buses like I²C, SPI or UART. Warning: May cause the device to slow down and have trouble staying connecting due to amount of generated messages. |
+| `ERROR`        | Red    | Only errors are logged. Errors prevent the ESP from working correctly. |
+| `WARN`         | Yellow | Warnings and errors. Warnings are recoverable issues like invalid sensor readings. |
+| `INFO`         | Green  | Errors, warnings and info messages are logged. |
+| `DEBUG`        | Cyan   | **Default** - Everything up to debug level. Includes sensor readings and status messages. |
+| `VERBOSE`      | Gray   | Like debug, but includes additional messages usually deemed to be spam. |
+| `VERY_VERBOSE` | White  | All internal messages including data flowing through I²C, SPI and UART buses. |
+
+> [!WARNING]
+> `VERY_VERBOSE` may cause the device to slow down and have trouble staying connected
+> due to the amount of generated messages.
 
 {{< anchor "logger-manual_tag_specific_levels" >}}
 


### PR DESCRIPTION
## Description:
Change the format of log levels to a table instead of a bullet list to make the association of the level and description more clear.


## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
