### PR TITLE
Fix typo in I²C documentation

### DIFF
--- a/content/components/i2c.md
+++ b/content/components/i2c.md
@@ -54,7 +54,7 @@ i2c:
   Defaults to `true`. Only available on ESP32.
 
 - **low_power_mode** (*Optional*, boolean): Enable the low-power (master only) I²C bus.
-  Only availible on ESP32C5, ESP32C6 and ESP32P4. Defaults to `false` unless required.
+  Only available on ESP32C5, ESP32C6 and ESP32P4. Defaults to `false` unless required.
 
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID for this I²C bus if you need multiple I²C buses.
 


### PR DESCRIPTION
Fix typo