### PR TITLE
[mhz19] Document detection_range feature

### DIFF
--- a/content/components/sensor/mhz19.md
+++ b/content/components/sensor/mhz19.md
@@ -53,6 +53,8 @@ sensor:
 
 - **warmup_time** (*Optional*, Time): The sensor has a warmup time and before that, it returns bogus readings (eg: 500ppm, 505ppm...). This setting discards readings until the warmup time happened (`NAN` is returned). The datasheet says preheating takes 1min, but empirical tests have shown it often takes more, so the 75s default should be enough to accommodate for that.
 
+- **detection_range** (*Optional*, 2000ppm, 5000ppm, 10000ppm): The CO_2 sensor can be configured to detect different ranges: 0-2000ppm, 0-5000ppm or 0-10000ppm. Sensors will come from factory with one of these values set, which can be changed with this parameter. The default is to not change the setting, so the previously set range is used.
+
 {{< img src="mhz19-pins.jpg" alt="Image" caption="Pins on the MH-Z19. Only the ones marked with a red circle need to be connected." width="80.0%" class="align-center" >}}
 
 {{< anchor "mhz19-calibrate_zero_action" >}}
@@ -115,6 +117,20 @@ switch:
       mhz19.abc_enable: my_mhz19_id
     on_turn_off:
       mhz19.abc_disable: my_mhz19_id
+```
+
+{{< anchor "mhz19-detection_range_set_action" >}}
+
+## `mhz19.detection_range_set` Action
+
+This [action](/automations/actions#all-actions) configures the detection range of the sensor with the given ID.
+
+```yaml
+on_...:
+  then:
+    - mhz19.detection_range_set:
+        id: my_mhz19_id
+        detection_range: 5000ppm
 ```
 
 ## See Also

--- a/content/components/sensor/mhz19.md
+++ b/content/components/sensor/mhz19.md
@@ -53,7 +53,7 @@ sensor:
 
 - **warmup_time** (*Optional*, Time): The sensor has a warmup time and before that, it returns bogus readings (eg: 500ppm, 505ppm...). This setting discards readings until the warmup time happened (`NAN` is returned). The datasheet says preheating takes 1min, but empirical tests have shown it often takes more, so the 75s default should be enough to accommodate for that.
 
-- **detection_range** (*Optional*, 2000ppm, 5000ppm, 10000ppm): The CO_2 sensor can be configured to detect different ranges: 0-2000ppm, 0-5000ppm or 0-10000ppm. Sensors will come from factory with one of these values set, which can be changed with this parameter. The default is to not change the setting, so the previously set range is used.
+- **detection_range** (*Optional*): The CO_2 sensor can be configured to detect different ranges: 0-2000ppm, 0-5000ppm, or 0-10000ppm. Valid values are `2000ppm`, `5000ppm`, or `10000ppm`. Sensors come from the factory with one of these ranges pre-configured, and this setting persists in the sensor's non-volatile memory. If not specified, the previously configured range is used.
 
 {{< img src="mhz19-pins.jpg" alt="Image" caption="Pins on the MH-Z19. Only the ones marked with a red circle need to be connected." width="80.0%" class="align-center" >}}
 


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/static/images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/_index.md`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image dht22
```

</details>
