### PR TITLE
[web_server][captive_portal] Document compression option

### DIFF
--- a/content/components/captive_portal.md
+++ b/content/components/captive_portal.md
@@ -35,7 +35,11 @@ wifi:
 captive_portal:
 ```
 
-No configuration variables.
+## Configuration variables
+
+- **compression** (*Optional*, string): The compression algorithm used for the embedded web assets.
+  Options are `br` (Brotli) or `gzip`. Brotli provides ~24% smaller size than gzip.
+  Defaults to `br`.
 
 ## See Also
 

--- a/content/components/web_server.md
+++ b/content/components/web_server.md
@@ -68,8 +68,8 @@ web_server:
   Defaults to `false`.
 
 - **compression** (*Optional*, string): The compression algorithm used for embedded web assets when `local` is enabled.
-  Options are `br` (Brotli) or `gzip`. Brotli provides ~10-12% smaller size than gzip for web server assets.
-  Defaults to `br`.
+  Options are `br` (Brotli) or `gzip`. Brotli typically results in smaller embedded web assets than gzip, especially for
+  text-based resources, but the exact size difference depends on the assets being compressed. Defaults to `br`.
 
 - **version** (*Optional*, string): `1`, `2` or `3`. Version 1 displays as a table. Version 2 uses web components
   and has more functionality. Version 3 uses HA-Styling. Defaults to `2`.

--- a/content/components/web_server.md
+++ b/content/components/web_server.md
@@ -67,6 +67,10 @@ web_server:
 - **local** (*Optional*, boolean): Include supporting javascript locally allowing it to work without internet access.
   Defaults to `false`.
 
+- **compression** (*Optional*, string): The compression algorithm used for embedded web assets when `local` is enabled.
+  Options are `br` (Brotli) or `gzip`. Brotli provides ~10-12% smaller size than gzip for web server assets.
+  Defaults to `br`.
+
 - **version** (*Optional*, string): `1`, `2` or `3`. Version 1 displays as a table. Version 2 uses web components
   and has more functionality. Version 3 uses HA-Styling. Defaults to `2`.
 


### PR DESCRIPTION
## Description:

Documents the new `compression` configuration option for `captive_portal` and `web_server` components.

This option allows users to choose between Brotli (`br`) and gzip compression for embedded web assets. Brotli is now the default, providing ~10-24% smaller flash usage compared to gzip.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#12959

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.
