### PR TITLE
[esp32_hosted] Add HTTP mode documentation for co-processor updates

### DIFF
--- a/content/components/update/esp32_hosted.md
+++ b/content/components/update/esp32_hosted.md
@@ -8,15 +8,22 @@ params:
 ---
 
 This platform allows you to update the firmware of an ESP32 co-processor connected via the
-{{< docref "/components/esp32_hosted" >}} component. The firmware binary is embedded into
-your device's flash at compile time and can be deployed to the co-processor on demand.
+[ESP32 Hosted](/components/esp32_hosted) component. Two update modes are supported:
+
+- **Embedded mode**: The firmware binary is embedded into your device's flash at compile time
+- **HTTP mode**: The firmware is fetched from a remote URL at runtime
 
 The component automatically detects the current co-processor firmware version and compares it to the
-version embedded in your device. If the versions differ, an update becomes available in Home Assistant
+available version. If the versions differ, an update becomes available in Home Assistant
 or through the ESPHome API.
 
+## Embedded Mode
+
+In embedded mode, the firmware binary is compiled into your device's flash. This is useful when you want
+to bundle a specific firmware version with your device.
+
 ```yaml
-# Example configuration entry
+# Example configuration entry for embedded mode
 # Note: Host device must be ESP32-H2 or ESP32-P4
 esp32_hosted:
   variant: ESP32C6  # Co-processor variant
@@ -31,19 +38,87 @@ esp32_hosted:
 
 update:
   - platform: esp32_hosted
+    type: embedded
     path: coprocessor-firmware.bin
     sha256: 1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
 ```
 
+## HTTP Mode
+
+In HTTP mode, the firmware is fetched from a remote manifest URL. This allows automatic updates
+without recompiling your ESPHome configuration. The component will periodically check for updates
+and select the best compatible version based on the host library version.
+
+```yaml
+# Example configuration entry for HTTP mode
+# Note: Host device must be ESP32-H2 or ESP32-P4
+esp32_hosted:
+  variant: ESP32C6  # Co-processor variant
+  reset_pin: GPIOXX
+  cmd_pin: GPIOXX
+  clk_pin: GPIOXX
+  d0_pin: GPIOXX
+  d1_pin: GPIOXX
+  d2_pin: GPIOXX
+  d3_pin: GPIOXX
+  active_high: true
+
+http_request:
+
+update:
+  - platform: esp32_hosted
+    type: http
+    source: https://esphome.github.io/esp-hosted-firmware/manifest/esp32c6.json
+    update_interval: 6h
+```
+
+### Manifest Format
+
+The HTTP mode requires a JSON manifest file with the following format:
+
+```json
+{
+  "versions": [
+    {
+      "version": "2.7.0",
+      "url": "https://example.com/firmware/esp32c6-2.7.0.bin",
+      "sha256": "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+    },
+    {
+      "version": "2.6.0",
+      "url": "https://example.com/firmware/esp32c6-2.6.0.bin",
+      "sha256": "fedcba0987654321fedcba0987654321fedcba0987654321fedcba0987654321"
+    }
+  ]
+}
+```
+
+The component will automatically select the highest version that is compatible with the host library
+(i.e., the firmware version must be less than or equal to the ESP-Hosted library version compiled
+into ESPHome).
+
 {{< anchor "update_esp32_hosted-configuration_variables" >}}
 
 ## Configuration variables
+
+- **type** (**Required**, string): The update mode to use. Must be either `embedded` or `http`.
+
+### Embedded mode options
 
 - **path** (**Required**, string): Path to the co-processor firmware binary file (`.bin`).
   The path is relative to your ESPHome configuration file.
 
 - **sha256** (**Required**, string): SHA256 hash of the firmware binary file. This is used to verify
   the integrity of the firmware both at compile time and at runtime before flashing to the co-processor.
+
+### HTTP mode options
+
+- **source** (**Required**, url): URL to the JSON manifest file containing available firmware versions.
+
+- **update_interval** (*Optional*, [Time](/guides/configuration-types#time)): How often to check for updates.
+  Defaults to `6h`.
+
+### Common options
 
 - All other options from [Update](/components/update#config-update).
 
@@ -54,50 +129,21 @@ This update platform requires:
 - **Host device** (running ESPHome): `ESP32-H2` or `ESP32-P4`
 - **Co-processor** (being updated): Any ESP32 variant supported by ESP-Hosted (e.g., `ESP32-C6` as shown in the example)
 
-The host device must have sufficient flash space to store the co-processor firmware binary.
+For embedded mode, the host device must have sufficient flash space to store the co-processor firmware binary.
 
-## Obtaining co-processor firmware
+## Co-processor firmware
 
-To build firmware for your ESP32 co-processor, refer to the
-[ESP IDF Get Started](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/get-started/index.html). The
-firmware should be built using the ESP-IDF framework and the resulting `.bin` file should be placed in your ESPHome
-configuration directory.
+Pre-built firmware binaries and manifests for supported co-processor variants are available at
+[esphome.github.io/esp-hosted-firmware](https://esphome.github.io/esp-hosted-firmware/).
+These can be used directly with HTTP mode, or downloaded for use with embedded mode.
 
-```sh
-# Build instructions for IDF 5.5.1 and ESP Hosted 2.7.0
-git clone -b v5.5.1 --recursive https://github.com/espressif/esp-idf.git
-cd esp-idf
-./install.sh esp32c6
-source export.sh  # for Linux/macOS
-export.bat        # for Windows
-cd ..
-idf.py create-project-from-example "espressif/esp_hosted==2.7.0:slave"
-cd slave/
-idf.py set-target esp32c6
-idf.py build
-```
-
-After building the firmware, copy it to your ESPHome configuration directory and generate its SHA256 hash:
-
-```sh
-# Copy the firmware to your ESPHome config directory
-cp build/network_adapter.bin /path/to/your/esphome/config/coprocessor-firmware.bin
-
-# Generate SHA256 hash (Linux/macOS)
-sha256sum /path/to/your/esphome/config/coprocessor-firmware.bin
-
-# Generate SHA256 hash (Windows PowerShell)
-Get-FileHash -Algorithm SHA256 coprocessor-firmware.bin
-
-# Generate SHA256 hash (Windows Command Prompt with certutil)
-certutil -hashfile coprocessor-firmware.bin SHA256
-```
-
-Use the generated hash in your `sha256` configuration parameter.
+For instructions on building custom firmware, see the [esp-hosted-firmware](https://github.com/esphome/esp-hosted-firmware) repository.
 
 ## See Also
 
-- {{< docref "/components/esp32_hosted" >}}
-- {{< docref "/components/update" >}}
+- [ESP32 Hosted](/components/esp32_hosted)
+- [Update](/components/update)
+- [HTTP Request](/components/http_request)
+- [ESP-Hosted Firmware](https://esphome.github.io/esp-hosted-firmware/)
 - [ESP-Hosted-MCU](https://github.com/espressif/esp-hosted-mcu) by [Espressif Systems](https://www.espressif.com/)
 - {{< apiref "esp32_hosted/update/esp32_hosted_update.h" "esp32_hosted/update/esp32_hosted_update.h" >}}

--- a/content/components/update/esp32_hosted.md
+++ b/content/components/update/esp32_hosted.md
@@ -24,18 +24,6 @@ to bundle a specific firmware version with your device.
 
 ```yaml
 # Example configuration entry for embedded mode
-# Note: Host device must be ESP32-H2 or ESP32-P4
-esp32_hosted:
-  variant: ESP32C6  # Co-processor variant
-  reset_pin: GPIOXX
-  cmd_pin: GPIOXX
-  clk_pin: GPIOXX
-  d0_pin: GPIOXX
-  d1_pin: GPIOXX
-  d2_pin: GPIOXX
-  d3_pin: GPIOXX
-  active_high: true
-
 update:
   - platform: esp32_hosted
     type: embedded
@@ -51,18 +39,6 @@ and select the best compatible version based on the host library version.
 
 ```yaml
 # Example configuration entry for HTTP mode
-# Note: Host device must be ESP32-H2 or ESP32-P4
-esp32_hosted:
-  variant: ESP32C6  # Co-processor variant
-  reset_pin: GPIOXX
-  cmd_pin: GPIOXX
-  clk_pin: GPIOXX
-  d0_pin: GPIOXX
-  d1_pin: GPIOXX
-  d2_pin: GPIOXX
-  d3_pin: GPIOXX
-  active_high: true
-
 http_request:
 
 update:


### PR DESCRIPTION
## Description:

Add documentation for the new HTTP-based firmware update mode for the ESP32 Hosted co-processor component. This mode allows fetching firmware from a remote manifest URL instead of embedding it in the binary.

Changes:
- Document both `embedded` and `http` update modes
- Add manifest format specification for HTTP mode
- Link to pre-built firmware at esphome.github.io/esp-hosted-firmware
- Link to GitHub repo for custom build instructions

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#13090

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/static/images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/_index.md`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image dht22
```

</details>