### PR TITLE
Simple typo

### DIFF
--- a/content/components/packages.md
+++ b/content/components/packages.md
@@ -170,7 +170,7 @@ switch:
 
 ## Conditionally including a package
 
-You can include a package based on a condition, or choose a package dinamically by loading your package with
+You can include a package based on a condition, or choose a package dynamically by loading your package with
 `!include` into a substitution variable instead of under `packages`:
 
 ```yaml


### PR DESCRIPTION
No linked issue, it's just a simple typo of 1 character

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.