### PR TITLE
[ultrasonic] Remove deprecated timeout option

### DIFF
--- a/content/components/sensor/ultrasonic.md
+++ b/content/components/sensor/ultrasonic.md
@@ -17,9 +17,7 @@ sounds.
 
 This sensor platform expects a sensor that can be sent a **trigger
 pulse** on a specific pin and will send out an **echo pulse** once a
-measurement has been taken. Because sometimes (for example if no object
-is detected) the echo pulse is never returned, this sensor also has a
-timeout option which specifies how long to wait for values.
+measurement has been taken.
 
 {{< img src="ultrasonic-full.jpg" alt="Image" caption="HC-SR04 Ultrasonic Distance Sensor." width="50.0%" class="align-center" >}}
 
@@ -48,9 +46,6 @@ sensor:
 - All other options from [Sensor](/components/sensor).
 
 Advanced options:
-
-- **timeout** (*Optional*, float): The number of meters for the
-  timeout. Most sensors can only sense up to 2 meters. Defaults to 2 meters.
 
 - **pulse_time** (*Optional*, [Time](/guides/configuration-types#time)): The duration for which the trigger pin will be
   active. Defaults to `10us`.


### PR DESCRIPTION
## Description:

Remove the deprecated `timeout` option from the ultrasonic sensor documentation.

The timeout option has been deprecated in ESPHome and no longer has any effect.

**Related issue (if applicable):** fixes https://github.com/esphome/esphome/issues/11177

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#12897

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)