### PR TITLE
Adjust BMP581 for component rename, additional sensor example, stage for SPI

### DIFF
--- a/content/components/sensor/bmp581.md
+++ b/content/components/sensor/bmp581.md
@@ -8,15 +8,17 @@ params:
 ---
 
 The `bmp581` sensor platform allows you to use your BMP581
-([datasheet](https://www.bosch-sensortec.com/media/boschsensortec/downloads/datasheets/bst-bmp581-ds004.pdf), [SparkFun](https://www.sparkfun.com/products/20170)) temperature and pressure sensors with ESPHome. The [I²C](/components/i2c) bus is
-required to be set up in your configuration for this sensor to work.
+([datasheet](https://www.bosch-sensortec.com/media/boschsensortec/downloads/datasheets/bst-bmp581-ds004.pdf), [SparkFun](https://www.sparkfun.com/products/20170) or [Adafruit](https://www.adafruit.com/product/6407)) temperature and pressure sensors with ESPHome. The [I²C](/components/i2c) bus is
+required to be set up in your configuration for this sensor to work. While technically possible, ESPHome does not yet support communication with this sensor via the SPI bus.
 
 {{< img src="bmp581.jpg" alt="Image" caption="BMP581 Temperature and Pressure Sensor. (Credit: [SparkFun](https://www.sparkfun.com/products/20170), image cropped and compressed)" width="50.0%" class="align-center" >}}
 
+## Over I²C
+
 ```yaml
-# Example configuration entry
+# Example configuration entry for I2C connection
 sensor:
-  - platform: bmp581
+  - platform: bmp581_i2c
     temperature:
       name: "Indoor Temperature"
     pressure:


### PR DESCRIPTION
## Description:

Update reflects proposed change to BMP581 component from `bmp581` to `bmp581_i2c`, to eventually support `bmp581_spi`. Also adds another BMP581-based sensor to documentation (Adafruit)

**Related issue (if applicable):** Based on feature request 3435: [https://github.com/orgs/esphome/discussions/3435](https://github.com/orgs/esphome/discussions/3435)
**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#12485

(This was previously worked on in #5778, but due to the initial incorrect branch I somehow started pulling in unrelated changes when I went to sync branches. This one should merge more cleanly.)

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.