### PR TITLE
format table of `logger`, `esp32_rmt_led_strip`, `remote_transmitter`

### DIFF
--- a/content/components/light/esp32_rmt_led_strip.md
+++ b/content/components/light/esp32_rmt_led_strip.md
@@ -59,13 +59,13 @@ light:
 | ------------- | ---------------- | ---------- |
 | ESP32         | 512 symbols      | 64 symbols |
 | ESP32-C3      | 96 symbols       | 48 symbols |
-| ESP32-C5 | 96 symbols | 48 symbols |
-| ESP32-C6 | 96 symbols | 48 symbols |
-| ESP32-C61 | 96 symbols | 48 symbols |
-| ESP32-H2 | 96 symbols | 48 symbols |
-| ESP32-P4 | 192 symbols | 48 symbols |
-| ESP32-S2 | 256 symbols | 64 symbols |
-| ESP32-S3 | 192 symbols | 48 symbols |
+| ESP32-C5      | 96 symbols       | 48 symbols |
+| ESP32-C6      | 96 symbols       | 48 symbols |
+| ESP32-C61     | 96 symbols       | 48 symbols |
+| ESP32-H2      | 96 symbols       | 48 symbols |
+| ESP32-P4      | 192 symbols      | 48 symbols |
+| ESP32-S2      | 256 symbols      | 64 symbols |
+| ESP32-S3      | 192 symbols      | 48 symbols |
 
 - **use_dma** (*Optional*, boolean): Enable DMA on variants that support it. If enabled `rmt_symbols` controls
   the DMA buffer size and can be set to a large value.

--- a/content/components/logger.md
+++ b/content/components/logger.md
@@ -84,18 +84,18 @@ so if you use any other configuration you will not get log messages over the on-
 
 ### Default UART GPIO Pins
 
-|          | `UART0`        | `UART0_SWAP`   | `UART1`        | `UART2`        | `USB_CDC` | `USB_SERIAL_JTAG` |
-| -------- | -------------- | -------------- | -------------- | -------------- | --------- | ----------------- |
-| ESP8266  | TX: 1, RX: 3   | TX: 15, RX: 13 | TX: 2, RX: N/A | N/A            | N/A       | N/A               |
-| ESP32    | TX: 1, RX: 3   | N/A            | TX: 10, RX: 9  | TX: 17, RX: 16 | N/A       | N/A               |
-| ESP32-C3 | TX: 21, RX: 20 | N/A | Undefined | N/A | N/A | 18/19 |
-| ESP32-C5 | TX: 10, RX: 11 | N/A | Undefined | N/A | N/A | 13/14 |
-| ESP32-C6 | TX: 16, RX: 17 | N/A | Undefined | N/A | N/A | 12/13 |
-| ESP32-C61 | TX: 5, RX: 4 | N/A | Undefined | N/A | N/A | 12/13 |
-| ESP32-P4 | TX: 37, RX: 38 | N/A | TX: 10, RX: 11 | N/A | N/A | 24/25 |
-| ESP32-S2 | TX: 43, RX: 44 | N/A | TX: 17, RX: 18 | N/A | 19/20 | N/A |
-| ESP32-S3 | TX: 43, RX: 44 | N/A | TX: 17, RX: 18 | Undefined | 19/20 | 19/20 |
-| NRF52    | pins varies by board | N/A | pins varies by board | Undefined | D+/D- | N/A |
+| Variant   | `UART0`        | `UART0_SWAP`   | `UART1`        | `UART2`        | `USB_CDC` | `USB_SERIAL_JTAG` |
+| --------- | -------------- | -------------- | -------------- | -------------- | --------- | ----------------- |
+| ESP8266   | TX: 1, RX: 3   | TX: 15, RX: 13 | TX: 2, RX: N/A | N/A            | N/A       | N/A               |
+| ESP32     | TX: 1, RX: 3   | N/A            | TX: 10, RX: 9  | TX: 17, RX: 16 | N/A       | N/A               |
+| ESP32-C3  | TX: 21, RX: 20 | N/A            | Undefined      | N/A            | N/A       | 18/19             |
+| ESP32-C5  | TX: 10, RX: 11 | N/A            | Undefined      | N/A            | N/A       | 13/14             |
+| ESP32-C6  | TX: 16, RX: 17 | N/A            | Undefined      | N/A            | N/A       | 12/13             |
+| ESP32-C61 | TX: 5, RX: 4   | N/A            | Undefined      | N/A            | N/A       | 12/13             |
+| ESP32-P4  | TX: 37, RX: 38 | N/A            | TX: 10, RX: 11 | N/A            | N/A       | 24/25             |
+| ESP32-S2  | TX: 43, RX: 44 | N/A            | TX: 17, RX: 18 | N/A            | 19/20     | N/A               |
+| ESP32-S3  | TX: 43, RX: 44 | N/A            | TX: 17, RX: 18 | Undefined      | 19/20     | 19/20             |
+| NRF52     | pins varies by board | N/A      | pins varies by board | Undefined | D+/D-    | N/A               |
 
 *Undefined* means that the logger component cannot use this hardware UART at this time.
 
@@ -108,19 +108,19 @@ hardware interfaces for logging. Many newer boards based on ESP32 variants (such
 are using the ESP's on-board USB hardware peripheral while boards based on older processors (such as
 the original ESP32 or ESP8266) continue to use USB-to-serial bridge ICs for communication.
 
-|          | Interface |
-| -------- | --------- |
-| ESP8266  | `UART0`   |
-| ESP32    | `UART0`   |
-| ESP32-C3 | `USB_SERIAL_JTAG` |
-| ESP32-C5 | `USB_SERIAL_JTAG` |
-| ESP32-C6 | `USB_SERIAL_JTAG` |
+| Variant   | Interface         |
+| --------- | ----------------- |
+| ESP8266   | `UART0`           |
+| ESP32     | `UART0`           |
+| ESP32-C3  | `USB_SERIAL_JTAG` |
+| ESP32-C5  | `USB_SERIAL_JTAG` |
+| ESP32-C6  | `USB_SERIAL_JTAG` |
 | ESP32-C61 | `USB_SERIAL_JTAG` |
-| ESP32-P4 | `USB_SERIAL_JTAG` |
-| ESP32-S2 | `USB_CDC`         |
-| ESP32-S3 | `USB_SERIAL_JTAG` |
-| RP2040   | `USB_CDC` |
-| NRF52    | `USB_CDC` |
+| ESP32-P4  | `USB_SERIAL_JTAG` |
+| ESP32-S2  | `USB_CDC`         |
+| ESP32-S3  | `USB_SERIAL_JTAG` |
+| RP2040    | `USB_CDC`         |
+| NRF52     | `USB_CDC`         |
 
 {{< anchor "logger-log_levels" >}}
 

--- a/content/components/remote_transmitter.md
+++ b/content/components/remote_transmitter.md
@@ -49,13 +49,13 @@ remote_transmitter:
 | ------------- | ---------------- | ---------- |
 | ESP32         | 512 symbols      | 64 symbols |
 | ESP32-C3      | 96 symbols       | 48 symbols |
-| ESP32-C5 | 96 symbols | 48 symbols |
-| ESP32-C6 | 96 symbols | 48 symbols |
-| ESP32-C61 | 96 symbols | 48 symbols |
-| ESP32-H2 | 96 symbols | 48 symbols |
-| ESP32-P4 | 192 symbols | 48 symbols |
-| ESP32-S2 | 256 symbols | 64 symbols |
-| ESP32-S3 | 192 symbols | 48 symbols |
+| ESP32-C5      | 96 symbols       | 48 symbols |
+| ESP32-C6      | 96 symbols       | 48 symbols |
+| ESP32-C61     | 96 symbols       | 48 symbols |
+| ESP32-H2      | 96 symbols       | 48 symbols |
+| ESP32-P4      | 192 symbols      | 48 symbols |
+| ESP32-S2      | 256 symbols      | 64 symbols |
+| ESP32-S3      | 192 symbols      | 48 symbols |
 
 - **clock_resolution** (*Optional*, int): The clock resolution used by the RMT peripheral in Hz. Defaults to `1000000`.
 - **non_blocking** (*Optional*, boolean): If enabled, any transmit will return immediately and the RMT will run in the


### PR DESCRIPTION
## Description:

only markdown table formating and add column title

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/static/images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/_index.md`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image dht22
```

</details>
