### PR TITLE
[nrf52] add supports for coredumps

### DIFF
--- a/content/components/_index.md
+++ b/content/components/_index.md
@@ -1091,7 +1091,7 @@ ESPHome to cellular networks. **Does not encompass Wi-Fi.**
 "Sun","components/sun","weather-sunny.svg","dark-invert"
 "Tuya MCU","components/tuya","tuya.png",""
 "Z-Wave Proxy","components/zwave_proxy","z-wave.svg",""
-"Zephyr GDB coredump","components/zephyr_coredump","gdb.svg",""
+"Zephyr GDB coredump","components/zephyr_coredump","bug-report.svg","dark-invert"
 {{< /imgtable >}}
 
 ## Cookbook

--- a/content/components/_index.md
+++ b/content/components/_index.md
@@ -138,6 +138,7 @@ ESPHome-specific components or components supporting ESPHome device provisioning
 "Safe Mode","components/safe_mode","restart-alert.svg","dark-invert"
 "Web Server","components/web_server","http.svg",""
 "ESP32 Camera Web Server","components/esp32_camera_web_server","camera.svg","dark-invert"
+"Zephyr GDB coredump","components/zephyr_coredump","bug-report.svg","dark-invert"
 {{< /imgtable >}}
 
 ## Update Installation
@@ -1091,7 +1092,6 @@ ESPHome to cellular networks. **Does not encompass Wi-Fi.**
 "Sun","components/sun","weather-sunny.svg","dark-invert"
 "Tuya MCU","components/tuya","tuya.png",""
 "Z-Wave Proxy","components/zwave_proxy","z-wave.svg",""
-"Zephyr GDB coredump","components/zephyr_coredump","bug-report.svg","dark-invert"
 {{< /imgtable >}}
 
 ## Cookbook

--- a/content/components/_index.md
+++ b/content/components/_index.md
@@ -1091,6 +1091,7 @@ ESPHome to cellular networks. **Does not encompass Wi-Fi.**
 "Sun","components/sun","weather-sunny.svg","dark-invert"
 "Tuya MCU","components/tuya","tuya.png",""
 "Z-Wave Proxy","components/zwave_proxy","z-wave.svg",""
+"Zephyr GDB coredump","components/zephyr_coredump","gdb.svg",""
 {{< /imgtable >}}
 
 ## Cookbook

--- a/content/components/zephyr_coredump.md
+++ b/content/components/zephyr_coredump.md
@@ -3,6 +3,11 @@ description: "Zephyr GDB coredump"
 title: "Zephyr GDB coredump"
 ---
 
+This component helps debug crashes without requiring SWD. When a crash occurs, the stack memory is saved to flash.
+On the next boot, the stored stack memory is printed to the logs.
+These logs can then be used to reconstruct the call stack, as described in the Zephyr coredump documentation:
+https://docs.zephyrproject.org/latest/services/debugging/coredump.html
+
 ```yaml
 # Example configuration entry
 esphome:
@@ -16,6 +21,54 @@ esphome:
           *p = 0xDEADBEEF;
 
 zephyr_coredump:
+```
+
+## Crash log example
+
+```
+[14:36:08.267][E][coredump:052]: #CD:BEGIN#
+[14:36:08.267][E][coredump:039]: #CD:5a450100030005001a0000004102004400d0670020b4670020efbeadde00b0ad
+[14:36:08.269][E][coredump:039]: #CD:de00000000296201002862010000000001505500200000000000000000000000
+[14:36:08.321][E][coredump:039]: #CD:ac0000
+[14:36:08.321][E][coredump:087]: #CD:END#
+[14:36:08.321][E][coredump:090]: Stored coredump printed.
+```
+
+## GDB callstack example
+
+```gdb
+0x00016228 in esphome::StatelessLambdaAction<>::play() (this=<optimized out>)
+    at .esphome/build/coredump-test/src/esphome/core/base_automation.h:231
+231	  void play(const Ts &...x) override { this->f_(x...); }
+(gdb) bt
+#0  0x00016228 in esphome::StatelessLambdaAction<>::play() (
+    this=<optimized out>)
+    at .esphome/build/coredump-test/src/esphome/core/base_automation.h:231
+#1  0x000163ce in esphome::Action<>::play_complex() (this=0x0 <get_data>)
+    at .esphome/build/coredump-test/zephyr/../src/esphome/core/automation.h:268
+#2  0x000163bc in esphome::Action<>::play_next_() (this=<optimized out>)
+    at .esphome/build/coredump-test/zephyr/../src/esphome/core/automation.h:299
+#3  0x000163de in esphome::DelayAction<>::play_complex()::{lambda()#1}::operator()() const (__closure=<optimized out>)
+    at .esphome/build/coredump-test/src/esphome/core/base_automation.h:195
+#4  std::__invoke_impl<void, esphome::DelayAction<>::play_complex()::{lambda()#1}&>(std::__invoke_other, esphome::DelayAction<>::play_complex()::{lambda()#1}&)
+    (__f=...)
+    at .platformio/packages/toolchain-gccarmnoneeabi/zephyr-sdk-0.17.4/arm-zephyr-eabi/arm-zephyr-eabi/include/c++/12.2.0/bits/invoke.h:61
+#5  std::__invoke_r<void, esphome::DelayAction<>::play_complex()::{lambda()#1}&>(esphome::DelayAction<>::play_complex()::{lambda()#1}&) (__fn=...)
+    at .platformio/packages/toolchain-gccarmnoneeabi/zephyr-sdk-0.17.4/arm-zephyr-eabi/arm-zephyr-eabi/include/c++/12.2.0/bits/invoke.h:111
+--Type <RET> for more, q to quit, c to continue without paging--
+#6  std::_Function_handler<void (), esphome::DelayAction<>::play_complex()::{lambda()#1}>::_M_invoke(std::_Any_data const&) (__functor=...)
+    at .platformio/packages/toolchain-gccarmnoneeabi/zephyr-sdk-0.17.4/arm-zephyr-eabi/arm-zephyr-eabi/include/c++/12.2.0/bits/std_function.h:290
+#7  0x000159f6 in std::function<void ()>::operator()() const (this=this@entry=0x20006b20)
+    at .platformio/packages/toolchain-gccarmnoneeabi/zephyr-sdk-0.17.4/arm-zephyr-eabi/arm-zephyr-eabi/include/c++/12.2.0/bits/std_function.h:591
+#8  0x0000470a in esphome::Scheduler::execute_item_ (this=this@entry=0x20001d98 <esphome::App>, item=0x20006b10, now=now@entry=0)
+    at .esphome/build/coredump-test/src/esphome/core/scheduler.cpp:617
+#9  0x000161a8 in esphome::Scheduler::call (this=this@entry=0x20001d98 <esphome::App>, now=0, now@entry=30372)
+    at .esphome/build/coredump-test/src/esphome/core/scheduler.cpp:528
+#10 0x00014ec0 in esphome::Application::before_loop_tasks_ (this=this@entry=0x20001d98 <esphome::App>, loop_start_time=loop_start_time@entry=30372)
+    at .esphome/build/coredump-test/src/esphome/core/application.cpp:520
+#11 0x00003850 in esphome::Application::loop (this=0x20001d98 <esphome::App>) at .esphome/build/coredump-test/src/esphome/core/application.cpp:152
+#12 0x00004d20 in loop () at i.yaml:135
+#13 0x00014b38 in main () at .esphome/build/coredump-test/src/esphome/components/zephyr/core.cpp:104
 ```
 
 ## See Also

--- a/content/components/zephyr_coredump.md
+++ b/content/components/zephyr_coredump.md
@@ -1,0 +1,20 @@
+---
+description: "Zephyr GDB coredump"
+title: "Zephyr GDB coredump"
+---
+
+```yaml
+# Example configuration entry
+esphome:
+  name: coredump-test
+  on_boot:
+    then:
+      - delay: 30s
+      - lambda: |-
+          volatile uint32_t *p = (uint32_t *)0xDEADBEEF;
+          *p = 0xDEADBEEF;
+
+zephyr_coredump:
+```
+
+## See Also

--- a/content/components/zephyr_coredump.md
+++ b/content/components/zephyr_coredump.md
@@ -5,7 +5,7 @@ title: "Zephyr GDB coredump"
 
 This component helps debug crashes without requiring SWD. When a crash occurs, the stack memory is saved to flash.
 On the next boot, the stored stack memory is printed to the logs.
-These logs can then be used to reconstruct the call stack, as described in the Zephyr coredump documentation:
+These logs can then be used to reconstruct the call stack, as described in the 
 [Zephyr coredump documentation](https://docs.zephyrproject.org/latest/services/debugging/coredump.html)
 
 ```yaml

--- a/content/components/zephyr_coredump.md
+++ b/content/components/zephyr_coredump.md
@@ -6,7 +6,7 @@ title: "Zephyr GDB coredump"
 This component helps debug crashes without requiring SWD. When a crash occurs, the stack memory is saved to flash.
 On the next boot, the stored stack memory is printed to the logs.
 These logs can then be used to reconstruct the call stack, as described in the Zephyr coredump documentation:
-https://docs.zephyrproject.org/latest/services/debugging/coredump.html
+[Zephyr coredump documentation](https://docs.zephyrproject.org/latest/services/debugging/coredump.html)
 
 ```yaml
 # Example configuration entry
@@ -25,7 +25,7 @@ zephyr_coredump:
 
 ## Crash log example
 
-```
+```log
 [14:36:08.267][E][coredump:052]: #CD:BEGIN#
 [14:36:08.267][E][coredump:039]: #CD:5a450100030005001a0000004102004400d0670020b4670020efbeadde00b0ad
 [14:36:08.269][E][coredump:039]: #CD:de00000000296201002862010000000001505500200000000000000000000000
@@ -39,7 +39,7 @@ zephyr_coredump:
 ```gdb
 0x00016228 in esphome::StatelessLambdaAction<>::play() (this=<optimized out>)
     at .esphome/build/coredump-test/src/esphome/core/base_automation.h:231
-231	  void play(const Ts &...x) override { this->f_(x...); }
+231  void play(const Ts &...x) override { this->f_(x...); }
 (gdb) bt
 #0  0x00016228 in esphome::StatelessLambdaAction<>::play() (
     this=<optimized out>)

--- a/content/components/zephyr_coredump.md
+++ b/content/components/zephyr_coredump.md
@@ -11,6 +11,7 @@ esphome:
     then:
       - delay: 30s
       - lambda: |-
+          // Intentionally trigger a crash
           volatile uint32_t *p = (uint32_t *)0xDEADBEEF;
           *p = 0xDEADBEEF;
 


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- https://github.com/esphome/esphome/pull/13122

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image GDB
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/static/images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/_index.md`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image dht22
```

</details>
