### PR TITLE
Fix for error detect in text sensor

### DIFF
--- a/content/components/sensor/bme68x_bsec2.md
+++ b/content/components/sensor/bme68x_bsec2.md
@@ -203,7 +203,7 @@ text_sensor:
       else if (int(id(iaq).state) >= 251 && int(id(iaq).state) <= 350) {
         return {"Severely polluted"};
       }
-      else if (int(id(iaq).state) >= 351) {
+      else if (int(id(iaq).state) >= 351 && int(id(iaq).state) <= 500) {
         return {"Extremely polluted"};
       }
       else {

--- a/content/components/sensor/bme68x_bsec2.md
+++ b/content/components/sensor/bme68x_bsec2.md
@@ -185,29 +185,22 @@ text_sensor:
   - platform: template
     name: "BME68x IAQ Classification"
     lambda: |-
-      if ( int(id(iaq).state) <= 50) {
+      if (int(id(iaq).state) <= 50) {
         return {"Excellent"};
-      }
-      else if (int(id(iaq).state) >= 51 && int(id(iaq).state) <= 100) {
+      } else if (int(id(iaq).state) >= 51 && int(id(iaq).state) <= 100) {
         return {"Good"};
-      }
-      else if (int(id(iaq).state) >= 101 && int(id(iaq).state) <= 150) {
+      } else if (int(id(iaq).state) >= 101 && int(id(iaq).state) <= 150) {
         return {"Lightly polluted"};
-      }
-      else if (int(id(iaq).state) >= 151 && int(id(iaq).state) <= 200) {
+      } else if (int(id(iaq).state) >= 151 && int(id(iaq).state) <= 200) {
         return {"Moderately polluted"};
-      }
-      else if (int(id(iaq).state) >= 201 && int(id(iaq).state) <= 250) {
+      } else if (int(id(iaq).state) >= 201 && int(id(iaq).state) <= 250) {
         return {"Heavily polluted"};
-      }
-      else if (int(id(iaq).state) >= 251 && int(id(iaq).state) <= 350) {
+      } else if (int(id(iaq).state) >= 251 && int(id(iaq).state) <= 350) {
         return {"Severely polluted"};
-      }
-      else if (int(id(iaq).state) >= 351 && int(id(iaq).state) <= 500) {
+      } else if (int(id(iaq).state) >= 351 && int(id(iaq).state) <= 500) {
         return {"Extremely polluted"};
-      }
-      else {
-        return {"error"};
+      } else {
+        return {"Error"};
       }
 ```
 


### PR DESCRIPTION
IAQ error in text sensor was never detected 
(maximal proper value is in fact 500, and value 2147483648=0x80000000 is example of an error)

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/static/images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/_index.md`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image dht22
```

</details>
