### PR TITLE
[infrared] New component documentation

### DIFF
--- a/content/components/_index.md
+++ b/content/components/_index.md
@@ -836,7 +836,7 @@ Components specifically for interacting with Home Assistant.
 "Voice Assistant","components/voice_assistant","voice-assistant.svg","dark-invert"
 {{< /imgtable >}}
 
-## Infrared
+## Infrared Components
 
 Used for creating infrared (IR) remote control transmitters and/or receivers.
 

--- a/content/components/_index.md
+++ b/content/components/_index.md
@@ -841,10 +841,7 @@ Components specifically for interacting with Home Assistant.
 Used for creating infrared (IR) remote control transmitters and/or receivers.
 
 {{< imgtable >}}
-"Infrared","components/infrared","remote.svg","dark-invert"
-"IR Remote Climate","components/climate/climate_ir","air-conditioner-ir.svg","dark-invert"
-"Remote Receiver","components/remote_receiver","remote.svg","dark-invert"
-"Remote Transmitter","components/remote_transmitter","remote.svg","dark-invert"
+"Infrared Core","components/infrared/index","folder-open.svg","dark-invert"
 {{< /imgtable >}}
 
 ## Light Components
@@ -1069,7 +1066,6 @@ ESPHome to cellular networks. **Does not encompass Wi-Fi.**
 
 {{< imgtable >}}
 "CC1101","components/cc1101","cc1101.webp",""
-"Infrared","components/infrared","remote.svg","dark-invert"
 "IR Remote Climate","components/climate/climate_ir","air-conditioner-ir.svg","dark-invert"
 "Remote Receiver","components/remote_receiver","remote.svg","dark-invert"
 "Remote Transmitter","components/remote_transmitter","remote.svg","dark-invert"

--- a/content/components/_index.md
+++ b/content/components/_index.md
@@ -836,6 +836,17 @@ Components specifically for interacting with Home Assistant.
 "Voice Assistant","components/voice_assistant","voice-assistant.svg","dark-invert"
 {{< /imgtable >}}
 
+## Infrared
+
+Used for creating infrared (IR) remote control transmitters and/or receivers.
+
+{{< imgtable >}}
+"Infrared","components/infrared","remote.svg","dark-invert"
+"IR Remote Climate","components/climate/climate_ir","air-conditioner-ir.svg","dark-invert"
+"Remote Receiver","components/remote_receiver","remote.svg","dark-invert"
+"Remote Transmitter","components/remote_transmitter","remote.svg","dark-invert"
+{{< /imgtable >}}
+
 ## Light Components
 
 {{< imgtable >}}

--- a/content/components/_index.md
+++ b/content/components/_index.md
@@ -1058,6 +1058,7 @@ ESPHome to cellular networks. **Does not encompass Wi-Fi.**
 
 {{< imgtable >}}
 "CC1101","components/cc1101","cc1101.webp",""
+"Infrared","components/infrared","remote.svg","dark-invert"
 "IR Remote Climate","components/climate/climate_ir","air-conditioner-ir.svg","dark-invert"
 "Remote Receiver","components/remote_receiver","remote.svg","dark-invert"
 "Remote Transmitter","components/remote_transmitter","remote.svg","dark-invert"

--- a/content/components/infrared/_index.md
+++ b/content/components/infrared/_index.md
@@ -59,13 +59,6 @@ Configuration variables:
   See <https://developers.home-assistant.io/docs/core/entity/#generic-properties>
   for a list of available options. Set to `""` to remove the default entity category.
 
-- If Webserver enabled and version 3 is selected, all other options from Webserver Component. See
-  [Webserver Version 3](/components/web_server#config-webserver-version-3-options).
-
-MQTT options:
-
-- All other options from [MQTT Component](/components/mqtt#config-mqtt-component).
-
 ## How It Works
 
 The infrared component operates using raw timing sequences, which represent alternating mark (signal on)

--- a/content/components/infrared/_index.md
+++ b/content/components/infrared/_index.md
@@ -90,12 +90,10 @@ Reception is non-blocking and can operate alongside other signal processing comp
 
 ## Platform Components
 
-- [IR/RF Proxy](/components/ir_rf_proxy) - Bridges ESPHome's remote_transmitter/remote_receiver components
-  with the infrared API for runtime signal control
+TBD
 
 ## See Also
 
-- [IR/RF Proxy](/components/ir_rf_proxy)
 - [Remote Transmitter](/components/remote_transmitter)
 - [Remote Receiver](/components/remote_receiver)
 - {{< apiref "infrared/infrared.h" "infrared/infrared.h" >}}

--- a/content/components/infrared/_index.md
+++ b/content/components/infrared/_index.md
@@ -1,0 +1,108 @@
+---
+description: "Instructions for setting up infrared components in ESPHome."
+title: "Infrared Component"
+params:
+  seo:
+    description: Instructions for setting up infrared components in ESPHome.
+    image: folder-open.svg
+---
+
+> [!IMPORTANT]
+> This component is EXPERIMENTAL. The API may change at any time
+> without following the normal breaking changes policy. Use at your own risk.
+> Once the API is considered stable, this warning will be removed.
+
+ESPHome has support for components to create infrared entities that provide a standardized API for
+transmitting and receiving raw infrared (and RF) signals. An infrared entity is represented in ESPHome
+as a stateless component (similar to buttons) that can transmit raw timing sequences or receive and
+forward timing sequences as events to API clients like Home Assistant.
+
+The infrared platform provides base infrastructure for IR/RF communication, establishing a unified
+interface between ESPHome devices and API clients. This enables runtime signal transmission without
+recompiling firmware, making it ideal for learning and replaying IR/RF commands.
+
+{{< anchor "config-infrared" >}}
+
+## Base Infrared Configuration
+
+All infrared components in ESPHome have a platform and a name. The component operates as a stateless
+entity, supporting actions (API commands to device transmissions) and events (device receptions to
+API client broadcasts).
+
+```yaml
+# Example infrared configuration
+infrared:
+  - platform: ...
+    name: Living Room IR Transmitter
+    id: my_ir_transmitter
+```
+
+Configuration variables:
+
+- **id** (*Optional*, string): Manually specify the ID for code generation. At least one of **id** and **name** must be specified.
+- **name** (*Optional*, string): The name for the infrared entity. At least one of **id** and **name** must be specified.
+
+> [!NOTE]
+> If you have a [friendly_name](/components/esphome#esphome-configuration_variables) set for your device and
+> you want the infrared entity to use that name, you can set `name: None`.
+
+- **icon** (*Optional*, icon): Manually set the icon to use for the infrared entity in the frontend.
+- **internal** (*Optional*, boolean): Mark this component as internal. Internal components will
+  not be exposed to the frontend (like Home Assistant). Only specifying an `id` without
+  a `name` will implicitly set this to true.
+
+- **disabled_by_default** (*Optional*, boolean): If true, then this entity should not be added to any client's frontend
+  (usually Home Assistant) without the user manually enabling it (via the Home Assistant UI).
+  Defaults to `false`.
+
+- **entity_category** (*Optional*, string): The category of the entity.
+  See <https://developers.home-assistant.io/docs/core/entity/#generic-properties>
+  for a list of available options. Set to `""` to remove the default entity category.
+
+- If Webserver enabled and version 3 is selected, all other options from Webserver Component. See
+  [Webserver Version 3](/components/web_server#config-webserver-version-3-options).
+
+MQTT options:
+
+- All other options from [MQTT Component](/components/mqtt#config-mqtt-component).
+
+## How It Works
+
+The infrared component operates using raw timing sequences, which represent alternating mark (signal on)
+and space (signal off) periods in microseconds. This provides maximum flexibility and can support virtually
+any IR or RF protocol.
+
+### Transmitting Signals
+
+When an infrared entity supports transmit capability, it can send raw timing sequences through the API.
+Transmission parameters include:
+
+- **Raw timings array**: Alternating mark/space durations in microseconds
+- **Carrier frequency**: Optional carrier frequency in Hz (0 = no carrier modulation, typical for RF)
+- **Repeat count**: Number of times to transmit the signal (defaults to 1)
+
+The raw timings format allows API clients like Home Assistant to encode protocol-specific commands into
+raw timings and transmit them through the infrared entity.
+
+### Receiving Signals
+
+When an infrared entity supports receive capability, it captures raw timing sequences and sends them
+to API clients as events. This enables:
+
+- Learning IR/RF commands from existing remotes
+- Analyzing unknown protocols
+- Creating universal remote controls
+
+Reception is non-blocking and can operate alongside other signal processing components.
+
+## Platform Components
+
+- [IR/RF Proxy](/components/ir_rf_proxy) - Bridges ESPHome's remote_transmitter/remote_receiver components
+  with the infrared API for runtime signal control
+
+## See Also
+
+- [IR/RF Proxy](/components/ir_rf_proxy)
+- [Remote Transmitter](/components/remote_transmitter)
+- [Remote Receiver](/components/remote_receiver)
+- {{< apiref "infrared/infrared.h" "infrared/infrared.h" >}}


### PR DESCRIPTION
## Description:

SSIA

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#13129

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [x] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/static/images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/_index.md`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image dht22
```

</details>
