### PR TITLE
[text_sensor] Adding some example datetime and date template text_sensors for display in Home Assistant

### DIFF
--- a/content/components/text_sensor/template.md
+++ b/content/components/text_sensor/template.md
@@ -109,6 +109,27 @@ text_sensor:
     update_interval: 600s
     lambda: |-
       return { ESPHOME_PROJECT_NAME };
+
+  - platform: template
+    name: "Example Datetime"
+    id: example_datetime_text_sensor
+    icon: "mdi:calendar-clock"
+    device_class: "timestamp"
+    update_interval: 5s
+    lambda: |-
+      auto t = id(example_datetime).state_as_esptime();
+      // Eventually make the timezone configurable, this doesn't handle DST
+      return t.strftime("%Y-%m-%dT%H:%M:%S-08:00");
+
+  - platform: template
+    name: "Example Date"
+    id: example_date_text_sensor
+    icon: "mdi:calendar-clock"
+    device_class: "date"
+    update_interval: 5s
+    lambda: |-
+      auto d = id(example_date).state_as_esptime();
+      return d.strftime("%Y-%m-%d");
 ```
 
 ## See Also

--- a/content/components/text_sensor/template.md
+++ b/content/components/text_sensor/template.md
@@ -137,6 +137,32 @@ text_sensor:
       return std::string(buf);
 
   - platform: template
+    name: "Example Date as Datetime"
+    id: example_date_as_datetime_text_sensor
+    icon: "mdi:calendar-clock"
+    device_class: "timestamp"
+    update_interval: 5s
+    lambda: |-
+      auto t = id(example_date).state_as_esptime();
+      // This handles getting the timezone offset as well
+      int32_t offset_sec = ESPTime::timezone_offset();  // seconds
+      char sign = offset_sec >= 0 ? '+' : '-';
+      offset_sec = abs(offset_sec);
+      int hours = offset_sec / 3600;
+      int minutes = (offset_sec % 3600) / 60;
+      char buf[40];
+      snprintf(
+        buf,
+        sizeof(buf),
+        "%s%c%02d:%02d",
+        t.strftime("%Y-%m-%dT00:00:00").c_str(),
+        sign,
+        hours,
+        minutes
+      );
+      return std::string(buf);
+
+  - platform: template
     name: "Example Date"
     id: example_date_text_sensor
     icon: "mdi:calendar"

--- a/content/components/text_sensor/template.md
+++ b/content/components/text_sensor/template.md
@@ -118,8 +118,23 @@ text_sensor:
     update_interval: 5s
     lambda: |-
       auto t = id(example_datetime).state_as_esptime();
-      // Eventually make the timezone configurable, this doesn't handle DST
-      return t.strftime("%Y-%m-%dT%H:%M:%S-08:00");
+      // This handles getting the timezone offset as well
+      int32_t offset_sec = ESPTime::timezone_offset();  // seconds
+      char sign = offset_sec >= 0 ? '+' : '-';
+      offset_sec = abs(offset_sec);
+      int hours = offset_sec / 3600;
+      int minutes = (offset_sec % 3600) / 60;
+      char buf[40];
+      snprintf(
+        buf,
+        sizeof(buf),
+        "%s%c%02d:%02d",
+        t.strftime("%Y-%m-%dT%H:%M:%S").c_str(),
+        sign,
+        hours,
+        minutes
+      );
+      return std::string(buf);
 
   - platform: template
     name: "Example Date"

--- a/content/components/text_sensor/template.md
+++ b/content/components/text_sensor/template.md
@@ -124,7 +124,7 @@ text_sensor:
   - platform: template
     name: "Example Date"
     id: example_date_text_sensor
-    icon: "mdi:calendar-clock"
+    icon: "mdi:calendar"
     device_class: "date"
     update_interval: 5s
     lambda: |-


### PR DESCRIPTION
## Description:

This allows for easy, viewable text sensors in Home Assistant that update with time since and allow for a better viewing experience.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/static/images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/_index.md`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image dht22
```

</details>
