### PR TITLE
Update LD2450 URL's

### DIFF
--- a/content/components/sensor/ld2450.md
+++ b/content/components/sensor/ld2450.md
@@ -27,7 +27,7 @@ for use indoors to enable the location tracking of moving human targets.
 
 [HLKRadarTool Android App](https://play.google.com/store/apps/details?id=com.hlk.hlkradartool)
 
-[HLKRadarTool iOS App](https://apps.apple.com/us/app/hlkradartool/id1638651152)
+[HLKRadarTool iOS App](https://apps.apple.com/app/id1638651152)
 
 > [!NOTE]
 > Ensure that the LD2450 firmware version is `V2.02.23090617` or later for proper integration functionality. You


### PR DESCRIPTION
## Description:
This PR updates the mobile app URL's in the LD2450 component to remove the region part of the URL (this gets determined automatically based on the user's region)
## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/static/images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/_index.md`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image dht22
```

</details>
