### PR TITLE
[micronova] Remove memory_write_location

### DIFF
--- a/content/components/micronova.md
+++ b/content/components/micronova.md
@@ -56,7 +56,7 @@ micronova:
 > switch or number accepts these parameters:
 >
 > - **memory_location** (*Optional*): The memory location where the parameter must be read. For most stoves this is 0x00 for RAM
->   or 0x20 for EPROM.
+>   or 0x20 for EPROM. Always specifiy the read location. The write bit is automatically set on write requests
 >
 > - **memory_address** (*Optional*): The address where the parameter is stored.
 

--- a/content/components/micronova.md
+++ b/content/components/micronova.md
@@ -55,7 +55,8 @@ micronova:
 > not specify them. However your Micronova boad may require you to specify alternate values. So every text sensor, button,
 > switch or number accepts these parameters:
 >
-> - **memory_location** (*Optional*): The memory location for the parameter (0x00 for RAM, 0x20 for EPROM on most stoves). The write bit is set automatically when writing.
+> - **memory_location** (*Optional*): The memory location for the parameter (0x00 for RAM, 0x20 for EPROM on most stoves).
+>   The write bit is set automatically when writing.
 >
 > - **memory_address** (*Optional*): The address where the parameter is stored.
 

--- a/content/components/micronova.md
+++ b/content/components/micronova.md
@@ -153,12 +153,6 @@ number:
   - **update_interval** (*Optional*, [Time](/guides/configuration-types#time)): The interval that the sensors should be checked. Defaults to 60 seconds.
   - All options from [Number](/components/number#config-number).
 
-> [!NOTE]
-> Besides **memory_location** and **memory_address** you can specify a specific **memory_write_location** parameter.
-> This parameter is a hex value for the **memory_location** where the new thermostat value must be written.
->
-> - **memory_write_location** (*Optional*): The **memory_location** where to write the new thermostat value.
-
 ## Buttons
 
 ```yaml

--- a/content/components/micronova.md
+++ b/content/components/micronova.md
@@ -55,8 +55,7 @@ micronova:
 > not specify them. However your Micronova boad may require you to specify alternate values. So every text sensor, button,
 > switch or number accepts these parameters:
 >
-> - **memory_location** (*Optional*): The memory location where the parameter must be read. For most stoves this is 0x00 for RAM
->   or 0x20 for EPROM. Always specifiy the read location. The write bit is automatically set on write requests
+> - **memory_location** (*Optional*): The memory location for the parameter (0x00 for RAM, 0x20 for EPROM on most stoves). The write bit is set automatically when writing.
 >
 > - **memory_address** (*Optional*): The address where the parameter is stored.
 


### PR DESCRIPTION
## Description:

Remove memory_write_location from the number entity 

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#12318

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/static/images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/_index.md`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image dht22
```

</details>
