### PR TITLE
[esp32] Document heap_in_iram advanced option

### DIFF
--- a/content/components/esp32.md
+++ b/content/components/esp32.md
@@ -227,6 +227,12 @@ The following options disable unused VFS features to save flash memory:
   This matches the default behavior in ESP-IDF 6.0 (see [migration guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/migration-guides/release-6.x/6.0/system.html#id1)).
   Set to `true` only if you encounter issues. Defaults to `false` (ring buffer functions in flash to save IRAM).
 
+- **heap_in_iram** (*Optional*, boolean): Keep heap functions (malloc, free, realloc, etc.) in IRAM instead of moving them
+  to flash. By default, heap functions are placed in flash to save ~4-6 KB of IRAM. This is safe because heap functions
+  should never be called from ISRs, and ESPHome's design minimizes heap churn during normal operation (allocations happen
+  primarily at setup, not in hot loops). Set to `true` only if you have a specific use case requiring faster heap operations.
+  Defaults to `false` (heap functions in flash to save IRAM).
+
 Some options can be disabled to save flash memory without affecting typical ESPHome functionality. The performance
 options (defaulting to `true`  ) improve socket operation performance but can be disabled if you need better
 multi-threaded scalability (which is uncommon since ESPHome uses an event loop).


### PR DESCRIPTION
## Description:

Add documentation for the new `heap_in_iram` advanced option in the ESP32 IDF framework configuration.

This option allows users to keep heap functions (malloc, free, realloc) in IRAM instead of the new default behavior of placing them in flash. The default (flash) saves ~4-6 KB of IRAM, which is the payoff from months of work reducing heap churn throughout the codebase.

**Related issue (if applicable):** n/a

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#12862

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.
