### PR TITLE
 [update] Add docs for update.check action

### DIFF
--- a/content/components/update/_index.md
+++ b/content/components/update/_index.md
@@ -57,6 +57,14 @@ Configuration variables:
 - **force_update** (*Optional*, boolean): Perform the update even if the device is already running the same version.
   Defaults to `false`.
 
+### `update.check` Action
+
+This action allows you to trigger the update entity to check for, but not install, updates.
+
+Configuration variables:
+
+- **id** (**Required**, [ID](/guides/configuration-types#id)): The ID of the update entity.
+
 ### `update.is_available` Condition
 
 This condition checks if an update is available for the device.


### PR DESCRIPTION
## Description:

Updates the documentation for the `update` component to include the `update.check` action introduced in the linked PR in esphome

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#12415

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/static/images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/_index.md`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image dht22
```

</details>
