### PR TITLE
[key_collector] Add missing start_keys documentation

### DIFF
--- a/content/components/_index.md
+++ b/content/components/_index.md
@@ -1059,6 +1059,7 @@ ESPHome to cellular networks. **Does not encompass Wi-Fi.**
 
 {{< imgtable >}}
 "Camera Encoder","components/camera/camera_encoder","camera.svg","dark-invert"
+"Key Collector","components/key_collector","matrix_keypad.jpg",""
 "ESP32 Camera","components/esp32_camera","camera.svg","dark-invert"
 "Exposure Notifications","components/exposure_notifications","exposure_notifications.png",""
 "GPS","components/gps","crosshairs-gps.svg","dark-invert"

--- a/content/components/key_collector.md
+++ b/content/components/key_collector.md
@@ -24,6 +24,7 @@ key_collector:
     source_id: mykeypad
     min_length: 4
     max_length: 4
+    start_keys: "A"
     end_keys: "#"
     end_key_required: true
     back_keys: "*"
@@ -53,6 +54,10 @@ key_collector:
 
 - **max_length** (*Optional*, integer): The maximum length of the desired key sequence, after
   which the sequence will trigger the `on_result` automation witout having to press any of the `end_keys`
+
+- **start_keys** (*Optional*, string): Keys used to start the sequence. If specified, no keys
+  will be collected until one of the start keys is pressed. The start key that was pressed is
+  available in the `start` variable in automations.
 
 - **end_keys** (*Optional*, string): Keys used to *enter* the sequence.
 - **end_key_required** (*Optional*, boolean): Only trigger `on_result` automation when one of


### PR DESCRIPTION
## Description:

Add documentation for the `start_keys` configuration parameter which was implemented but not documented. Also add key_collector to the main component index.

**Related issue (if applicable):** fixes https://github.com/esphome/esphome-docs/issues/5899

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- N/A (feature already exists in esphome)

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [x] Link added in `/components/_index.md` when creating new documents for new components or cookbook.