### PR TITLE
Fix typos throughout documentation

### DIFF
--- a/content/changelog/2023.12.0.md
+++ b/content/changelog/2023.12.0.md
@@ -36,12 +36,12 @@ duplicate pin definitions. See the [Pin Schema](/guides/configuration-types#pin-
 
 ## Touchscreen internal changes
 
-The touchscreen compoenent code has had a big overhaul which breaks any external components or open PRs for
+The touchscreen component code has had a big overhaul which breaks any external components or open PRs for
 new touchscreens. See {{< pr number="4596" repo="esphome" >}} for details if this affects you.
 
 ## MCP3008 breaking changes
 
-The MCP3008 has has a restructure of the code and at the same time the default update interval has been changed
+The MCP3008 has had a restructure of the code and at the same time the default update interval has been changed
 to 60 seconds, the units, device class and state class default have also been set to sane defaults expected for
 a voltage sensor.
 

--- a/content/changelog/2024.12.0.md
+++ b/content/changelog/2024.12.0.md
@@ -20,7 +20,7 @@ ESPHome has now updated the core ESP32 code to use [ESP-IDF](https://github.com/
 This is a major upgrade and should bring more features, chip support (Most notably the ESP32-C6 that people
 keep raving on about) and in general more stability.
 
-To acommodate this change, ESPHome has moved away from the "official" platformio provided ESP32 platform,
+To accommodate this change, ESPHome has moved away from the "official" platformio provided ESP32 platform,
 and is now using a community fork [pioarduino/platform-espressif32](https://github.com/pioarduino/platform-espressif32)
 as platformio has decided to stop providing ESP-IDF updates to their platform for Espressif chips. As a user,
 you should not notice any difference.

--- a/content/components/alarm_control_panel/template.md
+++ b/content/components/alarm_control_panel/template.md
@@ -84,7 +84,7 @@ control panel is armed, a fault on this type of zone will cause the alarm to go 
 The `instant_always` trigger mode is typically used for tamper inputs. Irrespective of whether the alarm control panel
 is armed, a fault will always cause the alarm to go directly to the `triggered` state.
 
-The `delayed_follower` trigger mode is typically specifed for interior passive infared (PIR) or microwave sensors. One
+The `delayed_follower` trigger mode is typically specified for interior passive infrared (PIR) or microwave sensors. One
 of two things happen when a `delayed_follower` zone is faulted:
 
 1. When the alarm panel is in the armed state, a fault on a zone with `delayed_follower` specified will cause the alarm
@@ -95,7 +95,7 @@ of two things happen when a `delayed_follower` zone is faulted:
 
 The `delayed_follower` trigger mode offers better protection if someone enters a premises via an unprotected window
 or door. If there is a PIR guarding the main hallway, it will cause an instant trigger of the alarm panel as someone
-entered the premises in a unusual manner. Likewise, if someone enters the premises though a door set to the `delayed`
+entered the premises in an unusual manner. Likewise, if someone enters the premises through a door set to the `delayed`
 trigger mode, and then triggers the PIR, the alarm will stay in the `pending` state until either they disarm the alarm,
 or the pending timer expires.
 

--- a/content/components/api.md
+++ b/content/components/api.md
@@ -104,7 +104,7 @@ api:
 
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID used for code generation.
 - **password** (*Optional*, **Deprecated**, string): The password to protect the API Server with. Defaults
-  to no password. It is recommended to use the `encryption` -> `key` above instead of the the `password`.
+  to no password. It is recommended to use the `encryption` -> `key` above instead of the `password`.
 
 - **on_client_connected** (*Optional*, [Action](/automations/actions#all-actions)): An automation to perform when a client
   connects to the API. See [`on_client_connected` Trigger](#api-on_client_connected_trigger).

--- a/content/components/climate/pid.md
+++ b/content/components/climate/pid.md
@@ -258,7 +258,7 @@ To autotune the control parameters:
 
 1. Set an appropriate setpoint (see note above) and turn on the climate controller (Heat, Cool or Auto).
 
-1. Click the *PID Climate Autotune* button and look at the the logs of the device.
+1. Click the *PID Climate Autotune* button and look at the logs of the device.
 
     You should see output like
 
@@ -298,7 +298,7 @@ To autotune the control parameters:
       Please copy these values into your YAML configuration! They will reset on the next reboot.
     ```
 
-    As soon as the the autotune procedure finishes, the climate starts to work with the calculated parameters
+    As soon as the autotune procedure finishes, the climate starts to work with the calculated parameters
     so that expected operation can be immediately verified.
 
     If satisfied, copy the values in `control_parameters` into your configuration:

--- a/content/components/cover/template.md
+++ b/content/components/cover/template.md
@@ -55,7 +55,7 @@ Possible return values for the optional lambda:
   be performed when the remote requests the cover to be stopped.
 
 - **toggle_action** (*Optional*, [Action](/automations/actions#all-actions)): The action that should
-  be performed when the remote requests to toggle the the cover.
+  be performed when the remote requests to toggle the cover.
 
 - **optimistic** (*Optional*, boolean): Whether to operate in optimistic mode - when in this mode,
   any command sent to the template cover will immediately update the reported state/position and no lambda

--- a/content/components/dfrobot_sen0395.md
+++ b/content/components/dfrobot_sen0395.md
@@ -140,9 +140,9 @@ switch:
 - **type** (**Required**): One of:
 
   - `presence_via_uart`  : when enabled, the module sends presence information via both the serial connection and
-    GPIO pin; when disabled, presense is indicated only via the GPIO pin.
+    GPIO pin; when disabled, presence is indicated only via the GPIO pin.
 
-  - `sensor_active`  : when enabled, presence detection is reported; when disabled, presense will not be reported.
+  - `sensor_active`  : when enabled, presence detection is reported; when disabled, presence will not be reported.
   - `start_after_boot`  : when enabled, the sensor will start immediately after power-on; when disabled, the sensor
     must be manually started.
 

--- a/content/components/display/ili9xxx.md
+++ b/content/components/display/ili9xxx.md
@@ -146,7 +146,7 @@ Each entry represents a single-byte command followed by zero or more data bytes.
 
 ### CUSTOM model
 
-The `CUSTOM` model selection is provided for otherwise unsupported displays, and requires both `dimensions:` and `init_sequence:` to be specfied. There is no pre-defined init sequence.
+The `CUSTOM` model selection is provided for otherwise unsupported displays, and requires both `dimensions:` and `init_sequence:` to be specified. There is no pre-defined init sequence.
 
 ### Configuration examples
 

--- a/content/components/display/mipi_spi.md
+++ b/content/components/display/mipi_spi.md
@@ -186,7 +186,7 @@ If converting from other code, make sure the length byte, if present, is not cop
 
 ## CUSTOM model
 
-The `CUSTOM` model selection is provided for otherwise unsupported displays, and requires both `dimensions:` and `init_sequence:` to be specfied. There is no pre-defined init sequence.
+The `CUSTOM` model selection is provided for otherwise unsupported displays, and requires both `dimensions:` and `init_sequence:` to be specified. There is no pre-defined init sequence.
 
 ## Using the `transform` options
 

--- a/content/components/display/ssd1325.md
+++ b/content/components/display/ssd1325.md
@@ -52,7 +52,7 @@ display:
 
 - **dc_pin** (**Required**, [Pin Schema](/guides/configuration-types#pin-schema)): The DC pin.
 - **reset_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The RESET pin.
-- **cs_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The pin on the ESP that that the CS line is connected to.
+- **cs_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The pin on the ESP that the CS line is connected to.
   The CS line can be connected to GND if this is the only device on the SPI bus.
 
 - **lambda** (*Optional*, [lambda](/automations/templates#config-lambda)): The lambda to use for rendering the content on the display.

--- a/content/components/display/ssd1331.md
+++ b/content/components/display/ssd1331.md
@@ -40,7 +40,7 @@ display:
 
 - **dc_pin** (**Required**, [Pin Schema](/guides/configuration-types#pin-schema)): The DC pin.
 - **reset_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The RESET pin.
-- **cs_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The pin on the ESP that that the CS line is connected to.
+- **cs_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The pin on the ESP that the CS line is connected to.
   The CS line can be connected to GND if this is the only device on the SPI bus.
 
 - **lambda** (*Optional*, [lambda](/automations/templates#config-lambda)): The lambda to use for rendering the content on the display.

--- a/content/components/display/ssd1351.md
+++ b/content/components/display/ssd1351.md
@@ -48,7 +48,7 @@ display:
   - `SSD1351 128x96` - SSD1351 with 128 columns and 96 rows
 
 - **dc_pin** (**Required**, [Pin Schema](/guides/configuration-types#pin-schema)): The DC pin.
-- **cs_pin** (**Required**, [Pin Schema](/guides/configuration-types#pin-schema)): The pin on the ESP that that the CS line is connected to.
+- **cs_pin** (**Required**, [Pin Schema](/guides/configuration-types#pin-schema)): The pin on the ESP that the CS line is connected to.
 - **reset_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The RESET pin.
 - **lambda** (*Optional*, [lambda](/automations/templates#config-lambda)): The lambda to use for rendering the content on the display.
   See [Display Rendering Engine](/components/display#display-engine) for more information.

--- a/content/components/display/st7567.md
+++ b/content/components/display/st7567.md
@@ -26,7 +26,7 @@ It's a monochrome LCD graphic display.
 >
 > **Electrical interference:** To reduce malfunction caused by noise, datasheet recommends to "use the refresh sequence regularly in a specified interval".
 >
-> Noone knows what exact interval is - it varies based on your electrical environment - some might need it every hour, for example.
+> No one knows what exact interval is - it varies based on your electrical environment - some might need it every hour, for example.
 > Without doing refresh sequence picture on LCD might get glitchy after some time.
 >
 > You can plan refresh by using `interval:` section and calling `request_refresh()` function, after that it will perform display

--- a/content/components/light/esp32_rmt_led_strip.md
+++ b/content/components/light/esp32_rmt_led_strip.md
@@ -47,7 +47,7 @@ light:
   can handle per second. For example, `16ms` will limit the light to a refresh rate of about 60Hz. Defaults to
   sending commands as quickly as changes are made to the lights.
 
-- **use_psram** (*Optional*, boolean): Set to `false` to force internal RAM allocation even if you have the the PSRAM
+- **use_psram** (*Optional*, boolean): Set to `false` to force internal RAM allocation even if you have the PSRAM
   component enabled. This can be useful if you're experiencing issues like flickering with your leds strip. Defaults to `true`.
 
 - **rmt_symbols** (*Optional*, int): When `use_dma` is enabled, this sets the size of the driver's internal DMA

--- a/content/components/logger.md
+++ b/content/components/logger.md
@@ -96,7 +96,7 @@ so if you use any other configuration you will not get log messages over the on-
 | ESP32-S3 | TX: 43, RX: 44 | N/A | TX: 17, RX: 18 | Undefined | 19/20 | 19/20 |
 | NRF52    | pins varies by board | N/A | pins varies by board | Undefined | D+/D- | N/A |
 
-*Undefined* means that the logger component cannot use this harware UART at this time.
+*Undefined* means that the logger component cannot use this hardware UART at this time.
 
 {{< anchor "logger-default_hardware_interfaces" >}}
 

--- a/content/components/lvgl/_index.md
+++ b/content/components/lvgl/_index.md
@@ -93,7 +93,7 @@ The following configuration variables apply to the main `lvgl` component, in ord
   - **long_press_time** (*Optional*, [Time](/guides/configuration-types#time)): For the touchscreen, delay after which the `on_long_pressed` [interaction trigger](/components/lvgl/widgets#lvgl-automation-triggers) will be called. Defaults to `400ms`.
   - **long_press_repeat_time** (*Optional*, [Time](/guides/configuration-types#time)): For the touchscreen, repeated interval after `long_press_time`, when `on_long_pressed_repeat` [interaction trigger](/components/lvgl/widgets#lvgl-automation-triggers) will be called. Defaults to `100ms`.
 - **encoders** (*Optional*, list): A list of rotary encoders interacting with the LVGL widgets on the display.
-  - **group** (*Optional*, string): A name for a group of widgets which will interact with the the input device. See the {{< docref "/components/lvgl/widgets" "common properties" >}} of the widgets for more information on groups.
+  - **group** (*Optional*, string): A name for a group of widgets which will interact with the input device. See the {{< docref "/components/lvgl/widgets" "common properties" >}} of the widgets for more information on groups.
   - **initial_focus** (*Optional*, [ID](/guides/configuration-types#id)): An optional ID for a widget to be given focus on startup (especially useful if there is only one focusable widget.)
   - **enter_button** (**Required**, [ID](/guides/configuration-types#id)): The ID of a {{< docref "/components/binary_sensor/index" "Binary Sensor" >}}, to be used as `ENTER` key.
   - **sensor** (*Optional*, [ID](/guides/configuration-types#id)): The ID of a {{< docref "/components/sensor/rotary_encoder" >}}; or a list with buttons for left/right interaction with the widgets:
@@ -102,7 +102,7 @@ The following configuration variables apply to the main `lvgl` component, in ord
   - **long_press_time** (*Optional*, [Time](/guides/configuration-types#time)): For the rotary encoder, delay after which the `on_long_pressed` [interaction trigger](/components/lvgl/widgets#lvgl-automation-triggers) will be called. Defaults to `400ms`. Can be disabled with `never`.
   - **long_press_repeat_time** (*Optional*, [Time](/guides/configuration-types#time)): For the rotary encoder, repeated interval after `long_press_time`, when `on_long_pressed_repeat` [interaction trigger](/components/lvgl/widgets#lvgl-automation-triggers) will be called. Defaults to `100ms`. Can be disabled with `never`.
 - **keypads** (*Optional*, list): A list of keypads interacting with the LVGL widgets on the display.
-  - **group** (*Optional*, string): A name for a group of widgets which will interact with the the input device. See the {{< docref "/components/lvgl/widgets" "common properties" >}} of the widgets for more information on groups.
+  - **group** (*Optional*, string): A name for a group of widgets which will interact with the input device. See the {{< docref "/components/lvgl/widgets" "common properties" >}} of the widgets for more information on groups.
   - **up** (*Optional*, [ID](/guides/configuration-types#id)): The ID of a {{< docref "/components/binary_sensor/index" "Binary Sensor" >}}, to be used as `UP` key.
   - **down** (*Optional*, [ID](/guides/configuration-types#id)): The ID of a {{< docref "/components/binary_sensor/index" "Binary Sensor" >}}, to be used as `DOWN` key.
   - **right** (*Optional*, [ID](/guides/configuration-types#id)): The ID of a {{< docref "/components/binary_sensor/index" "Binary Sensor" >}}, to be used as `RIGHT` key.

--- a/content/components/lvgl/widgets.md
+++ b/content/components/lvgl/widgets.md
@@ -56,7 +56,7 @@ The properties below are common to all widgets.
 
 {{< anchor "lvgl-widgetproperty-state" >}}
 
-- **state** (*Optional*, dict): Widgets or their (sub)parts can have have states, which support separate styling. These state styles inherit from the theme, but can be locally set or overridden within style definitions. Can be one of:
+- **state** (*Optional*, dict): Widgets or their (sub)parts can have states, which support separate styling. These state styles inherit from the theme, but can be locally set or overridden within style definitions. Can be one of:
   - **checked** (*Optional*, boolean): Toggled or checked state.
   - **disabled** (*Optional*, boolean): Disabled state (also usable with [shorthand](#lvgl-automation-shorthands) actions `lvgl.widget.enable` and `lvgl.widget.disable`  ).
   - **edited** (*Optional*, boolean): Edit by an encoder.
@@ -1048,7 +1048,7 @@ A label is the basic widget type that is used to display text.
   - `CLIP`  : Simply clip the parts of the text outside the label.
 - **recolor** (*Optional*, boolean): Enable recoloring of button text with `#`. This makes it possible to set the color of characters in the text individually by prefixing the text to be re-colored with a `#RRGGBB` hexadecimal color code followed by a *space*, and finally closed with a single hash `#` tag. For example: `Write a #FF0000 red# word`.
 - **scrollbar** (*Optional*, list): Settings for the indicator *part* to show the value. Supports a list of [styles](/components/lvgl#lvgl-styling) and state-based styles to customize. The scroll bar that is shown when the text is larger than the widget's size.
-- **selected** (*Optional*, list): Settings for the the style of the selected text. Only `text_color` and `bg_color` style properties can be used.
+- **selected** (*Optional*, list): Settings for the style of the selected text. Only `text_color` and `bg_color` style properties can be used.
 - **text_align** (*Optional*, enum): Alignment of the text in the widget - it doesn't align the object itself, only the lines inside the object. One of `LEFT`, `CENTER`, `RIGHT`, `AUTO`. Inherited from parent. Defaults to `AUTO`, which detects the text base direction and uses left or right alignment accordingly.
 - **text_color** (*Optional*, [color](/components/lvgl#lvgl-color)): Color to render the text in. Inherited from parent. Defaults to `0` (black).
 - **text_decor** (*Optional*, list): Choose decorations for the text: `NONE`, `UNDERLINE`, `STRIKETHROUGH` (multiple can be specified as YAML list). Inherited from parent. Defaults to `NONE`.

--- a/content/components/micronova.md
+++ b/content/components/micronova.md
@@ -53,8 +53,8 @@ micronova:
   Defaults to 60 seconds.
 
 > [!NOTE]
-> For all text sensors, sensors, numbers, buttons and switches hereafter most of the the default **memory_location** and **memory_address** parameters will work so you should
-> not specify them. However your Micronova boad may require you to specify alternate values. So every text sensor, button,
+> For all text sensors, sensors, numbers, buttons and switches hereafter most of the default **memory_location** and **memory_address** parameters will work so you should
+> not specify them. However your Micronova board may require you to specify alternate values. So every text sensor, button,
 > switch or number accepts these parameters:
 >
 > - **memory_location** (*Optional*): The memory location where the parameter must be read. For most stoves this is 0x00 for RAM
@@ -115,13 +115,13 @@ sensor:
 
   - **fan_rpm_offset** (*Optional*, integer): Offset the reported RPM value. Must be between 0 and 255. Defaults to 0.
   - All other options from [Sensor](/components/sensor).
-- **water_temperature** (*Optional*): Internal boiler water termperature.
+- **water_temperature** (*Optional*): Internal boiler water temperature.
   All options from [Sensor](/components/sensor).
 
 - **water_pressure** (*Optional*): Internal boiler water pressure.
   All options from [Sensor](/components/sensor).
 
-- **memory_address_sensor** (*Optional*): Can be any **memory_location** / **memory_address** you want to track. Usefull
+- **memory_address_sensor** (*Optional*): Can be any **memory_location** / **memory_address** you want to track. Useful
   when you don't know where the parameter is for your stove is.
   All options from [Sensor](/components/sensor).
 
@@ -140,7 +140,7 @@ number:
 ### Configuration variables
 
 - **thermostat_temperature** (*Optional*): Number that holds the current stove thermostat value.
-  - **step** (*Optional*): Temperature step. This value is used to multiply/devide the raw value when setting/reading the **thermostat_temperature**
+  - **step** (*Optional*): Temperature step. This value is used to multiply/divide the raw value when setting/reading the **thermostat_temperature**
   - All other options from [Number](/components/number#config-number).
 - **power_level** (*Optional*): Number that sets/reads the requested stove power.
   All options from [Number](/components/number#config-number).

--- a/content/components/microphone/i2s_audio.md
+++ b/content/components/microphone/i2s_audio.md
@@ -7,7 +7,7 @@ params:
     image: i2s_audio.svg
 ---
 
-The `i2s_audio` microphone platform allows you to receive audio via the the {{< docref "/components/i2s_audio" >}}.
+The `i2s_audio` microphone platform allows you to receive audio via the {{< docref "/components/i2s_audio" >}}.
 
 This platform only works on ESP32 based chips.
 

--- a/content/components/opentherm.md
+++ b/content/components/opentherm.md
@@ -341,7 +341,7 @@ available:
 
 Some boilers use non-standard message ids and formats. For example,
 [it's known](https://github.com/olegtarasov/esphome-opentherm/issues/11) that Daikin D2C boiler uses message id
-`162` instead of `56` to set target DHW temperature. In order to accomodate all sorts of non-standard behavior, I
+`162` instead of `56` to set target DHW temperature. In order to accommodate all sorts of non-standard behavior, I
 introduced two automations that allow editing the low-level OpenTherm message:
 
 - **before_send**: fired just before the fully formed message is sent to the boiler. When you use a lambda, the message

--- a/content/components/output/sigma_delta_output.md
+++ b/content/components/output/sigma_delta_output.md
@@ -58,8 +58,8 @@ Configuration variables:
 
 > [!NOTE]
 >
-> - If `pin` is defined, the GPIO pin state is writen before any action is executed.
-> - `state_change_action` and `turn_on_action`  /`turn_off_action` can be used togther. `state_change_action` is called before `turn_on_action`  /`turn_off_action`. It's recommended to use either `state_change_action` or `turn_on_action`  /`turn_off_action` to change the state of an output. Using both automations together is only recommended for monitoring.
+> - If `pin` is defined, the GPIO pin state is written before any action is executed.
+> - `state_change_action` and `turn_on_action`  /`turn_off_action` can be used together. `state_change_action` is called before `turn_on_action`  /`turn_off_action`. It's recommended to use either `state_change_action` or `turn_on_action`  /`turn_off_action` to change the state of an output. Using both automations together is only recommended for monitoring.
 
 > [!NOTE]
 > If the output must not be active for more than some fixed time before it has

--- a/content/components/output/slow_pwm.md
+++ b/content/components/output/slow_pwm.md
@@ -44,8 +44,8 @@ output:
 
 > [!NOTE]
 >
-> - If `pin` is defined the GPIO pin state is writen before any action is executed.
-> - `state_change_action` and `turn_on_action`  /`turn_off_action` can be used togther. `state_change_action` is called before `turn_on_action`  /`turn_off_action`. It's recommended to use either `state_change_action` or `turn_on_action`  /`turn_off_action` to change the state of an output. Using both automations together is only recommended for monitoring.
+> - If `pin` is defined the GPIO pin state is written before any action is executed.
+> - `state_change_action` and `turn_on_action`  /`turn_off_action` can be used together. `state_change_action` is called before `turn_on_action`  /`turn_off_action`. It's recommended to use either `state_change_action` or `turn_on_action`  /`turn_off_action` to change the state of an output. Using both automations together is only recommended for monitoring.
 
 ## Example
 

--- a/content/components/pn7160.md
+++ b/content/components/pn7160.md
@@ -34,7 +34,7 @@ In addition, the {{< docref "binary_sensor/nfc" >}} platform may be used to quic
 
 ## Over SPI
 
-The `pn7160_spi` component allows you to use [SPI-equipped](/components/spi) PN7160 NFC controllers with with ESPHome.
+The `pn7160_spi` component allows you to use [SPI-equipped](/components/spi) PN7160 NFC controllers with ESPHome.
 
 ```yaml
 pn7160_spi:

--- a/content/components/remote_receiver.md
+++ b/content/components/remote_receiver.md
@@ -413,7 +413,7 @@ Remote code selection (exactly one of these has to be included):
 
   - **first** (**Required**, uint32_t): The first 24-bit Coolix code to trigger on, see dumper output for more info.
   - **second** (*Optional*, uint32_t): The second 24-bit Coolix code to trigger on, see dumper output for more info.
-    If not set, trigger on on only single non-strict packet, specified by the `first` parameter.
+    If not set, trigger on only single non-strict packet, specified by the `first` parameter.
 
 - **dish**: Trigger on a decoded Dish Network remote code with the given data.
   Beware that Dish remotes use a different carrier frequency (57.6kHz) that many receiver hardware don't decode.

--- a/content/components/rf_bridge.md
+++ b/content/components/rf_bridge.md
@@ -175,8 +175,8 @@ Configuration options:
 
 ## Portisch firmware
 
-The radio microcontroller (MCU) can be flashed with an alternative firmware which allows for sniffining and transmitting
-advanced protocols (e.g raw, 0xB0, 0xB1, 0xA8) in addition to the standard recieve/transmit (0xA4,0xA5).
+The radio microcontroller (MCU) can be flashed with an alternative firmware which allows for sniffing and transmitting
+advanced protocols (e.g raw, 0xB0, 0xB1, 0xA8) in addition to the standard receive/transmit (0xA4,0xA5).
 If you have flashed the secondary MCU with the [Portisch firmware](https://github.com/Portisch/RF-Bridge-EFM8BB1) or [Mightymos firmware](https://github.com/mightymos/RF-Bridge-OB38S003),
 ESPHome is able to receive the extra protocols that can be decoded as well as activate the other modes supported. The below Triggers/actions are only for Portisch firmware.
 You can see a list of available commands and format in the [Portisch Wiki](https://github.com/Portisch/RF-Bridge-EFM8BB1/wiki/Commands)

--- a/content/components/sensor/a01nyub.md
+++ b/content/components/sensor/a01nyub.md
@@ -10,7 +10,7 @@ params:
 This sensor allows you to use A01NYUB waterproof ultrasonic sensor by DFRobot
 ([datasheet](https://wiki.dfrobot.com/A01NYUB%20Waterproof%20Ultrasonic%20Sensor%20SKU_SEN0313))
 with ESPHome to measure distances. This sensor can measure
-ranges between 28 centimeters and 750 centimeters with a resolution of 1 milimeter.
+ranges between 28 centimeters and 750 centimeters with a resolution of 1 millimeter.
 
 Since this sensor reads multiple times per second, [Sensor Filters](/components/sensor#sensor-filters) are highly recommended.
 

--- a/content/components/sensor/a02yyuw.md
+++ b/content/components/sensor/a02yyuw.md
@@ -10,7 +10,7 @@ params:
 This sensor allows you to use A02YYUW waterproof ultrasonic sensor by DFRobot
 ([datasheet](https://wiki.dfrobot.com/_A02YYUW_Waterproof_Ultrasonic_Sensor_SKU_SEN0311))
 with ESPHome to measure distances. This sensor can measure
-ranges between 3 centimeters and 450 centimeters with a resolution of 1 milimeter.
+ranges between 3 centimeters and 450 centimeters with a resolution of 1 millimeter.
 
 Since this sensor reads multiple times per second, [Sensor Filters](/components/sensor#sensor-filters) are highly recommended.
 

--- a/content/components/sensor/as5600.md
+++ b/content/components/sensor/as5600.md
@@ -60,7 +60,7 @@ as5600:
   - `low2`
   - `low3`
 
-- **watchdog** (*Optional*, boolean): Whether to enable the watchdog that puts the the chip in to
+- **watchdog** (*Optional*, boolean): Whether to enable the watchdog that puts the chip into
   low power mode 3. Check the datasheet for more information.
   Defaults to `off`.
 

--- a/content/components/sensor/atm90e32.md
+++ b/content/components/sensor/atm90e32.md
@@ -261,7 +261,7 @@ The default configuration is designed for:
 - Current transformer: [SCT-013-000](https://www.amazon.com/gp/product/B075541WVT)
 - Voltage transformer: [Jameco Reliapro 9V AC](https://www.amazon.com/gp/product/B00B886CWS)
 
-A load which uses a known amount of current can be used to calibrate. For for a more accurate calibration use a
+A load which uses a known amount of current can be used to calibrate. For a more accurate calibration use a
 [Kill-A-Watt](https://www.amazon.com/gp/product/B00009MDBU) meter or a multimeter capable of measuring mains voltage.
 
 ### Voltage

--- a/content/components/sensor/binary_sensor_map.md
+++ b/content/components/sensor/binary_sensor_map.md
@@ -41,7 +41,7 @@ sensor:
 
 binary_sensor:
   # If the Bayesian probability is greater than 0.6,
-  # then predict the event is occuring
+  # then predict the event is occurring
   - platform: analog_threshold
     name: "Bayesian Event Predicted State"
     sensor_id: bayesian_prob

--- a/content/components/sensor/daly_bms.md
+++ b/content/components/sensor/daly_bms.md
@@ -80,7 +80,7 @@ sensor:
 - **voltage** (*Optional*): Voltage of the battery pack connected to Daly BMS.
   All options from [Sensor](/components/sensor).
 
-- **current** (*Optional*): Current flowing trough the BMS (input or output from batttery).
+- **current** (*Optional*): Current flowing through the BMS (input or output from battery).
   All options from [Sensor](/components/sensor).
 
 - **battery_level** (*Optional*): Battery level in % (SoC).
@@ -164,9 +164,9 @@ binary_sensor:
 
 ## Control BMS
 
-At this moment Daly sensor platform don't suppport controlling you BMS, but you can make some stuff using uart.write
+At this moment Daly sensor platform doesn't support controlling your BMS, but you can make some stuff using uart.write
 
-First you need to setup binary sensors for charging and disharging MOS
+First you need to setup binary sensors for charging and discharging MOS
 
 ```yaml
 binary_sensor:

--- a/content/components/sensor/fs3000.md
+++ b/content/components/sensor/fs3000.md
@@ -30,7 +30,7 @@ sensor:
 ## Configuration variables
 
 - **model** (**Required**, string): Specify FS3000 model, can be `1005` or `1015`.
-- **address** (*Optional*, int): Manually specifiy the I²C address of the sensor. Defaults to `0x28`.
+- **address** (*Optional*, int): Manually specify the I²C address of the sensor. Defaults to `0x28`.
 - **update_interval** (*Optional*, [Time](/guides/configuration-types#time)): The interval to check the sensor. Defaults to `60s`.
 - All other options from [Sensor](/components/sensor).
 

--- a/content/components/sensor/gcja5.md
+++ b/content/components/sensor/gcja5.md
@@ -17,7 +17,7 @@ MUST have `EVEN` parity.
 
 The sensor itself will push values every second. You may wish to [filter](/components/sensor#sensor-filters) this value to reduce the amount of data you are ingesting.
 The sensor will internally track changes to the Laser Diode and Photo Diode over time to adjust and ensure accuracy.
-Based on continous runtime, the sensor is rated to last at least 5 years.
+Based on continuous runtime, the sensor is rated to last at least 5 years.
 
 ```yaml
 # Example configuration entry

--- a/content/components/sensor/gdk101.md
+++ b/content/components/sensor/gdk101.md
@@ -49,7 +49,7 @@ gdk101:
   the sensor. Defaults to `0x18` (`A0` and `A1` shorted).
   The address is made up using the state of `A0` as bit 1 and the state of `A1` as bit 2, so a total of four addresses is possible.
 
-- **update_interval** (*Optional*, int): Manually defined update iterval of sensor. Default to 60s.
+- **update_interval** (*Optional*, int): Manually defined update interval of sensor. Defaults to 60s.
 - **i2c_id** (*Optional*, string): Optional name of the bus.
 
 ## Sensor

--- a/content/components/sensor/iaqcore.md
+++ b/content/components/sensor/iaqcore.md
@@ -32,7 +32,7 @@ sensor:
 ## Configuration variables
 
 - **i2c_id** (*Optional*, ID): The id of the I²C Bus.
-- **address** (*Optional*, int): Manually specifiy the I²C address of the sensor. Defaults to `0x5A`.
+- **address** (*Optional*, int): Manually specify the I²C address of the sensor. Defaults to `0x5A`.
 - **update_interval** (*Optional*, [Time](/guides/configuration-types#time)): The interval to check the sensor. Defaults to `60s`.
 - **co2** (*Optional*): The configuration for the CO2 sensor. All options from
   [Sensor](/components/sensor).

--- a/content/components/sensor/ld2420.md
+++ b/content/components/sensor/ld2420.md
@@ -19,7 +19,7 @@ firmware v1.5.3 and 115200 on newer versions. The tx_pin changed from ot2 to ot1
 Firmware v1.5.4 and up now features the ability to observe gate energy signal levels and with this
 release we can dynamically calibrate gate still and move thresholds.
 
-This component has dynamic configuration functionallity with a compact UI format.
+This component has dynamic configuration functionality with a compact UI format.
 Select, number and button components provide configuration value inputs and control.
 
 {{< img src="ld2420.jpg" alt="Image" caption="HLK-LD2420 Low power motion and presence sensor." width="50.0%" class="align-center" >}}

--- a/content/components/sensor/mhz19.md
+++ b/content/components/sensor/mhz19.md
@@ -51,7 +51,7 @@ sensor:
   Set this value to `true` to enable ABC on boot.
   Doesn't send calibration command if not set (default sensor logic will be used).
 
-- **warmup_time** (*Optional*, Time): The sensor has a warmup time and before that, it returns bougus readings (eg: 500ppm, 505ppm...). This setting discards readings until the warmup time happened (`NAN` is returned). The datasheet says preheating takes 1min, but empirical tests have shown it often takes more, so the 75s default should be enough to accomodate for that.
+- **warmup_time** (*Optional*, Time): The sensor has a warmup time and before that, it returns bogus readings (eg: 500ppm, 505ppm...). This setting discards readings until the warmup time happened (`NAN` is returned). The datasheet says preheating takes 1min, but empirical tests have shown it often takes more, so the 75s default should be enough to accommodate for that.
 
 {{< img src="mhz19-pins.jpg" alt="Image" caption="Pins on the MH-Z19. Only the ones marked with a red circle need to be connected." width="80.0%" class="align-center" >}}
 

--- a/content/components/sensor/mopeka_std_check.md
+++ b/content/components/sensor/mopeka_std_check.md
@@ -119,7 +119,7 @@ mopeka_ble:
 ```
 
 After uploading, the ESP32 will immediately try to scan for BLE devices. For Mopeka Standard devices you must press and hold the green sync button for it to be identified.
-Or alternativly set the configuration flag `show_sensors_without_sync: true` to see all devices.
+Or alternatively set the configuration flag `show_sensors_without_sync: true` to see all devices.
 For all sensors found the `mopeka_ble` component will print a message like this one:
 
 ```log

--- a/content/components/sensor/qmc5883l.md
+++ b/content/components/sensor/qmc5883l.md
@@ -9,7 +9,7 @@ params:
 
 The `qmc5883l` allows you to use your QMC5883L triple-axis magnetometers
 ([datasheet](http://wiki.sunfounder.cc/images/7/72/QMC5883L-Datasheet-1.0.pdf)) with
-ESPHome. This sensor is very simular to the [HMC5883L](/components/sensor/hmc5883l#hmc5883l) sensor and is oftern found
+ESPHome. This sensor is very similar to the [HMC5883L](/components/sensor/hmc5883l#hmc5883l) sensor and is often found
 as a knock off replacement. The QMC5883L sensor performs on par to the HMC5883L sensor,
 though the configuration differs. The [I²C Bus](/components/i2c) is required to be set up in your
 configuration for this sensor to work.
@@ -63,7 +63,7 @@ sensor:
 
 - **range** (*Optional*, enum): The range parameter for the sensor.
 - **oversampling** (*Optional*, enum): The oversampling parameter for the sensor.
-- **update_interval** (*Optional*, [Time](/guides/configuration-types#time)): The interval to check the sensor. To acheive the highest
+- **update_interval** (*Optional*, [Time](/guides/configuration-types#time)): The interval to check the sensor. To achieve the highest
   date rate of `200Hz` this can be set to zero when `drdy_pin` is configured. Defaults to `60s`.
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID used for code generation.
 - **drdy_pin** (*Optional*, [Pin](/guides/configuration-types#pin)): The data ready pin. It is recommended to connect the data

--- a/content/components/sensor/veml7700.md
+++ b/content/components/sensor/veml7700.md
@@ -35,7 +35,7 @@ Should you desire to manually control those parameters - please note that:
 
 - Gain levels of 1/8 and 1/4 shall be used in most cases.
 - Gain levels of 1 an 2 are only intended to be used in low light conditions < 100 lux. For very high illuminations it shows high non-linearity.
-- In the range of 0 lux - 1000 lux the sensor measurements are stricly linear for Gain 1/4 and 1/8, after 1000 lux it shows non-linearity.
+- In the range of 0 lux - 1000 lux the sensor measurements are strictly linear for Gain 1/4 and 1/8, after 1000 lux it shows non-linearity.
 
 A lux compensation formula is used to get better readings in bright conditions.
 However, it gives quite high error in very bright direct sunlight (instead of 100-120 kilolux it might give 150-200k+).
@@ -51,7 +51,7 @@ In automatic measurement mode the component starts from Gain 1/8 and 100 ms (_de
 
 Please note, that in low light conditions measurement process might take several seconds due to long exposure periods and sensor reconfigurations.
 
-Starting values can be overriden by setting `gain` and `integration_time` parameters. The gain value gets adjusted first if possible.
+Starting values can be overridden by setting `gain` and `integration_time` parameters. The gain value gets adjusted first if possible.
 
 ## Lux compensation
 

--- a/content/components/sensor/zio_ultrasonic.md
+++ b/content/components/sensor/zio_ultrasonic.md
@@ -28,7 +28,7 @@ sensor:
 
 ## Configuration variables
 
-- **address** (*Optional*, int): Manually specifiy the I²C address of the sensor. Defaults to `0x00`.
+- **address** (*Optional*, int): Manually specify the I²C address of the sensor. Defaults to `0x00`.
 - **update_interval** (*Optional*, [Time](/guides/configuration-types#time)): The interval to check the sensor. Defaults to `60s`.
 - All other options from [Sensor](/components/sensor).
 

--- a/content/components/sml.md
+++ b/content/components/sml.md
@@ -153,7 +153,7 @@ text_sensor:
     format: uint
 ```
 
-The `format` parameter is optional. If ommited, the SML component will try to guess the correct datatype
+The `format` parameter is optional. If omitted, the SML component will try to guess the correct datatype
 from the received SML message.
 
 And in HomeAssistant:

--- a/content/components/speaker/i2s_audio.md
+++ b/content/components/speaker/i2s_audio.md
@@ -7,7 +7,7 @@ params:
     image: i2s_audio.svg
 ---
 
-The `i2s_audio` speaker platform allows you to receive audio via the the {{< docref "/components/i2s_audio" >}}.
+The `i2s_audio` speaker platform allows you to receive audio via the {{< docref "/components/i2s_audio" >}}.
 
 This platform only works on ESP32 based chips.
 

--- a/content/components/spi.md
+++ b/content/components/spi.md
@@ -33,7 +33,7 @@ output lines. This is required only for use with certain components.
 > [!NOTE]
 >
 > - Software mode supports only single-bit SPI.
-> - Quad mode SPI is available only on on ESP32 devices (all variants).
+> - Quad mode SPI is available only on ESP32 devices (all variants).
 > - Octal mode is available only on ESP32-S3, -S2 and -P4 variants.
 
 To set up SPI devices in ESPHome, you first need to place a top-level SPI component which defines the pins to

--- a/content/components/sprinkler.md
+++ b/content/components/sprinkler.md
@@ -1144,7 +1144,7 @@ on [cppreference.com](https://en.cppreference.com/w/cpp/utility/optional), but w
 - The `optional` type can contain a value of any C++ type (`bool`, `int`, `float`, etc.) (In C++ terms, it is a
   template.)
 
-The examples that follow illustrate use of the the sprinkler controller's methods within a
+The examples that follow illustrate use of the sprinkler controller's methods within a
 {{< docref "/components/display/index" "display" >}} lambda. The examples are intended to illustrate a pattern and (for sake of
 brevity) *are not complete*; at very least you'll need to fill out the {{< docref "/components/display/index" "display" >}}
 component's specific configuration details before you can use them.

--- a/content/components/tuya.md
+++ b/content/components/tuya.md
@@ -76,7 +76,7 @@ Automations:
 
 ### `on_datapoint_update`
 
-This automation will be triggered when a a Tuya datapoint update is received.
+This automation will be triggered when a Tuya datapoint update is received.
 A variable `x` is passed to the automation for use in lambdas.
 The type of `x` variable is depending on `datapoint_type` configuration variable:
 

--- a/content/components/web_server.md
+++ b/content/components/web_server.md
@@ -158,7 +158,7 @@ captive_portal:
 
 ## Advanced usage
 
-The following assume copies of the files with local paths - which are config dependant.
+The following assume copies of the files with local paths - which are config dependent.
 
 Example `web_server` version 1 configuration with CSS and JS included from esphome-docs.
 CSS and JS URL's are set to empty value, so no internet access is needed for this device to show it's web interface.

--- a/content/cookbook/ehmtx.md
+++ b/content/cookbook/ehmtx.md
@@ -17,7 +17,7 @@ with sensors etc.
 Based a on a 8x32 RGB flexible matrix it displays a clock, the date and up to 16 other screens provided by home assistant.
 Each screen (value/text) can be associated with a 8x8 bit RGB icon or gif animation (see installation).
 The values/text can be updated or deleted from the display queue. Each screen has a lifetime, if not refreshed in its
-lifetime it will disapear.
+lifetime it will disappear.
 
 ## ESPHome Configuration
 


### PR DESCRIPTION
## Description:

Fix various typos and spelling errors throughout the documentation, including:
- "compoenent" → "component"
- "has has" → "has had"
- "acommodate" → "accommodate"
- "specifed" → "specified"
- "infared" → "infrared"
- "presense" → "presence"
- "specfied" → "specified"
- "harware" → "hardware"
- "termperature" → "temperature"
- "devide" → "divide"
- "Usefull" → "Useful"
- "writen" → "written"
- "togther" → "together"
- "sniffining" → "sniffing"
- "recieve" → "receive"
- "Noone" → "No one"
- Duplicate words like "the the" → "the"
- And many more minor corrections

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

N/A

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [x] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/static/images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/_index.md`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image dht22
```

</details>