### PR TITLE
[wifi] Update DNS server options with default values

### DIFF
--- a/content/components/wifi.md
+++ b/content/components/wifi.md
@@ -56,8 +56,8 @@ wifi:
   - **static_ip** (**Required**, IPv4 address): The static IP of your node.
   - **gateway** (**Required**, IPv4 address): The gateway of the local network.
   - **subnet** (**Required**, IPv4 address): The subnet of the local network.
-  - **dns1** (*Optional*, IPv4 address): The main DNS server to use.
-  - **dns2** (*Optional*, IPv4 address): The backup DNS server to use.
+  - **dns1** (*Optional*, IPv4 address): The main DNS server to use.  Defaults to 0.0.0.0
+  - **dns2** (*Optional*, IPv4 address): The backup DNS server to use.  Defaults to 0.0.0.0
 
 - **use_address** (*Optional*, string): Manually override what address to use to connect
   to the ESP. Defaults to auto-generated value. Example, if you have changed your static IP and want to flash OTA to


### PR DESCRIPTION
Added default values for optional DNS server fields.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/static/images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/_index.md`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image dht22
```

</details>
