### PR TITLE
Update dallas_temp.md

### DIFF
--- a/content/components/sensor/dallas_temp.md
+++ b/content/components/sensor/dallas_temp.md
@@ -46,6 +46,11 @@ sensor:
 
 - All other options from [Sensor](/components/sensor).
 
+### Byte Order of the Address 
+EspHome (most recent version 2026-January) - uses reversed order of the bytes, compared to the Arduino IDE. That means, if you have an address for a sensor via the Arduino IDE that says 0x2870F5E0161301C7 - then you have to use 0xc7011316e0f57028 in EspHome. The bytes are pairwise ordered in reverse. The Arduino IDE version ends in the above example with c7 - the EspHome version the same address starts with c7. - The other pairs accordingly. The arduino IDE is LSB‑first. While EspHome is MSB‑first.
+
+If you don't have the addresses, use index instead of addresses for the first run. EspHome will print the addresses on the log at first use with index. After that, try with addresses, if you want.
+
 ### See Also
 
 - [Arduino DallasTemperature library](https://github.com/milesburton/Arduino-Temperature-Control-Library)


### PR DESCRIPTION
Added info on Arduino IDE LSB vs EspHome MSB on address IDs

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/static/images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/_index.md`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image dht22
```

</details>
