### PR TITLE
Update cc1101.md

### DIFF
--- a/content/components/cc1101.md
+++ b/content/components/cc1101.md
@@ -228,7 +228,9 @@ before `begin_rx`.
 ```yaml
 cc1101:
   cs_pin: GPIOXX
-  gdo0_pin: GPIOXX
+  gdo0_pin:
+    number: GPIOXX  # Must match GDO0
+    allow_other_uses: true
 
 remote_receiver:
   pin:
@@ -272,7 +274,9 @@ and input modes, simplifying the configuration.
 ```yaml
 cc1101:
   cs_pin: GPIOXX
-  gdo0_pin: GPIOXX
+  gdo0_pin:
+    number: GPIOXX  # Must match GDO0
+    allow_other_uses: true
 
 remote_receiver:
   pin:

--- a/content/components/cc1101.md
+++ b/content/components/cc1101.md
@@ -228,9 +228,6 @@ before `begin_rx`.
 ```yaml
 cc1101:
   cs_pin: GPIOXX
-  gdo0_pin:
-    number: GPIOXX  # Must match GDO0
-    allow_other_uses: true
 
 remote_receiver:
   pin:


### PR DESCRIPTION
Must set "allow_other_uses" to true even in gdo0_pin definition when using single pin

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/static/images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/_index.md`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image dht22
```

</details>
