### PR TITLE
[easy] Replace "name" key for color with "id" key in display docs

### DIFF
--- a/content/components/display/_index.md
+++ b/content/components/display/_index.md
@@ -395,7 +395,7 @@ binary_sensor:
     id: my_binary_sensor
 
 color:
-  - name: my_red
+  - id: my_red
     red: 100%
 
 display:


### PR DESCRIPTION
## Description:

This one example in the docs has a `name` key for a color, but this appears to be mistaken; every other example has `id` instead, and `id` appears to be correct.

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/static/images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/_index.md`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image dht22
```

</details>
