### PR TITLE
[micronova] Add required location and address to custom button and sensor

### DIFF
--- a/content/components/micronova.md
+++ b/content/components/micronova.md
@@ -126,7 +126,7 @@ sensor:
   - **update_interval** (*Optional*, [Time](/guides/configuration-types#time)): The interval that the sensors should be checked. Defaults to 60 seconds.
   - All options from [Sensor](/components/sensor).
 
-- **memory_address_sensor** (*Optional*): Can be any **memory_location** / **memory_address** you want to track. Usefull
+- **memory_address_sensor** (*Optional*): Can be any **memory_location** / **memory_address** you want to track. Useful
   when you don't know where the parameter is for your stove is.
   - **memory_location** (**Required**): The memory location for the parameter (0x00 for RAM, 0x20 for EPROM on most stoves).
   - **memory_address** (**Required**): The address where the parameter is stored.

--- a/content/components/micronova.md
+++ b/content/components/micronova.md
@@ -127,7 +127,7 @@ sensor:
   - All options from [Sensor](/components/sensor).
 
 - **memory_address_sensor** (*Optional*): Can be any **memory_location** / **memory_address** you want to track. Useful
-  when you don't know where the parameter is for your stove is.
+  when you don't know where the parameter for your stove is.
   - **memory_location** (**Required**): The memory location for the parameter (0x00 for RAM, 0x20 for EPROM on most stoves).
   - **memory_address** (**Required**): The address where the parameter is stored.
   - **update_interval** (*Optional*, [Time](/guides/configuration-types#time)): The interval that the sensors should be checked. Defaults to 60 seconds.

--- a/content/components/micronova.md
+++ b/content/components/micronova.md
@@ -128,6 +128,8 @@ sensor:
 
 - **memory_address_sensor** (*Optional*): Can be any **memory_location** / **memory_address** you want to track. Usefull
   when you don't know where the parameter is for your stove is.
+  - **memory_location** (**Required**): The memory location for the parameter (0x00 for RAM, 0x20 for EPROM on most stoves).
+  - **memory_address** (**Required**): The address where the parameter is stored.
   - **update_interval** (*Optional*, [Time](/guides/configuration-types#time)): The interval that the sensors should be checked. Defaults to 60 seconds.
   - All options from [Sensor](/components/sensor).
 
@@ -169,11 +171,9 @@ button:
 
 - **custom_button** (*Optional*): Write the hex value **memory_data** to a **memory_location** and **memory_address**
   All options from [Button](/components/button#config-button).
-
-> [!NOTE]
-> Besides **memory_location** and **memory_address** you must specify a specific **memory_data** parameter.
->
-> - **memory_data** (**Required**): The hex value to be written to the **memory_location** and **memory_address**.
+  - **memory_location** (**Required**): The memory location for the parameter (0x00 for RAM, 0x20 for EPROM on most stoves). The write bit is set automatically.
+  - **memory_address** (**Required**): The address where the parameter is stored.
+  - **memory_data** (**Required**): The hex value to be written to the **memory_location** and **memory_address**.
 
 ## Switches
 


### PR DESCRIPTION
…nsor

## Description:

Add required location and address to custom button and sensor config

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#12371

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/static/images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/_index.md`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image dht22
```

</details>
