### PR TITLE
[hub75] Update scan enum values

### DIFF
--- a/content/components/display/hub75.md
+++ b/content/components/display/hub75.md
@@ -187,6 +187,7 @@ For creating larger displays by chaining multiple panels:
   - `STANDARD_TWO_SCAN` - Standard 1/16 or 1/32 scan (most common)
   - `SCAN_1_4_16PX_HIGH` - 1/4 scan for 16px high panels
   - `SCAN_1_8_32PX_HIGH` - 1/8 scan for 32px high panels
+  - `SCAN_1_8_40PX_HIGH` - 1/8 scan for 40px high panels
   - `SCAN_1_8_64PX_HIGH` - 1/8 scan for 64px high panels
 
 - **shift_driver** (*Optional*, enum): LED shift register driver chip type. Defaults to `GENERIC`. One of:

--- a/content/components/display/hub75.md
+++ b/content/components/display/hub75.md
@@ -185,9 +185,9 @@ For creating larger displays by chaining multiple panels:
 
 - **scan_wiring** (*Optional*, enum): Panel scan wiring pattern. Defaults to `STANDARD_TWO_SCAN`. One of:
   - `STANDARD_TWO_SCAN` - Standard 1/16 or 1/32 scan (most common)
-  - `FOUR_SCAN_16PX_HIGH` - Four-scan for 16px high panels
-  - `FOUR_SCAN_32PX_HIGH` - Four-scan for 32px high panels
-  - `FOUR_SCAN_64PX_HIGH` - Four-scan for 64px high panels
+  - `SCAN_1_4_16PX_HIGH` - 1/4 scan for 16px high panels
+  - `SCAN_1_8_32PX_HIGH` - 1/8 scan for 32px high panels
+  - `SCAN_1_8_64PX_HIGH` - 1/8 scan for 64px high panels
 
 - **shift_driver** (*Optional*, enum): LED shift register driver chip type. Defaults to `GENERIC`. One of:
   - `GENERIC` - Standard shift register (default)


### PR DESCRIPTION
## Description:

Update docs to reflect new enum values for scan wiring options

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#13243

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/static/images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/_index.md`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image dht22
```

</details>
