### PR TITLE
Add docs for component: EPaper SPI E2271KS0C1

### DIFF
--- a/content/components/display/epaper_spi.md
+++ b/content/components/display/epaper_spi.md
@@ -31,10 +31,11 @@ display:
 These are the supported controller chips. Using just the chip name as the model will require full configuration with
 pins and dimensions specified.
 
-| Chip name              | Manufacturer | Product Description                                                                                                          |
-|------------------------|--------------|------------------------------------------------------------------------------------------------------------------------------|
-| Spectra-E6             | Eink         | <https://www.eink.com/brand/detail/Spectra6>                                                                                 |
-| SSD1677                | Solomon      | <https://www.solomon-systech.com/product/ssd1677/>                                                                           |
+| Chip name              | Manufacturer        | Product Description                                                                                                          |
+|------------------------|---------------------|------------------------------------------------------------------------------------------------------------------------------|
+| Spectra-E6             | Eink                | <https://www.eink.com/brand/detail/Spectra6>                                                                                 |
+| SSD1677                | Solomon             | <https://www.solomon-systech.com/product/ssd1677/>                                                                           |
+| E2271KS0C1             | Pervasive Displays  | <https://www.pervasivedisplays.com/product/2-71-e-ink-displays>                                                              |
 
 ## Supported integrated display boards
 
@@ -78,6 +79,8 @@ but can be overridden if needed.
   use `never` to only manually update the screen via `component.update`.
 - **full_update_every** (*Optional*, int): On screens that support partial updates, this sets the number of updates
   before a full update is forced. Defaults to `1` which will make every update a full update.
+- **temperature_c** (*Optional*, float): Ambient temperature in Celsius for temperature-compensated waveforms.
+  Only used by E2271KS0C1. Defaults to `25`.
 - **spi_id** (*Optional*, [ID](/guides/configuration-types#id)): Required to specify the ID of the [SPI Component](/components/spi) if your
   configuration defines multiple SPI buses. If only a single SPI bus is configured, this is optional.
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID used for code generation.
@@ -101,6 +104,24 @@ display:
     dc_pin: GPIOXX
     reset_pin: GPIOXX
     busy_pin: { number: GPIOXX, inverted: False, mode: { input: True, pulldown: True } }
+```
+
+### E2271KS0C1 example
+
+The Pervasive Displays E2271KS0C1 is a 2.7" display (264x176 pixels) with fast partial update support.
+
+```yaml
+display:
+  - platform: epaper_spi
+    model: E2271KS0C1
+    cs_pin: GPIO10
+    dc_pin: GPIO7
+    reset_pin: GPIO5
+    busy_pin: GPIO4
+    update_interval: 60s
+    full_update_every: 10
+    lambda: |-
+      it.printf(it.get_width() / 2, it.get_height() / 2, id(font), TextAlign::CENTER, "Hello World");
 ```
 
 ## See Also


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#12918

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/static/images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/_index.md`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image dht22
```

</details>
