### PR TITLE
Remove warning from AC dimmer component

### DIFF
--- a/content/components/output/ac_dimmer.md
+++ b/content/components/output/ac_dimmer.md
@@ -7,13 +7,6 @@ params:
     image: ac_dimmer.svg
 ---
 
-> [!WARNING]
-> This component has not been fully tested yet, if you are testing this component
-> please share your experience with the dimmer hardware and light model and
-> configuration here <https://github.com/esphome/feature-requests/issues/278>
->
-> Thanks!
-
 The `ac_dimmer` component allows you to connect a dimmable light or other load
 which supports phase control dimming to your ESPHome project.
 


### PR DESCRIPTION
The referenced feature request has not been commented on in over 5 years, and hasn't been mentioned in almost 4 years. It seems like this warning isn't relevant anymore.

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.