### PR TITLE
[cc1101] Add packet mode documentation

### DIFF
--- a/content/components/cc1101.md
+++ b/content/components/cc1101.md
@@ -192,8 +192,8 @@ remote_receiver:
 
 ### 2. Single Pin Wiring
 
-This wiring scheme uses a single MCU pin for both transmitting and receiving, connected to GDO0.
-Configure `gdo0_pin` to enable automatic pin mode switching.
+This wiring scheme uses a single MCU pin for both transmitting and receiving data, connected to GDO0.
+This requires careful configuration of the `remote_transmitter` and `remote_receiver` to avoid conflicts.
 
 - **GDO0 (Module Pin 3)**: Connect to a single MCU GPIO pin.
 - **GDO2 (Module Pin 8)**: Leave disconnected.

--- a/content/components/cc1101.md
+++ b/content/components/cc1101.md
@@ -146,37 +146,39 @@ cc1101:
   on_packet:
     then:
       - lambda: |-
-          ESP_LOGD("cc1101", "packet %s", format_hex(x).c_str());
-          ESP_LOGD("cc1101", "rssi %.1f dBm", rssi);
-          ESP_LOGD("cc1101", "lqi %u", lqi);
+          ESP_LOGD("cc1101", "packet %s rssi %.1f dBm lqi %u", format_hex(x).c_str(), rssi, lqi);
 ```
 
 ## Actions
 
-This component provides actions to control the radio state.
+### `cc1101.begin_tx` Action
 
-### Async Serial Mode Actions
+This [action](/automations/actions#all-actions) puts the radio into TX mode and switches `gdo0_pin` to output mode.
 
-This component provides actions to control the radio state, primarily used for coordinating transmission.
+### `cc1101.begin_rx` Action
 
-- **cc1101.begin_tx**: Puts the radio into TX mode and switches `gdo0_pin` to output mode.
-- **cc1101.begin_rx**: Puts the radio into RX mode and switches `gdo0_pin` to input mode.
-- **cc1101.set_idle**: Puts the radio into an idle state.
-- **cc1101.reset**: Resets the CC1101 chip and re-applies configuration.
+This [action](/automations/actions#all-actions) puts the radio into RX mode and switches `gdo0_pin` to input mode.
 
-### Packet Mode Actions
+### `cc1101.set_idle` Action
 
-- **cc1101.send_packet**: Transmits a packet. Only available when `packet_mode` is enabled.
-  - **data** (**Required**, list of bytes or lambda): The packet data to transmit.
+This [action](/automations/actions#all-actions) puts the radio into an idle state.
+
+### `cc1101.reset` Action
+
+This [action](/automations/actions#all-actions) resets the CC1101 chip and re-applies configuration.
+
+### `cc1101.send_packet` Action
+
+This [action](/automations/actions#all-actions) transmits a packet. Only available when `packet_mode` is enabled.
+
+#### Configuration variables
+
+- **data** (**Required**, list): The packet to send, length should match the configured `packet_length`.
 
 ```yaml
-button:
-  - platform: template
-    name: "Send Packet"
-    on_press:
-      then:
-        - cc1101.send_packet:
-            data: [0x12, 0x34, 0x56, 0x78]
+on_...:
+  - cc1101.send_packet:
+      data: [0x12, 0x34, 0x56, 0x78]
 ```
 
 ## Integration with Remote Receiver/Transmitter

--- a/content/components/cc1101.md
+++ b/content/components/cc1101.md
@@ -39,7 +39,7 @@ cc1101:
 - **cs_pin** (**Required**, [Pin](/guides/configuration-types/#pin)):
   The SPI Chip Select (CSN) pin connected to the module.
 - **gdo0_pin** (*Optional*, [Pin](/guides/configuration-types/#pin)):
-  The GDO0 pin. Required when `packet_mode` is enabled also used for single pin mode switching.
+  The GDO0 pin. Required when `packet_mode` is enabled, also used for single pin mode switching.
 
 ### General Settings
 

--- a/content/components/cc1101.md
+++ b/content/components/cc1101.md
@@ -70,27 +70,24 @@ cc1101:
 - **if_frequency** (*Optional*, frequency): Intermediate Frequency.
   Range: `25kHz` to `788kHz`. Defaults to `153kHz`.
 
-### Sync Word Settings
+### Packet Mode Settings
 
+These settings enable the CC1101's built-in packet handling with FIFO buffering, sync word detection,
+and optional CRC checking.
+
+- **packet_mode** (*Optional*, boolean): Enable FIFO packet mode. When enabled, `gdo0_pin` is
+  required. Defaults to `false`.
+- **packet_length** (*Optional*, int): Packet length in bytes. Set to `0` for variable length packets
+  (length byte prepended to data). Range: `0` to `64`. Defaults to `0`.
+- **crc_enable** (*Optional*, boolean): Enable CRC-16 calculation and checking. The CC1101 uses
+  CRC-16-IBM (polynomial 0x8005). Defaults to `false`.
+- **whitening** (*Optional*, boolean): Enable data whitening to improve DC balance. Defaults to `false`.
 - **sync_mode** (*Optional*, enum): Sync word detection mode.
   Options: `None`, `15/16`, `16/16`, `30/32`. Defaults to `16/16`.
 - **sync0** (*Optional*, hex): Lower sync word byte. Defaults to `0x91`.
 - **sync1** (*Optional*, hex): Upper sync word byte. Defaults to `0xD3`.
 - **num_preamble** (*Optional*, int): Number of preamble bytes to transmit.
   Range: `0` to `7` (maps to 2, 3, 4, 6, 8, 12, 16, 24 bytes). Defaults to `2` (4 bytes).
-
-### Packet Mode Settings
-
-These settings enable the CC1101's built-in packet handling with FIFO buffering, sync word detection,
-and optional CRC checking.
-
-- **packet_mode** (*Optional*, boolean): Enable FIFO packet mode. When enabled, `gdo0_pin` and
-  `packet_length` are required. Defaults to `false`.
-- **packet_length** (*Optional*, int): Fixed packet length in bytes. Required when `packet_mode` is
-  enabled. Range: `1` to `64`.
-- **crc_enable** (*Optional*, boolean): Enable CRC-16 calculation and checking. The CC1101 uses
-  CRC-16-IBM (polynomial 0x8005). Defaults to `false`.
-- **whitening** (*Optional*, boolean): Enable data whitening to improve DC balance. Defaults to `false`.
 
 ### AGC (Automatic Gain Control) Settings
 

--- a/content/components/cc1101.md
+++ b/content/components/cc1101.md
@@ -27,27 +27,10 @@ The component supports two operating modes:
 ## Component Configuration
 
 ```yaml
-# Minimal Example (Async Serial Mode for Remote Receiver/Transmitter)
+# Minimal Example
 cc1101:
   cs_pin: GPIOXX
   frequency: 433.92MHz
-```
-
-```yaml
-# Packet Mode Example
-cc1101:
-  cs_pin: GPIOXX
-  gdo0_pin: GPIOXX
-  frequency: 433.92MHz
-  modulation_type: GFSK
-  symbol_rate: 4800
-  packet_mode: true
-  packet_length: 8
-  on_packet:
-    then:
-      - lambda: |-
-          ESP_LOGD("cc1101", "Packet: %s (RSSI: %.1f dBm, LQI: %u)",
-                   format_hex(x).c_str(), rssi, lqi);
 ```
 
 ## Configuration Variables
@@ -57,7 +40,7 @@ cc1101:
 - **cs_pin** (**Required**, [Pin](/guides/configuration-types/#pin)):
   The SPI Chip Select (CSN) pin connected to the module.
 - **gdo0_pin** (*Optional*, [Pin](/guides/configuration-types/#pin)):
-  The GDO0 pin. Required when `packet_mode` is enabled. Also used for async serial mode pin switching.
+  The GDO0 pin. Required when `packet_mode` is enabled also used for single pin mode switching.
 
 ### General Settings
 
@@ -153,8 +136,7 @@ This component provides actions to control the radio state.
 
 ### Async Serial Mode Actions
 
-These actions are used for coordinating transmission with Remote Transmitter/Receiver. When `gdo0_pin`
-is configured, `begin_tx` and `begin_rx` automatically handle pin mode switching.
+This component provides actions to control the radio state, primarily used for coordinating transmission.
 
 - **cc1101.begin_tx**: Puts the radio into TX mode and switches `gdo0_pin` to output mode.
 - **cc1101.begin_rx**: Puts the radio into RX mode and switches `gdo0_pin` to input mode.
@@ -174,12 +156,6 @@ button:
       then:
         - cc1101.send_packet:
             data: [0x12, 0x34, 0x56, 0x78]
-
-        # Or with a lambda:
-        - cc1101.send_packet:
-            data: !lambda |-
-              std::vector<uint8_t> data = {0x12, 0x34, 0x56, 0x78};
-              return data;
 ```
 
 ## Integration with Remote Receiver/Transmitter
@@ -190,7 +166,7 @@ wiring schemes.
 
 ### 1. Dual Pin Wiring (Recommended)
 
-This is the simplest and recommended wiring scheme. It uses separate pins for transmitting and receiving.
+This is the simplest and recommended wiring scheme. It uses separate pins for transmitting and receiving data.
 
 - **GDO0 (Module Pin 3)**: Connect to the MCU pin used by `remote_transmitter`.
 - **GDO2 (Module Pin 8)**: Connect to the MCU pin used by `remote_receiver`.
@@ -222,10 +198,13 @@ Configure `gdo0_pin` to enable automatic pin mode switching.
 - **GDO0 (Module Pin 3)**: Connect to a single MCU GPIO pin.
 - **GDO2 (Module Pin 8)**: Leave disconnected.
 
-#### Single Pin with Open-Drain (ESP32)
+#### Single Pin with Open-Drain
 
-ESP32 should use open-drain mode for single-pin wiring. The `eot_level` option controls the pin state
-after transmission completes.
+ESP32 must use this method when using single-pin wiring. The shared pin should be set to open-drain with a
+pullup. The `eot_level` option (from `remote_transmitter`) controls the pin state after transmission
+completes - setting it to `false` keeps the pin low until explicitly released. In addition to setting the
+CC1101 mode in `on_transmit`/`on_complete`, the pin should be driven low before `begin_tx` and released
+before `begin_rx`.
 
 ```yaml
 cc1101:
@@ -307,12 +286,6 @@ communication failure. Check your wiring (MISO/MOSI/CS).
 - **Check Pinout**: For all modes, the data line must be connected to GDO0 (Module Pin 3),
   as the CC1101 chip only supports transmission input via the GDO0 pin.
 - **Check Pin Mode**: Ensure `gdo0_pin` is configured for automatic pin mode switching.
-
-### CRC Errors in Packet Mode
-
-The CC1101 uses CRC-16-IBM (polynomial 0x8005, initial value 0xFFFF). This is different from CRC-16-CCITT
-used by some other radios (like SX127x). If communicating with different radio types, you may need to
-disable CRC on both ends.
 
 ## See Also
 

--- a/content/components/cc1101.md
+++ b/content/components/cc1101.md
@@ -91,11 +91,6 @@ and optional CRC checking.
 - **crc_enable** (*Optional*, boolean): Enable CRC-16 calculation and checking. The CC1101 uses
   CRC-16-IBM (polynomial 0x8005). Defaults to `false`.
 - **whitening** (*Optional*, boolean): Enable data whitening to improve DC balance. Defaults to `false`.
-- **on_packet** (*Optional*, [Automation](/automations/actions)): Action to perform when a packet is
-  received. The following variables are available:
-  - `x` (`std::vector<uint8_t>`): The received packet data.
-  - `rssi` (`float`): Received Signal Strength Indicator in dBm.
-  - `lqi` (`uint8_t`): Link Quality Indicator (lower is better, 0-127).
 
 ### AGC (Automatic Gain Control) Settings
 
@@ -129,6 +124,32 @@ See the [CC1101 Datasheet](https://www.ti.com/lit/ds/symlink/cc1101.pdf) for det
   Options: `8`, `16`, `24`, `32`. Defaults to `32`.
 - **hyst_level** (*Optional*, enum): Hysteresis level to prevent gain oscillation on borderline signals.
   Options: `None`, `Low`, `Medium`, `High`.
+
+## Triggers
+
+### `on_packet` Trigger
+
+In packet mode, this trigger fires when a packet has been received. A variable `x` of type
+`std::vector<uint8_t>` containing the packet data is passed to the automation. The variables
+`rssi` (signal strength in dBm) and `lqi` (link quality indicator, 0-127, lower is better)
+are also available.
+
+```yaml
+cc1101:
+  cs_pin: GPIOXX
+  gdo0_pin: GPIOXX
+  frequency: 433.92MHz
+  modulation_type: GFSK
+  symbol_rate: 4800
+  packet_mode: true
+  packet_length: 8
+  on_packet:
+    then:
+      - lambda: |-
+          ESP_LOGD("cc1101", "packet %s", format_hex(x).c_str());
+          ESP_LOGD("cc1101", "rssi %.1f dBm", rssi);
+          ESP_LOGD("cc1101", "lqi %u", lqi);
+```
 
 ## Actions
 

--- a/content/components/cc1101.md
+++ b/content/components/cc1101.md
@@ -16,9 +16,8 @@ ESPHome via the [SPI Bus](/components/spi).
 
 The component supports two operating modes:
 
-- **Async Serial Mode** (default): Integrates with the [Remote Transmitter](/components/remote_transmitter)
+- **Async Mode** (default): Integrates with the [Remote Transmitter](/components/remote_transmitter)
   and [Remote Receiver](/components/remote_receiver) components for encoding and decoding RF protocols.
-  Best for ASK/OOK modulation.
 - **Packet Mode**: Built-in packet handling with sync word detection, CRC, and the `on_packet` trigger.
   Best for FSK/GFSK modulation when communicating with other packet-based radios.
 

--- a/content/components/cc1101.md
+++ b/content/components/cc1101.md
@@ -12,19 +12,42 @@ chip commonly used for wireless communication in the 300-928 MHz frequency bands
 
 The **CC1101** supports multiple modulation schemes (ASK/OOK, 2-FSK, 4-FSK, GFSK, MSK), configurable data
 rates from 600 to 500,000 baud, and adjustable output power from -30 dBm to +11 dBm. It connects to
-ESPHome via the [SPI Bus](/components/spi) and integrates with the
-[Remote Transmitter](/components/remote_transmitter) and
-[Remote Receiver](/components/remote_receiver) components for encoding and decoding RF protocols.
+ESPHome via the [SPI Bus](/components/spi).
+
+The component supports two operating modes:
+
+- **Async Serial Mode** (default): Integrates with the [Remote Transmitter](/components/remote_transmitter)
+  and [Remote Receiver](/components/remote_receiver) components for encoding and decoding RF protocols.
+  Best for ASK/OOK modulation.
+- **Packet Mode**: Built-in packet handling with sync word detection, CRC, and the `on_packet` trigger.
+  Best for FSK/GFSK modulation when communicating with other packet-based radios.
 
 {{< img src="cc1101-full.webp" alt="CC1101 Module" width="50.0%" class="align-center" >}}
 
 ## Component Configuration
 
 ```yaml
-# Minimal Example
+# Minimal Example (Async Serial Mode for Remote Receiver/Transmitter)
 cc1101:
   cs_pin: GPIOXX
   frequency: 433.92MHz
+```
+
+```yaml
+# Packet Mode Example
+cc1101:
+  cs_pin: GPIOXX
+  gdo0_pin: GPIOXX
+  frequency: 433.92MHz
+  modulation_type: GFSK
+  symbol_rate: 4800
+  packet_mode: true
+  packet_length: 8
+  on_packet:
+    then:
+      - lambda: |-
+          ESP_LOGD("cc1101", "Packet: %s (RSSI: %.1f dBm, LQI: %u)",
+                   format_hex(x).c_str(), rssi, lqi);
 ```
 
 ## Configuration Variables
@@ -33,6 +56,8 @@ cc1101:
 
 - **cs_pin** (**Required**, [Pin](/guides/configuration-types/#pin)):
   The SPI Chip Select (CSN) pin connected to the module.
+- **gdo0_pin** (*Optional*, [Pin](/guides/configuration-types/#pin)):
+  The GDO0 pin. Required when `packet_mode` is enabled. Also used for async serial mode pin switching.
 
 ### General Settings
 
@@ -47,6 +72,7 @@ cc1101:
 - **rx_attenuation** (*Optional*, enum): Internal RX attenuation.
   Options: `0dB`, `6dB`, `12dB`, `18dB`. Defaults to `0dB`.
 - **dc_blocking_filter** (*Optional*, boolean): Enable the digital DC blocking filter. Defaults to `true`.
+- **manchester** (*Optional*, boolean): Enable Manchester encoding. Defaults to `false`.
 
 ### Tuner Settings
 
@@ -60,8 +86,33 @@ cc1101:
   Range: `25kHz` to `405kHz`. Defaults to `200kHz`.
 - **if_frequency** (*Optional*, frequency): Intermediate Frequency.
   Range: `25kHz` to `788kHz`. Defaults to `153kHz`.
-- **pktlen** (*Optional*, int): Packet length configuration. Sets the expected packet size for
-  fixed-length packet mode. Range: `1` to `255`. Not typically needed for OOK/ASK modulation.
+
+### Sync Word Settings
+
+- **sync_mode** (*Optional*, enum): Sync word detection mode.
+  Options: `None`, `15/16`, `16/16`, `30/32`. Defaults to `16/16`.
+- **sync0** (*Optional*, hex): Lower sync word byte. Defaults to `0x91`.
+- **sync1** (*Optional*, hex): Upper sync word byte. Defaults to `0xD3`.
+- **num_preamble** (*Optional*, int): Number of preamble bytes to transmit.
+  Range: `0` to `7` (maps to 2, 3, 4, 6, 8, 12, 16, 24 bytes). Defaults to `2` (4 bytes).
+
+### Packet Mode Settings
+
+These settings enable the CC1101's built-in packet handling with FIFO buffering, sync word detection,
+and optional CRC checking.
+
+- **packet_mode** (*Optional*, boolean): Enable FIFO packet mode. When enabled, `gdo0_pin` and
+  `packet_length` are required. Defaults to `false`.
+- **packet_length** (*Optional*, int): Fixed packet length in bytes. Required when `packet_mode` is
+  enabled. Range: `1` to `64`.
+- **crc_enable** (*Optional*, boolean): Enable CRC-16 calculation and checking. The CC1101 uses
+  CRC-16-IBM (polynomial 0x8005). Defaults to `false`.
+- **whitening** (*Optional*, boolean): Enable data whitening to improve DC balance. Defaults to `false`.
+- **on_packet** (*Optional*, [Automation](/automations/actions)): Action to perform when a packet is
+  received. The following variables are available:
+  - `x` (`std::vector<uint8_t>`): The received packet data.
+  - `rssi` (`float`): Received Signal Strength Indicator in dBm.
+  - `lqi` (`uint8_t`): Link Quality Indicator (lower is better, 0-127).
 
 ### AGC (Automatic Gain Control) Settings
 
@@ -79,8 +130,10 @@ See the [CC1101 Datasheet](https://www.ti.com/lit/ds/symlink/cc1101.pdf) for det
   Options: `Default`, `-1`, `-2`, `-3`. Defaults to `-3`.
 - **lna_priority** (*Optional*, boolean): If true, reduce LNA gain before DVGA gain when decreasing
   overall gain. Useful for optimizing noise figure. Defaults to `false`.
+- **carrier_sense_above_threshold** (*Optional*, boolean): Only accept packets when carrier sense
+  indicates a signal is present. Defaults to `false`.
 - **carrier_sense_abs_thr** (*Optional*, int): Absolute RSSI threshold for carrier sense. The radio
-  considers a carrier present when RSSI exceeds this level.
+  considers a carrier present when RSSI exceeds this level. Range: `-8` to `7`.
 - **carrier_sense_rel_thr** (*Optional*, enum): Relative RSSI threshold for carrier sense, compared
   to the current noise floor. Options: `Default`, `+6dB`, `+10dB`, `+14dB`.
 - **filter_length_fsk_msk** (*Optional*, enum): Averaging length for AGC in FSK/MSK modes.
@@ -96,22 +149,48 @@ See the [CC1101 Datasheet](https://www.ti.com/lit/ds/symlink/cc1101.pdf) for det
 
 ## Actions
 
-This component provides actions to control the radio state, primarily used for coordinating transmission.
+This component provides actions to control the radio state.
 
-- **cc1101.begin_tx**: Puts the radio into TX mode. Must be called before transmitting.
-- **cc1101.begin_rx**: Puts the radio into RX mode. Call after transmitting to resume receiving.
-- **cc1101.set_idle**: Puts the radio into an idle state. In single-pin configurations, this should be
-  called before switching between TX and RX modes to ensure clean state transitions.
+### Async Serial Mode Actions
+
+These actions are used for coordinating transmission with Remote Transmitter/Receiver. When `gdo0_pin`
+is configured, `begin_tx` and `begin_rx` automatically handle pin mode switching.
+
+- **cc1101.begin_tx**: Puts the radio into TX mode and switches `gdo0_pin` to output mode.
+- **cc1101.begin_rx**: Puts the radio into RX mode and switches `gdo0_pin` to input mode.
+- **cc1101.set_idle**: Puts the radio into an idle state.
 - **cc1101.reset**: Resets the CC1101 chip and re-applies configuration.
+
+### Packet Mode Actions
+
+- **cc1101.send_packet**: Transmits a packet. Only available when `packet_mode` is enabled.
+  - **data** (**Required**, list of bytes or lambda): The packet data to transmit.
+
+```yaml
+button:
+  - platform: template
+    name: "Send Packet"
+    on_press:
+      then:
+        - cc1101.send_packet:
+            data: [0x12, 0x34, 0x56, 0x78]
+
+        # Or with a lambda:
+        - cc1101.send_packet:
+            data: !lambda |-
+              std::vector<uint8_t> data = {0x12, 0x34, 0x56, 0x78};
+              return data;
+```
 
 ## Integration with Remote Receiver/Transmitter
 
-The component automatically configures the GDO pins to support both dual and single pin wiring schemes
-without any extra configuration.
+For ASK/OOK modulation, the CC1101 integrates with Remote Receiver/Transmitter for protocol encoding
+and decoding. The component automatically configures the GDO pins to support both dual and single pin
+wiring schemes.
 
 ### 1. Dual Pin Wiring (Recommended)
 
-This is the simplest and recommended wiring scheme. It uses separate pins for transmitting and receiving data.
+This is the simplest and recommended wiring scheme. It uses separate pins for transmitting and receiving.
 
 - **GDO0 (Module Pin 3)**: Connect to the MCU pin used by `remote_transmitter`.
 - **GDO2 (Module Pin 8)**: Connect to the MCU pin used by `remote_receiver`.
@@ -121,7 +200,7 @@ cc1101:
   cs_pin: GPIOXX
 
 remote_transmitter:
-  pin: GPIOXX # Must match GDO0
+  pin: GPIOXX  # Must match GDO0
   carrier_duty_percent: 100%
   on_transmit:
     then:
@@ -131,34 +210,31 @@ remote_transmitter:
       - cc1101.begin_rx
 
 remote_receiver:
-  pin: GPIOXX # CC1101 GDO2
+  pin: GPIOXX  # Must match GDO2
   dump: all
 ```
 
 ### 2. Single Pin Wiring
 
-This wiring scheme uses a single MCU pin for both transmitting and receiving data, connected to GDO0.
-This requires careful configuration of the `remote_transmitter` and `remote_receiver` to avoid conflicts.
-Using an open-drain pin mode is recommended to simplify the setup.
+This wiring scheme uses a single MCU pin for both transmitting and receiving, connected to GDO0.
+Configure `gdo0_pin` to enable automatic pin mode switching.
 
 - **GDO0 (Module Pin 3)**: Connect to a single MCU GPIO pin.
 - **GDO2 (Module Pin 8)**: Leave disconnected.
 
-#### Single Pin with Open-Drain
+#### Single Pin with Open-Drain (ESP32)
 
-ESP32 must use this method when using single-pin wiring. The shared pin should be set to open-drain with a
-pullup. The `eot_level` option (from `remote_transmitter`) controls the pin state after transmission
-completes - setting it to `false` keeps the pin low until explicitly released. In addition to setting the
-CC1101 mode in `on_transmit`/`on_complete`, the pin should be driven low before `begin_tx` and released
-before `begin_rx`.
+ESP32 should use open-drain mode for single-pin wiring. The `eot_level` option controls the pin state
+after transmission completes.
 
 ```yaml
 cc1101:
   cs_pin: GPIOXX
+  gdo0_pin: GPIOXX
 
 remote_receiver:
   pin:
-    number: GPIOXX # Must match GDO0
+    number: GPIOXX  # Must match GDO0
     mode:
       input: true
       output: true
@@ -169,7 +245,7 @@ remote_receiver:
 
 remote_transmitter:
   pin:
-    number: GPIOXX # Must match GDO0
+    number: GPIOXX  # Must match GDO0
     mode:
       input: true
       output: true
@@ -190,43 +266,32 @@ remote_transmitter:
       - cc1101.begin_rx
 ```
 
-#### Single Pin with Mode Switching
+#### Single Pin with Automatic Mode Switching
 
-This method requires lambdas to manually switch the pin mode between input and output around transmissions.
-On boot, the pin must be set to input mode so the receiver can operate.
+When `gdo0_pin` is configured, `begin_tx` and `begin_rx` automatically switch the pin between output
+and input modes, simplifying the configuration.
 
 ```yaml
-esphome:
-  on_boot:
-    - priority: 0
-      then:
-        - lambda: id(rx_pin)->pin_mode(gpio::FLAG_INPUT);
-
 cc1101:
   cs_pin: GPIOXX
+  gdo0_pin: GPIOXX
 
 remote_receiver:
   pin:
-    id: rx_pin
-    number: GPIOXX # Must match GDO0
+    number: GPIOXX  # Must match GDO0
     allow_other_uses: true
   dump: all
 
 remote_transmitter:
   pin:
-    id: tx_pin
-    number: GPIOXX # Must match GDO0
+    number: GPIOXX  # Must match GDO0
     allow_other_uses: true
   carrier_duty_percent: 100%
   on_transmit:
     then:
-      - cc1101.set_idle
-      - lambda: id(tx_pin)->pin_mode(gpio::FLAG_OUTPUT);
       - cc1101.begin_tx
   on_complete:
     then:
-      - cc1101.set_idle
-      - lambda: id(rx_pin)->pin_mode(gpio::FLAG_INPUT);
       - cc1101.begin_rx
 ```
 
@@ -237,12 +302,17 @@ remote_transmitter:
 If you see a log entry stating `FF0F`, `0000`, or `FFFF` during setup, this indicates an SPI
 communication failure. Check your wiring (MISO/MOSI/CS).
 
-### No Signal during Transmit
+### No Signal During Transmit
 
 - **Check Pinout**: For all modes, the data line must be connected to GDO0 (Module Pin 3),
   as the CC1101 chip only supports transmission input via the GDO0 pin.
-- **Check Pin Mode**: If using the Single Pin with Mode Switching method,
-  ensure your `on_transmit`/`on_complete` logic correctly flips the pin mode.
+- **Check Pin Mode**: Ensure `gdo0_pin` is configured for automatic pin mode switching.
+
+### CRC Errors in Packet Mode
+
+The CC1101 uses CRC-16-IBM (polynomial 0x8005, initial value 0xFFFF). This is different from CRC-16-CCITT
+used by some other radios (like SX127x). If communicating with different radio types, you may need to
+disable CRC on both ends.
 
 ## See Also
 


### PR DESCRIPTION
## Description:

Add documentation for CC1101 packet mode support:

- Two operating modes: Async Mode (default) and Packet Mode
- Packet mode configuration options (`packet_mode`, `packet_length`, `crc_enable`, `whitening`)
- Sync word settings (`sync_mode`, `sync0`, `sync1`, `num_preamble`)
- `on_packet` trigger with RSSI and LQI parameters
- `cc1101.send_packet` action
- Updated action documentation to match ESPHome style
- Improved troubleshooting section

**Related issue (if applicable):** None

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#12474

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.