### PR TITLE
[mqtt.cover] Adds `mqtt_use_json_payload` option to `cover`.

### DIFF
--- a/content/components/cover/_index.md
+++ b/content/components/cover/_index.md
@@ -58,9 +58,9 @@ Advanced options:
 
 MQTT options:
 
-- **mqtt_state_format** (*Optional*, enum): Either `values` or `json`. When set to `json`, state changes will
-  be only published to the `state_topic` as a JSON object. When `values`, individual values are published
-  to the `state_topic`, `position_state_topic`, and `tilt_state_topic` separately. Defaults to `values`.
+- **mqtt_use_json_payload** (*Optional*, boolean): When set to `true`, state changes will
+  be published only to the `state_topic` as a JSON object. When `false`, individual values are published
+  to the `state_topic`, `position_state_topic`, and `tilt_state_topic` separately. Defaults to `false`.
 
 - **position_state_topic** (*Optional*, string): The topic to publish
   cover position changes to.

--- a/content/components/cover/_index.md
+++ b/content/components/cover/_index.md
@@ -58,6 +58,10 @@ Advanced options:
 
 MQTT options:
 
+- **mqtt_format** (*Optional*, enum): Either `values` or `json`. When set to `json`, state changes will
+  be only published to the `state_topic` as a JSON object. When `values`, individual values are published
+  to the `state_topic`, `position_state_topic`, and `tilt_state_topic` separately. Defaults to `values`.
+
 - **position_state_topic** (*Optional*, string): The topic to publish
   cover position changes to.
 

--- a/content/components/cover/_index.md
+++ b/content/components/cover/_index.md
@@ -58,7 +58,7 @@ Advanced options:
 
 MQTT options:
 
-- **mqtt_format** (*Optional*, enum): Either `values` or `json`. When set to `json`, state changes will
+- **mqtt_state_format** (*Optional*, enum): Either `values` or `json`. When set to `json`, state changes will
   be only published to the `state_topic` as a JSON object. When `values`, individual values are published
   to the `state_topic`, `position_state_topic`, and `tilt_state_topic` separately. Defaults to `values`.
 

--- a/content/components/cover/_index.md
+++ b/content/components/cover/_index.md
@@ -58,18 +58,23 @@ Advanced options:
 
 MQTT options:
 
-- **mqtt_use_json_payload** (*Optional*, boolean): When set to `true`, state changes will
-  be published only to the `state_topic` as a JSON object. When `false`, individual values are published
-  to the `state_topic`, `position_state_topic`, and `tilt_state_topic` separately. Defaults to `false`.
+- **mqtt_json_state_payload** (*Optional*, boolean): When set to `true`, state changes will
+  be published only to the `state_topic` as a single JSON object per state change. Example:
+
+  ```json
+  { "state": "open", "position": 100, "tilt": 50 }
+  ```
+
+  When `false`, individual values are published to the `state_topic`, `position_state_topic`, and `tilt_state_topic` separately. Defaults to `false`.
 
 - **position_state_topic** (*Optional*, string): The topic to publish
-  cover position changes to.
+  cover position changes to. Not valid if `mqtt_json_state_payload` is set to `true`.
 
 - **position_command_topic** (*Optional*, string): The topic to receive
   cover position commands on.
 
 - **tilt_state_topic** (*Optional*, string): The topic to publish cover
-  cover tilt state changes to.
+  cover tilt state changes to. Not valid if `mqtt_json_state_payload` is set to `true`.
 
 - **tilt_command_topic** (*Optional*, string): The topic to receive
   cover tilt commands on.


### PR DESCRIPTION
## Description:

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#12639

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.
