### PR TITLE
Update key_collector to add missing parameter...

### DIFF
--- a/src/content/docs/components/key_collector.mdx
+++ b/src/content/docs/components/key_collector.mdx
@@ -130,4 +130,4 @@ that publishes the collected key sequence when a successful result occurs.
 - [Wiegand keypad and tag reader](/components/wiegand/)
 - [LVGL Button Matrix widget](/components/lvgl/widgets#lvgl-widget-buttonmatrix)
 - [LVGL Keyboard widget](/components/lvgl/widgets#lvgl-widget-keyboard)
-- {{< apiref "key_collector/key_collector.h" "key_collector/key_collector.h" >}}
+- <APIRef text="key_collector.h" path="key_collector/key_collector.h" />

--- a/src/content/docs/components/key_collector.mdx
+++ b/src/content/docs/components/key_collector.mdx
@@ -20,6 +20,7 @@ can publish the result to a `text_sensor`.
 key_collector:
   - id: pincode_reader
     source_id: mykeypad
+    start_keys: "*"
     min_length: 4
     max_length: 4
     start_keys: "A"
@@ -47,31 +48,28 @@ key_collector:
 
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): Set the ID of this entry for use in lambdas.
 - **source_id** (*Optional*, [ID](/guides/configuration-types#id)): The ID of the key input device.
-- **min_length** (*Optional*, integer): The minimal length of the desired key sequence. Below
-  this, `on_result` automation will not trigger even if any of the `end_keys` was pressed.
-
-- **max_length** (*Optional*, integer): The maximum length of the desired key sequence, after
-  which the sequence will trigger the `on_result` automation witout having to press any of the `end_keys`
-
-- **start_keys** (*Optional*, string): Keys used to start the sequence. If specified, no keys
-  will be collected until one of the start keys is pressed. The start key that was pressed is
-  available in the `start` variable in automations.
-
-- **end_keys** (*Optional*, string): Keys used to *enter* the sequence.
-- **end_key_required** (*Optional*, boolean): Only trigger `on_result` automation when one of
-  the `end_keys` was pressed. Defaults to `false`.
-
+- **min_length** (*Optional*, integer): The minimum length of the desired key sequence. Below this limit,
+  `on_result` automation will not trigger even if any of the `end_keys` was pressed.
+- **max_length** (*Optional*, integer): The maximum length of the desired key sequence. After this limit
+  is reached, the collector will either ignore additional keys or trigger the `on_result` automation,
+  depending on `end_key_required`.
+- **start_keys** (*Optional*, string): Keys used to *start* the key sequence; when set, no keys
+  will be accepted until one of the start keys is pressed.
+- **end_keys** (*Optional*, string): Keys used to *finish* the key sequence and trigger the
+  `on_result` automation.
+- **end_key_required** (*Optional*, boolean): Only trigger `on_result` automation when one of the `end_keys`
+  was pressed, and not when `max_length` characters have been entered. Defaults to `false`.
 - **back_keys** (*Optional*, string): Keys used to delete the last pressed key. Like *Backspace* on a keyboard.
-- **clear_keys** (*Optional*, string): Keys used to entirely clear the sequence, all the pressed keys.
-- **allowed_keys** (*Optional*, string): Keys allowed to be used. If not specified, then any otherwise
-  unused keys will be allowed.
-
-- **timeout** (*Optional*, [Time](/guides/configuration-types#time)): Timeout after which to cancel building the sequence and delete all the keys.
+- **clear_keys** (*Optional*, string): Keys used to cancel building the key sequence and clear it.
+- **allowed_keys** (*Optional*, string): Keys allowed to be used, all others will be ignored. If not specified,
+  all keys are allowed.
+- **timeout** (*Optional*, [Time](/guides/configuration-types#time)): Timeout after which to cancel building
+  the key sequence and clear it.
 - **enable_on_boot** (*Optional*, boolean): If enabled, this key collector will be enabled on boot. Defaults to `true`.
 
 At least one of `end_keys` or `max_length` must be specified. The rest are optional.
-If both `end_keys` and `max_length` are specified, then once `max_length` keys are collected, no more will be
-accepted until an end key is pressed.
+When the sequence is cancelled, by timeout or one of `clear_keys`, a key from `start_keys` (if configured) must be
+entered again as well.
 
 ## Triggers
 
@@ -115,8 +113,9 @@ on_...:
     - key_collector.disable:
 ```
 
-## Lambda
+## Lambdas
 
+- `clear(bool progress_update=true)`: Clear collected keys.  
 - `send_key(uint8_t key)`: Send a key to the collector directly.
 
 ## Text Sensor
@@ -131,3 +130,4 @@ that publishes the collected key sequence when a successful result occurs.
 - [Wiegand keypad and tag reader](/components/wiegand/)
 - [LVGL Button Matrix widget](/components/lvgl/widgets#lvgl-widget-buttonmatrix)
 - [LVGL Keyboard widget](/components/lvgl/widgets#lvgl-widget-keyboard)
+- {{< apiref "key_collector/key_collector.h" "key_collector/key_collector.h" >}}

--- a/src/content/docs/components/key_collector.mdx
+++ b/src/content/docs/components/key_collector.mdx
@@ -60,34 +60,34 @@ key_collector:
 - **end_key_required** (*Optional*, boolean): Only trigger `on_result` automation when one of the `end_keys`
   was pressed, and not when `max_length` characters have been entered. Defaults to `false`.
 - **back_keys** (*Optional*, string): Keys used to delete the last pressed key. Like *Backspace* on a keyboard.
-- **clear_keys** (*Optional*, string): Keys used to cancel building the key sequence and clear it.
+- **clear_keys** (*Optional*, string): Keys used to cancel building the key sequence.
 - **allowed_keys** (*Optional*, string): Keys allowed to be used, all others will be ignored. If not specified,
   all keys are allowed.
 - **timeout** (*Optional*, [Time](/guides/configuration-types#time)): Timeout after which to cancel building
-  the key sequence and clear it.
+  the key sequence.
 - **enable_on_boot** (*Optional*, boolean): If enabled, this key collector will be enabled on boot. Defaults to `true`.
 
 At least one of `end_keys` or `max_length` must be specified. The rest are optional.
-When the sequence is cancelled, by timeout or one of `clear_keys`, a key from `start_keys` (if configured) must be
+When the key sequence is cancelled, by timeout or one of `clear_keys`, a key from `start_keys` (if configured) must be
 entered again as well.
 
 ## Triggers
 
 - **on_progress** (*Optional*, [Automation](/automations)): An automation to perform
-  when keys are pressed. The current sequence of pressed keys is placed in a `vector<uint8_t>` variable `x`
-  and `start` holds the start key that activated this sequence or else `0`.
+  when keys are pressed. The current key sequence is placed in a `vector<uint8_t>` variable `x`
+  and `start` holds the start key that activated this key sequence or else `0`.
   Useful if you want to have a display showing the current value or number of key presses,
   or a speaker beeping when keys are being pressed.
 
 - **on_result** (*Optional*, [Automation](/automations)): An automation to perform
-  when the sequence has been finished (eg. `max_length` has been reached or one of
+  when the key sequence has been finished (eg. `max_length` has been reached or one of
   the `end_keys` was pressed). The finalized key sequence is placed in a `vector<uint8_t>` variable `x`,
-  `start` holds the start key that activated this sequence or else `0`, and
-  `end` holds the end key that terminated this sequence or else `0`.
+  `start` holds the start key that activated this key sequence or else `0`, and
+  `end` holds the end key that terminated this key sequence or else `0`.
 
 - **on_timeout** (*Optional*, [Automation](/automations)): An automation to perform
-  if the timeout happens. The current sequence of pressed keys is placed in a `vector<uint8_t>` variable `x`
-  and `start` holds the start key that activated this sequence or else `0`.
+  if the timeout happens. The current key sequence is placed in a `vector<uint8_t>` variable `x`
+  and `start` holds the start key that activated this key sequence or else `0`.
 
 ## Actions
 
@@ -115,7 +115,7 @@ on_...:
 
 ## Lambdas
 
-- `clear(bool progress_update=true)`: Clear collected keys.  
+- `clear(bool progress_update=true)`: Cancel building the key sequence.  
 - `send_key(uint8_t key)`: Send a key to the collector directly.
 
 ## Text Sensor

--- a/src/content/docs/components/key_collector.mdx
+++ b/src/content/docs/components/key_collector.mdx
@@ -115,7 +115,7 @@ on_...:
 
 ## Lambdas
 
-- `clear(bool progress_update=true)`: Cancel building the key sequence.  
+- `clear(bool progress_update=true)`: Cancel building the key sequence. Set `progress_update` to `false` to skip triggering the `on_progress` automation.
 - `send_key(uint8_t key)`: Send a key to the collector directly.
 
 ## Text Sensor

--- a/src/content/docs/components/key_collector.mdx
+++ b/src/content/docs/components/key_collector.mdx
@@ -61,8 +61,8 @@ key_collector:
   was pressed, and not when `max_length` characters have been entered. Defaults to `false`.
 - **back_keys** (*Optional*, string): Keys used to delete the last pressed key. Like *Backspace* on a keyboard.
 - **clear_keys** (*Optional*, string): Keys used to cancel building the key sequence.
-- **allowed_keys** (*Optional*, string): Keys allowed to be used, all others will be ignored. If not specified,
-  all keys are allowed.
+- **allowed_keys** (*Optional*, string): Keys allowed to be used. If not specified, then any otherwise
+  unused keys will be allowed.
 - **timeout** (*Optional*, [Time](/guides/configuration-types#time)): Timeout after which to cancel building
   the key sequence.
 - **enable_on_boot** (*Optional*, boolean): If enabled, this key collector will be enabled on boot. Defaults to `true`.

--- a/src/content/docs/components/key_collector.mdx
+++ b/src/content/docs/components/key_collector.mdx
@@ -2,6 +2,7 @@
 description: "Key collector component"
 title: "Key collector component"
 ---
+import APIRef from '@components/APIRef.astro';
 
 <span id="key_collector"></span>
 


### PR DESCRIPTION
...and clarify processing logic

## Description:

Add `start_keys` to the configuration, and generally clarify how the key processing is done by updating other configuration descriptions.

Completes a subset of the changes proposed in [#5087](https://github.com/esphome/esphome-docs/pull/5087)

**Related issue (if applicable):** fixes [#5899](https://github.com/esphome/esphome-docs/issues/5899)

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

N/A

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.
