### PR TITLE
Add example for minimum ESPHome version in YAML

### DIFF
--- a/content/components/esphome.md
+++ b/content/components/esphome.md
@@ -396,6 +396,12 @@ This allows YAML files to specify the minimum version of ESPHome required to com
 This is useful in the case of packages where a published package might use features only
 available in a newer version of ESPHome. This allows for a more friendly error message.
 
+```yaml
+# Example configuration
+esphome:
+  min_version: 2025.11.0
+```
+
 {{< anchor "esphome-area" >}}
 
 ## Area Configuration


### PR DESCRIPTION
## Description:
Added example configuration for specifying minimum ESPHome version.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/static/images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/_index.md`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image dht22
```

</details>
