### PR TITLE
[epaper_spi] Document new waveshare displays

### DIFF
--- a/content/components/display/epaper_spi.md
+++ b/content/components/display/epaper_spi.md
@@ -36,7 +36,6 @@ pins and dimensions specified.
 | Spectra-E6             | Eink         | <https://www.eink.com/brand/detail/Spectra6>       |
 | SSD1677                | Solomon      | <https://www.solomon-systech.com/product/ssd1677/> |
 
-
 ## Supported display panels
 
 These models represent display panels with known dimensions, but without a microcontroller. The configuration will require

--- a/content/components/display/epaper_spi.md
+++ b/content/components/display/epaper_spi.md
@@ -31,10 +31,22 @@ display:
 These are the supported controller chips. Using just the chip name as the model will require full configuration with
 pins and dimensions specified.
 
-| Chip name              | Manufacturer | Product Description                                                                                                          |
-|------------------------|--------------|------------------------------------------------------------------------------------------------------------------------------|
-| Spectra-E6             | Eink         | <https://www.eink.com/brand/detail/Spectra6>                                                                                 |
-| SSD1677                | Solomon      | <https://www.solomon-systech.com/product/ssd1677/>                                                                           |
+| Chip name              | Manufacturer | Product Description                                |
+|------------------------|--------------|----------------------------------------------------|
+| Spectra-E6             | Eink         | <https://www.eink.com/brand/detail/Spectra6>       |
+| SSD1677                | Solomon      | <https://www.solomon-systech.com/product/ssd1677/> |
+
+
+## Supported display panels
+
+These models represent display panels with known dimensions, but without a microcontroller. The configuration will require
+the pins used to interface to the display to be specified.
+
+| Display name        | Manufacturer | Product Description                                |
+|---------------------|--------------|----------------------------------------------------|
+| Waveshare-2.13in-v3 | Waveshare    | <https://www.waveshare.com/pico-epaper-2.13.htm>   |
+| Waveshare-4.26in    | Waveshare    | <https://www.waveshare.com/4.26inch-e-paper.htm>   |
+
 
 ## Supported integrated display boards
 

--- a/content/components/display/epaper_spi.md
+++ b/content/components/display/epaper_spi.md
@@ -46,7 +46,6 @@ the pins used to interface to the display to be specified.
 | Waveshare-2.13in-v3 | Waveshare    | <https://www.waveshare.com/pico-epaper-2.13.htm>   |
 | Waveshare-4.26in    | Waveshare    | <https://www.waveshare.com/4.26inch-e-paper.htm>   |
 
-
 ## Supported integrated display boards
 
 These models correspond to displays integrated with a microcontroller, and have a full configuration predefined, so at


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#13117

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/static/images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/_index.md`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image dht22
```

</details>
