### PR TITLE
[thermostat] Update doc to allow `heat_cool_mode` without an automation

### DIFF
--- a/content/components/climate/thermostat.md
+++ b/content/components/climate/thermostat.md
@@ -230,8 +230,10 @@ indication of the current climate mode.
   its fan either immediately or, when `fan_only_cooling` is `true`, as needed based on the upper
   target temperature value).
 
-- **heat_cool_mode** (*Optional*, [Action](/automations/actions#all-actions)): The action to call when
-  the climate device is placed into "heat/cool" mode (it may both cool and heat as required).
+- **heat_cool_mode** (*Optional*, [Action](/automations/actions#all-actions) or boolean): The action to call when
+  the climate device is placed into "heat/cool" mode (it may both cool and heat as required). If no action is desired,
+  may be set to `true` to enable the mode without a related automation. Note that **both** `heat_action` **and**
+  `cool_action` ([see above](#heating-and-cooling-actions)) must be defined to enable this mode.
 
 - **auto_mode** (*Optional*, [Action](/automations/actions#all-actions)): The action to call when
   the climate device is placed into "auto" mode (it may both cool and heat as required). This mode is


### PR DESCRIPTION
## Description:

SSIA

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#13069

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
