### PR TITLE
Improve longpress example for binary sensor

### DIFF
--- a/content/components/binary_sensor/_index.md
+++ b/content/components/binary_sensor/_index.md
@@ -466,9 +466,9 @@ on_multi_click:
 
 While [`on_click`](#binary_sensor-on_click) only triggers on the falling edge of the signal,
 and [`on_double_click`](#binary_sensor-on_double_click) only on the second leading edge, an
-automation for `on_multi_click` can trigger at any time. Like an `ON for at least` without
-an `OFF` does not await a falling edge. This supports implementing a continuous longpress,
-optionally also handling clicks for the very same sensor:
+automation for `on_multi_click` can trigger at any time. For example, an `ON for at least`
+timing without an `OFF` does not await a falling edge. This supports implementing a
+continuous longpress, optionally also handling clicks for the very same sensor:
 
 ```yaml
 binary_sensor:
@@ -476,26 +476,26 @@ binary_sensor:
     id: button_1
     # ...
     on_multi_click:
+    # One can also replace this part with `on_click`
     - timing:
-      # One can also replace this part with `on_click`
-      - ON for at most 0.7s
-        then:
-          - light.turn_on:
-              id: light_1
-              brightness: 10%
+        - ON for at most 0.7s
+      then:
+        - light.turn_on:
+            id: light_1
+            brightness: 10%
     - timing:
-      - ON for at least 1s
-        then:
-          - while:
-              condition:
-                # Self-reference this very sensor
-                binary_sensor.is_on: button_1
-              then:
-                - light.dim_relative:
-                    id: light_1
-                    relative_brightness: 5%
-                    transition_length: 0.1s
-                - delay: 0.1s
+        - ON for at least 1s
+      then:
+        - while:
+            condition:
+              # Self-reference this very sensor
+              binary_sensor.is_on: button_1
+            then:
+              - light.dim_relative:
+                  id: light_1
+                  relative_brightness: 5%
+                  transition_length: 0.1s
+              - delay: 0.1s
 ```
 
 {{< anchor "binary_sensor-is_on_condition" >}}

--- a/content/components/binary_sensor/_index.md
+++ b/content/components/binary_sensor/_index.md
@@ -268,8 +268,6 @@ binary_sensor:
 
 Configuration variables: See [Automation](/automations).
 
-See [`on_click`](#binary_sensor-on_click) for an example using a single button for both `on_click` and a continuous longpress.
-
 {{< anchor "binary_sensor-on_release" >}}
 
 ### `on_release`
@@ -376,43 +374,6 @@ Configuration variables:
 >         - switch.turn_on: relay_1
 > ```
 
-> [!NOTE]
-> A single button can be used to handle both `on_click` and a continuous longpress, by making a
-> [Template Binary Sensor](/components/binary_sensor/template/) follow a GPIO button with a delay:
->
-> ```yaml
-> binary_sensor:
->   - platform: gpio
->     id: button_1
->     # ...
->     on_click:
->       min_length: 50ms
->       max_length: 350ms
->       then:
->         - light.turn_on:
->             id: light_1
->             brightness: 10%
->
->   - platform: template
->     # ...
->     condition:
->       binary_sensor.is_on: button_1
->     filters:
->       - delayed_on: 1s
->     on_press:
->       - while:
->           condition:
->             # Using `!lambda: 'return true;'` would run endlessly
->             # once triggered, so repeat the outer condition
->             binary_sensor.is_on: button_1
->           then:
->             - light.dim_relative:
->                 id: light_1
->                 relative_brightness: 5%
->                 transition_length: 0.1s
->             - delay: 0.1s
-> ```
-
 {{< anchor "binary_sensor-on_double_click" >}}
 
 ### `on_double_click`
@@ -501,6 +462,40 @@ on_multi_click:
     - OFF for at least 0.5s
   then:
     - logger.log: "Single Short Clicked"
+```
+
+While [`on_click`](#binary_sensor-on_click) only triggers on the falling edge of the signal,
+and [`on_double_click`](#binary_sensor-on_double_click) only on the second leading edge, an
+automation for `on_multi_click` can trigger at any time. Like an `ON for at least` without
+an `OFF` does not await a falling edge. This supports implementing a continuous longpress,
+optionally also handling clicks for the very same sensor:
+
+```yaml
+binary_sensor:
+  - platform: gpio
+    id: button_1
+    # ...
+    on_multi_click:
+    - timing:
+      # One can also replace this part with `on_click`
+      - ON for at most 0.7s
+        then:
+          - light.turn_on:
+              id: light_1
+              brightness: 10%
+    - timing:
+      - ON for at least 1s
+        then:
+          - while:
+              condition:
+                # Self-reference this very sensor
+                binary_sensor.is_on: button_1
+              then:
+                - light.dim_relative:
+                    id: light_1
+                    relative_brightness: 5%
+                    transition_length: 0.1s
+                - delay: 0.1s
 ```
 
 {{< anchor "binary_sensor-is_on_condition" >}}


### PR DESCRIPTION
## Description:

Yesterday, in #5746, I added a longpress example. That example uses an _additional_ Template Binary Sensor that references the GPIO Binary Sensor. Sorry for wasting yesterday's reviewer's time, as meanwhile I found the built-in support using `on_multiple_click`.

- Replaced my earlier example.
- Explained that `on_multi_click` is not awaiting the falling edge (makes a lot of sense, yet seeing "click" is why earlier I figured `on_multi_click` would not work for a longpress).
- Indentation of the `-timing` sequence mimics the other examples. (I know ESPHome [is forgiving about that](https://esphome.io/guides/yaml/#mappings), but let me know if you want another PR to fix this and other examples on this page.)

Based on: https://community.home-assistant.io/t/esphome-controle-dimmable-light-with-esp32-and-button/763808/10

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.
