### PR TITLE
[micronova] Add update_interval to switch entity

### DIFF
--- a/content/components/micronova.md
+++ b/content/components/micronova.md
@@ -186,7 +186,8 @@ switch:
 
 - **stove** (*Optional*): Turn the stove on or off. This switch will also reflect the current stove state.
   If the **stove_state** is "Off" the switch will be off, in all other states, the switch wil be on.
-  All options from [Switch](/components/switch#config-switch).
+  - **update_interval** (*Optional*, [Time](/guides/configuration-types#time)): The interval that the sensors should be checked. Defaults to 60 seconds.
+  - All options from [Switch](/components/switch#config-switch).
 
 > [!NOTE]
 > Besides **memory_location** and **memory_address** you can specify specific **memory_data_on** and **memory_data_off** parameters.

--- a/content/components/micronova.md
+++ b/content/components/micronova.md
@@ -186,7 +186,7 @@ switch:
 
 - **stove** (*Optional*): Turn the stove on or off. This switch will also reflect the current stove state.
   If the **stove_state** is "Off" the switch will be off, in all other states, the switch will be on.
-  - **update_interval** (*Optional*, [Time](/guides/configuration-types#time)): The interval that the sensors should be checked. Defaults to 60 seconds.
+  - **update_interval** (*Optional*, [Time](/guides/configuration-types#time)): The interval at which the state should be checked. Defaults to 60 seconds.
   - All options from [Switch](/components/switch#config-switch).
 
 > [!NOTE]

--- a/content/components/micronova.md
+++ b/content/components/micronova.md
@@ -186,8 +186,8 @@ switch:
 
 - **stove** (*Optional*): Turn the stove on or off. This switch will also reflect the current stove state.
   If the **stove_state** is "Off" the switch will be off, in all other states, the switch will be on.
-  - **update_interval** (*Optional*, [Time](/guides/configuration-types#time)): The interval at which the state should be
-    checked. Defaults to 60 seconds.
+  - **update_interval** (*Optional*, [Time](/guides/configuration-types#time)): The interval at which the state should
+    be checked. Defaults to 60 seconds.
   - All options from [Switch](/components/switch#config-switch).
 
 > [!NOTE]

--- a/content/components/micronova.md
+++ b/content/components/micronova.md
@@ -185,7 +185,7 @@ switch:
 ### Configuration variables
 
 - **stove** (*Optional*): Turn the stove on or off. This switch will also reflect the current stove state.
-  If the **stove_state** is "Off" the switch will be off, in all other states, the switch wil be on.
+  If the **stove_state** is "Off" the switch will be off, in all other states, the switch will be on.
   - **update_interval** (*Optional*, [Time](/guides/configuration-types#time)): The interval that the sensors should be checked. Defaults to 60 seconds.
   - All options from [Switch](/components/switch#config-switch).
 

--- a/content/components/micronova.md
+++ b/content/components/micronova.md
@@ -186,7 +186,8 @@ switch:
 
 - **stove** (*Optional*): Turn the stove on or off. This switch will also reflect the current stove state.
   If the **stove_state** is "Off" the switch will be off, in all other states, the switch will be on.
-  - **update_interval** (*Optional*, [Time](/guides/configuration-types#time)): The interval at which the state should be checked. Defaults to 60 seconds.
+  - **update_interval** (*Optional*, [Time](/guides/configuration-types#time)): The interval at which the state should be
+    checked. Defaults to 60 seconds.
   - All options from [Switch](/components/switch#config-switch).
 
 > [!NOTE]


### PR DESCRIPTION
## Description:

Add update interval to switch entity.
Target branch is `next` even when this is a bug fix as the code PR needs a breaking change (already merged)

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#12355

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/static/images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/_index.md`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image dht22
```

</details>
