### PR TITLE
Fan preset mode changes introduced in 2025.11

### DIFF
--- a/content/components/fan/_index.md
+++ b/content/components/fan/_index.md
@@ -351,18 +351,7 @@ advanced stuff (see the full API Reference for more info).
     }
 ```
 
-- `preset_mode`  : Retrieve the current preset mode of the fan.
-
-```yaml
-    // Within lambda, get the fan preset mode and conditionally do something
-    if (id(my_fan).preset_mode == "auto") {
-      // Fan preset mode is "auto", do something here
-    } else {
-      // Fan preset mode is not "auto", do something else here
-    }
-```
-
-- `turn_off()`  /`turn_on()`  /`toggle()`  : Manually turn the fan ON/OFF from code.
+- `turn_off()` / `turn_on()` / `toggle()`  : Manually turn the fan ON/OFF from code.
   Similar to the `fan.turn_on`, `fan.turn_off`, and `fan.toggle` actions,
   but can be used in complex lambda expressions.
 
@@ -378,16 +367,29 @@ advanced stuff (see the full API Reference for more info).
     call.set_direction(FanDirection::REVERSE);
     call.perform();
 
-    // Set a preset mode
-    auto call = id(my_fan).turn_on();
-    call.set_preset_mode("auto");
-    call.perform();
-
     // Toggle the fan on/off
     auto call = id(my_fan).toggle();
     call.perform();
 ```
 
-## Full Fan Index
+- `get_preset_mode()` / `set_preset_mode()` / `has_preset_mode()`  : Retrieve or set the preset mode of the fan.
 
-- {{< apiref "fan/fan_state.h" "fan/fan_state.h" >}}
+```yaml
+    // Within lambda, get the fan preset mode and conditionally do something.
+    // get_preset_mode() will return a null pointer when a value is not set,
+    // so check has_preset_mode() before using where a string is expected.
+    if (id(my_fan).has_preset_mode() && strcmp(id(my_fan).get_preset_mode(), "auto") == 0) {
+      // Fan preset mode is "auto", do something here.
+    } else {
+      // Fan preset mode is not set, or is not "auto". Do something else here.
+    }
+
+    // Turn the fan on and set a preset mode
+    auto call = id(my_fan).turn_on();
+    call.set_preset_mode("auto");
+    call.perform();
+```
+
+## See Also
+
+- {{< apiref "fan/fan.h" "fan/fan.h" >}}


### PR DESCRIPTION
## Description:
2025.11 changed the `preset_mode` property to has/get/set methods.  

`get_preset_mode()` now returns a null pointer when a value is not set, instead of the previous property being an empty string, which is worth noting in the documentation.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#11632

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/static/images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/_index.md`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image dht22
```

</details>
