### PR TITLE
[pmsx003] add new types

### DIFF
--- a/content/components/sensor/pmsx003.md
+++ b/content/components/sensor/pmsx003.md
@@ -11,14 +11,14 @@ The `pmsx003` sensor platform allows you to use your [Plantower](https://www.pla
 [PMS1003](https://www.plantower.com/static/upload/file/20220627/1656292073878896.pdf),
 [PMS3003](https://www.dynamoelectronics.com/descargas/PMS3003.pdf),
 [PMS5003](https://www.aqmd.gov/docs/default-source/aq-spec/resources-page/plantower-pms5003-manual_v2-3.pdf),
+PMS5003S,
+PMS5003T,
 [PMS5003ST](https://raw.githubusercontent.com/Arduinolibrary/DFRobot_SEN0233_Air_Quality_Monitor/master/PMS5003ST%20series%20data%20manua_English_V2.6%20.pdf),
 [PMS6003](https://www.laskakit.cz/user/related_files/203-pms6003.pdf),
 [PMS7003](https://download.kamami.pl/p564008-PMS7003%20series%20data%20manua_English_V2.5.pdf),
 [PMS9003M](https://evelta.com/content/datasheets/203-PMS9003M.pdf),
 [PMSA003](https://evelta.com/content/datasheets/PMSA003%20series%20data%20manual_English_V2.5.pdf),
-... laser based particulate matter sensors
-([datasheet](http://www.aqmd.gov/docs/default-source/aq-spec/resources-page/plantower-pms5003-manual_v2-3.pdf))
-sensors with ESPHome.
+laser based particulate matter sensors with ESPHome.
 
 As the communication with the PMSX003 is done using UART, you need
 to have an [UART bus](/components/uart) in your configuration with the `rx_pin` connected to the SEND/TX pin

--- a/content/components/sensor/pmsx003.md
+++ b/content/components/sensor/pmsx003.md
@@ -7,7 +7,16 @@ params:
     image: pmsx003.svg
 ---
 
-The `pmsx003` sensor platform allows you to use your Plantower PMS5003, PMS7003, ... laser based particulate matter sensors
+The `pmsx003` sensor platform allows you to use your [Plantower](https://www.plantower.com/en/products_33/)
+[PMS1003](https://www.plantower.com/static/upload/file/20220627/1656292073878896.pdf),
+[PMS3003](https://www.dynamoelectronics.com/descargas/PMS3003.pdf),
+[PMS5003](https://www.aqmd.gov/docs/default-source/aq-spec/resources-page/plantower-pms5003-manual_v2-3.pdf),
+[PMS5003ST](https://raw.githubusercontent.com/Arduinolibrary/DFRobot_SEN0233_Air_Quality_Monitor/master/PMS5003ST%20series%20data%20manua_English_V2.6%20.pdf),
+[PMS6003](https://www.laskakit.cz/user/related_files/203-pms6003.pdf),
+[PMS7003](https://download.kamami.pl/p564008-PMS7003%20series%20data%20manua_English_V2.5.pdf),
+[PMS9003M](https://evelta.com/content/datasheets/203-PMS9003M.pdf),
+[PMSA003](https://evelta.com/content/datasheets/PMSA003%20series%20data%20manual_English_V2.5.pdf),
+... laser based particulate matter sensors
 ([datasheet](http://www.aqmd.gov/docs/default-source/aq-spec/resources-page/plantower-pms5003-manual_v2-3.pdf))
 sensors with ESPHome.
 
@@ -15,13 +24,31 @@ As the communication with the PMSX003 is done using UART, you need
 to have an [UART bus](/components/uart) in your configuration with the `rx_pin` connected to the SEND/TX pin
 (may also be called the RX pin, depending on the model) of the PMS. Additionally, you need to set the baud rate to 9600.
 
-This platform supports three sensor types, which you need to specify using the `type:` configuration
-value:
+This platform supports multiple sensor types, which you need to specify using the `type:` configuration
+value.
 
-- `PMSX003` for generic PMS5003, PMS7003, ...; these sensors support `pm_1_0`, `pm_2_5` and `pm_10_0` output.
-- `PMS5003S` for PMS5003S. These support `pm_1_0`, `pm_2_5` and `pm_10_0` and `formaldehyde`.
-- `PMS5003T` for PMS5003T. These support `pm_1_0`, `pm_2_5` and `pm_10_0`, `temperature` and `humidity`.
-- `PMS5003ST` for PMS5003ST. These support `pm_2_5`, `temperature`, `humidity` and `formaldehyde`.
+| Type         | `PMS1003` | `PMS3003` | `PMSX003`                                  | `PMS5003S` | `PMS5003T` | `PMS5003ST` | `PMS9003M` |
+| ------------ | --------- | --------- | ------------------------------------------ | ---------- | ---------- | ----------- | ---------- |
+| Model        | `PMS1003` | `PMS3003` | `PMS5003`, `PMS6003`, `PMS7003`, `PMSA003` | `PMS5003S` | `PMS5003T` | `PMS5003ST` | `PMS9003M` |
+| PM1.0 STD    | ✅         | ✅         | ✅                                          | ✅          | ✅          | ✅           | ✅          |
+| PM2.5 STD    | ✅         | ✅         | ✅                                          | ✅          | ✅          | ✅           | ✅          |
+| PM10.0 STD   | ✅         | ✅         | ✅                                          | ✅          | ✅          | ✅           | ✅          |
+| PM1.0        | ✅         | ✅         | ✅                                          | ✅          | ✅          | ✅           | ✅          |
+| PM2.5        | ✅         | ✅         | ✅                                          | ✅          | ✅          | ✅           | ✅          |
+| PM10.0       | ✅         | ✅         | ✅                                          | ✅          | ✅          | ✅           | ✅          |
+| PM0.3 LoA    | ✅         | ❌         | ✅                                          | ✅          | ✅          | ✅           | ✅          |
+| PM0.5 LoA    | ✅         | ❌         | ✅                                          | ✅          | ✅          | ✅           | ✅          |
+| PM1.0 LoA    | ✅         | ❌         | ✅                                          | ✅          | ✅          | ✅           | ✅          |
+| PM2.5 LoA    | ✅         | ❌         | ✅                                          | ✅          | ✅          | ✅           | ✅          |
+| PM5.0 LoA    | ✅         | ❌         | ✅                                          | ✅          | ❌          | ✅           | ✅          |
+| PM10.0 LoA   | ✅         | ❌         | ✅                                          | ✅          | ❌          | ✅           | ✅          |
+| Formaldehyde | ❌         | ❌         | ❌                                          | ✅          | ❌          | ✅           | ❌          |
+| Temperature  | ❌         | ❌         | ❌                                          | ❌          | ✅          | ✅           | ❌          |
+| Humidity     | ❌         | ❌         | ❌                                          | ❌          | ✅          | ✅           | ❌          |
+| Version¹     | ✅         | ❌         | ❌                                          | ❌          | ❌          | ✅           | ✅          |
+| Error Code¹  | ✅         | ❌         | ❌                                          | ❌          | ❌          | ✅           | ✅          |
+
+¹ Currently not supported/provided as sensor by esphome
 
 ## Sensor Longevity
 
@@ -81,13 +108,13 @@ sensor:
 - **pm_10_0um** (*Optional*): Use the number of particles with diameter beyond 10.0um in 0.1L of air. Not supported by the `PMS5003T` type sensors.
   All options from [Sensor](/components/sensor).
 
+- **formaldehyde** (*Optional*): Use the formaldehyde (HCHO) concentration in µg per cubic meter for the `PMS5003S` and `PMS5003ST` type sensors.
+  All options from [Sensor](/components/sensor).
+
 - **temperature** (*Optional*): Use the temperature value in °C for the `PMS5003T` and `PMS5003ST` type sensors.
   All options from [Sensor](/components/sensor).
 
 - **humidity** (*Optional*): Use the humidity value in % for the `PMS5003T` and `PMS5003ST` type sensors.
-  All options from [Sensor](/components/sensor).
-
-- **formaldehyde** (*Optional*): Use the formaldehyde (HCHO) concentration in µg per cubic meter for the `PMS5003S` and `PMS5003ST` type sensors.
   All options from [Sensor](/components/sensor).
 
 - **update_interval** (*Optional*): Amount of time to wait between generating measurements. If this is longer than 30


### PR DESCRIPTION
## Description:

- add new types PMS1003, PMS3003, PMS9003M (PMS6003, PMS7003, PMSA003 already supported)
- sort sensors
- add feature table

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#13640

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/static/images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/_index.md`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image dht22
```

</details>
