### PR TITLE
Update remote receiver/transmitter for Drayton

### DIFF
--- a/content/components/remote_receiver.md
+++ b/content/components/remote_receiver.md
@@ -431,9 +431,10 @@ Remote code selection (exactly one of these has to be included):
 
 - **drayton**: Trigger on a decoded Drayton Digistat RF remote code with the given data.
 
-  - **address** (**Required**, int): The 16-bit ID code to trigger on, see dumper output for more info.
-  - **channel** (**Required**, int): The 7-bit switch/channel to listen for.
-  - **command** (**Required**, int): The 5-bit command to listen for.
+  - **address** (**Required**, int): The 16-bit ID code to trigger on. Bits 0-3 are normally zero. Bit 0 is only set when a Digistat powers on to allow a Drayton
+    receiver in 'learn' mode to receive this address. See dumper output for more info.
+  - **data** (*Optional*, int): The 4-bit data value to listen for. Defaults to '0'. Bit '3' represents thermostat on/off. Bit '1'
+    represents 'Low Batt'. e.g. 0x8=Thermostat ON, Battery OK.
 
 - **dyson**: Trigger on a decoded dyson cool AM07 infrared remote code with the given data.
 

--- a/content/components/remote_receiver.md
+++ b/content/components/remote_receiver.md
@@ -434,7 +434,11 @@ Remote code selection (exactly one of these has to be included):
   - **address** (**Required**, int): The 16-bit ID code to trigger on. Bits 0-3 are normally zero. Bit 0 is only set when a Digistat powers on to allow a Drayton
     receiver in 'learn' mode to receive this address. See dumper output for more info.
   - **data** (*Optional*, int): The 4-bit data value to listen for. Defaults to '0'. Bit '3' represents thermostat on/off. Bit '1'
-    represents 'Low Batt'. e.g. 0x8=Thermostat ON, Battery OK.
+    represents 'Low Batt'. e.g. 0x8=Thermostat ON, Battery OK. Should be used in preference to channel and command.
+  - **channel** (*Optional*, int): The 7-bit switch/channel to listen for. May be used, in conjunction with command, to maintain compatibility with first
+    implematation of the Drayton receiver. Use of data is preferred.
+  - **command** (*Optional*, int): The 5-bit command to listen for. May be used, in conjunction with channel, to maintain compatibility with first implematation of
+    the Drayton receiver. Use of data is preferred.
 
 - **dyson**: Trigger on a decoded dyson cool AM07 infrared remote code with the given data.
 

--- a/content/components/remote_transmitter.md
+++ b/content/components/remote_transmitter.md
@@ -368,7 +368,7 @@ This [action](/automations/actions#all-actions) sends a Draton Digistat RF remot
 on_...:
   - remote_transmitter.transmit_drayton:
       address: '0x6180'
-      data: '0x12'
+      data: '0x8'
 ```
 
 #### Configuration variables

--- a/content/components/remote_transmitter.md
+++ b/content/components/remote_transmitter.md
@@ -368,15 +368,15 @@ This [action](/automations/actions#all-actions) sends a Draton Digistat RF remot
 on_...:
   - remote_transmitter.transmit_drayton:
       address: '0x6180'
-      channel: '0x12'
-      command: '0x02'
+      data: '0x12'
 ```
 
 #### Configuration variables
 
-- **address** (**Required**, int): The 16-bit ID to send, see dumper output for more info.
-- **channel** (**Required**, int): The switch/channel to send, between 0 and 127 inclusive.
-- **command** (**Required**, int): The command to send, between 0 and 63 inclusive.
+- **address** (**Required**, int): The 16-bit ID to send. Bits 0-3 are normally zero. Setting bit 0 will allow a Drayton
+    receiver in 'learn' mode to receive this address. See dumper output for more info.
+- **data** (*Optional*, int): The data value to send, between 0 and 15 inclusive. Defaults to '0'. Bit '3' represents thermostat on/off. Bit '1'
+    represents 'Low Batt'. e.g. 0x8=Thermostat ON, Battery OK.
 - All other options from [Remote Transmitter Actions](#remote_transmitter-transmit_action).
 
 {{< anchor "remote_transmitter-transmit_dyson" >}}

--- a/content/components/remote_transmitter.md
+++ b/content/components/remote_transmitter.md
@@ -376,7 +376,11 @@ on_...:
 - **address** (**Required**, int): The 16-bit ID to send. Bits 0-3 are normally zero. Setting bit 0 will allow a Drayton
     receiver in 'learn' mode to receive this address. See dumper output for more info.
 - **data** (*Optional*, int): The data value to send, between 0 and 15 inclusive. Defaults to '0'. Bit '3' represents thermostat on/off. Bit '1'
-    represents 'Low Batt'. e.g. 0x8=Thermostat ON, Battery OK.
+    represents 'Low Batt'. e.g. 0x8=Thermostat ON, Battery OK.  Should be used in preference to channel and command.
+- **channel** (*Optional*, int): The 7-bit switch/channel to send. May be used, in conjunction with command, to maintain compatibility with first
+    implematation of the Drayton receiver. Use of data is preferred.
+- **command** (*Optional*, int): The 5-bit command to send. May be used, in conjunction with channel, to maintain compatibility with first implematation of
+    the Drayton receiver. Use of data is preferred.
 - All other options from [Remote Transmitter Actions](#remote_transmitter-transmit_action).
 
 {{< anchor "remote_transmitter-transmit_dyson" >}}


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#13060

## Checklist:

  - [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/static/images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/_index.md`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image dht22
```

</details>
