### PR TITLE
2025.11.5

### DIFF
--- a/content/changelog/2025.11.0.md
+++ b/content/changelog/2025.11.0.md
@@ -526,6 +526,20 @@ The 2025.11 release blog posts include comprehensive migration examples for comm
 
 <!-- markdownlint-disable MD013 -->
 
+## Release 2025.11.5 - December 9
+
+<details>
+<summary></summary>
+
+- [binary_sensor] Fix reporting of 'unknown' [esphome#12296](https://github.com/esphome/esphome/pull/12296) by [@clydebarrow](https://github.com/clydebarrow)
+- [lvgl] Number saves value on interactive change [esphome#12315](https://github.com/esphome/esphome/pull/12315) by [@clydebarrow](https://github.com/clydebarrow)
+- [scheduler] Fix missing lock when recycling items in defer queue processing [esphome#12343](https://github.com/esphome/esphome/pull/12343) by [@bdraco](https://github.com/bdraco)
+- [wifi] Fix scan timeout loop when scan returns zero networks [esphome#12354](https://github.com/esphome/esphome/pull/12354) by [@bdraco](https://github.com/bdraco)
+- [libretiny] Fix WiFi scan timeout loop when scan fails [esphome#12356](https://github.com/esphome/esphome/pull/12356) by [@bdraco](https://github.com/bdraco)
+- [mqtt] Fix logger method case sensitivity error [esphome#12379](https://github.com/esphome/esphome/pull/12379) by [@swoboda1337](https://github.com/swoboda1337)
+
+</details>
+
 ## Release 2025.11.4 - December 4
 
 <details>

--- a/content/guides/supporters.md
+++ b/content/guides/supporters.md
@@ -164,6 +164,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Ariff Saad (@arffsaad)](https://github.com/arffsaad)
 - [Ari Mandjelikian (@arim215)](https://github.com/arim215)
 - [ArkanStasarik (@ArkanStasarik)](https://github.com/ArkanStasarik)
+- [Sébastien Blanchet (@arno1801)](https://github.com/arno1801)
 - [Aleksandr Artemev (@artemyevav)](https://github.com/artemyevav)
 - [arturo182 (@arturo182)](https://github.com/arturo182)
 - [arunderwood (@arunderwood)](https://github.com/arunderwood)
@@ -186,6 +187,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [august huber (@augs)](https://github.com/augs)
 - [aus (@aus)](https://github.com/aus)
 - [AustinMorris (@AustinMorris)](https://github.com/AustinMorris)
+- [Arjan (@avbentem)](https://github.com/avbentem)
 - [Aviad Raviv (@aviadra)](https://github.com/aviadra)
 - [Avirsaam (@Avirsaam)](https://github.com/Avirsaam)
 - [Arsène von Wyss (@avonwyss)](https://github.com/avonwyss)
@@ -1009,6 +1011,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [jeff-h (@jeff-h)](https://github.com/jeff-h)
 - [Jeffrey Borg (@jeffborg)](https://github.com/jeffborg)
 - [Jeff Eberl (@jeffeb3)](https://github.com/jeffeb3)
+- [Jeff Hastings (@jeffmhastings)](https://github.com/jeffmhastings)
 - [Jeff Rescignano (@JeffResc)](https://github.com/JeffResc)
 - [Jej (@jej)](https://github.com/jej)
 - [Jens-Christian Skibakk (@jenscski)](https://github.com/jenscski)
@@ -1021,6 +1024,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Jesse Hills (@jesserockz)](https://github.com/jesserockz)
 - [Jessica Hamilton (@jessicah)](https://github.com/jessicah)
 - [Andrzej Skowroński (@jesterret)](https://github.com/jesterret)
+- [Jesús Vallejo (@jesusvallejo)](https://github.com/jesusvallejo)
 - [J.G.Aguado (@JGAguado)](https://github.com/JGAguado)
 - [James Szalay (@jgissend10)](https://github.com/jgissend10)
 - [Joel Goguen (@jgoguen)](https://github.com/jgoguen)
@@ -1437,6 +1441,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [mnltake (@mnltake)](https://github.com/mnltake)
 - [Matt N. (@mnoorenberghe)](https://github.com/mnoorenberghe)
 - [Michał Obrembski (@mobrembski)](https://github.com/mobrembski)
+- [MomentumV (@MomentumV)](https://github.com/MomentumV)
 - [monkeyclass (@monkeyclass)](https://github.com/monkeyclass)
 - [Moriah Morgan (@moriahjmorgan)](https://github.com/moriahjmorgan)
 - [Moriah Morgan (@moriahmorgan)](https://github.com/moriahmorgan)
@@ -1960,6 +1965,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Stanislav Habich (@standahabich)](https://github.com/standahabich)
 - [starwolf73 (@starwolf73)](https://github.com/starwolf73)
 - [Stas (@stas-sl)](https://github.com/stas-sl)
+- [STB3 (@STB3)](https://github.com/STB3)
 - [Stefan (@stefanroelofs)](https://github.com/stefanroelofs)
 - [Steffen Banhardt (@steffenbanhardt)](https://github.com/steffenbanhardt)
 - [stegm (@stegm)](https://github.com/stegm)
@@ -2284,4 +2290,4 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Christian Zufferey (@zuzu59)](https://github.com/zuzu59)
 - [Zynth-dev (@Zynth-dev)](https://github.com/Zynth-dev)
 
-*This page was last updated December 4, 2025.*
+*This page was last updated December 9, 2025.*

--- a/data/version.yaml
+++ b/data/version.yaml
@@ -1,2 +1,2 @@
-release: 2025.11.4
+release: 2025.11.5
 version: '2025.11'


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- Update Bluetooth Proxy buy links for GL-S10 and LilyGO T-ETH-POE [docs#5727](https://github.com/esphome/esphome-docs/pull/5727)
- Update readme logo [docs#5726](https://github.com/esphome/esphome-docs/pull/5726)
- [CI] Increase operations-per-run [docs#5733](https://github.com/esphome/esphome-docs/pull/5733)
- Improve readability of Log Levels [docs#5735](https://github.com/esphome/esphome-docs/pull/5735)
- Revise pull request template for component images [docs#5738](https://github.com/esphome/esphome-docs/pull/5738)
- Replace deprecated clk_mode with clk [docs#5744](https://github.com/esphome/esphome-docs/pull/5744)
- Add example to handle both on_click and longpress [docs#5746](https://github.com/esphome/esphome-docs/pull/5746)
- Update LD2450 URL's [docs#5749](https://github.com/esphome/esphome-docs/pull/5749)
- Improve longpress example for binary sensor [docs#5753](https://github.com/esphome/esphome-docs/pull/5753)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
