### PR TITLE
Document auto_set_reset option for MMC5603

### DIFF
--- a/content/components/sensor/mmc5603.md
+++ b/content/components/sensor/mmc5603.md
@@ -49,6 +49,10 @@ sensor:
 
 - **update_interval** (*Optional*, [Time](/guides/configuration-types#time)): The interval to check the sensor. Defaults to `60s`.
 
+- **auto_set_reset** (*Optional*, bool): enables the sensor's automatic SET/RESET feature (Auto_SR_en).
+  This greatly reduces temperature-induced drift and improves long-term stability of the magnetic field readings.
+  Defaults to `true`.
+
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID used for code generation.
 
 ## See Also

--- a/content/components/sensor/mmc5603.md
+++ b/content/components/sensor/mmc5603.md
@@ -49,7 +49,7 @@ sensor:
 
 - **update_interval** (*Optional*, [Time](/guides/configuration-types#time)): The interval to check the sensor. Defaults to `60s`.
 
-- **auto_set_reset** (*Optional*, bool): enables the sensor's automatic SET/RESET feature (Auto_SR_en).
+- **auto_set_reset** (*Optional*, bool): Enables the sensor's automatic SET/RESET feature (Auto_SR_en).
   This greatly reduces temperature-induced drift and improves long-term stability of the magnetic field readings.
   Defaults to `true`.
 

--- a/content/components/sensor/mmc5603.md
+++ b/content/components/sensor/mmc5603.md
@@ -51,6 +51,7 @@ sensor:
 
 - **auto_set_reset** (*Optional*, bool): Enables the sensor's automatic SET/RESET feature (Auto_SR_en).
   This greatly reduces temperature-induced drift and improves long-term stability of the magnetic field readings.
+  Note: auto_set_reset halves the maximum sampling rate (150Hz to 75Hz) as each read performs two measurements.
   Defaults to `true`.
 
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID used for code generation.

--- a/content/components/sensor/mmc5603.md
+++ b/content/components/sensor/mmc5603.md
@@ -51,8 +51,10 @@ sensor:
 
 - **auto_set_reset** (*Optional*, bool): Enables the sensor's automatic SET/RESET feature (Auto_SR_en).
   This greatly reduces temperature-induced drift and improves long-term stability of the magnetic field readings.
-  Note: auto_set_reset halves the maximum sampling rate (150Hz to 75Hz) as each read performs two measurements.
   Defaults to `true`.
+
+> [!NOTE]
+> Enabling `auto_set_reset` halves the maximum sampling rate (150Hz to 75Hz) as each read performs two measurements.
 
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID used for code generation.
 

--- a/content/components/sensor/mmc5603.md
+++ b/content/components/sensor/mmc5603.md
@@ -1,9 +1,9 @@
 ---
-description: "Instructions for setting up MMC5693 IMU compass sensors."
+description: "Instructions for setting up MMC5603 IMU compass sensors."
 title: "MMC5603 Magnetometer"
 params:
   seo:
-    description: Instructions for setting up MMC5693 IMU compass sensors.
+    description: Instructions for setting up MMC5603 IMU compass sensors.
     image: mmc5603.jpg
 ---
 
@@ -21,6 +21,7 @@ for this sensor to work.
 sensor:
   - platform: mmc5603
     address: 0x30
+    auto_set_reset: true
     field_strength_x:
       name: "MMC5603 Field Strength X"
     field_strength_y:


### PR DESCRIPTION
Documents adding an option to MMC5306

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#12556

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.
