### PR TITLE
[ledc,mqtt,resampler] Remove ESP-IDF framework restrictions from docs

### DIFF
--- a/content/components/mqtt.md
+++ b/content/components/mqtt.md
@@ -97,18 +97,18 @@ mqtt:
   for verifying SSL connections. See [SSL Fingerprints](#mqtt-ssl_fingerprints).
   for more information.
 
-- **certificate_authority** (*Optional*, string): Only with `esp-idf`. CA certificate in PEM format. See
-  [TLS with esp-idf (esp32)](#mqtt-tls-idf) for more information.
+- **certificate_authority** (*Optional*, string): Only on ESP32. CA certificate in PEM format. See
+  [TLS (ESP32)](#mqtt-tls-idf) for more information.
 
 > [!TIP]
 > For MQTT security recommendations including TLS configuration, see the [Security Best Practices](/guides/security_best_practices#mqtt) guide.
 
 - **client_certificate** (*Optional*, string): Only on `esp32`. Client certificate in PEM format.
 - **client_certificate_key** (*Optional*, string): Only on `esp32`. Client private key in PEM format.
-- **skip_cert_cn_check** (*Optional*, bool): Only with `esp-idf`. Don't verify if the common name in the server
+- **skip_cert_cn_check** (*Optional*, bool): Only on ESP32. Don't verify if the common name in the server
   certificate matches the value of `broker`.
 
-- **idf_send_async** (*Optional*, bool): Only with `esp-idf`. If true publishing the message happens from a separate mqtt task.
+- **idf_send_async** (*Optional*, bool): Only on ESP32. If true publishing the message happens from a separate mqtt task.
   The client only enqueues the message. Defaults to `false`.
   The advantage of asynchronous publishing is that it doesn't block the esphome main thread for potentially tens of seconds.
   The disadvantage is additional memory usage for the thread.
@@ -387,10 +387,10 @@ mqtt:
 
 {{< anchor "mqtt-tls-idf" >}}
 
-## TLS with esp-idf (esp32)
+## TLS (ESP32)
 
-If used with the esp-idf framework a TLS connection to a MQTT broker can be established.
-The servers CA certificate is required to validate the connection.
+On ESP32, a TLS connection to an MQTT broker can be established.
+The server's CA certificate is required to validate the connection.
 
 You have to download the server CA certificate in PEM format and add it to `certificate_authority`.
 Usually these are .crt files and you can open them with any text editor.

--- a/content/components/output/ledc.md
+++ b/content/components/output/ledc.md
@@ -35,8 +35,6 @@ which chooses adjacent channels with shared timers. See
 - **phase_angle** (*Optional*, float): Set a phase angle to the other channel of this timer.
   Range 0-360°, defaults to 0°
 
-Note: this variable is only available for the esp-idf framework
-
 ### Example Usage For a Light
 
 ```yaml

--- a/content/components/speaker/resampler.md
+++ b/content/components/speaker/resampler.md
@@ -36,7 +36,7 @@ speaker:
 - **sample_rate** (*Optional*, positive integer): Sample rate to convert to. Must be between `8000` and `48000`. Defaults to the output speaker's sample rate.
 - **filters** (*Optional*, positive integer): The number of windowed sinc interpolation filters to use. Must be between `2` and `1024`. Defaults to `16`.
 - **taps** (*Optional*, positive integer): The number of taps per windowed sinc interpolation filter. Must between `16` and `128` and divisible by 4. Defaults to `16`.
-- **task_stack_in_psram** (*Optional*, boolean): Only with `esp-idf`. Run the audio tasks in external memory. Defaults to `false`.
+- **task_stack_in_psram** (*Optional*, boolean): Run the audio tasks in external memory. Defaults to `false`.
 - All other options from [Speaker Component](/components/speaker#config-speaker).
 
 ## Improving quality


### PR DESCRIPTION
## Description:

Update documentation to reflect that the following features now work on both Arduino and ESP-IDF frameworks on ESP32:

- **LEDC `phase_angle`**: Removed note stating it's only available for ESP-IDF
- **MQTT TLS options** (`certificate_authority`, `skip_cert_cn_check`, `idf_send_async`): Changed "Only with esp-idf" to "Only on ESP32"
- **Resampler `task_stack_in_psram`**: Removed ESP-IDF restriction note

Also updated the MQTT TLS section title from "TLS with esp-idf (esp32)" to "TLS (ESP32)".

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#12442

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/static/images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/_index.md`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image dht22
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)