### PR TITLE
[hub75] Add set_brightness action

### DIFF
--- a/content/components/display/hub75.md
+++ b/content/components/display/hub75.md
@@ -313,40 +313,10 @@ The three key settings for LVGL are:
 This action allows you to dynamically change the brightness of the display at runtime.
 
 ```yaml
-# Example: Control brightness with a template number
-number:
-  - platform: template
-    name: "Display Brightness"
-    id: brightness
-    icon: "mdi:brightness-6"
-    min_value: 1
-    max_value: 255
-    step: 1
-    optimistic: true
-    restore_value: true
-    initial_value: 128
-    on_value:
-      then:
-        - hub75.set_brightness:
-            id: matrix_display
-            brightness: !lambda return x;
-
-# Example: Turn display off/on by setting brightness
-switch:
-  - platform: template
-    name: "Display Power"
-    id: display_power
-    icon: "mdi:power"
-    restore_mode: RESTORE_DEFAULT_ON
-    optimistic: true
-    turn_on_action:
-      - hub75.set_brightness:
-          id: matrix_display
-          brightness: 128
-    turn_off_action:
-      - hub75.set_brightness:
-          id: matrix_display
-          brightness: 0
+on_...:
+  - hub75.set_brightness:
+      id: matrix_display
+      brightness: 128
 ```
 
 **Configuration variables:**

--- a/content/components/display/hub75.md
+++ b/content/components/display/hub75.md
@@ -352,7 +352,7 @@ switch:
 **Configuration variables:**
 
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): The ID of the HUB75 display component. Only required if you have multiple `hub75` platform displays configured.
-- **brightness** (**Required**, int, [templatable](/guides/automations#templates)): The brightness level to set (0-255). A value of 0 effectively turns off the display, while 255 is maximum brightness.
+- **brightness** (**Required**, int, [templatable](/automations/templates)): The brightness level to set (0-255). A value of 0 effectively turns off the display, while 255 is maximum brightness.
 
 ## Configuration Examples
 

--- a/content/components/display/hub75.md
+++ b/content/components/display/hub75.md
@@ -306,6 +306,54 @@ The three key settings for LVGL are:
 - `auto_clear_enabled: false` - LVGL handles clearing
 - `double_buffer: false` - LVGL manages its own buffering
 
+## Actions
+
+### `hub75.set_brightness` Action
+
+This action allows you to dynamically change the brightness of the display at runtime.
+
+```yaml
+# Example: Control brightness with a template number
+number:
+  - platform: template
+    name: "Display Brightness"
+    id: brightness
+    icon: "mdi:brightness-6"
+    min_value: 1
+    max_value: 255
+    step: 1
+    optimistic: true
+    restore_value: true
+    initial_value: 128
+    on_value:
+      then:
+        - hub75.set_brightness:
+            id: matrix_display
+            brightness: !lambda return x;
+
+# Example: Turn display off/on by setting brightness
+switch:
+  - platform: template
+    name: "Display Power"
+    id: display_power
+    icon: "mdi:power"
+    restore_mode: RESTORE_DEFAULT_ON
+    optimistic: true
+    turn_on_action:
+      - hub75.set_brightness:
+          id: matrix_display
+          brightness: 128
+    turn_off_action:
+      - hub75.set_brightness:
+          id: matrix_display
+          brightness: 0
+```
+
+**Configuration variables:**
+
+- **id** (*Optional*, [ID](/guides/configuration-types#id)): The ID of the HUB75 display component. Only required if you have multiple `hub75` platform displays configured.
+- **brightness** (**Required**, int, [templatable](/guides/automations#templates)): The brightness level to set (0-255). A value of 0 effectively turns off the display, while 255 is maximum brightness.
+
 ## Configuration Examples
 
 ### Basic Single Panel (with Board Preset)


### PR DESCRIPTION
## Description:

Add simple hub75.set_brightness action

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#12521

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/static/images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/_index.md`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image dht22
```

</details>
