### PR TITLE
[docs] Add PR template instruction to Claude instructions

### DIFF
--- a/.claude/instructions.md
+++ b/.claude/instructions.md
@@ -197,6 +197,7 @@ Use GitHub-style alert syntax:
 - **Bug fixes and documentation corrections**: Target the `current` branch
 - **New features and new component docs**: Target the `next` branch
 - **Create separate branches** for each pull request (one PR per feature/fix)
+- **Always branch from the target branch**: Use `git checkout -b <branch-name> current` or `git checkout -b <branch-name> next` to ensure you're branching from the correct base, not whatever branch is currently checked out
 
 ### Commit Messages
 - Use clear, descriptive commit messages
@@ -209,8 +210,9 @@ Use GitHub-style alert syntax:
 ### Pull Request Process
 1. Ensure all changes are committed to the feature branch
 2. Push to origin: `git push -u origin <branch-name>`
-3. All automated tests must pass before review
-4. Follow retry logic for network failures (exponential backoff: 2s, 4s, 8s, 16s)
+3. Create the PR using the `.github/PULL_REQUEST_TEMPLATE.md` template - fill out all sections completely without removing any parts of the template
+4. All automated tests must pass before review
+5. Follow retry logic for network failures (exponential backoff: 2s, 4s, 8s, 16s)
 
 ## Testing and Preview
 


### PR DESCRIPTION
## Description:

Adds instruction to the Claude AI instructions file to use the PR template when creating pull requests.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** N/A

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)