### PR TITLE
2025.12.0b2

### DIFF
--- a/.claude/instructions.md
+++ b/.claude/instructions.md
@@ -197,6 +197,7 @@ Use GitHub-style alert syntax:
 - **Bug fixes and documentation corrections**: Target the `current` branch
 - **New features and new component docs**: Target the `next` branch
 - **Create separate branches** for each pull request (one PR per feature/fix)
+- **Always branch from the target branch**: Use `git checkout -b <branch-name> current` or `git checkout -b <branch-name> next` to ensure you're branching from the correct base, not whatever branch is currently checked out
 
 ### Commit Messages
 - Use clear, descriptive commit messages
@@ -209,8 +210,9 @@ Use GitHub-style alert syntax:
 ### Pull Request Process
 1. Ensure all changes are committed to the feature branch
 2. Push to origin: `git push -u origin <branch-name>`
-3. All automated tests must pass before review
-4. Follow retry logic for network failures (exponential backoff: 2s, 4s, 8s, 16s)
+3. Create the PR using the `.github/PULL_REQUEST_TEMPLATE.md` template - fill out all sections completely without removing any parts of the template
+4. All automated tests must pass before review
+5. Follow retry logic for network failures (exponential backoff: 2s, 4s, 8s, 16s)
 
 ## Testing and Preview
 

--- a/.github/workflows/auto-label-pr.yml
+++ b/.github/workflows/auto-label-pr.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Generate a token
         id: generate-token
-        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
         with:
           app-id: ${{ secrets.ESPHOME_GITHUB_APP_ID }}
           private-key: ${{ secrets.ESPHOME_GITHUB_APP_PRIVATE_KEY }}

--- a/content/changelog/2025.12.0.md
+++ b/content/changelog/2025.12.0.md
@@ -588,6 +588,10 @@ For detailed migration guides and API documentation, see the [ESPHome Developers
 - [micronova] Fix test UART package key to match directory name [esphome#12391](https://github.com/esphome/esphome/pull/12391) by [@bdraco](https://github.com/bdraco)
 - [tests] Fix clang-tidy warnings in custom_api_device_component fixture [esphome#12390](https://github.com/esphome/esphome/pull/12390) by [@bdraco](https://github.com/bdraco)
 - [core] Packages refactor and conditional package inclusion (package refactor part 1) [esphome#11605](https://github.com/esphome/esphome/pull/11605) by [@jpeletier](https://github.com/jpeletier) (new-feature)
+- [light] Add zero-copy support for API effect commands [esphome#12384](https://github.com/esphome/esphome/pull/12384) by [@bdraco](https://github.com/bdraco)
+- [api] Fix potential buffer overflow in noise PSK base64 decode [esphome#12395](https://github.com/esphome/esphome/pull/12395) by [@bdraco](https://github.com/bdraco)
+- [esp8266] Eliminate up to 16ms socket latency [esphome#12397](https://github.com/esphome/esphome/pull/12397) by [@bdraco](https://github.com/bdraco)
+- [http_request] Skip update check when network not connected [esphome#12418](https://github.com/esphome/esphome/pull/12418) by [@swoboda1337](https://github.com/swoboda1337)
 
 </details>
 

--- a/content/changelog/2025.12.0.md
+++ b/content/changelog/2025.12.0.md
@@ -12,13 +12,288 @@ params:
 "CC1101","components/cc1101","cc1101.webp",""
 "HC8","components/sensor/hc8","hc8.png",""
 "HLW8032","components/sensor/hlw8032","hlw8032.png",""
-"HUB75","components/display/hub75","hub75.svg",""
+"HUB75 LED Matrix","components/display/hub75","hub75.svg",""
 "STTS22H","components/sensor/stts22h","stts22h.jpg",""
 "ThermoPro BLE","components/sensor/thermopro_ble","thermopro_tp357.jpg",""
 "USB CDC-ACM","components/usb_cdc_acm","usb.svg","dark-invert"
 {{< /imgtable >}}
 
 ## Release Overview
+
+<!-- RELEASE_OVERVIEW_START -->
+ESPHome 2025.12.0 introduces API action responses for bidirectional communication with Home Assistant, conditional package inclusion for dynamic configurations, and HUB75 LED matrix display support. This release delivers significant memory optimizations saving up to 10KB of IRAM on ESP32 devices, eliminates per-packet heap allocations in API connections and socket latency on ESP8266, and adds 8 new components including the CC1101 sub-GHz transceiver and USB CDC-ACM support. LVGL receives multiple usability improvements, and the WiFi component has been refactored for instant callback-based updates across all platforms.
+<!-- RELEASE_OVERVIEW_END -->
+
+<!-- FEATURE_HIGHLIGHTS_START -->
+## API Action Responses
+
+The [Native API](/components/api) now supports actions that send structured responses back to clients like Home Assistant, enabling true bidirectional communication where actions return success/error status and JSON data payloads ([#12136](https://github.com/esphome/esphome/pull/12136)).
+
+**Key Features:**
+
+- **Status responses** - Report success or failure with optional error messages
+- **Data responses** - Return structured JSON data from actions using ArduinoJson
+- **Auto-detection** - Response mode automatically detected based on `api.respond` usage
+- **Three modes** - `none` (fire and forget), `status` (success/error only), or `optional`/`only` (with data)
+
+This unlocks new use cases like query-type actions that return device configuration, sensor readings, or diagnostic information directly to Home Assistant.
+
+```yaml
+api:
+  actions:
+    - action: get_sensor_reading
+      variables:
+        sensor_name: string
+      then:
+        - api.respond:
+            data: !lambda |-
+              root["sensor"] = sensor_name;
+              root["value"] = 42.5;
+              root["unit"] = "°C";
+```
+
+## Conditional Package Inclusion
+
+The [packages](/components/packages) system now supports conditional inclusion, a long-awaited feature that enables dynamic configuration based on substitution variables ([#11605](https://github.com/esphome/esphome/pull/11605)).
+
+**Key Features:**
+
+- **Conditional imports** - Include packages based on boolean conditions using Jinja2 expressions
+- **Package merging after substitutions** - Packages are now merged after substitution resolution, enabling generated components to merge correctly with manually defined ones
+- **LVGL extend support** - The `!extend` and `!remove` directives now work with LVGL-style configurations ([#11534](https://github.com/esphome/esphome/pull/11534))
+
+```yaml
+substitutions:
+  network_package: !include network.yaml
+  network_enabled: true
+
+packages:
+  - ${ network_enabled and network_package or {} }
+```
+
+This enables creating reusable configuration templates that adapt to different hardware variants or deployment scenarios.
+
+## HUB75 LED Matrix Display Support
+
+The new [hub75](/components/display/hub75) component brings native support for HUB75 LED matrix panels, enabling large-format LED displays for information dashboards, signage, and creative projects ([#11153](https://github.com/esphome/esphome/pull/11153)).
+
+**Key Features:**
+
+- **Multiple ESP32 variants** - Supports ESP32 (I2S), ESP32-S3 (LCD CAM + GDMA), and ESP32-P4 (PARLIO)
+- **Flexible configuration** - Configurable panel dimensions, clock speed, and pin assignments
+- **LVGL compatible** - Works seamlessly with LVGL for rich graphical interfaces
+- **Board presets** - Pre-configured settings for popular boards like Apollo Automation M1
+
+## CC1101 Sub-1GHz Transceiver
+
+The new [cc1101](/components/cc1101) component adds support for the Texas Instruments CC1101 Sub-1GHz transceiver, enabling 433MHz remote control integration and other sub-GHz wireless applications ([#11849](https://github.com/esphome/esphome/pull/11849)).
+
+**Key Features:**
+
+- **433.92MHz support** - Perfect for integrating 433MHz remotes and sensors
+- **ASK/OOK modulation** - Works with common remote control protocols
+- **Core integration** - Designed to work with `remote_receiver` and `remote_transmitter` components
+- **Robust initialization** - Non-blocking state machine with proper chip reset handling
+
+## USB CDC-ACM Support
+
+The new [usb_cdc_acm](/components/usb_cdc_acm) component enables USB virtual serial port functionality on ESP32-S2 and ESP32-S3 devices ([#11687](https://github.com/esphome/esphome/pull/11687)).
+
+**Key Features:**
+
+- **Multi-interface support** - Up to 2 independent CDC-ACM interfaces per device
+- **Configurable buffers** - Adjustable RX/TX ring buffer sizes
+- **Line state callbacks** - Notifications for DTR, RTS, baud rate, and other line coding changes
+- **Bridge-ready** - Designed to connect USB serial interfaces to UART or other serial interfaces
+
+## WiFi Info Callback Architecture
+
+The WiFi component has been refactored from polling-based updates to event-driven callbacks, significantly improving responsiveness ([#10748](https://github.com/esphome/esphome/pull/10748)).
+
+**Key Features:**
+
+- **Immediate updates** - WiFi info sensors now update instantly when state changes instead of waiting for poll intervals
+- **Reduced overhead** - Eliminates continuous polling in wifi_info sensors
+- **Platform consistency** - All platforms (ESP8266, ESP32, LibreTiny, Pico W) now use the same callback infrastructure
+- **New power save mode sensor** - Reports current WiFi power save mode ([#11480](https://github.com/esphome/esphome/pull/11480))
+- **AP active condition** - New `wifi.ap_active` condition for automation triggers ([#11852](https://github.com/esphome/esphome/pull/11852))
+
+## Low Latency UART Processing
+
+The UART component now supports a `wake_loop_on_rx` flag that wakes the main loop immediately when data arrives, enabling near-real-time serial processing ([#12172](https://github.com/esphome/esphome/pull/12172)).
+
+**Key Benefits:**
+
+- **Z-Wave Proxy performance** - Reduces latency by ~10ms for WiFi-connected [ZWA-2 devices](https://www.home-assistant.io/blog/2025/10/13/portable-z-wave-with-wifi-and-poe/), building on the USB-connected Ethernet/PoE optimizations from 2025.11.0 ([#12135](https://github.com/esphome/esphome/pull/12135))
+- **Real-time serial applications** - Any component requiring fast response to incoming serial data can now achieve sub-millisecond wake times by enabling this flag in their code
+- **Automatic infrastructure** - The socket wake infrastructure is automatically enabled when any UART requests RX wake
+
+## ESP8266 Socket Latency Elimination
+
+ESP8266 previously had higher network latency than ESP32 and LibreTiny because it used polling for socket data, sleeping up to 16ms before discovering incoming data. This affected every API request and Home Assistant command. The loop now wakes within microseconds of data arriving using ESP8266's `esp_schedule()` mechanism, bringing ESP8266 to near parity with ESP32 and LibreTiny. This is automatic for all ESP8266 devices with no configuration needed ([#12397](https://github.com/esphome/esphome/pull/12397)).
+
+## Memory and IRAM Optimizations
+
+This release includes substantial memory optimizations, particularly for ESP32 devices using ESP-IDF:
+
+**FreeRTOS and Ring Buffer Flash Placement:**
+
+- **~8KB IRAM savings** - FreeRTOS functions moved to flash by default ([#12182](https://github.com/esphome/esphome/pull/12182))
+- **~1.5KB additional IRAM savings** - Ring buffer functions moved to flash ([#12184](https://github.com/esphome/esphome/pull/12184))
+- **Escape hatches** - Use `freertos_in_iram: true` or `ringbuf_in_iram: true` if issues occur
+
+These changes prepare ESPHome for ESP-IDF 6.0 where flash placement becomes the default.
+
+**BLE Client Memory Reduction:**
+
+- **24-40 bytes per BLE client** - Replaced `std::string` with fixed `char[18]` for MAC address storage ([#12070](https://github.com/esphome/esphome/pull/12070))
+
+**Text Sensor Optimization:**
+
+- **24-32 bytes per text sensor** - Eliminated duplicate string storage when no filters configured ([#12205](https://github.com/esphome/esphome/pull/12205))
+
+**Dashboard Import Optimization:**
+
+- **Eliminates URL heap allocation**:
+  - Package import URL is now stored as a pointer to `.rodata` instead of a heap-allocated `std::string`.
+  - On ESP32, `.rodata` resides in flash, providing RAM savings.
+  - On ESP8266, `.rodata` is in RAM, but this still avoids heap overhead.
+  - ([#11951](https://github.com/esphome/esphome/pull/11951))
+
+**API Connection Optimizations:**
+
+The API connection layer received significant optimizations to reduce heap fragmentation and memory churn:
+
+- **Eliminated per-packet heap allocation** - Previously every API packet received required a new heap allocation. The receive buffer is now reused across packets, with excess capacity released after initial sync completes. This reduces heap fragmentation on busy devices. For quiet devices, the initial sync memory spike is released rather than held for the lifetime of the connection. (Connections can last for months.) ([#12133](https://github.com/esphome/esphome/pull/12133))
+- **Zero-copy API commands** - Select and light effect commands now process strings directly from protobuf buffer without heap allocation ([#12329](https://github.com/esphome/esphome/pull/12329), [#12384](https://github.com/esphome/esphome/pull/12384))
+- **Flash storage for device info** - Device info strings stored in flash on ESP8266 ([#12173](https://github.com/esphome/esphome/pull/12173))
+- **Flash storage for state subscriptions** - Home Assistant state subscriptions stored in flash instead of heap ([#12008](https://github.com/esphome/esphome/pull/12008))
+- **Reduced service call storage** - Home Assistant service call strings use less heap ([#12151](https://github.com/esphome/esphome/pull/12151))
+- **APINoiseContext optimization** - Removed shared_ptr overhead ([#11981](https://github.com/esphome/esphome/pull/11981))
+- **Loop-based reboot timeout** - Avoids scheduler heap churn ([#12291](https://github.com/esphome/esphome/pull/12291))
+
+**Sensor Timeout Filter Optimization:**
+
+- **Eliminates scheduler heap churn** - Timeout filters now use a loop-based implementation instead of scheduler timeouts. This is particularly important for LD2410/LD2420/LD2450 users with many timeout filters, where the old implementation caused ~70 heap operations/second and constant scheduler pool exhaustion when someone was in range of the sensor ([#11922](https://github.com/esphome/esphome/pull/11922))
+
+## New Hardware Support
+
+This release adds support for 8 new components and numerous display models:
+
+**New Sensor Components:**
+
+- [hlw8032](/components/sensor/hlw8032) - Single-phase power metering IC ([#7241](https://github.com/esphome/esphome/pull/7241))
+- [stts22h](/components/sensor/stts22h) - High-accuracy temperature sensor ([#11778](https://github.com/esphome/esphome/pull/11778))
+- [thermopro_ble](/components/sensor/thermopro_ble) - ThermoPro BLE temperature/humidity sensors ([#11835](https://github.com/esphome/esphome/pull/11835))
+- [hc8](/components/sensor/hc8) - HC8 CO2 sensor ([#11872](https://github.com/esphome/esphome/pull/11872))
+
+**New Time Component:**
+
+- [bm8563](/components/time/bm8563) - BM8563 I2C RTC ([#11616](https://github.com/esphome/esphome/pull/11616))
+
+**New Display Models:**
+
+- Waveshare 4.26" e-paper with SSD1677 controller ([#11887](https://github.com/esphome/esphome/pull/11887))
+- Waveshare S3 LCD 3.16" ([#12309](https://github.com/esphome/esphome/pull/12309))
+- Guition JC4827W543 480x272 display ([#12034](https://github.com/esphome/esphome/pull/12034))
+- Guition JC4880P443 480x800 MIPI DSI display ([#12068](https://github.com/esphome/esphome/pull/12068))
+- M5Stack Core2 display ([#12301](https://github.com/esphome/esphome/pull/12301))
+
+**Platform Enhancements:**
+
+- ESP32-C5 PSRAM support with quad mode and speeds up to 120MHz ([#12215](https://github.com/esphome/esphome/pull/12215))
+- Seeed XIAO ESP32-C6 board definition ([#12307](https://github.com/esphome/esphome/pull/12307))
+- Remote transmitter/receiver support for RP2040 ([#12048](https://github.com/esphome/esphome/pull/12048))
+- nRF52 DC-DC converter settings ([#11841](https://github.com/esphome/esphome/pull/11841))
+
+## LVGL Improvements
+
+Multiple enhancements improve the LVGL experience:
+
+- **Direct button text** - Set `text:` directly on buttons without nested label widgets ([#11964](https://github.com/esphome/esphome/pull/11964))
+- **Auto row/column padding** - `pad_all` now applies to inter-row/column spacing in flex layouts ([#11879](https://github.com/esphome/esphome/pull/11879))
+- **Display sync option** - New `update_when_display_idle` option syncs LVGL updates with display refresh ([#11896](https://github.com/esphome/esphome/pull/11896))
+- **Enhanced arc widget** - More arc parameters available in update actions ([#12066](https://github.com/esphome/esphome/pull/12066))
+- **Scroll properties** - Added missing scroll-related configuration options ([#11901](https://github.com/esphome/esphome/pull/11901))
+
+## Component Enhancements
+
+**Gree Climate:**
+
+- New `turbo`, `light`, `health`, and `xfan` switches for supported models ([#12160](https://github.com/esphome/esphome/pull/12160))
+
+**Climate IR:**
+
+- Optional humidity sensor support ([#9805](https://github.com/esphome/esphome/pull/9805))
+
+**SPS30 Particulate Sensor:**
+
+- Idle mode functionality to extend sensor life and reduce power consumption ([#12255](https://github.com/esphome/esphome/pull/12255))
+
+**PCA9685 PWM:**
+
+- Phase balancer option to fix LED flickering during animations ([#9792](https://github.com/esphome/esphome/pull/9792))
+
+**Prometheus:**
+
+- Event and text component metrics support ([#10240](https://github.com/esphome/esphome/pull/10240))
+
+**MCP3204 ADC:**
+
+- Differential mode measurement support ([#7436](https://github.com/esphome/esphome/pull/7436))
+
+## Developer Features
+
+**IDF Component Improvements:**
+
+- Shorthand syntax for ESP-IDF components like `espressif/esp_hosted^2.6.6` ([#12127](https://github.com/esphome/esphome/pull/12127))
+- YAML can now override component versions defined in code
+
+**API Enhancements:**
+
+- `state_subscription_only` flag for reliable API connection detection without logger false positives ([#11906](https://github.com/esphome/esphome/pull/11906))
+- New `measurement_angle` state class for angle sensors ([#12085](https://github.com/esphome/esphome/pull/12085))
+<!-- FEATURE_HIGHLIGHTS_END -->
+
+## Breaking Changes
+
+<!-- BREAKING_CHANGES_USERS_START -->
+### Component Changes
+
+- **Micronova**: Multiple configuration changes ([#12226](https://github.com/esphome/esphome/pull/12226), [#12318](https://github.com/esphome/esphome/pull/12318), [#12371](https://github.com/esphome/esphome/pull/12371)):
+  - `update_interval` moved from hub to individual entities - remove from `micronova:` section and add to each sensor/text_sensor
+  - `memory_location` now restricted to read locations (0x00-0x79) - subtract 0x80 from values above 0x79
+  - `memory_write_location` removed from number entities (now calculated automatically)
+  - Custom button/sensor entities now require explicit `memory_location` and `address` configuration
+
+- **Prometheus**: Light color metrics (`light_color_*`) are now only generated if the light component supports those color modes. This reduces memory usage on ESP8266 but may affect monitoring setups that expected all metrics regardless of light capabilities. [#9530](https://github.com/esphome/esphome/pull/9530)
+
+- **Text Sensor**: The public `raw_state` member has been removed. If you access `.raw_state` directly in a lambda, update to use `.get_raw_state()` instead. [#12205](https://github.com/esphome/esphome/pull/12205)
+
+### Platform Changes
+
+- **I2C on ESP32-C5/C6/P4**: Fixed I2C port logic for chips with Low Power (LP) I2C ports. Users with multiple I2C buses on these chips may need to verify their port assignments. [#12063](https://github.com/esphome/esphome/pull/12063)
+
+### Behavior Changes
+
+- **WiFi Info**: Text sensors now use callback-based updates instead of polling. Updates happen immediately when WiFi state changes rather than on fixed intervals. This improves responsiveness but may change timing behavior if your automations depended on the polling interval. [#10748](https://github.com/esphome/esphome/pull/10748)
+<!-- BREAKING_CHANGES_USERS_END -->
+
+### Breaking Changes for Developers
+
+<!-- BREAKING_CHANGES_DEVELOPERS_START -->
+- **Component::mark_failed() and status_set_error()**: The `const char*` overloads are deprecated and will be removed in 2026.6.0. Use `LOG_STR()` instead: `this->mark_failed(LOG_STR("Error message"))`. This fixes dangling pointer bugs when passing temporary strings. [#12021](https://github.com/esphome/esphome/pull/12021)
+
+- **BLEClientBase::address_str()**: Return type changed from `const std::string&` to `const char*`. Remove `.c_str()` calls: `client->address_str()` instead of `client->address_str().c_str()`. [#12070](https://github.com/esphome/esphome/pull/12070)
+
+- **TextSensor::raw_state**: Changed from public member to protected `raw_state_`. Use `get_raw_state()` method instead of direct member access. [#12205](https://github.com/esphome/esphome/pull/12205)
+
+- **WiFi component callbacks**: New callback architecture with `wifi_connect_state_callback_`, `ip_state_callback_`, and `wifi_scan_state_callback_`. Automation triggers moved to `automation.h`. [#10748](https://github.com/esphome/esphome/pull/10748)
+
+- **Micronova**: `MicroNovaFunctions` enum removed - value interpretation now determined at compile time. The `get_set_fan_speed_offset()` public method removed from sensor entity. [#12363](https://github.com/esphome/esphome/pull/12363)
+
+For detailed migration guides and API documentation, see the [ESPHome Developers Documentation](https://developers.esphome.io/).
+<!-- BREAKING_CHANGES_DEVELOPERS_END -->
 
 <!-- markdownlint-disable MD013 -->
 

--- a/content/components/_index.md
+++ b/content/components/_index.md
@@ -745,6 +745,7 @@ Often known as "tag" or "card" readers within the community.
 "ILI9486","components/display/ili9xxx","ili9341.jpg"
 "ILI9488","components/display/ili9xxx","ili9488.svg"
 "WSPICOLCD","components/display/ili9xxx","ili9488.svg"
+"HUB75 LED Matrix","components/display/hub75","hub75.svg"
 "Inkplate","components/display/inkplate","inkplate6.jpg"
 "LCD Display","components/display/lcd_display","lcd.jpg"
 "MAX7219 Dot Matrix","components/display/max7219digit","max7219digit.jpg"

--- a/content/components/display/_index.md
+++ b/content/components/display/_index.md
@@ -18,6 +18,7 @@ graphical displays with fully addressable pixels.
 - Graphical displays with fully addressable pixels, such as
   {{< docref "mipi_spi" "SPI interfaced LCDs" >}},
   {{< docref "waveshare_epaper" "E-Paper" >}},
+  {{< docref "hub75" "HUB75 LED matrices" >}},
   and {{< docref "ssd1306" "OLED" >}}.
 
 For graphical displays, which offer the greatest flexibility, there are two options for displaying content:

--- a/content/components/openthread.md
+++ b/content/components/openthread.md
@@ -58,10 +58,12 @@ openthread:
 - **channel** (int): Channel number from 11 to 26
 - **network_name** (string): A human-readable Network Name
 - **network_key** (string): OpenThread network key
-- **panid** (string): 2-byte Personal Area Network ID (PAN ID)
-- **extpanid** (string): 8-byte Extended Personal Area Network ID (XPAN ID)
+- **pan_id** (string): 2-byte Personal Area Network ID (PAN ID)
+- **ext_pan_id** (string): 8-byte Extended Personal Area Network ID (XPAN ID)
 - **pskc** (string): PSKc is used to authenticate an external Thread Commissioner to a Thread network
 - **mesh_local_prefix** (ipv6network): Used to build Mesh-Local IPv6 addresses (ML-EIDs), which are unique to each Thread device within the network partition
+- **force_dataset** (*Optional*, bool): Forces ESPHome configuration to override any previously stored OpenThread
+  network dataset on the device, ensuring configured parameters are always applied at startup. Defaults to `false`
 - **use_address** (*Optional*, string): Manually override what address to use to connect
   to the ESP. Defaults to auto-generated value.
 - **poll_period** (*Optional*, [Time](/guides/configuration-types#config-time)): When Poll_Period is set on an MTD device, the parent router will enqueue any messages and wait for the child to submit a poll data request

--- a/content/components/output/ac_dimmer.md
+++ b/content/components/output/ac_dimmer.md
@@ -7,13 +7,6 @@ params:
     image: ac_dimmer.svg
 ---
 
-> [!WARNING]
-> This component has not been fully tested yet, if you are testing this component
-> please share your experience with the dimmer hardware and light model and
-> configuration here <https://github.com/esphome/feature-requests/issues/278>
->
-> Thanks!
-
 The `ac_dimmer` component allows you to connect a dimmable light or other load
 which supports phase control dimming to your ESPHome project.
 

--- a/content/components/packages.md
+++ b/content/components/packages.md
@@ -168,6 +168,29 @@ switch:
     # ...
 ```
 
+## Conditionally including a package
+
+You can include a package based on a condition, or choose a package dinamically by loading your package with
+`!include` into a substitution variable instead of under `packages`:
+
+```yaml
+# In config.yaml
+substitutions:
+  left_garage_door: !include
+    file: garage-door.yaml
+    vars:
+      door_name: Left
+
+  enable_extra_door: true
+
+packages:
+  extra_door: ${ left_garage_door if enable_extra_door else {} }
+```
+
+The above utilizes a [Jinja expression](/components/substitutions#jinja-expressions) to determine whether
+`left_garage_door` package is actually included. `enable_extra_door` can be set from the
+[command line](/components/substitutions#command-line-substitutions) as well.
+
 {{< anchor "config-packages_extend" >}}
 
 ## Extend

--- a/content/components/update/esp32_hosted.md
+++ b/content/components/update/esp32_hosted.md
@@ -64,14 +64,14 @@ firmware should be built using the ESP-IDF framework and the resulting `.bin` fi
 configuration directory.
 
 ```sh
-# Build instructions for IDF 5.5.1 and ESP Hosted 2.6.1
+# Build instructions for IDF 5.5.1 and ESP Hosted 2.7.0
 git clone -b v5.5.1 --recursive https://github.com/espressif/esp-idf.git
 cd esp-idf
 ./install.sh esp32c6
 source export.sh  # for Linux/macOS
 export.bat        # for Windows
 cd ..
-idf.py create-project-from-example "espressif/esp_hosted^2.6.1:slave"
+idf.py create-project-from-example "espressif/esp_hosted^2.7.0:slave"
 cd slave/
 idf.py set-target esp32c6
 idf.py build

--- a/content/guides/supporters.md
+++ b/content/guides/supporters.md
@@ -2290,4 +2290,4 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Christian Zufferey (@zuzu59)](https://github.com/zuzu59)
 - [Zynth-dev (@Zynth-dev)](https://github.com/Zynth-dev)
 
-*This page was last updated December 9, 2025.*
+*This page was last updated December 12, 2025.*

--- a/data/version.yaml
+++ b/data/version.yaml
@@ -1,2 +1,2 @@
-release: 2025.12.0b1
+release: 2025.12.0b2
 version: '2025.12'


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- [esp32_hosted] Update ESP Hosted version to 2.7.0 [docs#5752](https://github.com/esphome/esphome-docs/pull/5752)
- [docs] Add PR template instruction to Claude instructions [docs#5751](https://github.com/esphome/esphome-docs/pull/5751)
- Bump actions/create-github-app-token from 2.1.4 to 2.2.1 [docs#5743](https://github.com/esphome/esphome-docs/pull/5743)
- [hub75] Add component to indexes [docs#5760](https://github.com/esphome/esphome-docs/pull/5760)
- Remove warning from AC dimmer component [docs#5759](https://github.com/esphome/esphome-docs/pull/5759)
- Document conditional package `!include` [docs#5536](https://github.com/esphome/esphome-docs/pull/5536)
- [openthread] Fix configuration keys and add missing `force_dataset` key [docs#5765](https://github.com/esphome/esphome-docs/pull/5765)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
