### PR TITLE
2025.12.3

### DIFF
--- a/content/changelog/2025.12.0.md
+++ b/content/changelog/2025.12.0.md
@@ -297,6 +297,16 @@ For detailed migration guides and API documentation, see the [ESPHome Developers
 
 <!-- markdownlint-disable MD013 -->
 
+## Release 2025.12.3 - December 30
+
+<details>
+<summary></summary>
+
+- [lvgl] Fix lambdas in canvas actions called from outside LVGL context [esphome#12671](https://github.com/esphome/esphome/pull/12671) by [@bdraco](https://github.com/bdraco)
+- [core] Fix incremental build failures when adding components on ESP32-Arduino [esphome#12745](https://github.com/esphome/esphome/pull/12745) by [@bdraco](https://github.com/bdraco)
+
+</details>
+
 ## Release 2025.12.2 - December 23
 
 <details>

--- a/content/guides/supporters.md
+++ b/content/guides/supporters.md
@@ -1224,6 +1224,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Thayne (@Legot)](https://github.com/Legot)
 - [lein1013 (@lein1013)](https://github.com/lein1013)
 - [Lennart (@lennart-k)](https://github.com/lennart-k)
+- [Leo Bergolth (@leo-b)](https://github.com/leo-b)
 - [Leonardo La Rocca (@leoli51)](https://github.com/leoli51)
 - [leoshusar (@leoshusar)](https://github.com/leoshusar)
 - [Leo Winter (@LeoWinterDE)](https://github.com/LeoWinterDE)
@@ -1997,6 +1998,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Stuart Parmenter (@stuartparmenter)](https://github.com/stuartparmenter)
 - [stubs12 (@stubs12)](https://github.com/stubs12)
 - [Felix Bühler (@Stunkymonkey)](https://github.com/Stunkymonkey)
+- [Steven Travers (@stvncode)](https://github.com/stvncode)
 - [Jordan Vohwinkel (@sublime93)](https://github.com/sublime93)
 - [sud33p (@sud33p)](https://github.com/sud33p)
 - [Jakub Boukal (@SukiCZ)](https://github.com/SukiCZ)
@@ -2307,4 +2309,4 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Christian Zufferey (@zuzu59)](https://github.com/zuzu59)
 - [Zynth-dev (@Zynth-dev)](https://github.com/Zynth-dev)
 
-*This page was last updated December 23, 2025.*
+*This page was last updated December 30, 2025.*

--- a/data/version.yaml
+++ b/data/version.yaml
@@ -1,2 +1,2 @@
-release: 2025.12.2
+release: 2025.12.3
 version: '2025.12'


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- typo: Update current_based.md [docs#5814](https://github.com/esphome/esphome-docs/pull/5814)
- Update cc1101.md [docs#5821](https://github.com/esphome/esphome-docs/pull/5821)
- Add WSL2 performance note for Docker users [docs#5823](https://github.com/esphome/esphome-docs/pull/5823)
- Move Python 3.14 warning to top of installation guide [docs#5812](https://github.com/esphome/esphome-docs/pull/5812)
- Fix typo in I²C documentation [docs#5824](https://github.com/esphome/esphome-docs/pull/5824)
- Fix for error detect in text sensor [docs#5822](https://github.com/esphome/esphome-docs/pull/5822)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
