### PR TITLE
2026.1.0b3

### DIFF
--- a/content/changelog/2026.1.0.md
+++ b/content/changelog/2026.1.0.md
@@ -1092,6 +1092,16 @@ For detailed migration guides and API documentation, see the [ESPHome Developers
 - [safe_mode] Detect bootloader rollback support at runtime [esphome#13230](https://github.com/esphome/esphome/pull/13230) by [@swoboda1337](https://github.com/swoboda1337)
 - [qr_code] Allocate and free memory for QR code buffer [esphome#13161](https://github.com/esphome/esphome/pull/13161) by [@rootnegativ1](https://github.com/rootnegativ1)
 - [web_server][captive_portal] Change default compression from Brotli to gzip [esphome#13246](https://github.com/esphome/esphome/pull/13246) by [@bdraco](https://github.com/bdraco)
+- [i2s_audio] Bugfix: Buffer overflow in software volume control [esphome#13190](https://github.com/esphome/esphome/pull/13190) by [@kahrendt](https://github.com/kahrendt)
+- [sprinkler] Fix scheduler deprecation warnings and heap churn with FixedVector [esphome#13251](https://github.com/esphome/esphome/pull/13251) by [@bdraco](https://github.com/bdraco)
+- [dallas_temp] Use const char* for set_timeout to fix deprecation warning and heap churn [esphome#13250](https://github.com/esphome/esphome/pull/13250) by [@bdraco](https://github.com/bdraco)
+- [api] Fix clock conflicts when multiple clients connected to homeassistant time [esphome#13253](https://github.com/esphome/esphome/pull/13253) by [@bdraco](https://github.com/bdraco)
+- [esp32_ble_client] Reduce GATT data event logging to prevent firmware update failures [esphome#13252](https://github.com/esphome/esphome/pull/13252) by [@bdraco](https://github.com/bdraco)
+- [ntc, resistance] change log level to verbose [esphome#13268](https://github.com/esphome/esphome/pull/13268) by [@mrtoy-me](https://github.com/mrtoy-me)
+- [api] Use subtraction for protobuf bounds checking [esphome#13306](https://github.com/esphome/esphome/pull/13306) by [@bdraco](https://github.com/bdraco)
+- [hmac_sha256] Replace unsafe sprintf with format_hex_to [esphome#13290](https://github.com/esphome/esphome/pull/13290) by [@bdraco](https://github.com/bdraco)
+- [hub75] Bump esp-hub75 version to 0.3.0 [esphome#13243](https://github.com/esphome/esphome/pull/13243) by [@stuartparmenter](https://github.com/stuartparmenter) (breaking-change)
+- [http_request] Unable to handle chunked responses [esphome#7884](https://github.com/esphome/esphome/pull/7884) by [@HLFCode](https://github.com/HLFCode)
 
 </details>
 

--- a/content/components/display/hub75.md
+++ b/content/components/display/hub75.md
@@ -185,9 +185,10 @@ For creating larger displays by chaining multiple panels:
 
 - **scan_wiring** (*Optional*, enum): Panel scan wiring pattern. Defaults to `STANDARD_TWO_SCAN`. One of:
   - `STANDARD_TWO_SCAN` - Standard 1/16 or 1/32 scan (most common)
-  - `FOUR_SCAN_16PX_HIGH` - Four-scan for 16px high panels
-  - `FOUR_SCAN_32PX_HIGH` - Four-scan for 32px high panels
-  - `FOUR_SCAN_64PX_HIGH` - Four-scan for 64px high panels
+  - `SCAN_1_4_16PX_HIGH` - 1/4 scan for 16px high panels
+  - `SCAN_1_8_32PX_HIGH` - 1/8 scan for 32px high panels
+  - `SCAN_1_8_40PX_HIGH` - 1/8 scan for 40px high panels
+  - `SCAN_1_8_64PX_HIGH` - 1/8 scan for 64px high panels
 
 - **shift_driver** (*Optional*, enum): LED shift register driver chip type. Defaults to `GENERIC`. One of:
   - `GENERIC` - Standard shift register (default)

--- a/content/guides/supporters.md
+++ b/content/guides/supporters.md
@@ -2321,4 +2321,4 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Christian Zufferey (@zuzu59)](https://github.com/zuzu59)
 - [Zynth-dev (@Zynth-dev)](https://github.com/Zynth-dev)
 
-*This page was last updated January 15, 2026.*
+*This page was last updated January 16, 2026.*

--- a/data/version.yaml
+++ b/data/version.yaml
@@ -1,2 +1,2 @@
-release: 2026.1.0b2
+release: 2026.1.0b3
 version: '2026.1'


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- [easy] Replace "name" key for color with "id" key in display docs [docs#5927](https://github.com/esphome/esphome-docs/pull/5927)
- [easy] Replace "name" key for color with "id" key in display docs [docs#5927](https://github.com/esphome/esphome-docs/pull/5927)
- [hub75] Update scan enum values [docs#5923](https://github.com/esphome/esphome-docs/pull/5923)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
