### PR TITLE
[logger] Update task_log_buffer_size to include LibreTiny support

### DIFF
--- a/content/components/logger.md
+++ b/content/components/logger.md
@@ -47,7 +47,7 @@ Advanced settings:
    for log messages. Decrease this if you're having memory problems.
    Defaults to `512`.
 
-- **task_log_buffer_size** (*Optional*, int): **ESP32 only**: The size of the internal thread-safe ring buffer for task log messages.
+- **task_log_buffer_size** (*Optional*, int): **ESP32 and LibreTiny only**: The size of the internal thread-safe ring buffer for task log messages.
    This prevents API disconnections when multiple threads attempt to log simultaneously.
    Set to `0` to disable the log buffer. Defaults to `768B`.
 


### PR DESCRIPTION
## Description:

Update `task_log_buffer_size` documentation to indicate LibreTiny platform support in addition to ESP32.

The logger component now supports thread-safe logging on LibreTiny platforms (BK72xx, RTL87xx, LN882x) using a mutex-protected circular buffer. This change updates the documentation to reflect the expanded platform support.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#13062

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.
