### PR TITLE
[select] Document `select.is` condition

### DIFF
--- a/content/components/select/_index.md
+++ b/content/components/select/_index.md
@@ -92,12 +92,15 @@ Configuration variables: See [Automation](/automations).
 
 ### `select.is` Condition
 
-This [Condition](/automations/actions#all-conditions) checks if the select is set to any one of a list of options.
+This [Condition](/automations/actions#all-conditions) checks if the select is set to any one of a list of options. A lambda may also be used for more complex computations.
 
 Configuration variables:
 
 - **id** (**Required**, [ID](/guides/configuration-types#id)): The ID of the select to test.
-- **options** (**Required**, list, [templatable](/automations/templates)): Either a lambda returning a `std::vector` of `std::string`, or a list of constant strings.
+- **options** (*Optional*, list): A string, or list of strings to compare with the current selection. The condition is true if any match.
+- **lambda** (*Optional*, [templatable](/automations/templates)): A lambda returning a boolean value. The current selection is passed in a `StringRef` argument called `current`.
+
+Only one of `options` and `lambda` must be provided.
 
 ```yaml
 # In some trigger:
@@ -120,7 +123,7 @@ on_...:
       condition:
         select.is:
           id: my_select
-          options: !lambda return {id(text_sensor).state, "Happy"};
+          lambda: return id(text_sensor).state == current || "Happy" == current;
       then:
         - logger.log: "Select is Happy, or matches some variable state"
 ```

--- a/content/components/select/_index.md
+++ b/content/components/select/_index.md
@@ -99,11 +99,16 @@ on_...:
       condition:
         select.is:
           id: my_select
-          options:
-            - Happy
-            - Ecstatic
+          options: [Happy, Ecstatic]
       then:
         - logger.log: "Select is Happy or Ecstatic"
+  - if:
+      condition:
+        select.is:
+          id: my_select
+          options: "Happy" # Single option 
+      then:
+        - logger.log: "Select matches Happy"
   - if:
       condition:
         select.is:

--- a/content/components/select/_index.md
+++ b/content/components/select/_index.md
@@ -92,7 +92,13 @@ Configuration variables: See [Automation](/automations).
 
 ### `select.is` Condition
 
-This [Condition](/automations/actions#all-conditions) checks if the select is set to a specific option, or any one of a list of options.
+This [Condition](/automations/actions#all-conditions) checks if the select is set to any one of a list of options.
+
+Configuration variables:
+
+- **id** (**Required**, [ID](/guides/configuration-types#id)): The ID of the select to test.
+- **options** (**Required**, list, [templatable](/automations/templates)): Either a lambda returning a `std::vector` of `std::string`, or a list of constant strings.
+
 
 ```yaml
 # In some trigger:
@@ -110,21 +116,15 @@ on_...:
           id: my_select
           options: "Happy" # Single option 
       then:
-        - logger.log: "Select matches Happy"
+        - logger.log: "Select is exactly Happy"
   - if:
       condition:
         select.is:
           id: my_select
-          options: !lambda return id(text_sensor).state;
+          options: !lambda return {id(text_sensor).state, "Happy"};
       then:
-        - logger.log: "Select matches desired state"
+        - logger.log: "Select is Happy, or matches some variable state"
 ```
-
-Configuration variables:
-
-- **id** (**Required**, [ID](/guides/configuration-types#id)): The ID of the select to test.
-- **options** (**Required**, list, [templatable](/automations/templates)): Either a lambda returning a string, or a list of constant strings.
-
 ## Actions
 
 {{< anchor "select-set_action" >}}

--- a/content/components/select/_index.md
+++ b/content/components/select/_index.md
@@ -99,7 +99,6 @@ Configuration variables:
 - **id** (**Required**, [ID](/guides/configuration-types#id)): The ID of the select to test.
 - **options** (**Required**, list, [templatable](/automations/templates)): Either a lambda returning a `std::vector` of `std::string`, or a list of constant strings.
 
-
 ```yaml
 # In some trigger:
 on_...:
@@ -125,6 +124,7 @@ on_...:
       then:
         - logger.log: "Select is Happy, or matches some variable state"
 ```
+
 ## Actions
 
 {{< anchor "select-set_action" >}}

--- a/content/components/select/_index.md
+++ b/content/components/select/_index.md
@@ -90,7 +90,7 @@ Configuration variables: See [Automation](/automations).
 
 ### `select.is` Condition
 
-This [Condition](/automations/actions#all-conditions) checks if the select is set to a specific option, or a list of options.
+This [Condition](/automations/actions#all-conditions) checks if the select is set to a specific option, or any one of a list of options.
 
 ```yaml
 # In some trigger:

--- a/content/components/select/_index.md
+++ b/content/components/select/_index.md
@@ -53,8 +53,6 @@ Configuration variables:
 
 - If Webserver enabled and version 3 is selected, All other options from Webserver Component.. See [Webserver Version 3](/components/web_server#config-webserver-version-3-options).
 
-Automations:
-
 - **on_value** (*Optional*, [Automation](/automations)): An automation to perform
   when a new value is published. See [`on_value`](#select-on_value).
 
@@ -62,11 +60,13 @@ MQTT Options:
 
 - All other options from [MQTT Component](/components/mqtt#config-mqtt-component).
 
-## Select Automation
+### Accessing the current option
 
 You can access the most recent state of the select in [lambdas](/automations/templates#config-lambda) using
 `id(select_id).current_option()`.
 For more information on using lambdas with select, see [lambda calls](#select-lambda_calls).
+
+## Triggers
 
 {{< anchor "select-on_value" >}}
 
@@ -87,6 +87,8 @@ select:
 ```
 
 Configuration variables: See [Automation](/automations).
+
+## Conditions
 
 ### `select.is` Condition
 
@@ -122,6 +124,8 @@ Configuration variables:
 
 - **id** (**Required**, [ID](/guides/configuration-types#id)): The ID of the select to test.
 - **options** (**Required**, list, [templatable](/automations/templates)): Either a lambda returning a string, or a list of constant strings.
+
+## Actions
 
 {{< anchor "select-set_action" >}}
 
@@ -284,10 +288,9 @@ Configuration variables:
 
 {{< anchor "select-lambda_calls" >}}
 
-### lambda calls
+## Using Selects in Lambdas
 
-From [lambdas](/automations/templates#config-lambda), you can call several methods on all selects to do some
-advanced stuff (see the full API Reference for more info).
+From [lambdas](/automations/templates#config-lambda), you can call several methods on selects (see the full API Reference for more info).
 
 - `.make_call()`  : Create a call for changing the select state.
 

--- a/content/components/select/_index.md
+++ b/content/components/select/_index.md
@@ -88,6 +88,36 @@ select:
 
 Configuration variables: See [Automation](/automations).
 
+### `select.is` Condition
+
+This [Condition](/automations/actions#all-conditions) checks if the select is set to a specific option, or a list of options.
+
+```yaml
+# In some trigger:
+on_...:
+  - if:
+      condition:
+        select.is:
+          id: my_select
+          options:
+            - Happy
+            - Ecstatic
+      then:
+        - logger.log: "Select is Happy or Ecstatic"
+  - if:
+      condition:
+        select.is:
+          id: my_select
+          options: !lambda return id(text_sensor).state;
+      then:
+        - logger.log: "Select matches desired state"
+```
+
+Configuration variables:
+
+- **id** (**Required**, [ID](/guides/configuration-types#id)): The ID of the select to test.
+- **options** (**Required**, list, [templatable](/automations/templates)): Either a lambda returning a string, or a list of constant strings.
+
 {{< anchor "select-set_action" >}}
 
 ### `select.set` Action


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#13267
## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/static/images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/_index.md`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image dht22
```

</details>
