### PR TITLE
Add WSL2 performance note for Docker users

### DIFF
--- a/content/guides/getting_started_command_line.md
+++ b/content/guides/getting_started_command_line.md
@@ -54,7 +54,7 @@ services:
 > Running ESPHome in Docker on WSL2 can be significantly slower
 > (10x or more) than native Linux or a traditional VM due to filesystem performance
 > issues when accessing files on Windows drives. For better performance, store your
-> ESPHome configuration files inside the WSL2 filesystem (e.g., `~/esphome/config`)
+> ESPHome files inside the WSL2 filesystem (e.g., `~/esphome/...`)
 > rather than on a Windows mount (e.g., `/mnt/c/...`). See [Issue #12568](https://github.com/esphome/esphome/issues/12568)
 > for more details.
 

--- a/content/guides/getting_started_command_line.md
+++ b/content/guides/getting_started_command_line.md
@@ -50,6 +50,14 @@ services:
 > need to mount the volume with the `nolock` option, otherwise platformio may
 > freeze on container startup as per [platformIO-core Issue 3089](https://github.com/platformio/platformio-core/issues/3089)
 
+> [!NOTE]
+> **WSL2 Performance:** Running ESPHome in Docker on WSL2 can be significantly slower
+> (10x or more) than native Linux or a traditional VM due to filesystem performance
+> issues when accessing files on Windows drives. For better performance, store your
+> ESPHome configuration files inside the WSL2 filesystem (e.g., `~/esphome/config`)
+> rather than on a Windows mount (e.g., `/mnt/c/...`). See [Issue #12568](https://github.com/esphome/esphome/issues/12568)
+> for more details.
+
 The project provides multiple docker tags; please pick the one that suits you
 better:
 

--- a/content/guides/getting_started_command_line.md
+++ b/content/guides/getting_started_command_line.md
@@ -50,7 +50,7 @@ services:
 > need to mount the volume with the `nolock` option, otherwise platformio may
 > freeze on container startup as per [platformIO-core Issue 3089](https://github.com/platformio/platformio-core/issues/3089)
 
-> [!NOTE]
+> [!WARNING]
 > Running ESPHome in Docker on WSL2 can be significantly slower
 > (10x or more) than native Linux or a traditional VM due to filesystem performance
 > issues when accessing files on Windows drives. For better performance, store your

--- a/content/guides/getting_started_command_line.md
+++ b/content/guides/getting_started_command_line.md
@@ -51,7 +51,7 @@ services:
 > freeze on container startup as per [platformIO-core Issue 3089](https://github.com/platformio/platformio-core/issues/3089)
 
 > [!NOTE]
-> **WSL2 Performance:** Running ESPHome in Docker on WSL2 can be significantly slower
+> Running ESPHome in Docker on WSL2 can be significantly slower
 > (10x or more) than native Linux or a traditional VM due to filesystem performance
 > issues when accessing files on Windows drives. For better performance, store your
 > ESPHome configuration files inside the WSL2 filesystem (e.g., `~/esphome/config`)


### PR DESCRIPTION
## Description:

Add a note warning users about WSL2 performance issues when running ESPHome in Docker. The note recommends storing config files inside the WSL2 filesystem (e.g., `~/esphome/config`) rather than on Windows mounts (e.g., `/mnt/c/...`) for better performance.

**Related issue (if applicable):** relates to https://github.com/esphome/esphome/issues/12568

fixes https://github.com/esphome/esphome/issues/12568

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- N/A

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)