### PR TITLE
Update examples to use stack-based formatting helpers

### DIFF
--- a/content/components/cc1101.md
+++ b/content/components/cc1101.md
@@ -145,8 +145,9 @@ cc1101:
   on_packet:
     then:
       - lambda: |-
+          char hex[256];  // Size appropriately for your data
           ESP_LOGD("cc1101", "packet %s freq_offset %.0f Hz rssi %.1f dBm lqi %u",
-                   format_hex(x).c_str(), freq_offset, rssi, lqi);
+                   format_hex_to(hex, x), freq_offset, rssi, lqi);
 ```
 
 ## Actions

--- a/content/components/espnow.md
+++ b/content/components/espnow.md
@@ -53,13 +53,15 @@ done and will not be available if there are any `delay` actions or others that d
 ```yaml
 espnow:
   on_...:
-    - logger.log:
-        format: "Sent to %s from %s: %s RSSI: %ddBm"
-        args:
-          - format_mac_address_pretty(info.des_addr).c_str()
-          - format_mac_address_pretty(info.src_addr).c_str()
-          - format_hex_pretty(data, size).c_str()
-          - info.rx_ctrl->rssi
+    - lambda: |-
+        char des_mac[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
+        char src_mac[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
+        char hex[256];
+        ESP_LOGD("espnow", "Sent to %s from %s: %s RSSI: %ddBm",
+                 format_mac_addr_upper(info.des_addr, des_mac),
+                 format_mac_addr_upper(info.src_addr, src_mac),
+                 format_hex_pretty_to(hex, data, size),
+                 info.rx_ctrl->rssi);
 ```
 
 {{< anchor "espnow-on_receive" >}}

--- a/content/components/rf_bridge.md
+++ b/content/components/rf_bridge.md
@@ -30,10 +30,10 @@ rf_bridge:
     - homeassistant.event:
         event: esphome.rf_code_received
         data:
-          sync: !lambda 'return format_hex(data.sync);'
-          low: !lambda 'return format_hex(data.low);'
-          high: !lambda 'return format_hex(data.high);'
-          code: !lambda 'return format_hex(data.code);'
+          sync: !lambda 'char buf[5]; return format_hex_to(buf, data.sync);'
+          low: !lambda 'char buf[5]; return format_hex_to(buf, data.low);'
+          high: !lambda 'char buf[5]; return format_hex_to(buf, data.high);'
+          code: !lambda 'char buf[9]; return format_hex_to(buf, data.code);'
 ```
 
 ## Configuration variables
@@ -57,10 +57,10 @@ on_code_received:
   - homeassistant.event:
       event: esphome.rf_code_received
       data:
-        sync: !lambda 'return format_hex(data.sync);'
-        low: !lambda 'return format_hex(data.low);'
-        high: !lambda 'return format_hex(data.high);'
-        code: !lambda 'return format_hex(data.code);'
+        sync: !lambda 'char buf[5]; return format_hex_to(buf, data.sync);'
+        low: !lambda 'char buf[5]; return format_hex_to(buf, data.low);'
+        high: !lambda 'char buf[5]; return format_hex_to(buf, data.high);'
+        code: !lambda 'char buf[9]; return format_hex_to(buf, data.code);'
 ```
 
 {{< anchor "rf_bridge-send_code_action" >}}
@@ -194,8 +194,8 @@ on_advanced_code_received:
   - homeassistant.event:
       event: esphome.rf_advanced_code_received
       data:
-        length: !lambda 'return format_hex(data.length);'
-        protocol: !lambda 'return format_hex(data.protocol);'
+        length: !lambda 'char buf[3]; return format_hex_to(buf, data.length);'
+        protocol: !lambda 'char buf[3]; return format_hex_to(buf, data.protocol);'
         code: !lambda 'return data.code;'
 ```
 
@@ -366,10 +366,10 @@ rf_bridge:
       - homeassistant.event:
           event: esphome.rf_code_received
           data:
-            sync: !lambda 'return format_hex(data.sync);'
-            low: !lambda 'return format_hex(data.low);'
-            high: !lambda 'return format_hex(data.high);'
-            code: !lambda 'return format_hex(data.code);'
+            sync: !lambda 'char buf[5]; return format_hex_to(buf, data.sync);'
+            low: !lambda 'char buf[5]; return format_hex_to(buf, data.low);'
+            high: !lambda 'char buf[5]; return format_hex_to(buf, data.high);'
+            code: !lambda 'char buf[9]; return format_hex_to(buf, data.code);'
 
     - homeassistant.event:
           event: esphome.rf_code_received
@@ -384,8 +384,8 @@ rf_bridge:
       - homeassistant.event:
           event: esphome.rf_advanced_code_received
           data:
-            length: !lambda 'return format_hex(data.length);'
-            protocol: !lambda 'return format_hex(data.protocol);'
+            length: !lambda 'char buf[3]; return format_hex_to(buf, data.length);'
+            protocol: !lambda 'char buf[3]; return format_hex_to(buf, data.protocol);'
             code: !lambda 'return data.code;'
 ```
 

--- a/content/components/sml.md
+++ b/content/components/sml.md
@@ -40,10 +40,11 @@ sml:
   uart_id: uart_bus
   on_data:
     - lambda: !lambda |-
+        char hex[512];  // Size appropriately for your data
         if (valid) {
-          id(mqttclient).publish("gridmeter/sensor/sml/state", format_hex(bytes));
+          id(mqttclient).publish("gridmeter/sensor/sml/state", format_hex_to(hex, bytes));
         } else {
-          id(mqttclient).publish("gridmeter/sensor/sml/error", format_hex(bytes));
+          id(mqttclient).publish("gridmeter/sensor/sml/error", format_hex_to(hex, bytes));
         }
 ```
 

--- a/content/components/sx126x.md
+++ b/content/components/sx126x.md
@@ -128,7 +128,8 @@ sx126x:
   on_packet:
     then:
       - lambda: |-
-          ESP_LOGD("lambda", "packet %s", format_hex(x).c_str());
+          char hex[256];  // Size appropriately for your data
+          ESP_LOGD("lambda", "packet %s", format_hex_to(hex, x));
           ESP_LOGD("lambda", "rssi %.2f", rssi);
           ESP_LOGD("lambda", "snr %.2f", snr);
 ```
@@ -226,7 +227,8 @@ sx126x:
   on_packet:
     then:
       - lambda: |-
-          ESP_LOGD("lambda", "packet %s", format_hex(x).c_str());
+          char hex[256];  // Size appropriately for your data
+          ESP_LOGD("lambda", "packet %s", format_hex_to(hex, x));
           ESP_LOGD("lambda", "rssi %.2f", rssi);
           ESP_LOGD("lambda", "snr %.2f", snr);
 
@@ -267,7 +269,8 @@ sx126x:
   on_packet:
     then:
       - lambda: |-
-          ESP_LOGD("lambda", "packet %s", format_hex(x).c_str());
+          char hex[256];  // Size appropriately for your data
+          ESP_LOGD("lambda", "packet %s", format_hex_to(hex, x));
           ESP_LOGD("lambda", "rssi %.2f", rssi);
 
   button:

--- a/content/components/sx127x.md
+++ b/content/components/sx127x.md
@@ -129,7 +129,8 @@ sx127x:
   on_packet:
     then:
       - lambda: |-
-          ESP_LOGD("lambda", "packet %s", format_hex(x).c_str());
+          char hex[256];  // Size appropriately for your data
+          ESP_LOGD("lambda", "packet %s", format_hex_to(hex, x));
           ESP_LOGD("lambda", "rssi %.2f", rssi);
           ESP_LOGD("lambda", "snr %.2f", snr);
 ```
@@ -223,7 +224,8 @@ sx127x:
   on_packet:
     then:
       - lambda: |-
-          ESP_LOGD("lambda", "packet %s", format_hex(x).c_str());
+          char hex[256];  // Size appropriately for your data
+          ESP_LOGD("lambda", "packet %s", format_hex_to(hex, x));
           ESP_LOGD("lambda", "rssi %.2f", rssi);
           ESP_LOGD("lambda", "snr %.2f", snr);
 
@@ -264,7 +266,8 @@ sx127x:
   on_packet:
     then:
       - lambda: |-
-          ESP_LOGD("lambda", "packet %s", format_hex(x).c_str());
+          char hex[256];  // Size appropriately for your data
+          ESP_LOGD("lambda", "packet %s", format_hex_to(hex, x));
 
   button:
     - platform: template


### PR DESCRIPTION
## Description:

Update documentation examples to use stack-based formatting helpers instead of heap-allocating `std::string`-returning functions.

ESP devices run for months with small heaps shared between Wi-Fi, BLE, LWIP, and application code. Over time, repeated allocations fragment the heap. The linked PR soft-deprecates these helpers and adds CI lint checks to prevent new usage in components.

This PR updates the documentation examples to demonstrate the recommended patterns.

**Changes:**

| File | Change |
|------|--------|
| `sx126x.md` | `format_hex(x).c_str()` → `format_hex_to(hex, x)` |
| `sx127x.md` | `format_hex(x).c_str()` → `format_hex_to(hex, x)` |
| `cc1101.md` | `format_hex(x).c_str()` → `format_hex_to(hex, x)` |
| `sml.md` | `format_hex(bytes)` → `format_hex_to(hex, bytes)` |
| `rf_bridge.md` | `format_hex(data.xxx)` → `format_hex_to(buf, data.xxx)` |
| `espnow.md` | `format_mac_address_pretty()` → `format_mac_addr_upper()` with stack buffer |

**Related issue (if applicable):** n/a

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#13156

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.
