### PR TITLE
Add entry for new model supported

### DIFF
--- a/content/components/display/waveshare_epaper.md
+++ b/content/components/display/waveshare_epaper.md
@@ -96,6 +96,7 @@ lambda: |-
   - `2.13in-ttgo-dke` - T5_V2.3 with DKE group display (DEPG0213BN) tested
   - `2.13inv2` - 2.13in V2 display (Pico e-Paper 2.13v2 and Cloud Module)
   - `2.13inv3` - 2.13in V3 display (Pico e-Paper 2.13v3)
+  - `2.66in-b`
   - `2.70in` - currently not working with the HAT Rev 2.1 version
   - `2.70inv2`
   - `2.70in-b` - Black/White/Red


### PR DESCRIPTION
## Description:

Add a new model entry for the Waveshare 2.66 inch e-paper (B) module

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#13323

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/static/images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/_index.md`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image dht22
```

</details>
