### PR TITLE
Add AQI documentation to remaining PM sensors

### DIFF
--- a/content/components/sensor/gcja5.md
+++ b/content/components/sensor/gcja5.md
@@ -30,6 +30,9 @@ sensor:
       name: "Particulate Matter <2.5µm Concentration"
     pm_10_0:
       name: "Particulate Matter <10.0µm Concentration"
+    aqi:
+      name: "Air Quality Index"
+      calculation_type: AQI
 ```
 
 ## Configuration variables
@@ -60,6 +63,13 @@ sensor:
 
 - **pmc_10_0** (*Optional*): Count of particles with diameter > 10 um in 0.1 L of air (#/0.1L).
   All options from [Sensor](/components/sensor).
+
+- **aqi** (*Optional*): Air Quality Index sensor. Requires both `pm_2_5` and `pm_10_0`
+  sensors to be configured. See {{< docref "/components/sensor/pmsx003#air-quality-index" >}} for more details.
+
+  - **calculation_type** (**Required**): The AQI calculation standard to use.
+    One of: `AQI` (US EPA) or `CAQI` (European).
+  - All other options from [Sensor](/components/sensor).
 
 ## See Also
 

--- a/content/components/sensor/pm2005.md
+++ b/content/components/sensor/pm2005.md
@@ -24,6 +24,9 @@ sensor:
       name: "PM2.5"
     pm_10_0:
       name: "PM10.0"
+    aqi:
+      name: "Air Quality Index"
+      calculation_type: AQI
 ```
 
 ## Configuration variables
@@ -43,6 +46,13 @@ sensor:
 - **pm_10_0** (*Optional*): Use the concentration of particulates of size less than 10.0µm in µg per cubic meter.
 
   - All options from [Sensor](/components/sensor).
+
+- **aqi** (*Optional*): Air Quality Index sensor. Requires both `pm_2_5` and `pm_10_0`
+  sensors to be configured. See {{< docref "/components/sensor/pmsx003#air-quality-index" >}} for more details.
+
+  - **calculation_type** (**Required**): The AQI calculation standard to use.
+    One of: `AQI` (US EPA) or `CAQI` (European).
+  - All other options from [Sensor](/components/sensor).
 
 ## See Also
 

--- a/content/components/sensor/pmsa003i.md
+++ b/content/components/sensor/pmsa003i.md
@@ -38,6 +38,9 @@ sensor:
       name: "PMC >5µm"
     pmc_10_0:
       name: "PMC >10µm"
+    aqi:
+      name: "Air Quality Index"
+      calculation_type: AQI
 ```
 
 ## Configuration variables
@@ -68,6 +71,13 @@ sensor:
 
 - **pmc_10_0** (*Optional*): Count of particles with diameter > 10 um in 0.1 L of air (#/0.1L).
   All options from [Sensor](/components/sensor).
+
+- **aqi** (*Optional*): Air Quality Index sensor. Requires both `pm_2_5` and `pm_10_0`
+  sensors to be configured. See {{< docref "/components/sensor/pmsx003#air-quality-index" >}} for more details.
+
+  - **calculation_type** (**Required**): The AQI calculation standard to use.
+    One of: `AQI` (US EPA) or `CAQI` (European).
+  - All other options from [Sensor](/components/sensor).
 
 - **standard_units** (*Optional*, boolean): `True` to use standard units or `False` to use environmental units. Defaults to `True`.
 - **address** (*Optional*, int): Manually specify the I²C address of the sensor.

--- a/content/components/sensor/sds011.md
+++ b/content/components/sensor/sds011.md
@@ -30,6 +30,9 @@ sensor:
       name: "Particulate Matter <2.5µm Concentration"
     pm_10_0:
       name: "Particulate Matter <10.0µm Concentration"
+    aqi:
+      name: "Air Quality Index"
+      calculation_type: AQI
     update_interval: 5min
 ```
 
@@ -50,6 +53,13 @@ Note that `update_interval` may not be set to `never`.
 
 - **pm_10_0** (*Optional*): Use the concentration of particulates of size less than 10.0µm in µg per cubic meter.
   All options from [Sensor](/components/sensor).
+
+- **aqi** (*Optional*): Air Quality Index sensor. Requires both `pm_2_5` and `pm_10_0`
+  sensors to be configured. See {{< docref "/components/sensor/pmsx003#air-quality-index" >}} for more details.
+
+  - **calculation_type** (**Required**): The AQI calculation standard to use.
+    One of: `AQI` (US EPA) or `CAQI` (European).
+  - All other options from [Sensor](/components/sensor).
 
 - **update_interval** (*Optional*, [Time](/guides/configuration-types#time)): The interval to check the sensor in minutes.
   This affects the working period of the SDS011 sensor. Defaults to `0min`.

--- a/content/components/sensor/sen5x.md
+++ b/content/components/sensor/sen5x.md
@@ -40,6 +40,9 @@ sensor:
       name: VOC
     nox:
       name: NOX
+    aqi:
+      name: "Air Quality Index"
+      calculation_type: AQI
 ```
 
 ## Configuration variables
@@ -154,6 +157,13 @@ sensor:
   improvement of the ambient RH/T output accuracy. There is a limited set of different modes available.
   Medium and high accelerations are particularly indicated for air quality monitors which are subjected to large
   temperature changes. Low acceleration is advised for stationary devices not subject to large variations in temperature.
+
+- **aqi** (*Optional*): Air Quality Index sensor. Requires both `pm_2_5` and `pm_10_0`
+  sensors to be configured. See {{< docref "/components/sensor/pmsx003#air-quality-index" >}} for more details.
+
+  - **calculation_type** (**Required**): The AQI calculation standard to use.
+    One of: `AQI` (US EPA) or `CAQI` (European).
+  - All other options from [Sensor](/components/sensor).
 
 - **address** (*Optional*, int): Manually specify the I²C address of the sensor.
   Defaults to `0x69`.

--- a/content/components/sensor/sm300d2.md
+++ b/content/components/sensor/sm300d2.md
@@ -49,6 +49,9 @@ sensor:
       name: "SM300D2 Temperature Value"
     humidity:
       name: "SM300D2 Humidity Value"
+    aqi:
+      name: "SM300D2 Air Quality Index"
+      calculation_type: AQI
     update_interval: 60s
 ```
 
@@ -81,6 +84,13 @@ sensor:
 - **humidity** (**Required**): The information for the relative humidity sensor. Readings in %.
 
   - All options from [Sensor](/components/sensor).
+
+- **aqi** (*Optional*): Air Quality Index sensor. Requires both `pm_2_5` and `pm_10_0`
+  sensors to be configured. See {{< docref "/components/sensor/pmsx003#air-quality-index" >}} for more details.
+
+  - **calculation_type** (**Required**): The AQI calculation standard to use.
+    One of: `AQI` (US EPA) or `CAQI` (European).
+  - All other options from [Sensor](/components/sensor).
 
 - **update_interval** (*Optional*, [Time](/guides/configuration-types#time)): The interval to check the
   sensor. Defaults to `60s`.

--- a/content/components/sensor/sps30.md
+++ b/content/components/sensor/sps30.md
@@ -48,6 +48,9 @@ sensor:
     pm_size:
       name: "Typical Particle size"
       id: "pm_size"
+    aqi:
+      name: "Air Quality Index"
+      calculation_type: AQI
     address: 0x69
     update_interval: 10s
     idle_interval: 5min
@@ -94,6 +97,13 @@ sensor:
 - **pm_size** (*Optional*): Typical particle size in μm.
 
   - All options from [Sensor](/components/sensor).
+
+- **aqi** (*Optional*): Air Quality Index sensor. Requires both `pm_2_5` and `pm_10_0`
+  sensors to be configured. See {{< docref "/components/sensor/pmsx003#air-quality-index" >}} for more details.
+
+  - **calculation_type** (**Required**): The AQI calculation standard to use.
+    One of: `AQI` (US EPA) or `CAQI` (European).
+  - All other options from [Sensor](/components/sensor).
 
 - **auto_cleaning_interval** (*Optional*): The interval in seconds of the periodic fan-cleaning.
 


### PR DESCRIPTION
## Description:
Adds Air Quality Index (AQI) documentation to 7 additional particulate matter sensors, following the same pattern established in #5703 for pmsx003 and hm3301.

 Updated documentation for the following sensors to include AQI configuration:
  - pm2005
  - sen5x
  - sds011
  - sps30
  - pmsa003i
  - gcja5
  - sm300d2

  Each sensor doc now includes:
  - AQI example in the YAML configuration block
  - aqi configuration variable documentation with a link to the detailed AQI explanation in the pmsx003 docs

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#12602

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.
