### PR TITLE
[light] Document LightEffect::get_name() returning StringRef

### DIFF
--- a/content/components/light/_index.md
+++ b/content/components/light/_index.md
@@ -690,19 +690,31 @@ light:
 
 #### Accessing Effect Names
 
-You can access the name of a light effect using the `get_name()` method, which returns a `std::string_view`:
+You can access the name of a light effect using the `get_name()` method, which returns a `StringRef`:
 
 ```cpp
 // Get all effects for a light
 auto &effects = id(my_light).get_effects();
 for (auto *effect : effects) {
-  std::string_view name = effect->get_name();
+  StringRef name = effect->get_name();
   // Compare with string literal
   if (name == "My Custom Effect") {
     ESP_LOGI("light", "Found my effect!");
   }
-  // Safe logging with size-limited format
-  ESP_LOGI("light", "Effect: %.*s", (int) name.size(), name.data());
+  // Safe logging with explicit size
+  ESP_LOGI("light", "Effect: %.*s", (int) name.size(), name.c_str());
+}
+```
+
+You can also get the currently active effect name from a light state using `get_effect_name()`:
+
+```cpp
+// Get currently active effect
+StringRef current = id(my_light).get_effect_name();
+if (current == "None") {
+  ESP_LOGI("light", "No effect active");
+} else {
+  ESP_LOGI("light", "Active effect: %.*s", (int) current.size(), current.c_str());
 }
 ```
 

--- a/content/components/light/_index.md
+++ b/content/components/light/_index.md
@@ -686,6 +686,26 @@ light:
 - **lambda** (**Required**, [lambda](/automations/templates#config-lambda)): The code to execute. `static` variables are especially
   useful.
 
+{{< anchor "light-effect-get_name" >}}
+
+#### Accessing Effect Names
+
+You can access the name of a light effect using the `get_name()` method, which returns a `std::string_view`:
+
+```cpp
+// Get all effects for a light
+auto &effects = id(my_light).get_effects();
+for (auto *effect : effects) {
+  std::string_view name = effect->get_name();
+  // Compare with string literal
+  if (name == "My Custom Effect") {
+    ESP_LOGI("light", "Found my effect!");
+  }
+  // Safe logging with size-limited format
+  ESP_LOGI("light", "Effect: %.*s", (int) name.size(), name.data());
+}
+```
+
 ### Addressable Rainbow Effect
 
 A light effect for individually-addressable LEDs that creates a moving rainbow over the whole LED strip using the HSV


### PR DESCRIPTION
# What does this implement/fix?

Document the breaking change to `LightEffect::get_name()` and `LightState::get_effect_name()` APIs which now return `StringRef` instead of `const char*`/`std::string`.

This is a **breaking change** for users with lambdas and external component developers.

**Related issue or feature (if applicable):**

- esphome/esphome#13105 - [light] Return StringRef from LightEffect::get_name() and LightState::get_effect_name()

## Checklist:
  - [x] The documentation follows the [documentation style](https://github.com/esphome/esphome-docs?tab=readme-ov-file#style)
