### PR TITLE
Add BTHome local sensors to Xiaomi Mijia

### DIFF
--- a/content/components/sensor/xiaomi_ble.md
+++ b/content/components/sensor/xiaomi_ble.md
@@ -186,7 +186,8 @@ There are the following possibilities to operate this sensor:
 
 - "Mi Like" advertisement (dummy bindkey required)
 - "Custom" advertisement (no bindkey required)
-- "pvvx" custom advertisement (no bindkey required, only PVVX firmware)
+- "pvvx" advertisement (no bindkey required, only PVVX firmware)
+- "BTHome" advertisement (no bindkey required, PVVX firmware default)
 
 Configuration example for Xiaomi stock firmware or ATC MiThermometer firmware set to "Mi Like" advertisement:
 
@@ -203,7 +204,25 @@ sensor:
       name: "LYWSD03MMC Battery Level"
 ```
 
-Configuration example for PVVX MiThermometer firmware set to "Custom" advertisement:
+Configuration example for PVVX MiThermometer firmware set to "BTHome" advertisement:
+
+```yaml
+sensor:
+  - platform: bthome_mithermometer
+    mac_address: AA:BB:CC:DD:EE:FF
+    temperature:
+      name: "BTHome Temperature"
+    humidity:
+      name: "BTHome Humidity"
+    battery_level:
+      name: "BTHome Battery Level"
+    battery_voltage:
+      name: "BTHome Battery Voltage"
+    signal_strength:
+      name: "BTHome Signal"
+```
+
+Configuration example for PVVX MiThermometer firmware set to "pvvx" advertisement:
 
 ```yaml
 sensor:
@@ -214,9 +233,9 @@ sensor:
     humidity:
       name: "PVVX Humidity"
     battery_level:
-      name: "PVVX Battery-Level"
+      name: "PVVX Battery Level"
     battery_voltage:
-      name: "PVVX Battery-Voltage"
+      name: "PVVX Battery Voltage"
     signal_strength:
       name: "PVVX Signal"
 ```
@@ -232,12 +251,15 @@ sensor:
     humidity:
       name: "ATC Humidity"
     battery_level:
-      name: "ATC Battery-Level"
+      name: "ATC Battery Level"
     battery_voltage:
-      name: "ATC Battery-Voltage"
+      name: "ATC Battery Voltage"
     signal_strength:
       name: "ATC Signal"
 ```
+
+> [!NOTE]
+> PVVX firmare deprecated any other advertisment format other than "BTHome" stating with version 6.0.
 
 ### XMWSDJ04MMC
 

--- a/content/components/sensor/xiaomi_ble.md
+++ b/content/components/sensor/xiaomi_ble.md
@@ -259,7 +259,7 @@ sensor:
 ```
 
 > [!NOTE]
-> PVVX firmare deprecated any other advertisment format other than "BTHome" stating with version 6.0.
+> PVVX firmare deprecated any other advertisment format other than "BTHome" starting with version 6.0.
 
 ### XMWSDJ04MMC
 


### PR DESCRIPTION
PVVX MiThermometer removes other advertisement formats from firmware starting with version 6.0, only BTHome format will remain.

Just changing from `pvvx_mithermometer` or `atc_mithermometer` to `bthome_mithermometer` will get you back up and running.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#12635

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/static/images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/_index.md`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image dht22
```

</details>
