### PR TITLE
Replace deprecated clk_mode with clk

### DIFF
--- a/content/components/bluetooth_proxy.md
+++ b/content/components/bluetooth_proxy.md
@@ -99,7 +99,9 @@ ethernet:
   type: LAN8720
   mdc_pin: GPIO23
   mdio_pin: GPIO18
-  clk_mode: GPIO17_OUT
+  clk:
+    mode: CLK_OUT
+    pin: GPIO17
   phy_addr: 0
   power_pin: GPIO12
 


### PR DESCRIPTION
## Description:

Usage of `clk_mode` is deprecated and should not be part of samples.

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.
