### PR TITLE
[nextion] Expose custom protocol frames as automation triggers

### DIFF
--- a/src/content/docs/components/binary_sensor/nextion.mdx
+++ b/src/content/docs/components/binary_sensor/nextion.mdx
@@ -194,6 +194,52 @@ printh FF FF FF
 - `prints r0.val,0`   The actual value to send. For a variable use the Nextion variable name `r0`   with out `.val`
 - `printh FF FF FF`   Nextion command ack
 
+{{< anchor "nextion_custom_binary_sensor_automation" >}}
+
+## Reacting to Custom Binary Sensor Protocol Frames (Automation)
+
+In addition to updating a Nextion binary sensor entity, the **Nextion Custom Binary Sensor Protocol (0x93)** can also trigger automations directly on the Nextion display component.
+
+This is useful when binary data from the Nextion is intended to be handled as an **event** rather than as persistent state, for example:
+- button or mode changes that should immediately trigger logic
+- lightweight command or control signals
+- custom interaction patterns where no Home Assistant entity is required
+
+### Example
+
+```yaml
+display:
+  - platform: nextion
+    id: nextion1
+    uart_id: uart_nextion
+    on_custom_binary_sensor:
+      then:
+        - lambda: |-
+            // key: name sent by the Nextion (string)
+            // value: decoded boolean value
+            if (key == "r0") {
+              ESP_LOGI("nextion", "Binary sensor r0 = %s", ONOFF(value));
+            }
+```
+
+### Parameters passed to the automation
+
+- **key** (`string`):  
+  The name sent by the Nextion using the custom binary sensor protocol.  
+  This corresponds to the value sent in `prints "<name>",0`.
+
+- **value** (`bool`):  
+  The boolean value decoded from the protocol frame.  
+  Any value greater than `0` is interpreted as `true`.
+
+### Notes
+
+- The automation is triggered **when the custom protocol frame is received**, not when a binary sensor entity updates.
+- Defining a `binary_sensor:` entry is **not required** to use this automation.
+- Existing Nextion binary sensor entities and polling behavior are unchanged.
+- This automation reflects the same protocol described in [Nextion Custom Binary Sensor Protocol](#nextion_custom_binary_sensor_protocol).
+- This mechanism allows event-driven handling of Nextion binary data without the overhead of maintaining a binary sensor entity when no persistent state is needed.
+
 ## See Also
 
 - [Nextion TFT LCD Display](/components/display/nextion/)

--- a/src/content/docs/components/binary_sensor/nextion.mdx
+++ b/src/content/docs/components/binary_sensor/nextion.mdx
@@ -201,6 +201,7 @@ printh FF FF FF
 In addition to updating a Nextion binary sensor entity, the **Nextion Custom Binary Sensor Protocol (0x93)** can also trigger automations directly on the Nextion display component.
 
 This is useful when binary data from the Nextion is intended to be handled as an **event** rather than as persistent state, for example:
+
 - button or mode changes that should immediately trigger logic
 - lightweight command or control signals
 - custom interaction patterns where no Home Assistant entity is required

--- a/src/content/docs/components/binary_sensor/nextion.mdx
+++ b/src/content/docs/components/binary_sensor/nextion.mdx
@@ -194,7 +194,7 @@ printh FF FF FF
 - `prints r0.val,0`   The actual value to send. For a variable use the Nextion variable name `r0`   with out `.val`
 - `printh FF FF FF`   Nextion command ack
 
-{{< anchor "nextion_custom_binary_sensor_automation" >}}
+<span id="nextion_custom_binary_sensor_automation"></span>
 
 ## Reacting to Custom Binary Sensor Protocol Frames (Automation)
 

--- a/src/content/docs/components/sensor/nextion.mdx
+++ b/src/content/docs/components/sensor/nextion.mdx
@@ -208,6 +208,7 @@ printh FF FF FF
 In addition to updating a Nextion sensor entity, the **Nextion Custom Sensor Protocol (0x91)** can also trigger automations directly on the Nextion display component.
 
 This is useful when the sensor data is intended to be handled as an **event** rather than as persistent state, for example:
+
 - lightweight command or control messages
 - compact numeric payloads
 - custom protocols where no Home Assistant entity is required

--- a/src/content/docs/components/sensor/nextion.mdx
+++ b/src/content/docs/components/sensor/nextion.mdx
@@ -201,6 +201,51 @@ printh FF FF FF
 - `prints temperature.val,0` The actual value to send. For a variable use the Nextion variable name `temperature` with out `.val`
 - `printh FF FF FF` Nextion command ack
 
+{{< anchor "nextion_custom_sensor_automation" >}}
+
+## Reacting to Custom Sensor Protocol Frames (Automation)
+
+In addition to updating a Nextion sensor entity, the **Nextion Custom Sensor Protocol (0x91)** can also trigger automations directly on the Nextion display component.
+
+This is useful when the sensor data is intended to be handled as an **event** rather than as persistent state, for example:
+- lightweight command or control messages
+- compact numeric payloads
+- custom protocols where no Home Assistant entity is required
+
+### Example
+
+```yaml
+display:
+  - platform: nextion
+    id: nextion1
+    uart_id: uart_nextion
+    on_custom_sensor:
+      then:
+        - lambda: |-
+            // key: name sent by the Nextion (string)
+            // value: decoded integer value
+            if (key == "temperature") {
+              ESP_LOGI("nextion", "Temperature=%d", value);
+            }
+```
+
+### Parameters passed to the automation
+
+- **key** (`string`):  
+  The name sent by the Nextion using the custom sensor protocol.  
+  This corresponds to the value sent in `prints "<name>",0`.
+
+- **value** (`int`):  
+  The integer value decoded from the protocol frame.
+
+### Notes
+
+- The automation is triggered **when the custom protocol frame is received**, not when a sensor entity updates.
+- Defining a `sensor:` entry is **not required** to use this automation.
+- Existing Nextion sensor entities and polling behavior are unchanged.
+- This automation reflects the same protocol described in [Nextion Custom Sensor Protocol](#nextion_custom_sensor_protocol).
+- This mechanism allows event-driven handling of Nextion data without the overhead of maintaining a sensor entity when no persistent state is needed.
+
 ## See Also
 
 - [Nextion TFT LCD Display](/components/display/nextion/)

--- a/src/content/docs/components/sensor/nextion.mdx
+++ b/src/content/docs/components/sensor/nextion.mdx
@@ -201,7 +201,7 @@ printh FF FF FF
 - `prints temperature.val,0` The actual value to send. For a variable use the Nextion variable name `temperature` with out `.val`
 - `printh FF FF FF` Nextion command ack
 
-{{< anchor "nextion_custom_sensor_automation" >}}
+<span id="nextion_custom_sensor_automation"></span>
 
 ## Reacting to Custom Sensor Protocol Frames (Automation)
 

--- a/src/content/docs/components/switch/nextion.mdx
+++ b/src/content/docs/components/switch/nextion.mdx
@@ -168,7 +168,7 @@ printh FF FF FF
 - `prints r0.val,0` The actual value to send. For a variable use the Nextion variable name `r0` with out `.val`
 - `printh FF FF FF` Nextion command ack
 
-{{< anchor "nextion_custom_switch_automation" >}}
+<span id="nextion_custom_switch_automation"></span>
 
 ## Reacting to Custom Switch Protocol Frames (Automation)
 

--- a/src/content/docs/components/switch/nextion.mdx
+++ b/src/content/docs/components/switch/nextion.mdx
@@ -175,6 +175,7 @@ printh FF FF FF
 In addition to updating a Nextion switch entity, the **Nextion Custom Switch Protocol (0x90)** can also trigger automations directly on the Nextion display component.
 
 This is useful when switch data from the Nextion is intended to be handled as an **event** rather than as persistent state, for example:
+
 - immediate reactions to user interaction
 - lightweight command or control messages
 - custom logic where no Home Assistant switch entity is required

--- a/src/content/docs/components/switch/nextion.mdx
+++ b/src/content/docs/components/switch/nextion.mdx
@@ -168,6 +168,52 @@ printh FF FF FF
 - `prints r0.val,0` The actual value to send. For a variable use the Nextion variable name `r0` with out `.val`
 - `printh FF FF FF` Nextion command ack
 
+{{< anchor "nextion_custom_switch_automation" >}}
+
+## Reacting to Custom Switch Protocol Frames (Automation)
+
+In addition to updating a Nextion switch entity, the **Nextion Custom Switch Protocol (0x90)** can also trigger automations directly on the Nextion display component.
+
+This is useful when switch data from the Nextion is intended to be handled as an **event** rather than as persistent state, for example:
+- immediate reactions to user interaction
+- lightweight command or control messages
+- custom logic where no Home Assistant switch entity is required
+
+### Example
+
+```yaml
+display:
+  - platform: nextion
+    id: nextion1
+    uart_id: uart_nextion
+    on_custom_switch:
+      then:
+        - lambda: |-
+            // key: name sent by the Nextion (string)
+            // value: decoded boolean value
+            if (key == "r0") {
+              ESP_LOGI("nextion", "Switch r0 = %s", ONOFF(value));
+            }
+```
+
+### Parameters passed to the automation
+
+- **key** (`string`):  
+  The name sent by the Nextion using the custom switch protocol.  
+  This corresponds to the value sent in `prints "<name>",0`.
+
+- **value** (`bool`):  
+  The boolean value decoded from the protocol frame.  
+  Any value greater than `0` is interpreted as `true`.
+
+### Notes
+
+- The automation is triggered **when the custom protocol frame is received**, not when a switch entity updates.
+- Defining a `switch:` entry is **not required** to use this automation.
+- Existing Nextion switch entities and polling behavior are unchanged.
+- This automation reflects the same protocol described in [Nextion Custom Switch Protocol](#nextion_custom_switch_protocol).
+- This mechanism allows event-driven handling of Nextion switch data without the overhead of maintaining a switch entity when no persistent state is needed.
+
 ## See Also
 
 - [Nextion TFT LCD Display](/components/display/nextion/)

--- a/src/content/docs/components/text_sensor/nextion.mdx
+++ b/src/content/docs/components/text_sensor/nextion.mdx
@@ -163,7 +163,7 @@ printh FF FF FF
 - `printh 00` Sends a NULL
 - `printh FF FF FF` Nextion command ack
 
-{{< anchor "nextion_custom_text_sensor_automation" >}}
+<span id="nextion_custom_text_sensor_automation"></span>
 
 ## Reacting to Custom Text Sensor Protocol Frames (Automation)
 

--- a/src/content/docs/components/text_sensor/nextion.mdx
+++ b/src/content/docs/components/text_sensor/nextion.mdx
@@ -170,6 +170,7 @@ printh FF FF FF
 In addition to updating a Nextion text sensor entity, the **Nextion Custom Text Sensor Protocol (0x92)** can also trigger automations directly on the Nextion display component.
 
 This is useful when text data from the Nextion is intended to be handled as an **event** rather than as persistent state, for example:
+
 - lightweight command messages
 - CSV or structured text payloads
 - custom communication patterns where no Home Assistant text sensor entity is required

--- a/src/content/docs/components/text_sensor/nextion.mdx
+++ b/src/content/docs/components/text_sensor/nextion.mdx
@@ -163,6 +163,51 @@ printh FF FF FF
 - `printh 00` Sends a NULL
 - `printh FF FF FF` Nextion command ack
 
+{{< anchor "nextion_custom_text_sensor_automation" >}}
+
+## Reacting to Custom Text Sensor Protocol Frames (Automation)
+
+In addition to updating a Nextion text sensor entity, the **Nextion Custom Text Sensor Protocol (0x92)** can also trigger automations directly on the Nextion display component.
+
+This is useful when text data from the Nextion is intended to be handled as an **event** rather than as persistent state, for example:
+- lightweight command messages
+- CSV or structured text payloads
+- custom communication patterns where no Home Assistant text sensor entity is required
+
+### Example
+
+```yaml
+display:
+  - platform: nextion
+    id: nextion1
+    uart_id: uart_nextion
+    on_custom_text_sensor:
+      then:
+        - lambda: |-
+            // key: name sent by the Nextion (string)
+            // value: decoded text value
+            if (key == "text0") {
+              ESP_LOGI("nextion", "Received text: %s", value.c_str());
+            }
+```
+
+### Parameters passed to the automation
+
+- **key** (`string`):  
+  The name sent by the Nextion using the custom text sensor protocol.  
+  This corresponds to the value sent in `prints "<name>",0`.
+
+- **value** (`string`):  
+  The text value decoded from the protocol frame.
+
+### Notes
+
+- The automation is triggered **when the custom protocol frame is received**, not when a text sensor entity updates.
+- Defining a `text_sensor:` entry is **not required** to use this automation.
+- Existing Nextion text sensor entities and polling behavior are unchanged.
+- This automation reflects the same protocol described in [Nextion Custom Text Sensor Protocol](#nextion_custom_text_sensor_protocol).
+- This mechanism allows event-driven handling of Nextion text data without the overhead of maintaining a text sensor entity when no persistent state is needed.
+
 ## See Also
 
 - [Nextion TFT LCD Display](/components/display/nextion/)


### PR DESCRIPTION
## Description:

This PR exposes Nextion custom protocol frames (0x90–0x93) as ESPHome automations, allowing users to react to incoming Nextion data without defining sensor, text_sensor, binary_sensor, or switch entities.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**
- esphome/esphome#13248

## Checklist:

  - [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/static/images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/_index.md`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image dht22
```

</details>
