### PR TITLE
[captive_portal] Document web_server access while captive portal is active

### DIFF
--- a/content/components/captive_portal.md
+++ b/content/components/captive_portal.md
@@ -20,6 +20,14 @@ this will be overwritten by any subsequent serial upload so make sure to also up
 
 Additionally, you can upload a new firmware file.
 
+## Web Server Access
+
+When both `captive_portal` and [web_server](/components/web_server/) components are enabled,
+you can access the full web server control interface while the captive portal is active. A
+"Device Control" link will appear in the captive portal UI, or you can navigate directly to
+<http://192.168.4.1/?web_server>. This allows you to control the device's entities (switches,
+lights, sensors, etc.) even when the device is in AP fallback mode.
+
 When you connect to the fallback network, the web interface should open automatically (see also
 login to network notifications). If that does not work, you can also navigate to <http://192.168.4.1/>
 manually in your browser.


### PR DESCRIPTION
## Description:

Document the new web_server access feature when captive_portal is active.

When both `captive_portal` and `web_server` components are enabled, users can now access the web server control interface while the captive portal is active via `/?web_server`. A "Device Control" link appears in the captive portal UI.

**Related issue (if applicable):** related to https://github.com/esphome/feature-requests/issues/2676

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#13089

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.
