### PR TITLE
[api] Remove deprecated password option from documentation

### DIFF
--- a/content/components/api.md
+++ b/content/components/api.md
@@ -108,8 +108,6 @@ api:
   Can be disabled by setting this to `0s`. Defaults to `15min`.
 
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID used for code generation.
-- **password** (*Optional*, **Deprecated**, string): The password to protect the API Server with. Defaults
-  to no password. It is recommended to use the `encryption` -> `key` above instead of the `password`.
 
 - **on_client_connected** (*Optional*, [Action](/automations/actions#all-actions)): An automation to perform when a client
   connects to the API. See [`on_client_connected` Trigger](#api-on_client_connected_trigger).


### PR DESCRIPTION
## Description:

Removes the deprecated `password` configuration option from the API component documentation.

Password authentication was removed in ESPHome 2026.1.0 (esphome/esphome#12819). This PR updates the documentation to reflect that change.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#12819

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.
