### PR TITLE
[select] Update current_option() to return StringRef

### DIFF
--- a/content/components/select/_index.md
+++ b/content/components/select/_index.md
@@ -268,28 +268,19 @@ advanced stuff (see the full API Reference for more info).
   to select the first option or `call.select_next(true)` to select the next
   option with the cycle feature enabled.
 
-- `.current_option()`  : Retrieve the currently selected option of the select. Returns `const char*`.
+- `.current_option()`  : Retrieve the currently selected option of the select. Returns `std::string_view`.
 
 ```cpp
     // For example, create a custom log message when an option is selected:
-    auto state = id(my_select).current_option();
-    ESP_LOGI("main", "Option of my select: %s", state);
+    auto option = id(my_select).current_option();
+    ESP_LOGI("main", "Option of my select: %.*s", (int) option.size(), option.data());
 ```
 
 ```yaml
-    # Check if a specific option is selected (using strcmp)
+    # Check if a specific option is selected (direct comparison works with string_view)
     - if:
         condition:
-          - lambda: 'return strcmp(id(my_select).current_option(), "my_option_value") == 0;'
-```
-
-```yaml
-    # Or convert to std::string for comparison
-    - if:
-        condition:
-          - lambda: |-
-              std::string current = id(my_select).current_option();
-              return current == "my_option_value";
+          - lambda: 'return id(my_select).current_option() == "my_option_value";'
 ```
 
 - `.size()`  : Retrieve the number of options in the select.

--- a/content/components/select/_index.md
+++ b/content/components/select/_index.md
@@ -268,12 +268,12 @@ advanced stuff (see the full API Reference for more info).
   to select the first option or `call.select_next(true)` to select the next
   option with the cycle feature enabled.
 
-- `.current_option()`  : Retrieve the currently selected option of the select. Returns `std::string_view`.
+- `.current_option()`  : Retrieve the currently selected option of the select. Returns `StringRef`.
 
 ```cpp
     // For example, create a custom log message when an option is selected:
     auto option = id(my_select).current_option();
-    ESP_LOGI("main", "Option of my select: %.*s", (int) option.size(), option.data());
+    ESP_LOGI("main", "Option of my select: %.*s", (int) option.size(), option.c_str());
 ```
 
 ```yaml

--- a/content/components/select/_index.md
+++ b/content/components/select/_index.md
@@ -277,7 +277,7 @@ advanced stuff (see the full API Reference for more info).
 ```
 
 ```yaml
-    # Check if a specific option is selected (direct comparison works with string_view)
+    # Check if a specific option is selected (direct string comparison in a lambda condition)
     - if:
         condition:
           - lambda: 'return id(my_select).current_option() == "my_option_value";'


### PR DESCRIPTION
# What does this implement/fix?

Updates Select component documentation to reflect that `current_option()` now returns `StringRef` instead of `const char*`.

This is a **breaking change** for users with lambdas and external component developers.

**Changes:**
- Updated return type from `const char*` to `StringRef`
- Updated logging example to use `%.*s` format with size/c_str
- Simplified comparison example to show direct `==` comparison (no need for `strcmp()`)
- Added stream printing example using `write()` with explicit size

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#13095

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.
