### PR TITLE
Fix typo in substitutions.md documentation

### DIFF
--- a/content/components/substitutions.md
+++ b/content/components/substitutions.md
@@ -139,7 +139,7 @@ lvgl:
         text: Distance is ${math.sqrt(x*x+y*y)}.
 ```
 
-To see what mathematical functions ara available,
+To see what mathematical functions are available,
 refer to [Python math library](https://docs.python.org/3/library/math.html) documentation.
 
 ### Built-in functions


### PR DESCRIPTION
## Description:
Just a typo. Supersedes #5247, which was against an old structure but was recently approved by @nagyrobi .

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/static/images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/_index.md`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image dht22
```

</details>
