### PR TITLE
Remove mention of ac_dimmer as not compatible with esp-idf

### DIFF
--- a/content/guides/esp32_arduino_to_idf.md
+++ b/content/guides/esp32_arduino_to_idf.md
@@ -117,7 +117,6 @@ when available:
 
 The following components currently require Arduino framework and don't have ESP-IDF alternatives or native ESP-IDF support yet:
 
-- {{< docref "/components/output/ac_dimmer" "ac_dimmer" >}} - AC dimmer control
 - {{< docref "/components/climate/climate_ir" "heatpumpir" >}} - IR-based heat pump control
 - {{< docref "/components/climate/midea" "midea" >}} - Midea air conditioner control
 - {{< docref "/components/light/index" "WLED Effect" >}} - WLED UDP Realtime Control integration


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes https://github.com/esphome/backlog/issues/55

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#7072

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

