### PR TITLE
VL53L0X sensor, updated XSHUT connection instructions

### DIFF
--- a/content/components/sensor/vl53l0x.md
+++ b/content/components/sensor/vl53l0x.md
@@ -29,8 +29,7 @@ The [I²C Bus](/components/i2c) is required to be set up in your configuration f
 - `GPIO1` is not used by ESPHome
 - `XSHUT` connects to free GPIO pin. Enable/disable device. This is optional if there is only one
   VL53L0X sensor on the I²C bus and the default `0x29` address is used. Depending on your sensor, this
-  might be required even with only one sensor on the I²C bus. This is always required pulling
-  multiple sensors.
+  might be required even with only one sensor on the I²C bus. This is always required for multiple sensors.
 
 {{< img src="vl53l0x-full.jpg" alt="Image" caption="VL53L0X Time Of Flight Distance Sensor." width="50.0%" class="align-center" >}}
 

--- a/content/components/sensor/vl53l0x.md
+++ b/content/components/sensor/vl53l0x.md
@@ -28,7 +28,9 @@ The [I²C Bus](/components/i2c) is required to be set up in your configuration f
 - `SDA` connects I2C SDA (data)
 - `GPIO1` is not used by ESPHome
 - `XSHUT` connects to free GPIO pin. Enable/disable device. This is optional if there is only one
-  VL53L0X sensor on the I²C bus and the default `0x29` address is used. Otherwise this is required.
+  VL53L0X sensor on the I²C bus and the default `0x29` address is used. Depending on your sensor, this
+  might be required even with only one sensor on the I²C bus. This is always required pulling
+  multiple sensors.
 
 {{< img src="vl53l0x-full.jpg" alt="Image" caption="VL53L0X Time Of Flight Distance Sensor." width="50.0%" class="align-center" >}}
 


### PR DESCRIPTION
## Description:
XSHUT might be required when using one sensor and is always required when using multiple sensors. Sensor will be marked as failed on startup and provide no readings without XSHUT. This behavior is present in some variants of the sensor.

**Related issue (if applicable):** fixes <link to issue>
N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 
N/A

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/static/images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/_index.md`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image dht22
```

</details>
