### PR TITLE
2025.12.5

### DIFF
--- a/content/changelog/2025.12.0.md
+++ b/content/changelog/2025.12.0.md
@@ -297,6 +297,19 @@ For detailed migration guides and API documentation, see the [ESPHome Developers
 
 <!-- markdownlint-disable MD013 -->
 
+## Release 2025.12.5 - January 6
+
+<details>
+<summary></summary>
+
+- [lvgl] Fix arc background angles [esphome#12773](https://github.com/esphome/esphome/pull/12773) by [@clydebarrow](https://github.com/clydebarrow)
+- [sn74hc595]: fix 'Attempted read from write-only channel' when using esp-idf framework [esphome#12801](https://github.com/esphome/esphome/pull/12801) by [@aanikei](https://github.com/aanikei)
+- [wts01] Fix negative values for WTS01 sensor [esphome#12835](https://github.com/esphome/esphome/pull/12835) by [@cnrd](https://github.com/cnrd)
+- [esp32_ble] Remove requirement for configured network [esphome#12891](https://github.com/esphome/esphome/pull/12891) by [@clydebarrow](https://github.com/clydebarrow)
+- [cc1101] Add PLL lock verification and retry support [esphome#13006](https://github.com/esphome/esphome/pull/13006) by [@swoboda1337](https://github.com/swoboda1337)
+
+</details>
+
 ## Release 2025.12.4 - December 31
 
 <details>

--- a/content/guides/supporters.md
+++ b/content/guides/supporters.md
@@ -788,6 +788,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Ian Reinhart Geiser (@geiseri)](https://github.com/geiseri)
 - [GelidusResearch (@GelidusResearch)](https://github.com/GelidusResearch)
 - [Gene Hand (@genehand)](https://github.com/genehand)
+- [generalmat82 (@generalmat82)](https://github.com/generalmat82)
 - [R Huish (@genestealer)](https://github.com/genestealer)
 - [Geoff Davis (@geoffdavis)](https://github.com/geoffdavis)
 - [Geoffrey Van Landeghem (@geoffrey-vl)](https://github.com/geoffrey-vl)
@@ -1125,6 +1126,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Kamahat (@kamahat)](https://github.com/kamahat)
 - [Kapil Yedidi (@kapily)](https://github.com/kapily)
 - [Karl0ss (@karl0ss)](https://github.com/karl0ss)
+- [Karlie Meads (@karliemeads)](https://github.com/karliemeads)
 - [Karol Zlot (@karolzlot)](https://github.com/karolzlot)
 - [kartman85 (@kartman85)](https://github.com/kartman85)
 - [Kattni (@kattni)](https://github.com/kattni)
@@ -2244,6 +2246,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Rick van Hattem (@WoLpH)](https://github.com/WoLpH)
 - [Rick van Hattem (@wolph)](https://github.com/wolph)
 - [workingmanrob (@workingmanrob)](https://github.com/workingmanrob)
+- [Peter Zsak (@wroadd)](https://github.com/wroadd)
 - [Dawid Wróbel (@wrobelda)](https://github.com/wrobelda)
 - [Sven Serlier (@wrt54g)](https://github.com/wrt54g)
 - [Wojtek Strzalka (@wstrzalka)](https://github.com/wstrzalka)
@@ -2309,4 +2312,4 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Christian Zufferey (@zuzu59)](https://github.com/zuzu59)
 - [Zynth-dev (@Zynth-dev)](https://github.com/Zynth-dev)
 
-*This page was last updated December 31, 2025.*
+*This page was last updated January 6, 2026.*

--- a/data/version.yaml
+++ b/data/version.yaml
@@ -1,2 +1,2 @@
-release: 2025.12.4
+release: 2025.12.5
 version: '2025.12'


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- Update URLs in projects [docs#5842](https://github.com/esphome/esphome-docs/pull/5842)
- Fix esp_hosted version specifier [docs#5831](https://github.com/esphome/esphome-docs/pull/5831)
- Add links to 1-wire platform documentation from the main 1-Wire documentation [docs#5845](https://github.com/esphome/esphome-docs/pull/5845)
- format table of `logger`, `esp32_rmt_led_strip`, `remote_transmitter` [docs#5848](https://github.com/esphome/esphome-docs/pull/5848)
- [faq] Improve "Which ESP should I use" recommendations [docs#5860](https://github.com/esphome/esphome-docs/pull/5860)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
