### PR TITLE
[event] Update docs for StringRef return type

### DIFF
--- a/content/components/event/_index.md
+++ b/content/components/event/_index.md
@@ -125,13 +125,26 @@ Configuration variables:
 
 ### lambda Calls
 
-From [lambdas](/automations/templates#config-lambda), you can trigger an event.
+From [lambdas](/automations/templates#config-lambda), you can interact with an event.
 
-- `trigger(std::string event_type)`  : Trigger an event with the specified type.
+- `trigger(std::string event_type)`: Trigger an event with the specified type.
+- `has_event()`: Returns `true` if an event has been triggered, `false` otherwise.
+- `get_last_event_type()`: Returns the last triggered event type as `std::string_view`, or an empty string view if no event has been triggered yet.
 
 ```cpp
     // Within lambda, trigger the event.
     id(my_event).trigger("custom_event");
+
+    // Check if an event has been triggered
+    if (id(my_event).has_event()) {
+      auto event_type = id(my_event).get_last_event_type();
+      // Compare with string literal using ==
+      if (event_type == "custom_event") {
+        ESP_LOGD("main", "Custom event was triggered");
+      }
+      // Log using %.*s format for string_view
+      ESP_LOGD("main", "Last event: %.*s", (int) event_type.size(), event_type.data());
+    }
 ```
 
 ## See Also

--- a/content/components/event/_index.md
+++ b/content/components/event/_index.md
@@ -129,7 +129,7 @@ From [lambdas](/automations/templates#config-lambda), you can interact with an e
 
 - `trigger(std::string event_type)`: Trigger an event with the specified type.
 - `has_event()`: Returns `true` if an event has been triggered, `false` otherwise.
-- `get_last_event_type()`: Returns the last triggered event type as `std::string_view`, or an empty string view if no event has been triggered yet.
+- `get_last_event_type()`: Returns the last triggered event type as `StringRef`, or an empty StringRef if no event has been triggered yet.
 
 ```cpp
     // Within lambda, trigger the event.
@@ -142,8 +142,8 @@ From [lambdas](/automations/templates#config-lambda), you can interact with an e
       if (event_type == "custom_event") {
         ESP_LOGD("main", "Custom event was triggered");
       }
-      // Log using %.*s format for string_view
-      ESP_LOGD("main", "Last event: %.*s", (int) event_type.size(), event_type.data());
+      // Log using %.*s format for StringRef
+      ESP_LOGD("main", "Last event: %.*s", (int) event_type.size(), event_type.c_str());
     }
 ```
 


### PR DESCRIPTION
## Description:

Update documentation to reflect that `Event::get_last_event_type()` now returns `StringRef` instead of `const char*`.

Also documents the new `has_event()` method for checking if an event has been triggered.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#13104

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.
