### PR TITLE
Revise pull request template for component images

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -30,7 +30,7 @@ If you are adding a new component to ESPHome, you can automatically generate a s
 
 2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.
 
-3. Extract the SVG file and place it in the `/components/images/` folder of this repository.
+3. Extract the SVG file and place it in the `/static/images/` folder of this repository.
 
 4. Use the image in your component's index table entry in `/components/_index.md`.
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,7 +13,7 @@
     or
   - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.
 
-  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.
+  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.
 
 <details>
 <summary><strong>New Component Images</strong></summary>
@@ -22,21 +22,21 @@ If you are adding a new component to ESPHome, you can automatically generate a s
 
 **To generate a component image:**
 
-1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):
+1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):
 
    ```
-   @esphomebot generate image COMPONENT_NAME
+   @esphomebot generate image component_name
    ```
 
 2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.
 
-3. Extract the SVG file and place it in the `images/` folder of this repository.
+3. Extract the SVG file and place it in the `/components/images/` folder of this repository.
 
-4. Use the image in your component's index table entry in `/components/index.rst`.
+4. Use the image in your component's index table entry in `/components/_index.md`.
 
 **Example:** For a component called "DHT22 Temperature Sensor", use:
 ```
-@esphomebot generate image DHT22
+@esphomebot generate image dht22
 ```
 
 </details>


### PR DESCRIPTION
Updated pull request template to reflect changes in file structure and naming conventions for component images.

## Description:
rst -> md and image generation must be lower case.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
