### PR TITLE
[esp32] Document all IDF component version operators in shorthand syntax

### DIFF
--- a/content/components/esp32.md
+++ b/content/components/esp32.md
@@ -254,7 +254,9 @@ components that are available in the [ESP Component Registry](https://components
 
 ### Simple
 
-For components from the ESP Component Registry, you can use the shorthand syntax `owner/component^version`:
+For components from the ESP Component Registry, you can use the shorthand syntax `owner/component<operator>version`.
+All [IDF Component Manager version operators](https://docs.espressif.com/projects/idf-component-manager/en/latest/reference/versioning.html)
+are supported (e.g., `^`, `~`, `==`, `>=`):
 
 ```yaml
 esp32:


### PR DESCRIPTION
## Description:

Update the IDF components documentation to clarify that all IDF Component Manager version operators are supported in the shorthand syntax, not just `^`.

Supported operators: `^`, `~`, `~=`, `==`, `!=`, `>=`, `>`, `<=`, `<`

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#12499

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/static/images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/_index.md`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image dht22
```

</details>