### PR TITLE
Remove duplicate register_count for modbus_controller select

### DIFF
--- a/content/components/select/modbus_controller.md
+++ b/content/components/select/modbus_controller.md
@@ -37,7 +37,7 @@ registers.
   by `value_type`.
 
 - **skip_updates** (*Optional*, int): By default, all sensors of a modbus_controller are updated together. For data points that don't change very frequently, updates can be skipped. A value of 5 would only update this sensor range in every 6th update cycle. Note: The modbus_controller groups components by address ranges to reduce number of transactions. All components with the same starting address will be updated in one request. `skip_updates` applies for *all* components in the same range.
-- **register_count** (*Optional*, int): The number of consecutive registers this read request should span or skip in a single command. Default is 1. See [Optimizing modbus communications](/components/modbus_controller#modbus_register_count) for more details.
+
 - **force_new_range** (*Optional*, boolean): If possible sensors with sequential addresses are
   grouped together and requested in one range. Setting this to `true` enforces the start of a new
   range at that address.


### PR DESCRIPTION
## Description:

The `register_count` option for modbus_controller select was accidentally duplicated in 9e4ff6e250d8276e5a4ca84d36a69231ec5eef0f. See Line 34 directly above.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** NA

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.
