### PR TITLE
[cc1101] Document freq_offset trigger variable

### DIFF
--- a/content/components/cc1101.md
+++ b/content/components/cc1101.md
@@ -126,9 +126,13 @@ See the [CC1101 Datasheet](https://www.ti.com/lit/ds/symlink/cc1101.pdf) for det
 ### `on_packet` Trigger
 
 In packet mode, this trigger fires when a packet has been received. A variable `x` of type
-`std::vector<uint8_t>` containing the packet data is passed to the automation. The variables
-`rssi` (signal strength in dBm) and `lqi` (link quality indicator, 0-127, lower is better)
-are also available.
+`std::vector<uint8_t>` containing the packet data is passed to the automation. The following
+variables are also available:
+
+- `freq_offset`: Frequency offset estimate in Hz from the FREQEST register. This indicates how far
+  the received signal's frequency deviated from the configured carrier frequency.
+- `rssi`: Signal strength in dBm.
+- `lqi`: Link quality indicator (0-127, lower is better).
 
 ```yaml
 cc1101:
@@ -142,7 +146,8 @@ cc1101:
   on_packet:
     then:
       - lambda: |-
-          ESP_LOGD("cc1101", "packet %s rssi %.1f dBm lqi %u", format_hex(x).c_str(), rssi, lqi);
+          ESP_LOGD("cc1101", "packet %s freq_offset %.0f Hz rssi %.1f dBm lqi %u",
+                   format_hex(x).c_str(), freq_offset, rssi, lqi);
 ```
 
 ## Actions

--- a/content/components/cc1101.md
+++ b/content/components/cc1101.md
@@ -129,8 +129,7 @@ In packet mode, this trigger fires when a packet has been received. A variable `
 `std::vector<uint8_t>` containing the packet data is passed to the automation. The following
 variables are also available:
 
-- `freq_offset`: Frequency offset estimate in Hz from the FREQEST register. This indicates how far
-  the received signal's frequency deviated from the configured carrier frequency.
+- `freq_offset`: Frequency offset estimate in Hz.
 - `rssi`: Signal strength in dBm.
 - `lqi`: Link quality indicator (0-127, lower is better).
 


### PR DESCRIPTION
## Description:

Documents the new `freq_offset` variable available in the `on_packet` trigger for the CC1101 component. This variable provides the frequency offset estimate in Hz from the FREQEST register, indicating how far the received signal's frequency deviated from the configured carrier frequency.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#13008

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/static/images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/_index.md`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image dht22
```

</details>