### PR TITLE
[changelog] 2025.12.0: Add missing memory optimizations, fix descriptions

### DIFF
--- a/content/changelog/2025.12.0.md
+++ b/content/changelog/2025.12.0.md
@@ -164,7 +164,7 @@ These changes prepare ESPHome for ESP-IDF 6.0 where flash placement becomes the 
 
 The API connection layer received significant optimizations to reduce heap fragmentation and memory churn:
 
-- **Eliminated per-packet heap allocation** - Previously every API packet received required a new heap allocation. The receive buffer is now reused across packets, with excess capacity released after initial sync completes. This reduces heap fragmentation on busy devices, and for quiet devices means the initial sync memory spike is released rather than held for the lifetime of the connection (which can be months) ([#12133](https://github.com/esphome/esphome/pull/12133))
+- **Eliminated per-packet heap allocation** - Previously every API packet received required a new heap allocation. The receive buffer is now reused across packets, with excess capacity released after initial sync completes. This reduces heap fragmentation on busy devices. For quiet devices, the initial sync memory spike is released rather than held for the lifetime of the connection. (Connections can last for months.) ([#12133](https://github.com/esphome/esphome/pull/12133))
 - **Zero-copy API commands** - Select and light effect commands now process strings directly from protobuf buffer without heap allocation ([#12329](https://github.com/esphome/esphome/pull/12329), [#12384](https://github.com/esphome/esphome/pull/12384))
 - **Flash storage for device info** - Device info strings stored in flash on ESP8266 ([#12173](https://github.com/esphome/esphome/pull/12173))
 - **Flash storage for state subscriptions** - Home Assistant state subscriptions stored in flash instead of heap ([#12008](https://github.com/esphome/esphome/pull/12008))

--- a/content/changelog/2025.12.0.md
+++ b/content/changelog/2025.12.0.md
@@ -212,7 +212,7 @@ Multiple enhancements improve the LVGL experience:
 - **Enhanced arc widget** - More arc parameters available in update actions ([#12066](https://github.com/esphome/esphome/pull/12066))
 - **Scroll properties** - Added missing scroll-related configuration options ([#11901](https://github.com/esphome/esphome/pull/11901))
 
-## Climate and Component Enhancements
+## Component Enhancements
 
 **Gree Climate:**
 

--- a/content/changelog/2025.12.0.md
+++ b/content/changelog/2025.12.0.md
@@ -21,7 +21,7 @@ params:
 ## Release Overview
 
 <!-- RELEASE_OVERVIEW_START -->
-ESPHome 2025.12.0 introduces API action responses for bidirectional communication with Home Assistant, conditional package inclusion for dynamic configurations, and HUB75 LED matrix display support. This release delivers significant memory optimizations saving up to 10KB of IRAM on ESP32 devices and eliminates per-packet heap allocations in API connections, eliminates socket latency on ESP8266, and adds 8 new components including the CC1101 sub-GHz transceiver and USB CDC-ACM support. LVGL receives multiple usability improvements, and the WiFi component has been refactored for instant callback-based updates across all platforms.
+ESPHome 2025.12.0 introduces API action responses for bidirectional communication with Home Assistant, conditional package inclusion for dynamic configurations, and HUB75 LED matrix display support. This release delivers significant memory optimizations saving up to 10KB of IRAM on ESP32 devices, eliminates per-packet heap allocations in API connections and socket latency on ESP8266, and adds 8 new components including the CC1101 sub-GHz transceiver and USB CDC-ACM support. LVGL receives multiple usability improvements, and the WiFi component has been refactored for instant callback-based updates across all platforms.
 <!-- RELEASE_OVERVIEW_END -->
 
 <!-- FEATURE_HIGHLIGHTS_START -->

--- a/content/changelog/2025.12.0.md
+++ b/content/changelog/2025.12.0.md
@@ -27,7 +27,7 @@ ESPHome 2025.12.0 introduces API action responses for bidirectional communicatio
 <!-- FEATURE_HIGHLIGHTS_START -->
 ## API Action Responses
 
-ESPHome actions can now send structured responses back to clients like Home Assistant, enabling true bidirectional communication where actions return success/error status and JSON data payloads ([#12136](https://github.com/esphome/esphome/pull/12136)).
+The [Native API](/components/api) now supports actions that send structured responses back to clients like Home Assistant, enabling true bidirectional communication where actions return success/error status and JSON data payloads ([#12136](https://github.com/esphome/esphome/pull/12136)).
 
 **Key Features:**
 
@@ -54,7 +54,7 @@ api:
 
 ## Conditional Package Inclusion
 
-The configuration system now supports conditional package inclusion, a long-awaited feature that enables dynamic configuration based on substitution variables ([#11605](https://github.com/esphome/esphome/pull/11605)).
+The [packages](/components/packages) system now supports conditional inclusion, a long-awaited feature that enables dynamic configuration based on substitution variables ([#11605](https://github.com/esphome/esphome/pull/11605)).
 
 **Key Features:**
 
@@ -130,7 +130,7 @@ The UART component now supports a `wake_loop_on_rx` flag that wakes the main loo
 
 ## ESP8266 Socket Latency Elimination
 
-ESP8266 previously had higher network latency than ESP32 and LibreTiny because it used polling for socket data, sleeping up to 16ms before discovering incoming data. This affected every API request and Home Assistant command. The loop now wakes within microseconds of data arriving using ESP8266's `esp_schedule()` mechanism, bringing ESP8266 to parity with ESP32 and LibreTiny. This is automatic for all ESP8266 devices with no configuration needed ([#12397](https://github.com/esphome/esphome/pull/12397)).
+ESP8266 previously had higher network latency than ESP32 and LibreTiny because it used polling for socket data, sleeping up to 16ms before discovering incoming data. This affected every API request and Home Assistant command. The loop now wakes within microseconds of data arriving using ESP8266's `esp_schedule()` mechanism, bringing ESP8266 to near parity with ESP32 and LibreTiny. This is automatic for all ESP8266 devices with no configuration needed ([#12397](https://github.com/esphome/esphome/pull/12397)).
 
 ## Memory and IRAM Optimizations
 

--- a/content/changelog/2025.12.0.md
+++ b/content/changelog/2025.12.0.md
@@ -256,11 +256,11 @@ Multiple enhancements improve the LVGL experience:
 <!-- BREAKING_CHANGES_USERS_START -->
 ### Component Changes
 
-- **Micronova**: The `update_interval` configuration has moved from the hub to individual entities, allowing different update intervals per sensor. Remove `update_interval` from the `micronova:` hub section and add it to each sensor/text_sensor entity instead. [#12226](https://github.com/esphome/esphome/pull/12226)
-
-- **Micronova**: The `memory_location` configuration is now restricted to read memory locations (0x00-0x79). If you have values above 0x79, subtract 0x80 (e.g., 0x80 becomes 0x00, 0xA0 becomes 0x20). The `memory_write_location` option on number entities has been removed as it's now calculated automatically. [#12318](https://github.com/esphome/esphome/pull/12318)
-
-- **Micronova**: Custom button and sensor entities now require explicit `memory_location` and `address` configuration - the misleading default values have been removed. [#12371](https://github.com/esphome/esphome/pull/12371)
+- **Micronova**: Multiple configuration changes ([#12226](https://github.com/esphome/esphome/pull/12226), [#12318](https://github.com/esphome/esphome/pull/12318), [#12371](https://github.com/esphome/esphome/pull/12371)):
+  - `update_interval` moved from hub to individual entities - remove from `micronova:` section and add to each sensor/text_sensor
+  - `memory_location` now restricted to read locations (0x00-0x79) - subtract 0x80 from values above 0x79
+  - `memory_write_location` removed from number entities (now calculated automatically)
+  - Custom button/sensor entities now require explicit `memory_location` and `address` configuration
 
 - **Prometheus**: Light color metrics (`light_color_*`) are now only generated if the light component supports those color modes. This reduces memory usage on ESP8266 but may affect monitoring setups that expected all metrics regardless of light capabilities. [#9530](https://github.com/esphome/esphome/pull/9530)
 

--- a/content/changelog/2025.12.0.md
+++ b/content/changelog/2025.12.0.md
@@ -154,7 +154,11 @@ These changes prepare ESPHome for ESP-IDF 6.0 where flash placement becomes the 
 
 **Dashboard Import Optimization:**
 
-- **Eliminates URL heap allocation** - Package import URL now stored as pointer to .rodata instead of heap-allocated std::string. Saves more on ESP32 where .rodata is in flash; on ESP8266 .rodata is in RAM but still avoids heap overhead ([#11951](https://github.com/esphome/esphome/pull/11951))
+- **Eliminates URL heap allocation**:
+  - Package import URL is now stored as a pointer to `.rodata` instead of a heap-allocated `std::string`.
+  - On ESP32, `.rodata` resides in flash, providing RAM savings.
+  - On ESP8266, `.rodata` is in RAM, but this still avoids heap overhead.
+  - ([#11951](https://github.com/esphome/esphome/pull/11951))
 
 **API Connection Optimizations:**
 

--- a/content/changelog/2025.12.0.md
+++ b/content/changelog/2025.12.0.md
@@ -21,7 +21,7 @@ params:
 ## Release Overview
 
 <!-- RELEASE_OVERVIEW_START -->
-ESPHome 2025.12.0 introduces API action responses for bidirectional communication with Home Assistant, conditional package inclusion for dynamic configurations, and HUB75 LED matrix display support. This release delivers significant memory optimizations saving up to 10KB of IRAM on ESP32 devices, eliminates socket latency on ESP8266, and adds 8 new components including the CC1101 sub-GHz transceiver and USB CDC-ACM support. LVGL receives multiple usability improvements, and the WiFi component has been refactored for instant callback-based updates across all platforms.
+ESPHome 2025.12.0 introduces API action responses for bidirectional communication with Home Assistant, conditional package inclusion for dynamic configurations, and HUB75 LED matrix display support. This release delivers significant memory optimizations saving up to 10KB of IRAM on ESP32 devices and eliminates per-packet heap allocations in API connections, eliminates socket latency on ESP8266, and adds 8 new components including the CC1101 sub-GHz transceiver and USB CDC-ACM support. LVGL receives multiple usability improvements, and the WiFi component has been refactored for instant callback-based updates across all platforms.
 <!-- RELEASE_OVERVIEW_END -->
 
 <!-- FEATURE_HIGHLIGHTS_START -->
@@ -84,18 +84,6 @@ The new [hub75](/components/display/hub75) component brings native support for H
 - **LVGL compatible** - Works seamlessly with LVGL for rich graphical interfaces
 - **Board presets** - Pre-configured settings for popular boards like Apollo Automation M1
 
-```yaml
-display:
-  - platform: hub75
-    id: matrix
-    panel_width: 64
-    panel_height: 64
-    clock_speed: 20MHz
-    r1_pin: 1
-    g1_pin: 5
-    # ... additional pins
-```
-
 ## CC1101 Sub-1GHz Transceiver
 
 The new [cc1101](/components/cc1101) component adds support for the Texas Instruments CC1101 Sub-1GHz transceiver, enabling 433MHz remote control integration and other sub-GHz wireless applications ([#11849](https://github.com/esphome/esphome/pull/11849)).
@@ -106,16 +94,6 @@ The new [cc1101](/components/cc1101) component adds support for the Texas Instru
 - **ASK/OOK modulation** - Works with common remote control protocols
 - **Core integration** - Designed to work with `remote_receiver` and `remote_transmitter` components
 - **Robust initialization** - Non-blocking state machine with proper chip reset handling
-
-```yaml
-cc1101:
-  id: cc1101_transceiver
-  cs_pin: GPIO5
-  frequency: 433.92MHz
-  modulation: ASK/OOK
-  bandwidth: 203kHz
-  symbol_rate: 5000
-```
 
 ## USB CDC-ACM Support
 
@@ -146,21 +124,13 @@ The UART component now supports a `wake_loop_on_rx` flag that wakes the main loo
 
 **Key Benefits:**
 
-- **Z-Wave Proxy performance** - Reduces latency by ~10ms, bringing wired Ethernet performance within milliseconds of direct USB/serial connection ([#12135](https://github.com/esphome/esphome/pull/12135))
-- **Real-time serial applications** - Any component requiring fast response to incoming serial data can now achieve sub-millisecond wake times
+- **Z-Wave Proxy performance** - Reduces latency by ~10ms for WiFi-connected [ZWA-2 devices](https://www.home-assistant.io/blog/2025/10/13/portable-z-wave-with-wifi-and-poe/), building on the USB-connected Ethernet/PoE optimizations from 2025.11.0 ([#12135](https://github.com/esphome/esphome/pull/12135))
+- **Real-time serial applications** - Any component requiring fast response to incoming serial data can now achieve sub-millisecond wake times by enabling this flag in their code
 - **Automatic infrastructure** - The socket wake infrastructure is automatically enabled when any UART requests RX wake
 
 ## ESP8266 Socket Latency Elimination
 
-ESP8266 devices now respond to network requests with the same speed as ESP32 devices ([#12397](https://github.com/esphome/esphome/pull/12397)).
-
-**The Problem:**
-
-ESP8266 used polling for socket data, sleeping up to 16ms before discovering incoming data. This affected every API request and Home Assistant command.
-
-**The Solution:**
-
-The loop now wakes within microseconds of data arriving using ESP8266's `esp_schedule()` mechanism, matching ESP32 and LibreTiny behavior. This is automatic for all ESP8266 devices with no configuration needed.
+ESP8266 previously had higher network latency than ESP32 and LibreTiny because it used polling for socket data, sleeping up to 16ms before discovering incoming data. This affected every API request and Home Assistant command. The loop now wakes within microseconds of data arriving using ESP8266's `esp_schedule()` mechanism, bringing ESP8266 to parity with ESP32 and LibreTiny. This is automatic for all ESP8266 devices with no configuration needed ([#12397](https://github.com/esphome/esphome/pull/12397)).
 
 ## Memory and IRAM Optimizations
 
@@ -184,7 +154,23 @@ These changes prepare ESPHome for ESP-IDF 6.0 where flash placement becomes the 
 
 **Dashboard Import Optimization:**
 
-- **~20 bytes per device** - Package import URL now stored as pointer to flash instead of heap-allocated string ([#11951](https://github.com/esphome/esphome/pull/11951))
+- **Eliminates URL heap allocation** - Package import URL now stored as pointer to .rodata instead of heap-allocated std::string. Saves more on ESP32 where .rodata is in flash; on ESP8266 .rodata is in RAM but still avoids heap overhead ([#11951](https://github.com/esphome/esphome/pull/11951))
+
+**API Connection Optimizations:**
+
+The API connection layer received significant optimizations to reduce heap fragmentation and memory churn:
+
+- **Eliminated per-packet heap allocation** - Previously every API packet received required a new heap allocation. The receive buffer is now reused across packets, with excess capacity released after initial sync completes. This reduces heap fragmentation on busy devices, and for quiet devices means the initial sync memory spike is released rather than held for the lifetime of the connection (which can be months) ([#12133](https://github.com/esphome/esphome/pull/12133))
+- **Zero-copy API commands** - Select and light effect commands now process strings directly from protobuf buffer without heap allocation ([#12329](https://github.com/esphome/esphome/pull/12329), [#12384](https://github.com/esphome/esphome/pull/12384))
+- **Flash storage for device info** - Device info strings stored in flash on ESP8266 ([#12173](https://github.com/esphome/esphome/pull/12173))
+- **Flash storage for state subscriptions** - Home Assistant state subscriptions stored in flash instead of heap ([#12008](https://github.com/esphome/esphome/pull/12008))
+- **Reduced service call storage** - Home Assistant service call strings use less heap ([#12151](https://github.com/esphome/esphome/pull/12151))
+- **APINoiseContext optimization** - Removed shared_ptr overhead ([#11981](https://github.com/esphome/esphome/pull/11981))
+- **Loop-based reboot timeout** - Avoids scheduler heap churn ([#12291](https://github.com/esphome/esphome/pull/12291))
+
+**Sensor Timeout Filter Optimization:**
+
+- **Eliminates scheduler heap churn** - Timeout filters now use a loop-based implementation instead of scheduler timeouts. This is particularly important for LD2410/LD2420/LD2450 users with many timeout filters, where the old implementation caused ~70 heap operations/second and constant scheduler pool exhaustion when someone was in range of the sensor ([#11922](https://github.com/esphome/esphome/pull/11922))
 
 ## New Hardware Support
 


### PR DESCRIPTION
## Description:

Clean up and improve 2025.12.0 release notes for accuracy and readability.

**Changes:**

- Updated Release Overview to mention per-packet heap allocation elimination in API connections
- Removed YAML examples for hub75 and cc1101 (cc1101 example had incorrect config keys; users can click docs links instead)
- Updated Z-Wave Proxy description: clarified it's for WiFi-connected ZWA-2 devices, added blog post link, noted it builds on USB-connected Ethernet/PoE work from 2025.11.0
- Updated real-time serial applications bullet to clarify the flag must be enabled in component code
- Consolidated ESP8266 Socket Latency section into single flowing paragraph; added context that ESP8266 previously had higher latency than ESP32/LibreTiny
- Fixed dashboard_import description: clarified .rodata is in flash on ESP32 but RAM on ESP8266 (both avoid heap overhead)
- Added API Connection Optimizations section highlighting:
  - esphome/esphome#12133 (rx_buf heap churn elimination)
  - esphome/esphome#12329, esphome/esphome#12384 (zero-copy API commands)
  - esphome/esphome#12173 (flash storage for device info on ESP8266)
  - esphome/esphome#12008 (flash storage for state subscriptions)
  - esphome/esphome#12151 (reduced service call storage)
  - esphome/esphome#11981 (APINoiseContext shared_ptr removal)
  - esphome/esphome#12291 (loop-based reboot timeout)
- Added Sensor Timeout Filter Optimization section (esphome/esphome#11922) - important for LD2410/LD2420/LD2450 users
- Consolidated three Micronova breaking changes into single entry with sub-bullets (esphome/esphome#12226, esphome/esphome#12318, esphome/esphome#12371)
- Renamed "Climate and Component Enhancements" to "Component Enhancements" (less confusing)
- Added link to [Native API](/components/api) docs in API Action Responses section
- Added link to [packages](/components/packages) docs in Conditional Package Inclusion section
- Changed ESP8266 "parity" to "near parity" (ESP8266 is inherently slower)

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- N/A

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

