### PR TITLE
[ir_rf_proxy] New component documentation

### DIFF
--- a/content/components/_index.md
+++ b/content/components/_index.md
@@ -828,7 +828,6 @@ Components specifically for interacting with Home Assistant.
 {{< imgtable >}}
 "Binary Sensor","components/binary_sensor/homeassistant","home-assistant.svg","dark-invert"
 "Bluetooth Proxy","components/bluetooth_proxy","bluetooth.svg","dark-invert"
-"IR/RF Proxy","components/ir_rf_proxy","remote.svg","dark-invert"
 "micro Wake Word","components/micro_wake_word","voice-assistant.svg","dark-invert"
 "Number","components/number/homeassistant","home-assistant.svg","dark-invert"
 "Sensor","components/sensor/homeassistant","home-assistant.svg","dark-invert"
@@ -843,6 +842,7 @@ Used for creating infrared (IR) remote control transmitters and/or receivers.
 
 {{< imgtable >}}
 "Infrared Core","components/infrared/index","folder-open.svg","dark-invert"
+"IR/RF Proxy","components/ir_rf_proxy","remote.svg","dark-invert"
 {{< /imgtable >}}
 
 ## Light Components

--- a/content/components/_index.md
+++ b/content/components/_index.md
@@ -828,6 +828,7 @@ Components specifically for interacting with Home Assistant.
 {{< imgtable >}}
 "Binary Sensor","components/binary_sensor/homeassistant","home-assistant.svg","dark-invert"
 "Bluetooth Proxy","components/bluetooth_proxy","bluetooth.svg","dark-invert"
+"Infrared Proxy","components/infrared_proxy","remote.svg","dark-invert"
 "micro Wake Word","components/micro_wake_word","voice-assistant.svg","dark-invert"
 "Number","components/number/homeassistant","home-assistant.svg","dark-invert"
 "Sensor","components/sensor/homeassistant","home-assistant.svg","dark-invert"

--- a/content/components/_index.md
+++ b/content/components/_index.md
@@ -828,7 +828,7 @@ Components specifically for interacting with Home Assistant.
 {{< imgtable >}}
 "Binary Sensor","components/binary_sensor/homeassistant","home-assistant.svg","dark-invert"
 "Bluetooth Proxy","components/bluetooth_proxy","bluetooth.svg","dark-invert"
-"Infrared Proxy","components/infrared_proxy","remote.svg","dark-invert"
+"IR/RF Proxy","components/ir_rf_proxy","remote.svg","dark-invert"
 "micro Wake Word","components/micro_wake_word","voice-assistant.svg","dark-invert"
 "Number","components/number/homeassistant","home-assistant.svg","dark-invert"
 "Sensor","components/sensor/homeassistant","home-assistant.svg","dark-invert"

--- a/content/components/infrared/_index.md
+++ b/content/components/infrared/_index.md
@@ -90,10 +90,12 @@ Reception is non-blocking and can operate alongside other signal processing comp
 
 ## Platform Components
 
-TBD
+- [IR/RF Proxy](/components/ir_rf_proxy) - Bridges ESPHome's remote_transmitter/remote_receiver components
+  with the infrared API for runtime signal control
 
 ## See Also
 
+- [IR/RF Proxy](/components/ir_rf_proxy)
 - [Remote Transmitter](/components/remote_transmitter)
 - [Remote Receiver](/components/remote_receiver)
 - {{< apiref "infrared/infrared.h" "infrared/infrared.h" >}}

--- a/content/components/infrared/_index.md
+++ b/content/components/infrared/_index.md
@@ -95,7 +95,6 @@ Reception is non-blocking and can operate alongside other signal processing comp
 
 ## See Also
 
-- [IR/RF Proxy](/components/ir_rf_proxy)
 - [Remote Transmitter](/components/remote_transmitter)
 - [Remote Receiver](/components/remote_receiver)
 - {{< apiref "infrared/infrared.h" "infrared/infrared.h" >}}

--- a/content/components/infrared_proxy.md
+++ b/content/components/infrared_proxy.md
@@ -1,0 +1,112 @@
+---
+description: "Instructions for setting up the Infrared Proxy in ESPHome."
+title: "Infrared Proxy"
+params:
+  seo:
+    description: Instructions for setting up the Infrared Proxy in ESPHome.
+    image: infrared.svg
+---
+
+ESPHome's infrared proxy component works with Home Assistant to expand its remote control capabilities. This component
+provides a unified API-accessible interface for transmitting and receiving infrared and RF signals, acting as a bridge
+between Home Assistant (or other API clients) and ESPHome's existing [remote_receiver](/components/remote_receiver) and
+[remote_transmitter](/components/remote_transmitter) components. Note that at least one of these components is required
+in your device's configuration if you wish to use the infrared proxy component.
+
+The infrared proxy enables runtime signal transmission without recompiling and/or reinstalling (flashing) firmware,
+making it ideal for learning and replaying IR/RF commands, creating universal remote controls, and integrating with
+Home Assistant's remote control features.
+
+```yaml
+# Example configuration entry
+infrared_proxy:
+  # IR transmitter instance
+  - id: living_room_ir
+    name: Living Room IR Transmitter
+    remote_transmitter_id: ir_tx
+
+  # IR receiver instance
+  - id: ir_learner
+    name: IR Receiver
+    remote_receiver_id: ir_rx
+```
+
+### Configuration variables
+
+- **id** (**Required**, [ID](/guides/configuration-types#id)): Unique identifier for the infrared proxy instance.
+- **name** (*Optional*, string): The name of the infrared proxy instance.
+- **remote_transmitter_id** (*Optional*, [ID](/guides/configuration-types#id)): The ID of the
+  [remote_transmitter](/components/remote_transmitter) component to use for sending signals. Exactly one of
+  `remote_transmitter_id` or `remote_receiver_id` must be specified.
+- **remote_receiver_id** (*Optional*, [ID](/guides/configuration-types#id)): The ID of the
+  [remote_receiver](/components/remote_receiver) component to use for receiving signals. Exactly one of
+  `remote_transmitter_id` or `remote_receiver_id` must be specified.
+- **frequency** (*Optional*, int): The operating frequency in Hz. Set to a non-zero value for RF hardware. Defaults to
+  `0` (infrared). This value is used to distinguish between IR and RF hardware types and is passed to Home Assistant,
+  allowing it to identify integrations this infrared proxy instance can potentially support.
+- **icon** (*Optional*, icon): Manually set the icon for this entity.
+- **entity_category** (*Optional*, string): The category of the entity. See
+  <https://developers.home-assistant.io/docs/core/entity/#registry-properties> for a list of available options.
+- **disabled_by_default** (*Optional*, boolean): If the entity should be disabled by default. Defaults to `false`.
+
+> [!NOTE]
+> When configuring a transmitter for infrared (`frequency: 0` or not set), ensure the linked `remote_transmitter` has
+> `carrier_duty_percent` set to an appropriate value, typically 30-50%. This is required for proper infrared
+> transmission. If `carrier_duty_percent` is set to 0% or 100% and `frequency` is not set or is set to zero, a
+> validation error will occur.
+
+## How It Works
+
+The infrared proxy component creates API-accessible entities that can be controlled from Home Assistant or other API
+clients. Each instance can be configured as either a transmitter or receiver by specifying the appropriate hardware
+component ID.
+
+### Transmitting Signals
+
+The infrared proxy transmits signals using raw timings, which provides full remote control over the exact waveform sent
+to the hardware. When configured with a `remote_transmitter_id`, the component can transmit IR/RF signals by accepting
+an [array of microsecond timing values](/components/remote_transmitter#remote_transmittertransmit_raw-action)
+representing alternating mark (LED on) and space (LED off) periods.
+
+**Transmission parameters:**
+
+- **Raw timings array**: Alternating mark/space durations in microseconds (just as the
+  [remote_transmitter.transmit_raw](/components/remote_transmitter#remote_transmittertransmit_raw-action) action uses)
+- **Carrier frequency**: Optional carrier frequency in Hz (0 = no carrier modulation, typical for RF)
+- **Repeat count**: Number of times to transmit the signal (defaults to 1)
+
+The raw timings format allows for maximum flexibility and can support more or less any protocol, whether implemented in
+ESPHome or not. Home Assistant integrations can encode protocol-specific commands into raw timings and transmit them
+through the infrared proxy component.
+
+### Receiving Signals
+
+When configured with a `remote_receiver_id`, the infrared proxy captures raw IR/RF timings and sends them to API
+clients for decoding or analysis. This enables:
+
+- Learning IR/RF commands from existing remotes
+- Analyzing unknown protocols
+- Creating universal remote controls
+
+Reception is non-blocking, allowing other listeners to also process signals simultaneously.
+
+## Hardware Support
+
+The infrared proxy can work with both infrared and RF hardware:
+
+- **Infrared**: Do not set `frequency` (or set `frequency: 0`, which is the default) and use standard IR LEDs/receivers
+- **RF**: Set `frequency` to match your RF hardware (for example, `315000000` for 315 MHz or `433920000` for 433.92 MHz)
+
+You can create separate instances for different purposes:
+
+- Transmit-only (specify only `remote_transmitter_id`)
+- Receive-only (specify only `remote_receiver_id`)
+- Multiple instances of any of the above for different hardware or frequencies. For example, a single ESPHome device
+  could have multiple transmitter LEDs, each in a different room/cabinet.
+
+## See Also
+
+- [Remote Transmitter](/components/remote_transmitter)
+- [Remote Receiver](/components/remote_receiver)
+- {{< apiref "infrared_proxy/infrared_proxy.h" "infrared_proxy/infrared_proxy.h" >}}
+- [Home Assistant Remote Integration](https://www.home-assistant.io/integrations/remote/)

--- a/content/components/ir_rf_proxy.md
+++ b/content/components/ir_rf_proxy.md
@@ -50,7 +50,7 @@ infrared:
   hardware types and is passed to Home Assistant, allowing it to identify integrations this IR/RF proxy instance can
   potentially support.
 
-  All other configuration variables from [infrared](/components/infrared/index).
+  All other configuration variables from [infrared](/components/infrared).
 
 > [!NOTE]
 > When configuring a transmitter for infrared (`frequency: 0` or not set), ensure the linked `remote_transmitter` has

--- a/content/components/ir_rf_proxy.md
+++ b/content/components/ir_rf_proxy.md
@@ -39,8 +39,6 @@ infrared:
 
 ### Configuration variables
 
-- **id** (**Required**, [ID](/guides/configuration-types#id)): Unique identifier for the IR/RF proxy instance.
-- **name** (*Optional*, string): The name of the IR/RF proxy instance.
 - **remote_transmitter_id** (*Optional*, [ID](/guides/configuration-types#id)): The ID of the
   [remote_transmitter](/components/remote_transmitter) component to use for sending signals. Exactly one of
   `remote_transmitter_id` or `remote_receiver_id` must be specified.
@@ -51,10 +49,8 @@ infrared:
   a non-zero value for RF hardware. Defaults to `0` (infrared). This value is used to distinguish between IR and RF
   hardware types and is passed to Home Assistant, allowing it to identify integrations this IR/RF proxy instance can
   potentially support.
-- **icon** (*Optional*, icon): Manually set the icon for this entity.
-- **entity_category** (*Optional*, string): The category of the entity. See
-  <https://developers.home-assistant.io/docs/core/entity/#registry-properties> for a list of available options.
-- **disabled_by_default** (*Optional*, boolean): If the entity should be disabled by default. Defaults to `false`.
+
+  All other configuration variables from [infrared](/components/infrared/index).
 
 > [!NOTE]
 > When configuring a transmitter for infrared (`frequency: 0` or not set), ensure the linked `remote_transmitter` has
@@ -116,4 +112,3 @@ You can create separate instances for different purposes:
 - [Remote Transmitter](/components/remote_transmitter)
 - [Remote Receiver](/components/remote_receiver)
 - {{< apiref "ir_rf_proxy/ir_rf_proxy.h" "ir_rf_proxy/ir_rf_proxy.h" >}}
-- [Home Assistant Remote Integration](https://www.home-assistant.io/integrations/remote/)

--- a/content/components/ir_rf_proxy.md
+++ b/content/components/ir_rf_proxy.md
@@ -8,7 +8,9 @@ params:
 ---
 
 > [!IMPORTANT]
-> This component/platform is under active development; it may change in any number of ways.
+> This component is EXPERIMENTAL. The API may change at any time
+> without following the normal breaking changes policy. Use at your own risk.
+> Once the API is considered stable, this warning will be removed.
 
 ESPHome's IR/RF proxy component works with Home Assistant to expand its remote control capabilities. This component
 provides a unified API-accessible interface for transmitting and receiving infrared and RF signals, acting as a bridge

--- a/content/components/ir_rf_proxy.md
+++ b/content/components/ir_rf_proxy.md
@@ -7,6 +7,9 @@ params:
     image: infrared.svg
 ---
 
+> [!IMPORTANT]
+> This component/platform is under active development; it may change in any number of ways.
+
 ESPHome's IR/RF proxy component works with Home Assistant to expand its remote control capabilities. This component
 provides a unified API-accessible interface for transmitting and receiving infrared and RF signals, acting as a bridge
 between Home Assistant (or other API clients) and ESPHome's existing [remote_receiver](/components/remote_receiver) and
@@ -19,15 +22,16 @@ Home Assistant's remote control features.
 
 ```yaml
 # Example configuration entry
-ir_rf_proxy:
+infrared:
   # IR transmitter instance
-  - id: living_room_ir
-    name: Living Room IR Transmitter
+  - platform: ir_rf_proxy
+    name: IR Proxy Transmitter
+    id: ir_proxy_tx
     remote_transmitter_id: ir_tx
-
   # IR receiver instance
-  - id: ir_learner
-    name: IR Receiver
+  - platform: ir_rf_proxy
+    name: IR Proxy Receiver
+    id: ir_proxy_rx
     remote_receiver_id: ir_rx
 ```
 
@@ -41,9 +45,10 @@ ir_rf_proxy:
 - **remote_receiver_id** (*Optional*, [ID](/guides/configuration-types#id)): The ID of the
   [remote_receiver](/components/remote_receiver) component to use for receiving signals. Exactly one of
   `remote_transmitter_id` or `remote_receiver_id` must be specified.
-- **frequency** (*Optional*, int): The operating frequency in Hz. Set to a non-zero value for RF hardware. Defaults to
-  `0` (infrared). This value is used to distinguish between IR and RF hardware types and is passed to Home Assistant,
-  allowing it to identify integrations this IR/RF proxy instance can potentially support.
+- **frequency** (*Optional*, frequency): The operating frequency (for example, `433 MHz`, `315 MHz`, `900 MHz`). Set to
+  a non-zero value for RF hardware. Defaults to `0` (infrared). This value is used to distinguish between IR and RF
+  hardware types and is passed to Home Assistant, allowing it to identify integrations this IR/RF proxy instance can
+  potentially support.
 - **icon** (*Optional*, icon): Manually set the icon for this entity.
 - **entity_category** (*Optional*, string): The category of the entity. See
   <https://developers.home-assistant.io/docs/core/entity/#registry-properties> for a list of available options.
@@ -95,7 +100,7 @@ Reception is non-blocking, allowing other listeners to also process signals simu
 The IR/RF proxy can work with both infrared and RF hardware:
 
 - **Infrared**: Do not set `frequency` (or set `frequency: 0`, which is the default) and use standard IR LEDs/receivers
-- **RF**: Set `frequency` to match your RF hardware (for example, `315000000` for 315 MHz or `433920000` for 433.92 MHz)
+- **RF**: Set `frequency` to match your RF hardware (for example, `315 MHz` for 315 MHz or `433 MHz` for 433.92 MHz)
 
 You can create separate instances for different purposes:
 

--- a/content/components/ir_rf_proxy.md
+++ b/content/components/ir_rf_proxy.md
@@ -1,25 +1,25 @@
 ---
-description: "Instructions for setting up the Infrared Proxy in ESPHome."
-title: "Infrared Proxy"
+description: "Instructions for setting up the IR/RF Proxy in ESPHome."
+title: "IR/RF Proxy"
 params:
   seo:
-    description: Instructions for setting up the Infrared Proxy in ESPHome.
+    description: Instructions for setting up the IR/RF Proxy in ESPHome.
     image: infrared.svg
 ---
 
-ESPHome's infrared proxy component works with Home Assistant to expand its remote control capabilities. This component
+ESPHome's IR/RF proxy component works with Home Assistant to expand its remote control capabilities. This component
 provides a unified API-accessible interface for transmitting and receiving infrared and RF signals, acting as a bridge
 between Home Assistant (or other API clients) and ESPHome's existing [remote_receiver](/components/remote_receiver) and
 [remote_transmitter](/components/remote_transmitter) components. Note that at least one of these components is required
-in your device's configuration if you wish to use the infrared proxy component.
+in your device's configuration if you wish to use the IR/RF proxy component.
 
-The infrared proxy enables runtime signal transmission without recompiling and/or reinstalling (flashing) firmware,
+The IR/RF proxy enables runtime signal transmission without recompiling and/or reinstalling (flashing) firmware,
 making it ideal for learning and replaying IR/RF commands, creating universal remote controls, and integrating with
 Home Assistant's remote control features.
 
 ```yaml
 # Example configuration entry
-infrared_proxy:
+ir_rf_proxy:
   # IR transmitter instance
   - id: living_room_ir
     name: Living Room IR Transmitter
@@ -33,8 +33,8 @@ infrared_proxy:
 
 ### Configuration variables
 
-- **id** (**Required**, [ID](/guides/configuration-types#id)): Unique identifier for the infrared proxy instance.
-- **name** (*Optional*, string): The name of the infrared proxy instance.
+- **id** (**Required**, [ID](/guides/configuration-types#id)): Unique identifier for the IR/RF proxy instance.
+- **name** (*Optional*, string): The name of the IR/RF proxy instance.
 - **remote_transmitter_id** (*Optional*, [ID](/guides/configuration-types#id)): The ID of the
   [remote_transmitter](/components/remote_transmitter) component to use for sending signals. Exactly one of
   `remote_transmitter_id` or `remote_receiver_id` must be specified.
@@ -43,7 +43,7 @@ infrared_proxy:
   `remote_transmitter_id` or `remote_receiver_id` must be specified.
 - **frequency** (*Optional*, int): The operating frequency in Hz. Set to a non-zero value for RF hardware. Defaults to
   `0` (infrared). This value is used to distinguish between IR and RF hardware types and is passed to Home Assistant,
-  allowing it to identify integrations this infrared proxy instance can potentially support.
+  allowing it to identify integrations this IR/RF proxy instance can potentially support.
 - **icon** (*Optional*, icon): Manually set the icon for this entity.
 - **entity_category** (*Optional*, string): The category of the entity. See
   <https://developers.home-assistant.io/docs/core/entity/#registry-properties> for a list of available options.
@@ -57,13 +57,13 @@ infrared_proxy:
 
 ## How It Works
 
-The infrared proxy component creates API-accessible entities that can be controlled from Home Assistant or other API
+The IR/RF proxy component creates API-accessible entities that can be controlled from Home Assistant or other API
 clients. Each instance can be configured as either a transmitter or receiver by specifying the appropriate hardware
 component ID.
 
 ### Transmitting Signals
 
-The infrared proxy transmits signals using raw timings, which provides full remote control over the exact waveform sent
+The IR/RF proxy transmits signals using raw timings, which provides full remote control over the exact waveform sent
 to the hardware. When configured with a `remote_transmitter_id`, the component can transmit IR/RF signals by accepting
 an [array of microsecond timing values](/components/remote_transmitter#remote_transmittertransmit_raw-action)
 representing alternating mark (LED on) and space (LED off) periods.
@@ -77,12 +77,12 @@ representing alternating mark (LED on) and space (LED off) periods.
 
 The raw timings format allows for maximum flexibility and can support more or less any protocol, whether implemented in
 ESPHome or not. Home Assistant integrations can encode protocol-specific commands into raw timings and transmit them
-through the infrared proxy component.
+through the IR/RF proxy component.
 
 ### Receiving Signals
 
-When configured with a `remote_receiver_id`, the infrared proxy captures raw IR/RF timings and sends them to API
-clients for decoding or analysis. This enables:
+When configured with a `remote_receiver_id`, the IR/RF proxy captures raw timings and sends them to API clients for
+decoding or analysis. This enables:
 
 - Learning IR/RF commands from existing remotes
 - Analyzing unknown protocols
@@ -92,7 +92,7 @@ Reception is non-blocking, allowing other listeners to also process signals simu
 
 ## Hardware Support
 
-The infrared proxy can work with both infrared and RF hardware:
+The IR/RF proxy can work with both infrared and RF hardware:
 
 - **Infrared**: Do not set `frequency` (or set `frequency: 0`, which is the default) and use standard IR LEDs/receivers
 - **RF**: Set `frequency` to match your RF hardware (for example, `315000000` for 315 MHz or `433920000` for 433.92 MHz)
@@ -108,5 +108,5 @@ You can create separate instances for different purposes:
 
 - [Remote Transmitter](/components/remote_transmitter)
 - [Remote Receiver](/components/remote_receiver)
-- {{< apiref "infrared_proxy/infrared_proxy.h" "infrared_proxy/infrared_proxy.h" >}}
+- {{< apiref "ir_rf_proxy/ir_rf_proxy.h" "ir_rf_proxy/ir_rf_proxy.h" >}}
 - [Home Assistant Remote Integration](https://www.home-assistant.io/integrations/remote/)

--- a/content/components/ir_rf_proxy.md
+++ b/content/components/ir_rf_proxy.md
@@ -37,7 +37,7 @@ infrared:
     remote_receiver_id: ir_rx
 ```
 
-### Configuration variables
+## Configuration variables
 
 - **id** (**Required**, [ID](/guides/configuration-types#id)): Unique identifier for the IR/RF proxy instance.
 - **name** (*Optional*, string): The name of the IR/RF proxy instance.


### PR DESCRIPTION
## Description:

SSIA

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#12985

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [x] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/static/images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/_index.md`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image dht22
```

</details>
