### PR TITLE
[esp32] Add OTA rollback documentation

### DIFF
--- a/content/components/esp32.md
+++ b/content/components/esp32.md
@@ -152,6 +152,16 @@ esp32:
   errors (e.g., with complex code or deep recursion). Higher values reduce heap availability. Valid range is 8192-32768
   bytes. Defaults to 8192 bytes.
 
+- **enable_ota_rollback** (*Optional*, boolean): Enable OTA rollback support. When enabled, the bootloader will
+  automatically roll back to the previous firmware if the device crashes or resets before the boot is marked as
+  successful. This works in conjunction with the [safe_mode](/components/safe_mode) component - after the
+  `boot_is_good_after` time (default 60s), the firmware is marked as valid. If the device crashes before that,
+  it will roll back to the previous working firmware. Defaults to `true`.
+
+> [!NOTE]
+> OTA rollback requires the bootloader to be compiled with rollback support. Existing devices may need to be
+> reflashed via serial to update the bootloader - OTA updates do not update the bootloader.
+
 **LWIP Optimization Options (ESP-IDF only):**
 
 The following options are available under the `advanced` section when using the ESP-IDF framework to optimize


### PR DESCRIPTION
## Description:

Adds documentation for the new `enable_ota_rollback` advanced configuration option for ESP32.

**Related issue (if applicable):** fixes https://github.com/esphome/backlog/issues/81

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#12460

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/static/images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/_index.md`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image dht22
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>