### PR TITLE
Adjust BMP581 for component rename, additional sensor examples

### DIFF
--- a/content/components/sx126x.md
+++ b/content/components/sx126x.md
@@ -12,7 +12,8 @@ params:
 The SX126x component allows you to configure the SX1261, SX1262, SX1268 and LLCC68 transceivers
 ([datasheet](https://www.semtech.com/products/wireless-rf/lora-connect/sx1262#documentation)) in
 ESPHome. Transceivers are connected via the [SPI Bus](/components/spi). Supported frequencies range from
-150 MHz to 960 MHz. Supported modulations include LoRa, FSK, GFSK, MSK and GMSK. The SX126x
+150 MHz to 960 MHz, including the popular 315 MHz, 433 MHz, 868 MHz, and 915 MHz ISM bands.
+Supported modulations include LoRa, FSK, GFSK, MSK and GMSK. The SX126x
 component may be used as a platform for the [Packet Transport Component](/components/packet_transport#packet-transport) component, enabling sensor data
 to be sent directly from one ESPHome node to another.
 

--- a/content/components/sx127x.md
+++ b/content/components/sx127x.md
@@ -12,7 +12,8 @@ params:
 The SX127x component allows you to configure the SX1276, SX1277, SX1278 and SX1279 transceivers
 ([datasheet](https://www.semtech.com/products/wireless-rf/lora-connect/sx1278#documentation)) in
 ESPHome. Transceivers are connected via the [SPI Bus](/components/spi). Supported frequencies range from
-137 MHz to 1020 MHz. Supported modulations include LoRa, OOK, FSK, GFSK, MSK and GMSK. The SX127x
+137 MHz to 1020 MHz, including the popular 315 MHz, 433 MHz, 868 MHz, and 915 MHz ISM bands.
+Supported modulations include LoRa, OOK, FSK, GFSK, MSK and GMSK. The SX127x
 component may be used as a platform for the [Packet Transport Component](/components/packet_transport#packet-transport) component, enabling sensor data
 to be sent directly from one ESPHome node to another.
 

--- a/content/guides/diy.md
+++ b/content/guides/diy.md
@@ -65,6 +65,7 @@ unless it's truly exceptional, etc.
 - [An IoT clock designed for children](https://github.com/chrisns/childrens-clock) by {{< ghuser name="chrisns" >}}
 - [Remote controller RC433 for garage door open](https://dedeideas.eu/index.php/en-us/rc433-pre-home-assistant-en) by [lubomirkarlik](https://dedeideas.eu/index.php/en-us/about-me)
 - [How to create an ESPHome external component](https://medium.com/@vinsce/create-an-esphome-external-component-part-1-introduction-config-validation-and-code-generation-e0389e674bd6) by {{< ghuser name="vinsce" >}}
+- [Smart garage door remote modification when direct opener wiring isn't feasible](https://github.com/linux4life798/smart-garage-remote) by {{< ghuser name="linux4life798" >}}
 
 ## Custom Components & Code
 


### PR DESCRIPTION
## Description:

Update reflects proposed change to BMP581 component from `bmp581` to `bmp581_i2c`, to eventually support `bmp581_spi`. Also adds another BMP581-based sensor to documentation (Adafruit)

**Related issue (if applicable):** Based on feature request 3435: [https://github.com/orgs/esphome/discussions/3435](https://github.com/orgs/esphome/discussions/3435)
**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#12485

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

