### PR TITLE
[tuya] add color_type_lowercase option

### DIFF
--- a/content/components/light/tuya.md
+++ b/content/components/light/tuya.md
@@ -64,7 +64,9 @@ light:
   - `RGB`  : Use a 6 digit hex RGB value
   - `HSV`  : Use a 12 digit hex HSV value
   - `RGBHSV`  : Use a 14 digit hex RGBHSV value
-  - `RGB_LOWERCASE`  : Use a lowercase 6 digit hex RGB value
+
+- **color_type_lowercase** (*Optional*, boolean): Some lights require the color hex string to be lowercase.
+  Defaults to false.
 
 - **min_value** (*Optional*, int): The lowest dimmer value allowed. My dimmer had a
   minimum of 25 and wouldn't even accept anything lower, but this option is available if necessary.

--- a/content/components/light/tuya.md
+++ b/content/components/light/tuya.md
@@ -61,9 +61,10 @@ light:
   If this is set, along with **color_datapoint**, then ESPHome will use this value to format
   the color sent to **color_datapoint**.
 
-  - `rgb`  : Use a 6 digit hex RGB value
-  - `hsv`  : Use a 12 digit hex HSV value
-  - `rgbhsv`  : Use a 14 digit hex RGBHSV value
+  - `RGB`  : Use a 6 digit hex RGB value
+  - `HSV`  : Use a 12 digit hex HSV value
+  - `RGBHSV`  : Use a 14 digit hex RGBHSV value
+  - `RGB_LOWERCASE`  : Use a lowercase 6 digit hex RGB value
 
 - **min_value** (*Optional*, int): The lowest dimmer value allowed. My dimmer had a
   minimum of 25 and wouldn't even accept anything lower, but this option is available if necessary.


### PR DESCRIPTION
## Description:
Some lights will not work with the regular colortypes, they require the hex string to be lowercase.
This adds the `color_type_lowercase` option to the docs.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#13101

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.