### PR TITLE
add 500khz to possible data rates

### DIFF
--- a/content/components/spi.md
+++ b/content/components/spi.md
@@ -146,7 +146,7 @@ spi_device:
 ### Configuration variables
 
 - **data_rate** (*Optional*): Set the data rate of the controller. One of `80MHz`, `40MHz`, `20MHz`, `10MHz`,
-  `5MHz`, `4MHz`, `2MHz`, `1MHz` (default), `200kHz`, `75kHz` or `1kHz`. A numeric value in Hz can alternatively
+  `5MHz`, `4MHz`, `2MHz`, `1MHz` (default), `500kHz`, `200kHz`, `75kHz` or `1kHz`. A numeric value in Hz can alternatively
   be specified.
 
 - **spi_mode** (*Optional*): Set the controller mode - one of `mode0`, `mode1`, `mode2`, `mode3`. The default is `mode3`.

--- a/content/components/spi.md
+++ b/content/components/spi.md
@@ -145,9 +145,8 @@ spi_device:
 
 ### Configuration variables
 
-- **data_rate** (*Optional*): Set the data rate of the controller. One of `80MHz`, `40MHz`, `20MHz`, `10MHz`,
-  `5MHz`, `4MHz`, `2MHz`, `1MHz` (default), `500kHz`, `200kHz`, `75kHz` or `1kHz`. A numeric value in Hz can alternatively
-  be specified.
+- **data_rate** (*Optional*): Set the data rate of the controller. This may be a numeric value in Hz or a string with
+  a unit suffix, e.g. "100kHz" or "20MHz". Must be at least 1000Hz, see below for other constraints.
 
 - **spi_mode** (*Optional*): Set the controller mode - one of `mode0`, `mode1`, `mode2`, `mode3`. The default is `mode3`.
   See table below for more information
@@ -158,6 +157,19 @@ spi_device:
   `False`. Setting this to `True` will enable more than 6 devices to be connected to hardware SPI buses.
 
 - **interface** (*Optional*): Controls which hardware or software SPI implementation should be used.
+
+## Data rates
+
+Any data rate may be set that is above 1000Hz, less than the maximum available for the target platform, and can
+be achieved by division from the SPI clock source. Clock source frequencies are:
+
+| Platform | Clock Source |
+|----------|--------------|
+| ESP32    | 80MHz        |
+| ESP8266  | 40MHz        |
+| RP2040   | 62.5MHz      |
+
+The requested rate must be able to be generated from the clock source with integer division, with a 5% error allowed.
 
 ## SPI modes
 


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes [<link to issue>](https://github.com/esphome/esphome/issues/12653)

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 
https://github.com/esphome/esphome/pull/12753
- esphome/esphome#12753

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

<details>
<summary><strong>Added 500Khz as possible spoi data rate</strong></summary>


</details>
