### PR TITLE
Update web_server and captive_portal compression default to gzip

### DIFF
--- a/content/components/captive_portal.md
+++ b/content/components/captive_portal.md
@@ -38,8 +38,9 @@ captive_portal:
 ## Configuration variables
 
 - **compression** (*Optional*, string): The compression algorithm used for the embedded web assets.
-  Options are `br` (Brotli) or `gzip`. Brotli provides ~24% smaller size than gzip.
-  Defaults to `br`.
+  Options are `gzip` or `br` (Brotli). Brotli provides ~24% smaller size than gzip, but some browsers
+  only support Brotli over HTTPS connections. Since the captive portal is served over HTTP, gzip is recommended
+  for maximum compatibility. Defaults to `gzip`.
 
 ## See Also
 

--- a/content/components/web_server.md
+++ b/content/components/web_server.md
@@ -68,8 +68,9 @@ web_server:
   Defaults to `false`.
 
 - **compression** (*Optional*, string): The compression algorithm used for embedded web assets when `local` is enabled.
-  Options are `br` (Brotli) or `gzip`. Brotli typically results in smaller embedded web assets than gzip, especially for
-  text-based resources, but the exact size difference depends on the assets being compressed. Defaults to `br`.
+  Options are `gzip` or `br` (Brotli). Brotli provides smaller embedded web assets (~10% smaller than gzip), but some
+  browsers only support Brotli over HTTPS connections. Since ESPHome devices typically serve over HTTP, gzip
+  is recommended for maximum compatibility. Defaults to `gzip`.
 
 - **version** (*Optional*, string): `1`, `2` or `3`. Version 1 displays as a table. Version 2 uses web components
   and has more functionality. Version 3 uses HA-Styling. Defaults to `2`.


### PR DESCRIPTION
## Description:

Updates documentation for `web_server` and `captive_portal` components to reflect that the default compression algorithm has changed from Brotli (`br`) to `gzip`.

Some browsers only support Brotli over HTTPS connections, so gzip is now the recommended default for maximum compatibility over HTTP.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#13246

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.
