### PR TITLE
[bluetooth_proxy] Improve documentation clarity and best practices

### DIFF
--- a/content/components/bluetooth_proxy.md
+++ b/content/components/bluetooth_proxy.md
@@ -40,7 +40,9 @@ The Bluetooth proxy depends on {{< docref "esp32_ble_tracker/" >}} so make sure 
 
 ### How Active Connections Work
 
-The Bluetooth proxy provides Home Assistant with a limited number of simultaneous active GATT connections (configured via `connection_slots`, default 3). Devices that maintain a *continuous active* connection consume one slot constantly, while devices that do *periodic disconnections and reconnections* allow more devices to share the available slots on a statistical basis.
+The Bluetooth proxy provides Home Assistant with a limited number of simultaneous active GATT connections (configured via `connection_slots`). The default is 3 slots for WiFi-based proxies. Ethernet-based proxies can generally handle 4 slots reliably since they don't share the radio with WiFi traffic.
+
+Devices that stay connected continuously (like some locks or thermostats) use one slot the entire time. Devices that connect briefly to exchange data and then disconnect (like many sensors) free up the slot for other devices, so you can use more devices than you have slots.
 
 Passively broadcasted sensor data (advertised by devices without requiring active connections, such as many BTHome sensors) is received separately and is not limited by the number of connection slots.
 

--- a/content/components/bluetooth_proxy.md
+++ b/content/components/bluetooth_proxy.md
@@ -16,7 +16,7 @@ and Home Assistant.
 Note that while this component is named `bluetooth_proxy`, only BLE devices (and their Home Assistant integrations)
 are supported.
 
-If you'd like to buy a ready-made Bluetooth proxy or flash your own device, see [ESPHome projects with Bluetooth proxy support](/projects/index.html?type=bluetooth).
+If you'd like to buy a ready-made Bluetooth proxy or flash your own device, see [ESPHome projects](/projects/).
 
 ## Configuration
 

--- a/content/components/bluetooth_proxy.md
+++ b/content/components/bluetooth_proxy.md
@@ -16,7 +16,8 @@ and Home Assistant.
 Note that while this component is named `bluetooth_proxy`, only BLE devices (and their Home Assistant integrations)
 are supported.
 
-If you'd like to buy a ready-made Bluetooth proxy or flash your own device, see [ESPHome projects with Bluetooth proxy support](/projects/?type=bluetooth).
+If you'd like to buy a ready-made Bluetooth proxy or flash your own device, see
+[ESPHome projects with Bluetooth proxy support](/projects/?type=bluetooth).
 
 ## Configuration
 
@@ -30,7 +31,8 @@ bluetooth_proxy:
 - **active** (*Optional*, boolean): Enables proxying active GATT connections to BLE devices.
   This is separate from active *scanning* (configured in [ESP32 BLE Tracker](/components/esp32_ble_tracker)).
   Defaults to `true`.
-- **cache_services** (*Optional*, boolean): Enables caching GATT services in NVS flash storage which significantly speeds up active connections. Defaults to `true`.
+- **cache_services** (*Optional*, boolean): Enables caching GATT services in NVS flash storage which
+  significantly speeds up active connections. Defaults to `true`.
 - **connection_slots** (*Optional*, int): The maximum number of BLE connection slots to use.
   Each configured slot consumes ~1KB of RAM, with a maximum of `9`. It is recommended not to exceed `5`
   connection slots to avoid stability and memory issues. Defaults to `3`.
@@ -38,15 +40,22 @@ bluetooth_proxy:
   The value must not exceed the total configured `max_connections`
   for [ESP32 BLE](/components/esp32_ble).
 
-The Bluetooth proxy depends on [ESP32 BLE Tracker](/components/esp32_ble_tracker) so make sure to add that to your configuration.
+The Bluetooth proxy depends on [ESP32 BLE Tracker](/components/esp32_ble_tracker) so make sure to add that
+to your configuration.
 
 ### How Active Connections Work
 
-The Bluetooth proxy provides Home Assistant with a limited number of simultaneous active GATT connections (configured via `connection_slots`). The default is 3 slots. Ethernet-based proxies can generally handle 4 slots reliably since they don't share the radio with WiFi traffic. Set `connection_slots: 4` if you need more connections (each slot uses additional RAM).
+The Bluetooth proxy provides Home Assistant with a limited number of simultaneous active GATT connections
+(configured via `connection_slots`). The default is 3 slots. Ethernet-based proxies can generally handle
+4 slots reliably since they don't share the radio with WiFi traffic. Set `connection_slots: 4` if you need
+more connections (each slot uses additional RAM).
 
-Devices that stay connected continuously (like some locks or thermostats) use one slot the entire time. Devices that connect briefly to exchange data and then disconnect (like many sensors) free up the slot for other devices, so you can use more devices than you have slots.
+Devices that stay connected continuously (like some locks or thermostats) use one slot the entire time.
+Devices that connect briefly to exchange data and then disconnect (like many sensors) free up the slot
+for other devices, so you can use more devices than you have slots.
 
-Passively broadcasted sensor data (advertised by devices without requiring active connections, such as many BTHome sensors) is received separately and is not limited by the number of connection slots.
+Passively broadcasted sensor data (advertised by devices without requiring active connections, such as
+many BTHome sensors) is received separately and is not limited by the number of connection slots.
 
 ## Improving reception performance
 
@@ -77,11 +86,15 @@ esp32_ble_tracker:
     active: false
 ```
 
-Avoid placing the ESP node in racks, close to routers/switches or other network equipment as EMI interference will degrade Bluetooth signal reception. For best results put as far away as possible, at least 3 meters distance from any other such equipment. Place your ESPHome devices close to the Bluetooth devices that you want to interact with for the best experience.
+Avoid placing the ESP node in racks, close to routers/switches or other network equipment as EMI
+interference will degrade Bluetooth signal reception. For best results put as far away as possible,
+at least 3 meters distance from any other such equipment. Place your ESPHome devices close to the
+Bluetooth devices that you want to interact with for the best experience.
 
 ## Complete sample recommended configuration for a WiFi-connected Bluetooth proxy
 
-Below is a complete sample recommended configuration for a WiFi-connected Bluetooth proxy. If you experience issues with your proxy, try reducing your configuration to be as similar to this as possible.
+Below is a complete sample recommended configuration for a WiFi-connected Bluetooth proxy. If you
+experience issues with your proxy, try reducing your configuration to be as similar to this as possible.
 
 ```yaml
 substitutions:
@@ -117,9 +130,12 @@ bluetooth_proxy:
 
 ## Complete sample recommended configuration for an ethernet-connected Bluetooth proxy
 
-Below is a complete sample recommended configuration for an ethernet-connected Bluetooth proxy. This configuration is not for a Wi-Fi based proxy. If you experience issues with your proxy, try reducing your configuration to be as similar to this as possible.
+Below is a complete sample recommended configuration for an ethernet-connected Bluetooth proxy. This
+configuration is not for a Wi-Fi based proxy. If you experience issues with your proxy, try reducing
+your configuration to be as similar to this as possible.
 
-This configuration is for an Olimex ESP32-PoE-ISO board with an Ethernet connection to the network. If you use a different board, you must change the `board` substitution to match your board.
+This configuration is for an Olimex ESP32-PoE-ISO board with an Ethernet connection to the network.
+If you use a different board, you must change the `board` substitution to match your board.
 
 ```yaml
 substitutions:
@@ -180,7 +196,9 @@ If you experience memory issues, consider the following:
 
 ### Device Compatibility
 
-Not all BLE devices are supported and ESPHome does not decode or keep a list. To find out if your device is supported, please search for it in the [Home Assistant Integrations](https://www.home-assistant.io/integrations/) list.
+Not all BLE devices are supported and ESPHome does not decode or keep a list. To find out if your device
+is supported, please search for it in the
+[Home Assistant Integrations](https://www.home-assistant.io/integrations/) list.
 
 ## See Also
 

--- a/content/components/bluetooth_proxy.md
+++ b/content/components/bluetooth_proxy.md
@@ -67,9 +67,9 @@ Use a board with an Ethernet connection to the network, to offload ESP32's radio
 
 ### Passive vs Active Scanning
 
-Passive scanning (the default) works for most BLE devices and is sufficient for ongoing operation. Active scanning is typically only needed when initially adding new devices to Home Assistant, as it requests additional scan response data from devices. Active scanning also increases battery drain on battery-powered BLE devices.
+Passive scanning works for most BLE devices and is sufficient for ongoing operation. Active scanning requests additional scan response data from devices and is typically only needed when initially adding new devices to Home Assistant. Active scanning also increases battery drain on battery-powered BLE devices.
 
-If you experience overheating even with default scan parameters, you can try disabling active scanning in [ESP32 BLE Tracker](/components/esp32_ble_tracker) if your devices don't require it:
+The [ESP32 BLE Tracker](/components/esp32_ble_tracker) component defaults to active scanning (`active: true`). If you experience overheating, you can try switching to passive scanning if your devices don't require active scans:
 
 ```yaml
 esp32_ble_tracker:

--- a/content/components/bluetooth_proxy.md
+++ b/content/components/bluetooth_proxy.md
@@ -16,7 +16,7 @@ and Home Assistant.
 Note that while this component is named `bluetooth_proxy`, only BLE devices (and their Home Assistant integrations)
 are supported.
 
-If you'd like to buy a ready-made Bluetooth proxy or flash your own device, see [ESPHome projects](/projects/).
+If you'd like to buy a ready-made Bluetooth proxy or flash your own device, see [ESPHome projects with Bluetooth proxy support](/projects/?type=bluetooth).
 
 ## Configuration
 

--- a/content/components/bluetooth_proxy.md
+++ b/content/components/bluetooth_proxy.md
@@ -52,7 +52,7 @@ bluetooth_proxy:
 - **cache_services** (*Optional*, boolean): Enables caching GATT services in NVS flash storage which significantly speeds up active connections. Defaults to `true`.
 - **connection_slots** (*Optional*, int): The maximum number of BLE connection slots to use.
   Each configured slot consumes ~1KB of RAM, with a maximum of `9`. It is recommended not to exceed `5`
-  connection slots to avoid memory issues. Defaults to `3`.
+  connection slots to avoid memory issues. Defaults to `3`. Ethernet-based proxies can generally handle `4` connection slots reliably.
   The value must not exceed the total configured `max_connections`
   for {{< docref "esp32_ble/" >}}.
 
@@ -78,6 +78,42 @@ esp32_ble_tracker:
 ```
 
 Avoid placing the ESP node in racks, close to routers/switches or other network equipment as EMI interference will degrade Bluetooth signal reception. For best results put as far away as possible, at least 3 meters distance from any other such equipment. Place your ESPHome devices close to the Bluetooth devices that you want to interact with for the best experience.
+
+## Complete sample recommended configuration for a WiFi-connected Bluetooth proxy
+
+Below is a complete sample recommended configuration for a WiFi-connected Bluetooth proxy. If you experience issues with your proxy, try reducing your configuration to be as similar to this as possible.
+
+```yaml
+substitutions:
+  name: my-bluetooth-proxy
+
+esphome:
+  name: ${name}
+  name_add_mac_suffix: true
+
+esp32:
+  board: esp32dev
+  framework:
+    type: esp-idf
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+
+# Enable logging
+logger:
+
+# Enable Home Assistant API
+api:
+
+ota:
+  platform: esphome
+
+esp32_ble_tracker:
+
+bluetooth_proxy:
+  active: true
+```
 
 ## Complete sample recommended configuration for an ethernet-connected Bluetooth proxy
 
@@ -126,7 +162,7 @@ esp32_ble_tracker:
 
 bluetooth_proxy:
   active: true
-  connection_slots: 3
+  connection_slots: 4
 ```
 
 ## See Also

--- a/content/components/bluetooth_proxy.md
+++ b/content/components/bluetooth_proxy.md
@@ -40,7 +40,7 @@ The Bluetooth proxy depends on {{< docref "esp32_ble_tracker/" >}} so make sure 
 
 ### How Active Connections Work
 
-The Bluetooth proxy provides Home Assistant with a limited number of simultaneous active GATT connections (configured via `connection_slots`). The default is 3 slots for WiFi-based proxies. Ethernet-based proxies can generally handle 4 slots reliably since they don't share the radio with WiFi traffic.
+The Bluetooth proxy provides Home Assistant with a limited number of simultaneous active GATT connections (configured via `connection_slots`). The default is 3 slots. Ethernet-based proxies can generally handle 4 slots reliably since they don't share the radio with WiFi traffic—set `connection_slots: 4` if you need more connections (each slot uses additional RAM).
 
 Devices that stay connected continuously (like some locks or thermostats) use one slot the entire time. Devices that connect briefly to exchange data and then disconnect (like many sensors) free up the slot for other devices, so you can use more devices than you have slots.
 

--- a/content/components/bluetooth_proxy.md
+++ b/content/components/bluetooth_proxy.md
@@ -67,7 +67,9 @@ Active scanning requests additional scan response data from devices and is typic
 only needed when initially adding new devices to Home Assistant. Active scanning also
 increases battery drain on battery-powered BLE devices.
 
-The [ESP32 BLE Tracker](/components/esp32_ble_tracker) component defaults to active scanning (`active: true`). If you experience overheating, you can try switching to passive scanning if your devices don't require active scans:
+The [ESP32 BLE Tracker](/components/esp32_ble_tracker) component defaults to active scanning
+(`active: true`). If you experience overheating, you can try switching to passive scanning
+if your devices don't require active scans:
 
 ```yaml
 esp32_ble_tracker:

--- a/content/components/bluetooth_proxy.md
+++ b/content/components/bluetooth_proxy.md
@@ -27,15 +27,17 @@ bluetooth_proxy:
   # active: false
 ```
 
-- **active** (*Optional*, boolean): Enables proxying active GATT connections to BLE devices. This is separate from active *scanning* (configured in [ESP32 BLE Tracker](/components/esp32_ble_tracker)). Defaults to `true`.
+- **active** (*Optional*, boolean): Enables proxying active GATT connections to BLE devices.
+  This is separate from active *scanning* (configured in [ESP32 BLE Tracker](/components/esp32_ble_tracker)).
+  Defaults to `true`.
 - **cache_services** (*Optional*, boolean): Enables caching GATT services in NVS flash storage which significantly speeds up active connections. Defaults to `true`.
 - **connection_slots** (*Optional*, int): The maximum number of BLE connection slots to use.
   Each configured slot consumes ~1KB of RAM, with a maximum of `9`. It is recommended not to exceed `5`
   connection slots to avoid memory issues. Defaults to `3`. Ethernet-based proxies can generally handle `4` connection slots reliably.
   The value must not exceed the total configured `max_connections`
-  for {{< docref "esp32_ble/" >}}.
+  for [ESP32 BLE](/components/esp32_ble).
 
-The Bluetooth proxy depends on {{< docref "esp32_ble_tracker/" >}} so make sure to add that to your configuration.
+The Bluetooth proxy depends on [ESP32 BLE Tracker](/components/esp32_ble_tracker) so make sure to add that to your configuration.
 
 ### How Active Connections Work
 
@@ -79,7 +81,7 @@ esphome:
   name_add_mac_suffix: true
 
 esp32:
-  board: esp32dev
+  variant: esp32
   framework:
     type: esp-idf
 
@@ -119,6 +121,7 @@ esphome:
 
 esp32:
   board: ${board}
+  variant: esp32
   framework:
     type: esp-idf
 
@@ -158,8 +161,11 @@ bluetooth_proxy:
 
 If you experience memory issues, consider the following:
 
-- **Framework:** The `esp-idf` framework is recommended over `arduino` as it uses less memory. When switching frameworks, update the device with a serial cable as the partition table differs. {{< docref "/components/ota" >}} updates will not change the partition table.
-- **Web Server:** The {{< docref "web_server/" >}} component uses additional RAM. Disabling it can help if you experience memory-related issues.
+- **Framework:** The `esp-idf` framework is recommended over `arduino` as it uses less memory.
+  When switching frameworks, update the device with a serial cable as the partition table differs.
+  [OTA](/components/ota) updates will not change the partition table.
+- **Web Server:** The [Web Server](/components/web_server) component uses additional RAM.
+  Disabling it can help if you experience memory-related issues.
 
 ### Device Compatibility
 
@@ -167,6 +173,6 @@ Not all BLE devices are supported and ESPHome does not decode or keep a list. To
 
 ## See Also
 
-- {{< docref "esp32_ble_tracker/" >}}
+- [ESP32 BLE Tracker](/components/esp32_ble_tracker)
 - {{< apiref "bluetooth_proxy/bluetooth_proxy.h" "bluetooth_proxy/bluetooth_proxy.h" >}}
 - BTHome <https://bthome.io/>

--- a/content/components/bluetooth_proxy.md
+++ b/content/components/bluetooth_proxy.md
@@ -47,7 +47,7 @@ Passively broadcasted sensor data (advertised by devices without requiring activ
 
 ## Improving reception performance
 
-Use a board with an Ethernet connection to the network, to offload ESP32's radio module from WiFi traffic, this gains performance on Bluetooth side.
+Use a board with an Ethernet connection to the network, to offload ESP32's radio module from WiFi traffic. This improves Bluetooth performance. For best results, choose a board with an external antenna (e.g., prefer Olimex ESP32-PoE-ISO-EA over Olimex ESP32-PoE-ISO).
 
 > [!NOTE]
 > The default scan parameters are recommended for most users. Changing `interval` or `window` from their defaults typically provides no meaningful benefit while increasing CPU usage and network traffic. Aggressive scan settings can cause overheating on some PoE-based proxies, and WiFi instability on WiFi-based proxies.

--- a/content/components/bluetooth_proxy.md
+++ b/content/components/bluetooth_proxy.md
@@ -48,7 +48,7 @@ bluetooth_proxy:
   # active: false
 ```
 
-- **active** (*Optional*, boolean): Enables proxying active GATT connections to BLE devices. This is separate from active *scanning* (configured in {{< docref "esp32_ble_tracker/" >}}). Defaults to `true`.
+- **active** (*Optional*, boolean): Enables proxying active GATT connections to BLE devices. This is separate from active *scanning* (configured in [ESP32 BLE Tracker](/components/esp32_ble_tracker#scan-parameters)). Defaults to `true`.
 - **cache_services** (*Optional*, boolean): Enables caching GATT services in NVS flash storage which significantly speeds up active connections. Defaults to `true`.
 - **connection_slots** (*Optional*, int): The maximum number of BLE connection slots to use.
   Each configured slot consumes ~1KB of RAM, with a maximum of `9`. It is recommended not to exceed `5`
@@ -69,7 +69,7 @@ Use a board with an Ethernet connection to the network, to offload ESP32's radio
 
 Passive scanning (the default) works for most BLE devices and is sufficient for ongoing operation. Active scanning is typically only needed when initially adding new devices to Home Assistant, as it requests additional scan response data from devices. Active scanning also increases battery drain on battery-powered BLE devices.
 
-If you experience overheating even with default scan parameters, you can try disabling active scanning in {{< docref "esp32_ble_tracker/" >}} if your devices don't require it:
+If you experience overheating even with default scan parameters, you can try disabling active scanning in [ESP32 BLE Tracker](/components/esp32_ble_tracker#scan-parameters) if your devices don't require it:
 
 ```yaml
 esp32_ble_tracker:

--- a/content/components/bluetooth_proxy.md
+++ b/content/components/bluetooth_proxy.md
@@ -19,26 +19,6 @@ are supported.
 If you're looking to create an ESPHome node that is just a Bluetooth Proxy, see
 our [Bluetooth Proxy installer](https://esphome.github.io/bluetooth-proxies/) website.
 
-> [!WARNING]
-> Active connections
->
-> The Bluetooth proxy of ESPHome provides Home Assistant with a maximum number of 3 simultaneous active connections.
-> Devices which maintain a *continuous active* connection will consume one of these constantly, whilst devices which
-> do *periodic disconnections and reconnections* will permit using more than 3 of them (on a statistical basis).
-> Passively broadcasted sensor data (that is advertised by certain devices without active connections) is received
-> separately from these, and is not limited to a specific number.
->
-> The {{< docref "esp32/" >}} component should be configured to use the `esp-idf` framework, as the `arduino` framework
-> uses significantly more memory and performs poorly with the Bluetooth proxy enabled. When switching from
-> `arduino` to `esp-idf`, make sure to update the device with a serial cable as the partition table is
-> different between the two frameworks as {{< docref "/components/ota" >}} updates will not change the partition table.
->
-> The {{< docref "web_server/" >}} component should be disabled as the device is likely
-> to run out of memory and will malfunction when both components are enabled simultaneously.
->
-> Not all devices are supported and ESPHome does not decode or keep a list. To find out if your device is supported,
-> please search for it in the [Home Assistant Integrations](https://www.home-assistant.io/integrations/) list.
-
 ## Configuration
 
 ```yaml
@@ -164,6 +144,23 @@ bluetooth_proxy:
   active: true
   connection_slots: 4
 ```
+
+## Troubleshooting
+
+### Active Connection Limits
+
+The Bluetooth proxy provides Home Assistant with a maximum number of simultaneous active connections (default 3, configurable via `connection_slots`). Devices which maintain a *continuous active* connection will consume one slot constantly, whilst devices which do *periodic disconnections and reconnections* will permit using more devices on a statistical basis. Passively broadcasted sensor data is received separately and is not limited to a specific number.
+
+### Memory Issues
+
+If you experience memory issues, consider the following:
+
+- **Framework:** The `esp-idf` framework is recommended over `arduino` as it uses less memory. When switching frameworks, update the device with a serial cable as the partition table differs—{{< docref "/components/ota" >}} updates will not change the partition table.
+- **Web Server:** The {{< docref "web_server/" >}} component uses additional RAM. Disabling it can help if you experience memory-related issues.
+
+### Device Compatibility
+
+Not all BLE devices are supported and ESPHome does not decode or keep a list. To find out if your device is supported, please search for it in the [Home Assistant Integrations](https://www.home-assistant.io/integrations/) list.
 
 ## See Also
 

--- a/content/components/bluetooth_proxy.md
+++ b/content/components/bluetooth_proxy.md
@@ -39,7 +39,7 @@ The Bluetooth proxy depends on {{< docref "esp32_ble_tracker/" >}} so make sure 
 
 ### How Active Connections Work
 
-The Bluetooth proxy provides Home Assistant with a limited number of simultaneous active GATT connections (configured via `connection_slots`). The default is 3 slots. Ethernet-based proxies can generally handle 4 slots reliably since they don't share the radio with WiFi traffic—set `connection_slots: 4` if you need more connections (each slot uses additional RAM).
+The Bluetooth proxy provides Home Assistant with a limited number of simultaneous active GATT connections (configured via `connection_slots`). The default is 3 slots. Ethernet-based proxies can generally handle 4 slots reliably since they don't share the radio with WiFi traffic. Set `connection_slots: 4` if you need more connections (each slot uses additional RAM).
 
 Devices that stay connected continuously (like some locks or thermostats) use one slot the entire time. Devices that connect briefly to exchange data and then disconnect (like many sensors) free up the slot for other devices, so you can use more devices than you have slots.
 
@@ -158,7 +158,7 @@ bluetooth_proxy:
 
 If you experience memory issues, consider the following:
 
-- **Framework:** The `esp-idf` framework is recommended over `arduino` as it uses less memory. When switching frameworks, update the device with a serial cable as the partition table differs—{{< docref "/components/ota" >}} updates will not change the partition table.
+- **Framework:** The `esp-idf` framework is recommended over `arduino` as it uses less memory. When switching frameworks, update the device with a serial cable as the partition table differs. {{< docref "/components/ota" >}} updates will not change the partition table.
 - **Web Server:** The {{< docref "web_server/" >}} component uses additional RAM. Disabling it can help if you experience memory-related issues.
 
 ### Device Compatibility

--- a/content/components/bluetooth_proxy.md
+++ b/content/components/bluetooth_proxy.md
@@ -38,6 +38,12 @@ bluetooth_proxy:
 
 The Bluetooth proxy depends on {{< docref "esp32_ble_tracker/" >}} so make sure to add that to your configuration.
 
+### How Active Connections Work
+
+The Bluetooth proxy provides Home Assistant with a limited number of simultaneous active GATT connections (configured via `connection_slots`, default 3). Devices that maintain a *continuous active* connection consume one slot constantly, while devices that do *periodic disconnections and reconnections* allow more devices to share the available slots on a statistical basis.
+
+Passively broadcasted sensor data (advertised by devices without requiring active connections, such as many BTHome sensors) is received separately and is not limited by the number of connection slots.
+
 ## Improving reception performance
 
 Use a board with an Ethernet connection to the network, to offload ESP32's radio module from WiFi traffic, this gains performance on Bluetooth side.

--- a/content/components/bluetooth_proxy.md
+++ b/content/components/bluetooth_proxy.md
@@ -153,10 +153,6 @@ bluetooth_proxy:
 
 ## Troubleshooting
 
-### Active Connection Limits
-
-The Bluetooth proxy provides Home Assistant with a maximum number of simultaneous active connections (default 3, configurable via `connection_slots`). Devices which maintain a *continuous active* connection will consume one slot constantly, whilst devices which do *periodic disconnections and reconnections* will permit using more devices on a statistical basis. Passively broadcasted sensor data is received separately and is not limited to a specific number.
-
 ### Memory Issues
 
 If you experience memory issues, consider the following:

--- a/content/components/bluetooth_proxy.md
+++ b/content/components/bluetooth_proxy.md
@@ -50,14 +50,22 @@ Passively broadcasted sensor data (advertised by devices without requiring activ
 
 ## Improving reception performance
 
-Use a board with an Ethernet connection to the network, to offload ESP32's radio module from WiFi traffic. This improves Bluetooth performance. For best results, choose a board with an external antenna (e.g., prefer Olimex ESP32-PoE-ISO-EA over Olimex ESP32-PoE-ISO).
+Use a board with an Ethernet connection to the network to offload ESP32's radio module
+from WiFi traffic, which improves Bluetooth performance. For best results, use a board
+with an external antenna (e.g., Olimex ESP32-PoE-ISO-EA over Olimex ESP32-PoE-ISO).
 
 > [!NOTE]
-> The default scan parameters are recommended for most users. Changing `interval` or `window` from their defaults typically provides no meaningful benefit while increasing CPU usage and network traffic. Aggressive scan settings can cause overheating on some PoE-based proxies, and WiFi instability on WiFi-based proxies.
+> The default scan parameters are recommended for most users. Changing `interval` or
+> `window` from their defaults typically provides no meaningful benefit while increasing
+> CPU usage and network traffic. Aggressive scan settings can cause overheating on
+> PoE-based proxies and WiFi instability on WiFi-based proxies.
 
 ### Passive vs Active Scanning
 
-Passive scanning works for most BLE devices and is sufficient for ongoing operation. Active scanning requests additional scan response data from devices and is typically only needed when initially adding new devices to Home Assistant. Active scanning also increases battery drain on battery-powered BLE devices.
+Passive scanning works for most BLE devices and is sufficient for ongoing operation.
+Active scanning requests additional scan response data from devices and is typically
+only needed when initially adding new devices to Home Assistant. Active scanning also
+increases battery drain on battery-powered BLE devices.
 
 The [ESP32 BLE Tracker](/components/esp32_ble_tracker) component defaults to active scanning (`active: true`). If you experience overheating, you can try switching to passive scanning if your devices don't require active scans:
 

--- a/content/components/bluetooth_proxy.md
+++ b/content/components/bluetooth_proxy.md
@@ -33,7 +33,8 @@ bluetooth_proxy:
 - **cache_services** (*Optional*, boolean): Enables caching GATT services in NVS flash storage which significantly speeds up active connections. Defaults to `true`.
 - **connection_slots** (*Optional*, int): The maximum number of BLE connection slots to use.
   Each configured slot consumes ~1KB of RAM, with a maximum of `9`. It is recommended not to exceed `5`
-  connection slots to avoid memory issues. Defaults to `3`. Ethernet-based proxies can generally handle `4` connection slots reliably.
+  connection slots to avoid stability and memory issues. Defaults to `3`.
+  Ethernet-based proxies can generally handle `4` connection slots reliably.
   The value must not exceed the total configured `max_connections`
   for [ESP32 BLE](/components/esp32_ble).
 

--- a/content/components/bluetooth_proxy.md
+++ b/content/components/bluetooth_proxy.md
@@ -48,7 +48,7 @@ bluetooth_proxy:
   # active: false
 ```
 
-- **active** (*Optional*, boolean): Enables proxying active GATT connections to BLE devices. This is separate from active *scanning* (configured in [ESP32 BLE Tracker](/components/esp32_ble_tracker#scan-parameters)). Defaults to `true`.
+- **active** (*Optional*, boolean): Enables proxying active GATT connections to BLE devices. This is separate from active *scanning* (configured in [ESP32 BLE Tracker](/components/esp32_ble_tracker)). Defaults to `true`.
 - **cache_services** (*Optional*, boolean): Enables caching GATT services in NVS flash storage which significantly speeds up active connections. Defaults to `true`.
 - **connection_slots** (*Optional*, int): The maximum number of BLE connection slots to use.
   Each configured slot consumes ~1KB of RAM, with a maximum of `9`. It is recommended not to exceed `5`
@@ -69,7 +69,7 @@ Use a board with an Ethernet connection to the network, to offload ESP32's radio
 
 Passive scanning (the default) works for most BLE devices and is sufficient for ongoing operation. Active scanning is typically only needed when initially adding new devices to Home Assistant, as it requests additional scan response data from devices. Active scanning also increases battery drain on battery-powered BLE devices.
 
-If you experience overheating even with default scan parameters, you can try disabling active scanning in [ESP32 BLE Tracker](/components/esp32_ble_tracker#scan-parameters) if your devices don't require it:
+If you experience overheating even with default scan parameters, you can try disabling active scanning in [ESP32 BLE Tracker](/components/esp32_ble_tracker) if your devices don't require it:
 
 ```yaml
 esp32_ble_tracker:

--- a/content/components/bluetooth_proxy.md
+++ b/content/components/bluetooth_proxy.md
@@ -48,7 +48,7 @@ bluetooth_proxy:
   # active: false
 ```
 
-- **active** (*Optional*, boolean): Enables proxying active connections. Defaults to `true`.
+- **active** (*Optional*, boolean): Enables proxying active GATT connections to BLE devices. This is separate from active *scanning* (configured in {{< docref "esp32_ble_tracker/" >}}). Defaults to `true`.
 - **cache_services** (*Optional*, boolean): Enables caching GATT services in NVS flash storage which significantly speeds up active connections. Defaults to `true`.
 - **connection_slots** (*Optional*, int): The maximum number of BLE connection slots to use.
   Each configured slot consumes ~1KB of RAM, with a maximum of `9`. It is recommended not to exceed `5`
@@ -61,17 +61,21 @@ The Bluetooth proxy depends on {{< docref "esp32_ble_tracker/" >}} so make sure 
 ## Improving reception performance
 
 Use a board with an Ethernet connection to the network, to offload ESP32's radio module from WiFi traffic, this gains performance on Bluetooth side.
-To maximize the chances of catching advertisements of the sensors, you can set `interval` equal to `window` in {{< docref "/components/esp32_ble_tracker" >}} scan parameter settings:
+
+> [!NOTE]
+> The default scan parameters are recommended for most users. Changing `interval` or `window` from their defaults typically provides no meaningful benefit while increasing CPU usage and network traffic. Aggressive scan settings can cause overheating on some PoE-based proxies, and WiFi instability on WiFi-based proxies.
+
+### Passive vs Active Scanning
+
+Passive scanning (the default) works for most BLE devices and is sufficient for ongoing operation. Active scanning is typically only needed when initially adding new devices to Home Assistant, as it requests additional scan response data from devices. Active scanning also increases battery drain on battery-powered BLE devices.
+
+If you experience overheating even with default scan parameters, you can try disabling active scanning in {{< docref "esp32_ble_tracker/" >}} if your devices don't require it:
 
 ```yaml
 esp32_ble_tracker:
   scan_parameters:
-    interval: 1100ms
-    window: 1100ms
+    active: false
 ```
-
-> [!NOTE]
-> For WiFi-based proxies, changing the `interval` or `window` from their default values may result in an unstable WiFi connection. Using the default values for `interval` and `window` will usually resolve any instability.
 
 Avoid placing the ESP node in racks, close to routers/switches or other network equipment as EMI interference will degrade Bluetooth signal reception. For best results put as far away as possible, at least 3 meters distance from any other such equipment. Place your ESPHome devices close to the Bluetooth devices that you want to interact with for the best experience.
 
@@ -115,10 +119,10 @@ ota:
   platform: esphome
 
 esp32_ble_tracker:
-  scan_parameters:
-    interval: 1100ms
-    window: 1100ms
-    active: true
+  # The default scan parameters are recommended.
+  # Aggressive scan settings (e.g., interval/window of 1100ms) typically
+  # provide no benefit while increasing CPU usage and may cause
+  # overheating on some PoE-based proxies.
 
 bluetooth_proxy:
   active: true

--- a/content/components/bluetooth_proxy.md
+++ b/content/components/bluetooth_proxy.md
@@ -16,8 +16,7 @@ and Home Assistant.
 Note that while this component is named `bluetooth_proxy`, only BLE devices (and their Home Assistant integrations)
 are supported.
 
-If you're looking to create an ESPHome node that is just a Bluetooth Proxy, see
-our [Bluetooth Proxy installer](https://esphome.github.io/bluetooth-proxies/) website.
+If you'd like to buy a ready-made Bluetooth proxy or flash your own device, see [ESPHome projects with Bluetooth proxy support](/projects/index.html?type=bluetooth).
 
 ## Configuration
 


### PR DESCRIPTION
## Description:

Comprehensive documentation refresh for the Bluetooth Proxy component. Improves clarity, aligns with best practices, and makes the page more welcoming by reorganizing content.

**Changes made:**

1. **Recommend default scan parameters** - The defaults are optimized for reliability and work well for the vast majority of users. Aggressive settings (`interval: 1100ms`, `window: 1100ms`) typically provide no meaningful benefit while causing:
   - Overheating on some PoE-based proxies
   - WiFi instability on WiFi-based proxies
   - Increased CPU usage and network traffic

2. **Clarified `active` option terminology** - The `bluetooth_proxy: active: true` option enables proxying active GATT *connections*, which is separate from active *scanning* configured in `esp32_ble_tracker`. This was a common source of confusion.

3. **Added "How Active Connections Work" section** - Explains connection slots (default 3, ethernet can handle 4 but uses more RAM), how continuous vs periodic connections affect slot usage with relatable examples (locks vs sensors), and that passive broadcast data is not limited by slots.

4. **Added "Passive vs Active Scanning" section** explaining:
   - Passive scanning works for most BLE devices and is sufficient for ongoing operation
   - `esp32_ble_tracker` defaults to active scanning (`active: true`)
   - Active scanning is typically only needed when initially adding new devices to Home Assistant
   - Active scanning increases battery drain on battery-powered BLE devices
   - Switching to passive scanning can help mitigate overheating issues

5. **Added WiFi-based proxy example configuration** - Simple, clean example using all defaults for WiFi-connected proxies.

6. **Updated ethernet example configuration** - Use default scan parameters with comments explaining why they are recommended. Updated to use 4 connection slots since ethernet-based proxies can handle this reliably.

7. **Added note about connection slots for ethernet** - Ethernet-based proxies can generally handle 4 connection slots reliably (vs default of 3).

8. **Reorganized and softened warnings** - Moved the large warning block from the top of the page to a "Troubleshooting" section at the bottom. Reframed the framework and web server notes as troubleshooting tips rather than requirements, since recent ESPHome versions have significantly reduced memory usage for these components. They're still good first things to try if experiencing issues, but no longer critical warnings.

9. **Updated project links** - Replaced dead `esphome.github.io/bluetooth-proxies/` link with link to ESPHome projects page filtered for Bluetooth proxy devices.

**Related issue (if applicable):** N/A - Addressing widespread user reports of overheating and WiFi issues caused by copied configuration snippets.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

N/A - Documentation only change.

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.
