### PR TITLE
[spi] Update docs for ESP-IDF driver on ESP32 Arduino

### DIFF
--- a/content/components/spi.md
+++ b/content/components/spi.md
@@ -154,7 +154,7 @@ spi_device:
 
 - **bit_order** (*Optional*): Set the bit order - choose one of `msb_first` (default) or `lsb_first`.
 - **cs_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The CS pin.
-- **release_device** (*Optional*, boolean): For ESP-IDF, release the bus device between transactions. The default is
+- **release_device** (*Optional*, boolean): For ESP32, release the bus device between transactions. The default is
   `False`. Setting this to `True` will enable more than 6 devices to be connected to hardware SPI buses.
 
 - **interface** (*Optional*): Controls which hardware or software SPI implementation should be used.
@@ -173,9 +173,9 @@ of the specific peripheral chip.
 | 2    | high                | leading     | /CS activation and rising CLK  | falling CLK     |
 | 3    | high                | trailing    | falling CLK                    | rising CLK      |
 
-## ESP-IDF limit on bus devices
+## ESP32 limit on bus devices
 
-ESP-IDF has a software limit of 6 devices to be connected to hardware SPI buses. This limit can't be readily
+ESP32 has a software limit of 6 devices to be connected to hardware SPI buses. This limit can't be readily
 changed but can be worked around by releasing the bus device between transactions, so that no more than 6 devices
 are configured at one time. The `release_device` option can be used to enable this on a per-device basis. It will
 add additional time to an SPI transaction, so should be used only with devices that don't require frequent


### PR DESCRIPTION
## Description:

Update SPI documentation to reflect that ESP32 now uses the ESP-IDF SPI driver for both Arduino and ESP-IDF frameworks.

Changes:
- Updated `release_device` option description from "For ESP-IDF" to "For ESP32"
- Renamed section from "ESP-IDF limit on bus devices" to "ESP32 limit on bus devices"
- Updated section text to indicate this applies to all ESP32 configurations

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#12420

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)