### PR TITLE
Fix esp_hosted version specifier

### DIFF
--- a/content/components/update/esp32_hosted.md
+++ b/content/components/update/esp32_hosted.md
@@ -71,7 +71,7 @@ cd esp-idf
 source export.sh  # for Linux/macOS
 export.bat        # for Windows
 cd ..
-idf.py create-project-from-example "espressif/esp_hosted^2.7.0:slave"
+idf.py create-project-from-example "espressif/esp_hosted==2.7.0:slave"
 cd slave/
 idf.py set-target esp32c6
 idf.py build


### PR DESCRIPTION
## Description:

Use `==2.7.0` instead of `^2.7.0` to pin the exact esp_hosted version in the build instructions.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

N/A

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/static/images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/_index.md`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image dht22
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)