### PR TITLE
Add documentation for HMAC-MD5 OTA support

### DIFF
--- a/content/components/ota/http_request.md
+++ b/content/components/ota/http_request.md
@@ -41,17 +41,36 @@ on_...:
         md5_url: http://example.com/firmware.md5
         url: https://example.com/firmware.ota.bin
     - logger.log: "This message should be not displayed because the device reboots"
+
+# Example with HMAC-MD5 verification
+on_...:
+  then:
+    - ota.http_request.flash:
+        hmac_md5_url: http://example.com/firmware.hmac
+        hmac_key: "my_secret_key"
+        url: https://example.com/firmware.ota.bin
 ```
 
 ### Configuration variables
 
 - **md5** (*Optional*, string, [templatable](/automations/templates)): The
   [MD5sum](https://en.wikipedia.org/wiki/Md5sum) of the firmware file pointed to by `url` (below). May not be used
-  with `md5_url` (below); must be specified if `md5_url` is not.
+  with `md5_url`, `hmac_md5`, or `hmac_md5_url`; must be specified if none of the other hash options are provided.
 
 - **md5_url** (*Optional*, string, [templatable](/automations/templates)): The URL of the file containing an
   [MD5sum](https://en.wikipedia.org/wiki/Md5sum) of the firmware file pointed to by `url` (below). May not be used
-  with `md5` (above); must be specified if `md5` is not.
+  with `md5`, `hmac_md5`, or `hmac_md5_url`; must be specified if none of the other hash options are provided.
+
+- **hmac_md5** (*Optional*, string, [templatable](/automations/templates)): The
+  [HMAC-MD5](https://en.wikipedia.org/wiki/HMAC) hash of the firmware file pointed to by `url` (below). Requires
+  `hmac_key` to be specified. May not be used with `md5`, `md5_url`, or `hmac_md5_url`.
+
+- **hmac_md5_url** (*Optional*, string, [templatable](/automations/templates)): The URL of the file containing an
+  [HMAC-MD5](https://en.wikipedia.org/wiki/HMAC) hash of the firmware file pointed to by `url` (below). Requires
+  `hmac_key` to be specified. May not be used with `md5`, `md5_url`, or `hmac_md5`.
+
+- **hmac_key** (*Optional*, string, [templatable](/automations/templates)): The secret key used for HMAC-MD5
+  verification. Required when using `hmac_md5` or `hmac_md5_url`.
 
 - **url** (**Required**, string, [templatable](/automations/templates)): The URL of the binary file containing the
   (new) firmware to be installed.
@@ -102,7 +121,25 @@ on_...:
 > `firmware.md5` file. The `md5_url` configuration variable should point to this file on the web server.
 > It is used by the OTA updating mechanism to ensure the integrity of the (new) firmware as it is installed.
 >
-> **If, for any reason, the MD5sum provided does not match the MD5sum computed as the firmware is installed, the
+> - The [HMAC-MD5](https://en.wikipedia.org/wiki/HMAC) hash provides enhanced security by using a secret key.
+>   It can be generated with the following command(s):
+>
+>   - On macOS and most Linux distributions with OpenSSL:
+>
+> ```shell
+>         openssl dgst -md5 -hmac "your_secret_key" firmware.ota.bin | cut -d' ' -f2 > firmware.hmac
+> ```
+>
+> - On systems with Python:
+>
+> ```shell
+>         python3 -c "import hmac, hashlib; print(hmac.new(b'your_secret_key', open('firmware.ota.bin', 'rb').read(), hashlib.md5).hexdigest())" > firmware.hmac
+> ```
+>
+> Replace `"your_secret_key"` with the same key specified in the `hmac_key` configuration variable.
+> The `hmac_md5_url` configuration variable should point to this file on the web server.
+>
+> **If, for any reason, the MD5sum or HMAC-MD5 provided does not match the computed hash as the firmware is installed, the
 > device will continue to use the original firmware and the new firmware is discarded.**
 
 ## See Also

--- a/content/components/update/http_request.md
+++ b/content/components/update/http_request.md
@@ -21,6 +21,13 @@ update:
   - platform: http_request
     name: Firmware Update
     source: http://example.com/manifest.json
+
+# Example with HMAC-MD5 support
+update:
+  - platform: http_request
+    name: Firmware Update
+    source: http://example.com/manifest.json
+    hmac_key: "my_secret_key"
 ```
 
 {{< anchor "update_http_request-configuration_variables" >}}
@@ -28,6 +35,7 @@ update:
 ## Configuration variables
 
 - **source** (**Required**, string): The URL of the YAML manifest file containing the firmware metadata.
+- **hmac_key** (*Optional*, string): The secret key used for HMAC-MD5 verification when the manifest contains `hmac_md5` instead of `md5`.
 - **update_interval** (*Optional*, [Time](/guides/configuration-types#time)): The interval at which to check for (**not install**) updates.
   Defaults to 6 hours.
 
@@ -58,7 +66,27 @@ the `ota` block that is structured as follows:
 }
 ```
 
-While `release_url` and `summary` are optional, all other fields shown here are required.
+For enhanced security, you can use HMAC-MD5 instead of MD5:
+
+```json
+{
+  "name": "My ESPHome Project",
+  "version": "2024.6.1",
+  "builds": [
+    {
+      "chipFamily": "ESP32-C3",
+      "ota": {
+        "hmac_md5": "abcdef1234567890abcdef1234567890",
+        "path": "/local/esp32c3/firmware.bin",
+        "release_url": "http://example.com/releases/10",
+        "summary": "Another update",
+      }
+    }
+  ]
+}
+```
+
+While `release_url` and `summary` are optional, all other fields shown here are required. When using `hmac_md5`, the `hmac_key` must be configured in the update component.
 
 If `path` begins with:
 


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes https://github.com/esphome/feature-requests/issues/2833

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#12419

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

