### PR TITLE
Add specific ISM band text to SX126x and SX127x for searchability

### DIFF
--- a/content/components/sx126x.md
+++ b/content/components/sx126x.md
@@ -12,7 +12,8 @@ params:
 The SX126x component allows you to configure the SX1261, SX1262, SX1268 and LLCC68 transceivers
 ([datasheet](https://www.semtech.com/products/wireless-rf/lora-connect/sx1262#documentation)) in
 ESPHome. Transceivers are connected via the [SPI Bus](/components/spi). Supported frequencies range from
-150 MHz to 960 MHz. Supported modulations include LoRa, FSK, GFSK, MSK and GMSK. The SX126x
+150 MHz to 960 MHz, including the popular 315 MHz, 433 MHz, 868 MHz, and 915 MHz ISM bands.
+Supported modulations include LoRa, FSK, GFSK, MSK and GMSK. The SX126x
 component may be used as a platform for the [Packet Transport Component](/components/packet_transport#packet-transport) component, enabling sensor data
 to be sent directly from one ESPHome node to another.
 

--- a/content/components/sx127x.md
+++ b/content/components/sx127x.md
@@ -12,7 +12,8 @@ params:
 The SX127x component allows you to configure the SX1276, SX1277, SX1278 and SX1279 transceivers
 ([datasheet](https://www.semtech.com/products/wireless-rf/lora-connect/sx1278#documentation)) in
 ESPHome. Transceivers are connected via the [SPI Bus](/components/spi). Supported frequencies range from
-137 MHz to 1020 MHz. Supported modulations include LoRa, OOK, FSK, GFSK, MSK and GMSK. The SX127x
+137 MHz to 1020 MHz, including the popular 315 MHz, 433 MHz, 868 MHz, and 915 MHz ISM bands.
+Supported modulations include LoRa, OOK, FSK, GFSK, MSK and GMSK. The SX127x
 component may be used as a platform for the [Packet Transport Component](/components/packet_transport#packet-transport) component, enabling sensor data
 to be sent directly from one ESPHome node to another.
 


### PR DESCRIPTION
## Description:

Adds text specifically mentioning the 315 MHz, 433 MHz, 868 MHz, and 915 MHz ISM bands in the SX126x and SX127x component to make it easier to find these when searching the esphome documentation for these specific frequencies. This matches the text in the CC1101 documentation.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** N/A

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.