### PR TITLE
Move Python 3.14 warning to top of installation guide

### DIFF
--- a/content/guides/installing_esphome.md
+++ b/content/guides/installing_esphome.md
@@ -3,9 +3,13 @@ description: "Installing ESPHome Manually"
 title: "Installing ESPHome Manually"
 ---
 
+> [!WARNING]
+> **Python 3.14 is not yet supported.** Please use Python 3.11, 3.12, or 3.13.
+> Python 3.14 introduced breaking changes that ESPHome's dependencies have not yet adapted to.
+
 ## Windows
 
-Download Python from [the official site](https://www.python.org/downloads/). Confirm that the version is at least 3.11; versions 3.14 or higher are not yet recommended.
+Download Python from [the official site](https://www.python.org/downloads/). Use Python 3.11, 3.12, or 3.13.
 
 {{< img src="python-win-installer.png"
   alt="Python installer window with arrows pointing to \"Add Python to PATH\" and \"Install Now\""


### PR DESCRIPTION
## Description:

Move the Python 3.14 compatibility warning from the Windows section to a prominent position at the top of the installation guide page. This ensures all users see the warning regardless of which platform section they read first.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** N/A

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.