### PR TITLE
[pca9685] Document phase_balancer option

### DIFF
--- a/content/components/output/pca9685.md
+++ b/content/components/output/pca9685.md
@@ -53,6 +53,22 @@ output:
     channel: 0
 ```
 
+```yaml
+# Example configuration entry with disabled phase_balancer
+pca9685:
+  - id: pca9685_hub1
+    phase_balancer: none
+
+# Individual outputs
+output:
+  - platform: pca9685
+    pca9685_id: 'pca9685_hub1'
+    channel: 0
+  - platform: pca9685
+    pca9685_id: 'pca9685_hub1'
+    channel: 1
+```
+
 ### Configuration variables
 
 - **frequency** (*Optional*, float): The frequency to let the
@@ -65,6 +81,20 @@ output:
 
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): The id to use for
    this pca9685 component. Use this if you have multiple PCA9685s connected at the same time
+
+- **phase_balancer** (*Optional*, string): The phase balancer algorithm to use.
+  See [Phase Balancer](#phase-balancer) below.
+
+### Phase Balancer
+
+The PCA9685 allows setting different phase angles on each output. The following algorithms can be used
+to set the phase angle of each output:
+
+- `linear` (default): The phase angle is set by distributing all defined outputs equally among 360°.
+  So with 3 outputs the first would have 0°, the second 120° and the last 240°. This algorithm can
+  cause flickering when animating the light, because the PCA9685 chip will need an additional frame
+  where no PWM is generated if the start angle is higher than the stop angle.
+- `none`: The phase angle is always 0°. This is the safer option if you control LED lights.
 
 {{< anchor "pca9685-output" >}}
 


### PR DESCRIPTION
## Description:

Document the new `phase_balancer` configuration option for the PCA9685 component.

The PCA9685 chip allows for flexible phase angles. The `phase_balancer` option controls how phase
angles are distributed across output channels:

- `linear` (default): Distributes outputs equally among 360° (e.g., 0°, 120°, 240° for 3 outputs)
- `none`: Sets all phase angles to 0°, which is safer for LED lights and avoids flickering during animations

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#9792

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.