### PR TITLE
[esp32_hosted] Update ESP Hosted version to 2.7.0

### DIFF
--- a/content/components/update/esp32_hosted.md
+++ b/content/components/update/esp32_hosted.md
@@ -64,14 +64,14 @@ firmware should be built using the ESP-IDF framework and the resulting `.bin` fi
 configuration directory.
 
 ```sh
-# Build instructions for IDF 5.5.1 and ESP Hosted 2.6.1
+# Build instructions for IDF 5.5.1 and ESP Hosted 2.7.0
 git clone -b v5.5.1 --recursive https://github.com/espressif/esp-idf.git
 cd esp-idf
 ./install.sh esp32c6
 source export.sh  # for Linux/macOS
 export.bat        # for Windows
 cd ..
-idf.py create-project-from-example "espressif/esp_hosted^2.6.1:slave"
+idf.py create-project-from-example "espressif/esp_hosted^2.7.0:slave"
 cd slave/
 idf.py set-target esp32c6
 idf.py build


### PR DESCRIPTION
## Description:

Updates the ESP Hosted version in the build instructions from 2.6.1 to 2.7.0.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** N/A

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)