### PR TITLE
[debug] Document min_free sensor and ESP32 fragmentation support

### DIFF
--- a/content/components/debug.md
+++ b/content/components/debug.md
@@ -30,10 +30,12 @@ sensor:
   - platform: debug
     free:
       name: "Heap Free"
-    fragmentation:
-      name: "Heap Fragmentation"
     block:
       name: "Heap Max Block"
+    min_free:
+      name: "Heap Min Free"
+    fragmentation:
+      name: "Heap Fragmentation"
     loop_time:
       name: "Loop Time"
     psram:
@@ -76,11 +78,13 @@ sensor:
 
 - **free** (*Optional*): Reports the free heap size in bytes. All options from [Sensor](/components/sensor).
 
-- **fragmentation** (*Optional*): Reports the fragmentation metric of the heap
-  (0% is clean, more than ~50% is not harmless). Only available on ESP8266 with Arduino 2.5.2+.
-  All options from [Sensor](/components/sensor).
-
 - **block** (*Optional*): Reports the largest contiguous free RAM block on the heap in bytes. All options from [Sensor](/components/sensor).
+
+- **min_free** (*Optional*): Reports the minimum free heap size since boot in bytes. This is useful for detecting memory leaks or high-water-mark usage. Only available on ESP32 and LibreTiny. All options from [Sensor](/components/sensor).
+
+- **fragmentation** (*Optional*): Reports the fragmentation metric of the heap
+  (0% is clean, more than ~50% may cause allocation failures). Available on ESP8266 with Arduino 2.5.2+ and ESP32.
+  All options from [Sensor](/components/sensor).
 
 - **loop_time** (*Optional*): Reports the longest time between successive iterations of the main loop. All options from [Sensor](/components/sensor).
 


### PR DESCRIPTION
## Description:

Document new `min_free` heap sensor for ESP32 and LibreTiny platforms, and update `fragmentation` sensor to show ESP32 support.

- Add `min_free` sensor documentation - reports minimum free heap since boot
- Update `fragmentation` to indicate ESP32 support (was ESP8266-only)
- Add `min_free` to example configuration
- Fix awkward "not harmless" wording to "may cause allocation failures"

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#13231

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.
