### PR TITLE
Update frequency range checks

### DIFF
--- a/content/components/at581x.md
+++ b/content/components/at581x.md
@@ -137,7 +137,7 @@ on_...:
   changing other options. Ignored if not set or set to `false`. Upon applying the settings a frontend reset
   will be performed anyway, this is only useful if the sensor is not answering or locked up.
 
-- **frequency** (*Optional*, int): Any of the possible frequencies (5696, 5715, 5730, 5748, 5765, 5784, 5800, 5819, 5836, 5851, 5869, 5888) in MHz.
+- **frequency** (*Optional*, enum): Any of the possible frequencies (5696, 5715, 5730, 5748, 5765, 5784, 5800, 5819, 5836, 5851, 5869, 5888) in MHz. Defaults to `5800MHz`
 - **sensing_distance** (*Optional*, int): A unitless number, in range 0-1023, specifying the maximum distance to detect motion
 - **poweron_selfcheck_time** (*Optional*, int): The delay to perform self check and calibration on power on. Recommended not to change this
 - **protect_time** (*Optional*, int): The delay after an end-of-trigger event where the detection will not trigger anymore. Max 65535ms

--- a/content/components/at581x.md
+++ b/content/components/at581x.md
@@ -137,7 +137,7 @@ on_...:
   changing other options. Ignored if not set or set to `false`. Upon applying the settings a frontend reset
   will be performed anyway, this is only useful if the sensor is not answering or locked up.
 
-- **frequency** (*Optional*, enum): Any of the possible frequencies (5696, 5715, 5730, 5748, 5765, 5784, 5800, 5819, 5836, 5851, 5869, 5888) in MHz. Defaults to `5800MHz`
+- **frequency** (*Optional*, enum): Any of the possible frequencies (5696, 5715, 5730, 5748, 5765, 5784, 5800, 5819, 5836, 5851, 5869, 5888) in MHz. Defaults to `5800MHz`.
 - **sensing_distance** (*Optional*, int): A unitless number, in range 0-1023, specifying the maximum distance to detect motion
 - **poweron_selfcheck_time** (*Optional*, int): The delay to perform self check and calibration on power on. Recommended not to change this
 - **protect_time** (*Optional*, int): The delay after an end-of-trigger event where the detection will not trigger anymore. Max 65535ms

--- a/content/components/canbus/mcp2515.md
+++ b/content/components/canbus/mcp2515.md
@@ -45,8 +45,8 @@ canbus:
 - **cs_pin** (**Required**, [Pin Schema](/guides/configuration-types#pin-schema)): Is used to signal to a SPI device when it should
   listen for data on the SPI bus. Each SPI device has its own `CS` line. Sometimes also called `SS`.
 
-- **clock** (*Optional*, frequency): The frequency of the clock crystal used on the MCP2515 device. One of `8MHZ`,
-  `12MHz`, `16MHZ` or `20MHZ`. Defaults to `8MHZ`.
+- **clock** (*Optional*, enum): The frequency of the clock crystal used on the MCP2515 device. One of `8MHZ`,
+  `12MHZ`, `16MHZ` or `20MHZ`. Defaults to `8MHZ`.
 
 - **mode** (*Optional*, enum): Operating mode. One of:
 

--- a/content/components/esp32_camera.md
+++ b/content/components/esp32_camera.md
@@ -57,8 +57,8 @@ Connection Options:
 - **external_clock** (**Required**): The configuration of the external clock to drive the camera.
 
   - **pin** (**Required**, pin): The pin the external clock line is connected to.
-  - **frequency** (*Optional*, float): The frequency of the external clock, must be between 10
-    and 20MHz. Defaults to `20MHz`.
+  - **frequency** (*Optional*, frequency): The frequency of the external clock, must be between `8MHz`
+    and `20MHz`. Defaults to `20MHz`.
 
 - **i2c_id** (**Required**, [ID](/guides/configuration-types#id)): The ID of the [I²C bus](/components/i2c) the camera is connected to.
 - **reset_pin** (*Optional*, pin): The ESP pin the reset pin of the camera is connected to.

--- a/content/components/i2c.md
+++ b/content/components/i2c.md
@@ -39,7 +39,7 @@ i2c:
 - **scan** (*Optional*, boolean): If ESPHome should do a search of the I²C address space on startup.
   Defaults to `true`.
 
-- **frequency** (*Optional*, float): Set the frequency the I²C bus should operate on.
+- **frequency** (*Optional*, frequency): Set the frequency the I²C bus should operate on.
   Defaults to `50kHz`. Default for NRF52 is `100kHz`. Values are `10kHz`, `50kHz`, `100kHz`, `200kHz`, ... `800kHz`.
   NRF52 supports only `100kHz` and `400kHz`.
 

--- a/content/components/libretiny.md
+++ b/content/components/libretiny.md
@@ -147,7 +147,7 @@ sensor:
 output:
   - platform: libretiny_pwm
     pin: PWM2
-    frequency: 1000 Hz
+    frequency: 1kHz
     id: pwm_output
 # using light with the PWM
 light:

--- a/content/components/output/esp8266_pwm.md
+++ b/content/components/output/esp8266_pwm.md
@@ -17,7 +17,7 @@ like the one on the ESP32 (see {{< docref "ledc/" >}}) are preferred.
 output:
   - platform: esp8266_pwm
     pin: GPIOXX
-    frequency: 1000 Hz
+    frequency: 1kHz
     id: pwm_output
 
 # Example usage in a light
@@ -32,7 +32,7 @@ light:
 - **pin** (**Required**, [Pin Schema](/guides/configuration-types#pin-schema)): The pin to use PWM on.
 - **id** (**Required**, [ID](/guides/configuration-types#id)): The id to use for this output component.
 - **frequency** (*Optional*, frequency): The frequency to run the PWM with. Lower frequencies
-  have more visual artifacts, but can represent much more colors. Defaults to `1000 Hz`.
+  have more visual artifacts, but can represent much more colors. Defaults to `1kHz`.
 
 - All other options from [Output](/components/output#config-output).
 
@@ -60,8 +60,8 @@ on_...:
 Configuration variables:
 
 - **id** (**Required**, [ID](/guides/configuration-types#id)): The ID of the PWM output to change.
-- **frequency** (**Required**, [templatable](/automations/templates), float): The frequency
-  to set in hertz.
+- **frequency** (**Required**, [templatable](/automations/templates), frequency): The frequency
+  to set in Hz.
 
 ## See Also
 

--- a/content/components/output/ledc.md
+++ b/content/components/output/ledc.md
@@ -17,8 +17,8 @@ bit depth which means the output is not that accurate for frequencies above ~300
 
 - **pin** (**Required**, [Pin](/guides/configuration-types#pin)): The pin to use LEDC on. Can only be GPIO0-GPIO33.
 - **id** (**Required**, [ID](/guides/configuration-types#id)): The id to use for this output component.
-- **frequency** (*Optional*, float): At which frequency to run the LEDC
-  channel's timer. Defaults to 1000Hz.
+- **frequency** (*Optional*, frequency): At which frequency to run the LEDC
+  channel's timer. Defaults to `1kHz`.
 
 - All other options from [Output](/components/output#config-output).
 
@@ -77,7 +77,7 @@ on_press:
     ######################################################
     - output.ledc.set_frequency:
         id: buzzer
-        frequency: "1000Hz"
+        frequency: "1kHz"
     ######################################################
     # level sets the %age time the PWM is on
     ######################################################
@@ -99,9 +99,9 @@ a long transition, e.g. turning slowly off.
 | ------------- | ------------- | ----------------------------------- |
 | 1220Hz        | 16            | 65536                               |
 | 2441Hz        | 15            | 32768                               |
-| 4882Hz | 14 | 16384 |
-| 9765Hz | 13 | 8192 |
-| 19531Hz | 12 | 4096 |
+| 4882Hz        | 14            | 16384                               |
+| 9765Hz        | 13            | 8192                                |
+| 19531Hz       | 12            | 4096                                |
 
 The ESP8266 for instance has *usually* a frequency of 1000Hz with a resolution of 10 bits.
 This means that there are only 4 steps between each value.
@@ -123,8 +123,8 @@ on_...:
 Configuration variables:
 
 - **id** (**Required**, [ID](/guides/configuration-types#id)): The ID of the LEDC output to change.
-- **frequency** (**Required**, [templatable](/automations/templates), float): The frequency
-  to set in hertz.
+- **frequency** (**Required**, [templatable](/automations/templates), frequency): The frequency
+  to set in Hz.
 
 ## See Also
 

--- a/content/components/output/libretiny_pwm.md
+++ b/content/components/output/libretiny_pwm.md
@@ -16,7 +16,7 @@ and which PWM pins it supports.
 output:
   - platform: libretiny_pwm
     pin: P8
-    frequency: 1000 Hz
+    frequency: 1kHz
     id: pwm_output
 
 # Example usage in a light
@@ -31,7 +31,7 @@ light:
 - **pin** (**Required**, [Pin Schema](/guides/configuration-types#pin-schema)): The pin to use PWM on.
 - **id** (**Required**, [ID](/guides/configuration-types#id)): The id to use for this output component.
 - **frequency** (*Optional*, frequency): The frequency to run the PWM with. Lower frequencies
-  have more visual artifacts, but can represent much more colors. Defaults to `1000 Hz`.
+  have more visual artifacts, but can represent much more colors. Defaults to `1kHz`.
 
 - All other options from [Output](/components/output#config-output).
 
@@ -52,8 +52,8 @@ on_...:
 Configuration variables:
 
 - **id** (**Required**, [ID](/guides/configuration-types#id)): The ID of the PWM output to change.
-- **frequency** (**Required**, [templatable](/automations/templates), float): The frequency
-  to set in hertz.
+- **frequency** (**Required**, [templatable](/automations/templates), frequency): The frequency
+  to set in Hz.
 
 ## See Also
 

--- a/content/components/output/pca9685.md
+++ b/content/components/output/pca9685.md
@@ -71,9 +71,9 @@ output:
 
 ### Configuration variables
 
-- **frequency** (*Optional*, float): The frequency to let the
-   component drive all PWM outputs at. Must be in range from 24Hz to
-   1525.88Hz. Defaults to `1000Hz`.
+- **frequency** (*Optional*, frequency): The frequency to let the
+   component drive all PWM outputs at. Must be in range from `23.84Hz` to
+   `1525.88Hz`. Defaults to `1kHz`.
 
 - **external_clock_input** (*Optional*, bool): Enable external clock input. PRE_SCALE register will by set to 3. Default to `false`.
 - **address** (*Optional*, int): The I²C address of the driver.

--- a/content/components/packet_transport/sx126x.md
+++ b/content/components/packet_transport/sx126x.md
@@ -23,7 +23,7 @@ sx126x:
   pa_power: 3
   bandwidth: 125_0kHz
   crc_enable: true
-  frequency: 433920000
+  frequency: 433.92MHz
   modulation: LORA
   hw_version: sx1262
   rf_switch: true

--- a/content/components/packet_transport/sx127x.md
+++ b/content/components/packet_transport/sx127x.md
@@ -23,7 +23,7 @@ sx127x:
   pa_power: 8
   bandwidth: 125_0kHz
   crc_enable: true
-  frequency: 433920000
+  frequency: 433.92MHz
   modulation: LORA
   rx_start: true
   sync_value: 0x33

--- a/content/components/sensor/ade7880.md
+++ b/content/components/sensor/ade7880.md
@@ -69,9 +69,9 @@ database growth) of the connected Home Assistant correspondingly.
   'software reset' of the chip when needed, but this could fail if the
   chip is not responding properly to the I2C bus.
 
-- **frequency** (*Optional*, string): The AC line frequency of the
+- **frequency** (*Optional*, frequency): The AC line frequency of the
   supply voltage. The supported range is `45Hz` to
-  `65Hz`. Defaults to `50Hz`.
+  `66Hz`. Defaults to `50Hz`.
 
 - **phase_a** (*Optional*): The configuration variables for the 'A'
   phase inputs of the chip. Refer to the configuration examples below

--- a/content/components/servo.md
+++ b/content/components/servo.md
@@ -35,7 +35,7 @@ output:
   - platform: esp8266_pwm
     id: pwm_output
     pin: GPIOXX
-    frequency: 50 Hz
+    frequency: 50Hz
 ```
 
 ## Configuration variables

--- a/content/components/sx126x.md
+++ b/content/components/sx126x.md
@@ -108,7 +108,7 @@ sx126x:
 - **sync_value** (**Optional**, list): Synchronization bytes, list of 1 to 8 bytes, found after the preamble
   and before the payload.
 
-- **deviation** (**Optional**, frequency): Transmitter FSK frequency deviation, values range from 0 to 100 kHz. Defaults to `5kHz`
+- **deviation** (**Optional**, frequency): Transmitter FSK frequency deviation, values range from 0 to 100 kHz. Defaults to `5kHz`.
 - **shaping** (**Optional**, enum): Transmitter data shaping can be `GAUSSIAN_BT_0_3`, `GAUSSIAN_BT_0_5`,
   `GAUSSIAN_BT_0_7`, `GAUSSIAN_BT_1_0` or `NONE`.
 

--- a/content/components/sx126x.md
+++ b/content/components/sx126x.md
@@ -28,7 +28,7 @@ sx126x:
   pa_power: 3
   bandwidth: 125_0kHz
   crc_enable: true
-  frequency: 433920000
+  frequency: 433.92MHz
   modulation: LORA
   hw_version: sx1262
   rf_switch: true
@@ -46,7 +46,7 @@ sx126x:
 - **cs_pin** (**Required**, [Pin Schema](/guides/configuration-types#pin-schema)): SPI chip select pin.
 - **dio1_pin** (**Optional**, [Pin Schema](/guides/configuration-types#pin-schema)): Digital IO pin 1.
 - **rst_pin** (**Required**, [Pin Schema](/guides/configuration-types#pin-schema)): Reset pin.
-- **frequency** (**Required**, int): Frequency in Hz of the transceiver.
+- **frequency** (**Required**, frequency): Frequency in Hz of the transceiver.
 - **hw_version** (**Required**, enum): Valid values are `sx1261`, `sx1262`, `sx1268` or `llcc68`.
 - **modulation** (**Required**, enum): Modulation can be `FSK` or `LORA`.
 - **pa_power** (**Optional**, int): Transmitter power, range is from -3 to 15 dBm when `hw_version` is
@@ -108,7 +108,7 @@ sx126x:
 - **sync_value** (**Optional**, list): Synchronization bytes, list of 1 to 8 bytes, found after the preamble
   and before the payload.
 
-- **deviation** (**Optional**, int): Transmitter FSK frequency deviation, values range from 0 to 100,000 Hz.
+- **deviation** (**Optional**, frequency): Transmitter FSK frequency deviation, values range from 0 to 100 kHz. Defaults to `5kHz`
 - **shaping** (**Optional**, enum): Transmitter data shaping can be `GAUSSIAN_BT_0_3`, `GAUSSIAN_BT_0_5`,
   `GAUSSIAN_BT_0_7`, `GAUSSIAN_BT_1_0` or `NONE`.
 
@@ -213,7 +213,7 @@ sx126x:
   pa_power: 3
   bandwidth: 125_0kHz
   crc_enable: true
-  frequency: 433920000
+  frequency: 433.92MHz
   modulation: LORA
   hw_version: sx1262
   rf_switch: true
@@ -253,7 +253,7 @@ sx126x:
   pa_power: 3
   bandwidth: 78_2kHz
   crc_enable: true
-  frequency: 433920000
+  frequency: 433.92MHz
   modulation: FSK
   payload_length: 8
   hw_version: sx1262

--- a/content/components/sx127x.md
+++ b/content/components/sx127x.md
@@ -24,7 +24,7 @@ sx127x:
   cs_pin: GPIO18
   rst_pin: GPIO23
   bandwidth: 50_0kHz
-  frequency: 433920000
+  frequency: 433.92MHz
   modulation: OOK
   packet_mode: false
   rx_start: true
@@ -37,7 +37,7 @@ sx127x:
 - **rst_pin** (**Required**, [Pin Schema](/guides/configuration-types#pin-schema)): Reset pin.
 - **dio0_pin** (**Optional**, [Pin Schema](/guides/configuration-types#pin-schema)): Digital IO pin 0.
 - **auto_cal** (**Optional**, bool): Enable automatic image calibration on temperature changes. Defaults to `true`.
-- **frequency** (**Required**, int): Frequency in Hz of the transceiver.
+- **frequency** (**Required**, frequency): Frequency in Hz of the transceiver.
 - **modulation** (**Required**, enum): Modulation can be `OOK`, `FSK` or `LORA`  `.
 - **pa_pin** (**Optional**, enum): Transmitter output pin, can be `BOOST` or `RFO`.
 - **pa_power** (**Optional**, int): Transmitter power, range is from 2 to 17 dBm when `pa_pin` is `BOOST` and
@@ -107,7 +107,7 @@ sx127x:
   (ie closer to -128) too much noise will get through. When receiving FSK without a preamble configured
   `rx_floor` is used to trigger the receiver.
 
-- **deviation** (**Optional**, int): Transmitter FSK frequency deviation, values range from 0 to 100,000 Hz.
+- **deviation** (**Optional**, frequency): Transmitter FSK frequency deviation, values range from 0 to 100 kHz. Defaults to `5kHz`
 - **shaping** (**Optional**, enum): Transmitter data shaping. In OOK can be `CUTOFF_BR_X_2`,
   `CUTOFF_BR_X_1` or `NONE`. In FSK can be `GAUSSIAN_BT_0_3`, `GAUSSIAN_BT_0_5`,
   `GAUSSIAN_BT_1_0` or `NONE`. Not recommended in continuous mode as the data on DIO2
@@ -214,7 +214,7 @@ sx127x:
   pa_power: 4
   bandwidth: 125_0kHz
   crc_enable: true
-  frequency: 433920000
+  frequency: 433.92MHz
   modulation: LORA
   rx_start: true
   sync_value: 0x33
@@ -251,7 +251,7 @@ sx127x:
   bitrate: 4800
   bitsync: true
   crc_enable: true
-  frequency: 433920000
+  frequency: 433.92MHz
   modulation: FSK
   packet_mode: true
   payload_length: 8
@@ -289,7 +289,7 @@ sx127x:
   cs_pin: GPIO18
   rst_pin: GPIO23
   bandwidth: 50_0kHz
-  frequency: 433920000
+  frequency: 433.92MHz
   modulation: OOK
   packet_mode: false
   rx_start: true
@@ -317,7 +317,7 @@ sx127x:
   cs_pin: GPIO18
   rst_pin: GPIO23
   bandwidth: 50_0kHz
-  frequency: 433920000
+  frequency: 433.92MHz
   modulation: OOK
   packet_mode: false
   rx_start: false
@@ -357,7 +357,7 @@ sx127x:
   cs_pin: GPIO18
   rst_pin: GPIO23
   bandwidth: 50_0kHz
-  frequency: 433920000
+  frequency: 433.92MHz
   modulation: OOK
   packet_mode: false
   rx_start: true

--- a/content/components/sx127x.md
+++ b/content/components/sx127x.md
@@ -107,7 +107,7 @@ sx127x:
   (ie closer to -128) too much noise will get through. When receiving FSK without a preamble configured
   `rx_floor` is used to trigger the receiver.
 
-- **deviation** (**Optional**, frequency): Transmitter FSK frequency deviation, values range from 0 to 100 kHz. Defaults to `5kHz`
+- **deviation** (**Optional**, frequency): Transmitter FSK frequency deviation, values range from 0 to 100 kHz. Defaults to `5kHz`.
 - **shaping** (**Optional**, enum): Transmitter data shaping. In OOK can be `CUTOFF_BR_X_2`,
   `CUTOFF_BR_X_1` or `NONE`. In FSK can be `GAUSSIAN_BT_0_3`, `GAUSSIAN_BT_0_5`,
   `GAUSSIAN_BT_1_0` or `NONE`. Not recommended in continuous mode as the data on DIO2


### PR DESCRIPTION
## Description:
- use frequency ranges
- unify Hz
- add some default values
- fix wrong values (use exact value from code)

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#12490

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/static/images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/_index.md`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image dht22
```

</details>
