### PR TITLE
Add links to 1-wire platform documentation from the main 1-Wire documentation

### DIFF
--- a/content/components/one_wire/_index.md
+++ b/content/components/one_wire/_index.md
@@ -11,13 +11,9 @@ The `one_wire` component allows you to use supported 1-Wire devices in ESPHome.
 
 ## Platforms
 
-### GPIO
-```yaml
-# Example configuration entry
-one_wire:
-  - platform: gpio
-    pin: GPIOXX
-```
+- [**GPIO**](/components/one_wire/gpio/) Create a 1-Wire bus on a GPIO pin
+- [**DS2484**](/components/one_wire/ds2484/) An I2C-to-1-Wire bridge device
+
 ### Configuration variables:
 
 - **pin** (**Required**, [Pin](/guides/configuration-types#pin)): The pin for the 1-Wire bus

--- a/content/components/one_wire/_index.md
+++ b/content/components/one_wire/_index.md
@@ -10,6 +10,7 @@ params:
 The `one_wire` component allows you to use supported 1-Wire devices in ESPHome.
 
 ## Hardware
+
 The 1-Wire bus the devices are connected to should have an external pull-up resistor of about 4.7KΩ. A resistor of
 *about* 4.7KΩ connected between `3.3V` and the 1-Wire bus's GPIO/data pin should suffice. Values ± 1KΩ will generally
 work fine as well, provided you don't have unusually long wires.

--- a/content/components/one_wire/_index.md
+++ b/content/components/one_wire/_index.md
@@ -9,20 +9,15 @@ params:
 
 The `one_wire` component allows you to use supported 1-Wire devices in ESPHome.
 
-## Platforms
-
-- [**GPIO**](/components/one_wire/gpio/) Create a 1-Wire bus on a GPIO pin
-- [**DS2484**](/components/one_wire/ds2484/) An I2C-to-1-Wire bridge device
-
-### Configuration variables:
-
-- **pin** (**Required**, [Pin](/guides/configuration-types#pin)): The pin for the 1-Wire bus
-- **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID for this 1-Wire bus if you need multiple busses.
-
 ## Hardware
 The 1-Wire bus the devices are connected to should have an external pull-up resistor of about 4.7KΩ. A resistor of
 *about* 4.7KΩ connected between `3.3V` and the 1-Wire bus's GPIO/data pin should suffice. Values ± 1KΩ will generally
 work fine as well, provided you don't have unusually long wires.
+
+## Platforms
+
+- [**GPIO**](/components/one_wire/gpio/) Create a 1-Wire bus on a GPIO pin
+- [**DS2484**](/components/one_wire/ds2484/) An I2C-to-1-Wire bridge device
 
 ## Obtaining Sensor IDs
 

--- a/content/components/one_wire/_index.md
+++ b/content/components/one_wire/_index.md
@@ -9,11 +9,24 @@ params:
 
 The `one_wire` component allows you to use supported 1-Wire devices in ESPHome.
 
+## Platforms
+
+### GPIO
+```yaml
+# Example configuration entry
+one_wire:
+  - platform: gpio
+    pin: GPIOXX
+```
+### Configuration variables:
+
+- **pin** (**Required**, [Pin](/guides/configuration-types#pin)): The pin for the 1-Wire bus
+- **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID for this 1-Wire bus if you need multiple busses.
+
+## Hardware
 The 1-Wire bus the devices are connected to should have an external pull-up resistor of about 4.7KΩ. A resistor of
 *about* 4.7KΩ connected between `3.3V` and the 1-Wire bus's GPIO/data pin should suffice. Values ± 1KΩ will generally
 work fine as well, provided you don't have unusually long wires.
-
-## Platforms
 
 ## Obtaining Sensor IDs
 


### PR DESCRIPTION
## Description:

It seems at some point the onewire documentation was split into two components for the platforms.

The `## Platforms` header was there, but there were no links to these. This just adds that. 

This is useful as sensors such as the DS18B20 link to this page 

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.