### PR TITLE
[nrf52] Document optional reset_pin for DFU component

### DIFF
--- a/content/components/nrf52.md
+++ b/content/components/nrf52.md
@@ -78,7 +78,7 @@ There are two ways to reference GPIO pins:
 
 The `dfu` component enables automatic entry into **DFU (Device Firmware Update)** mode by monitoring
 the USB CDC serial connection. When a host opens the port at **1200 baud**, the component triggers
-a reset via a GPIO pin to put the device into DFU mode.
+a reset to put the device into DFU mode.
 
 ESPHome uses this component internally when uploading firmware via:
 
@@ -88,6 +88,8 @@ esphome upload d.yaml
 
 ### Example Configuration
 
+With reset pin (recommended):
+
 ```yaml
 nrf52:
   dfu:
@@ -96,9 +98,16 @@ nrf52:
       inverted: true
 ```
 
+Without reset pin (less reliable):
+
+```yaml
+nrf52:
+  dfu: {}
+```
+
 ### Configuration variables
 
-- **reset_pin** (*Required*, [Pin](/guides/configuration-types#pin)): The pin to use for trigger a hardware reset. This pin should be connected to the MCU's reset line or to a circuit that causes the bootloader to enter DFU mode after reset.
+- **reset_pin** (*Optional*, [Pin](/guides/configuration-types#pin)): The pin to use to trigger a hardware reset. This pin should be connected to the MCU's reset line or to a circuit that causes the bootloader to enter DFU mode after reset. When omitted, the device will attempt to enter DFU mode without a hardware reset, which is less reliable and may require multiple attempts.
 
 ## REGOUT0
 


### PR DESCRIPTION
## Description:

**Related issue (if applicable):

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#11684

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
