### PR TITLE
[bme68x_bsec2] document sensor id

### DIFF
--- a/content/components/sensor/bme68x_bsec2.md
+++ b/content/components/sensor/bme68x_bsec2.md
@@ -96,6 +96,8 @@ sensor:
 - **bme68x_bsec2_id** (_Optional_, [ID](/guides/configuration-types#id)): The ID of the `bme68x_bsec2_i2c` component sensors will refer
   to. Useful when multiple devices are present in your configuration.
 
+- **id** (_Optional_, [ID](/guides/configuration-types#id)): This id has no effect other than providing a target for package management.
+
 - **temperature** (_Optional_): Configuration for the temperature sensor.
 
   - **sample_rate** (_Optional_, string): Optional sample rate override for this sensor. Can be `LP` for low power

--- a/content/components/sensor/bme68x_bsec2.md
+++ b/content/components/sensor/bme68x_bsec2.md
@@ -96,7 +96,7 @@ sensor:
 - **bme68x_bsec2_id** (_Optional_, [ID](/guides/configuration-types#id)): The ID of the `bme68x_bsec2_i2c` component sensors will refer
   to. Useful when multiple devices are present in your configuration.
 
-- **id** (_Optional_, [ID](/guides/configuration-types#id)): This id has no effect other than providing a target for package management.
+- **id** (_Optional_, [ID](/guides/configuration-types#id)): This ID has no effect other than providing a target for package management.
 
 - **temperature** (_Optional_): Configuration for the temperature sensor.
 


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#12649

## Checklist:

  - [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/static/images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/_index.md`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image dht22
```

</details>
