### PR TITLE
Fix release notes generator to exclude PRs from previous release beta and patches

### DIFF
--- a/script/generate_release_notes.py
+++ b/script/generate_release_notes.py
@@ -368,6 +368,43 @@ class ReleaseNotesGenerator:
 
         return sorted(pr_numbers)
 
+    def _collect_prs_from_tags(
+        self,
+        all_tags: set[str],
+        tag_format: callable,
+        prev_tag_format: callable,
+        release_type: str,
+        max_releases: int = 100,
+    ) -> set[int]:
+        """Collect PRs from a sequence of releases.
+
+        Args:
+            all_tags: Set of all available tags
+            tag_format: Function(n) -> tag name for release n
+            prev_tag_format: Function(n) -> tag name for the previous release to compare against
+            release_type: Description for logging (e.g., "beta release", "patch release")
+            max_releases: Maximum number of releases to check
+        """
+        prs: set[int] = set()
+        release_num = 1
+
+        while release_num <= max_releases:
+            tag = tag_format(release_num)
+
+            if tag not in all_tags:
+                break
+
+            print(f"  Found {release_type}: {tag}")
+
+            prev_tag = prev_tag_format(release_num)
+            if prev_tag is not None:
+                found_prs = self.get_pr_numbers_from_commits(prev_tag, tag)
+                prs.update(found_prs)
+
+            release_num += 1
+
+        return prs
+
     def _get_previous_release_prs(self, base_version: Version) -> set[int]:
         """Get all PRs from the previous release cycle (betas + patches).
 
@@ -379,61 +416,29 @@ class ReleaseNotesGenerator:
         were already released, even if their commits appear in the comparison
         due to different branch structures (dev vs release branch).
         """
-        all_prs: set[int] = set()
         all_tags = self._fetch_all_tags()
+        year = base_version.year
+        month = base_version.month
 
         # Get PRs from beta releases
-        print(
-            f"Checking for beta releases of {base_version.year}.{base_version.month}.0..."
+        print(f"Checking for beta releases of {year}.{month}.0...")
+        beta_prs = self._collect_prs_from_tags(
+            all_tags,
+            tag_format=lambda n: f"{year}.{month}.0b{n}",
+            prev_tag_format=lambda n: f"{year}.{month}.0b{n - 1}" if n > 1 else None,
+            release_type="beta release",
         )
-        beta_num = 1
-        max_betas = 100
-        prev_beta_tag: str | None = None
-
-        while beta_num <= max_betas:
-            beta_tag = f"{base_version.year}.{base_version.month}.0b{beta_num}"
-
-            if beta_tag not in all_tags:
-                break
-
-            print(f"  Found beta release: {beta_tag}")
-
-            if prev_beta_tag:
-                # Get PRs between previous beta and this beta
-                prs = self.get_pr_numbers_from_commits(prev_beta_tag, beta_tag)
-                all_prs.update(prs)
-
-            prev_beta_tag = beta_tag
-            beta_num += 1
 
         # Get PRs from patch releases
-        print(
-            f"Checking for patch releases of {base_version.year}.{base_version.month}.x..."
+        print(f"Checking for patch releases of {year}.{month}.x...")
+        patch_prs = self._collect_prs_from_tags(
+            all_tags,
+            tag_format=lambda n: f"{year}.{month}.{n}",
+            prev_tag_format=lambda n: f"{year}.{month}.{n - 1}",
+            release_type="patch release",
         )
-        patch_num = 1
-        max_patches = 100
 
-        while patch_num <= max_patches:
-            patch_tag = f"{base_version.year}.{base_version.month}.{patch_num}"
-
-            if patch_tag not in all_tags:
-                break
-
-            print(f"  Found patch release: {patch_tag}")
-
-            # Get PRs between base and this patch
-            base_tag = f"{base_version.year}.{base_version.month}.{patch_num - 1}"
-            prs = self.get_pr_numbers_from_commits(base_tag, patch_tag)
-            all_prs.update(prs)
-
-            patch_num += 1
-
-        if patch_num > max_patches:
-            print(
-                f"Warning: Reached maximum patch limit ({max_patches}). Some patches may have been skipped."
-            )
-
-        return all_prs
+        return beta_prs | patch_prs
 
     def discover_prs(self) -> list[int]:
         """Discover PRs for this release"""

--- a/script/generate_release_notes.py
+++ b/script/generate_release_notes.py
@@ -388,7 +388,7 @@ class ReleaseNotesGenerator:
         )
         beta_num = 1
         max_betas = 100
-        prev_beta_tag = None
+        prev_beta_tag: str | None = None
 
         while beta_num <= max_betas:
             beta_tag = f"{base_version.year}.{base_version.month}.0b{beta_num}"

--- a/script/generate_release_notes.py
+++ b/script/generate_release_notes.py
@@ -368,20 +368,55 @@ class ReleaseNotesGenerator:
 
         return sorted(pr_numbers)
 
-    def _get_patch_release_prs(self, base_version: Version) -> list[int]:
-        """Get all PRs that were included in patch releases (e.g., 2025.10.1, 2025.10.2)"""
-        patch_prs = set()
-        patch_num = 1
-        max_patches = 100  # Safety limit to prevent infinite loops
+    def _get_previous_release_prs(self, base_version: Version) -> set[int]:
+        """Get all PRs from the previous release cycle (betas + patches).
 
+        This finds PRs that were included in:
+        1. Beta releases (e.g., 2025.11.0b1, b2, b3, etc.)
+        2. Patch releases (e.g., 2025.11.1, 2025.11.2, etc.)
+
+        These PRs should be excluded from the current release notes since they
+        were already released, even if their commits appear in the comparison
+        due to different branch structures (dev vs release branch).
+        """
+        all_prs: set[int] = set()
+        all_tags = self._fetch_all_tags()
+
+        # Get PRs from beta releases
+        print(
+            f"Checking for beta releases of {base_version.year}.{base_version.month}.0..."
+        )
+        beta_num = 1
+        max_betas = 20
+        prev_beta_tag = None
+
+        while beta_num <= max_betas:
+            beta_tag = f"{base_version.year}.{base_version.month}.0b{beta_num}"
+
+            if beta_tag not in all_tags:
+                break
+
+            print(f"  Found beta release: {beta_tag}")
+
+            if prev_beta_tag:
+                # Get PRs between previous beta and this beta
+                prs = self.get_pr_numbers_from_commits(prev_beta_tag, beta_tag)
+                all_prs.update(prs)
+
+            prev_beta_tag = beta_tag
+            beta_num += 1
+
+        # Get PRs from patch releases
         print(
             f"Checking for patch releases of {base_version.year}.{base_version.month}.x..."
         )
+        patch_num = 1
+        max_patches = 100
 
         while patch_num <= max_patches:
             patch_tag = f"{base_version.year}.{base_version.month}.{patch_num}"
 
-            if not self.tag_exists(patch_tag):
+            if patch_tag not in all_tags:
                 break
 
             print(f"  Found patch release: {patch_tag}")
@@ -389,7 +424,7 @@ class ReleaseNotesGenerator:
             # Get PRs between base and this patch
             base_tag = f"{base_version.year}.{base_version.month}.{patch_num - 1}"
             prs = self.get_pr_numbers_from_commits(base_tag, patch_tag)
-            patch_prs.update(prs)
+            all_prs.update(prs)
 
             patch_num += 1
 
@@ -398,7 +433,7 @@ class ReleaseNotesGenerator:
                 f"Warning: Reached maximum patch limit ({max_patches}). Some patches may have been skipped."
             )
 
-        return sorted(patch_prs)
+        return all_prs
 
     def discover_prs(self) -> list[int]:
         """Discover PRs for this release"""
@@ -422,25 +457,28 @@ class ReleaseNotesGenerator:
             print("Cannot determine which PRs are new")
             sys.exit(1)
 
+        # Get PRs from the previous release cycle (betas + patches) to exclude.
+        # These PRs were already released, but may appear in the commit comparison
+        # due to different branch structures (dev vs release branch).
+        previous_prs = self._get_previous_release_prs(previous_base)
+
         if beta_tag_exists:
             # Beta branch exists - use everything from previous release to beta
             print(f"Beta tag '{beta_tag}' exists")
             print(f"Comparing tags: {previous_tag}...{beta_tag}")
-            pr_numbers = self.get_pr_numbers_from_commits(previous_tag, beta_tag)
+            all_prs = self.get_pr_numbers_from_commits(previous_tag, beta_tag)
         else:
-            # Beta doesn't exist yet - use dev branch but exclude patch releases
+            # Beta doesn't exist yet - use dev branch
             print(f"Beta tag '{beta_tag}' does not exist yet")
-            print("Using dev branch and excluding patch releases")
-
-            # Get all PRs from previous version to dev
+            print(f"Comparing tags: {previous_tag}...dev")
             all_prs = self.get_pr_numbers_from_commits(previous_tag, "dev")
 
-            # Find and exclude PRs from patch releases
-            patch_prs = self._get_patch_release_prs(previous_version)
-            pr_numbers = sorted(set(all_prs) - set(patch_prs))
-
-            if patch_prs:
-                print(f"Excluded {len(patch_prs)} PRs from patch releases")
+        # Exclude PRs already in previous release cycle
+        all_prs_set = set(all_prs)
+        pr_numbers = sorted(all_prs_set - previous_prs)
+        if previous_prs:
+            excluded = len(all_prs_set & previous_prs)
+            print(f"Excluded {excluded} PRs already in previous release cycle")
 
         return pr_numbers
 
@@ -838,7 +876,7 @@ class ReleaseNotesGenerator:
         """Replace version placeholders"""
         # Format date
         now = datetime.now()
-        date_str = now.strftime('%B %Y')
+        date_str = now.strftime("%B %Y")
 
         template = template.replace("{VERSION}", str(self.version))
         template = template.replace("{DATE}", date_str)

--- a/script/generate_release_notes.py
+++ b/script/generate_release_notes.py
@@ -387,7 +387,7 @@ class ReleaseNotesGenerator:
             f"Checking for beta releases of {base_version.year}.{base_version.month}.0..."
         )
         beta_num = 1
-        max_betas = 20
+        max_betas = 100
         prev_beta_tag = None
 
         while beta_num <= max_betas:

--- a/script/generate_release_notes.py
+++ b/script/generate_release_notes.py
@@ -73,6 +73,7 @@ For further help, see the ESPHome documentation or contact maintainers.
 from __future__ import annotations
 
 import argparse
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
 import json
@@ -371,8 +372,8 @@ class ReleaseNotesGenerator:
     def _collect_prs_from_tags(
         self,
         all_tags: set[str],
-        tag_format: callable,
-        prev_tag_format: callable,
+        tag_format: Callable[[int], str],
+        prev_tag_format: Callable[[int], str | None],
         release_type: str,
         max_releases: int = 100,
     ) -> set[int]:


### PR DESCRIPTION
## Description:

Fixes a bug in the release notes generator where PRs that were already included in the previous release cycle would incorrectly appear in the new release's notes.

**The Problem:**

When generating release notes for version 2025.12.0, the script compares `2025.11.5...2025.12.0b1`. This comparison shows commits reachable from `2025.12.0b1` but not from `2025.11.5`.

Due to the backmerge workflow (merging `beta` into `dev` after releases), commits from the previous beta cycle are in dev's history. Since `2025.11.5` is on the `release` branch and `2025.12.0b1` is on `dev`, PRs that were in the 2025.11.0 betas appear as "new" commits even though they were already released.

**The Fix:**

- Renamed `_get_patch_release_prs()` to `_get_previous_release_prs()`
- The method now collects PRs from **both** beta releases AND patch releases of the previous version
- These PRs are excluded when generating release notes for the next version
- This ensures PRs are only listed in the release where they first appeared

**Example:**
- PR #11953 was included in 2025.11.0b4
- Due to the `beta` → `dev` backmerge, the commit appears in `git log 2025.11.5...2025.12.0b1`
- Previously: It incorrectly appeared in 2025.12.0 release notes
- Now: It is correctly excluded from 2025.12.0 release notes

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** N/A

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook. (N/A - script change only)
