### PR TITLE
Update midea.md to include power_multiplier in documentation

### DIFF
--- a/content/components/climate/midea.md
+++ b/content/components/climate/midea.md
@@ -92,7 +92,7 @@ climate:
   - All options from [Sensor](/components/sensor).
 - **power_usage** (*Optional*): The information for the current power consumption
   sensor.
-  - **power_usage** (*Optional*, float): Multiplying facotr to correct the reported power usage. Defaults to 0.
+  - **power_multiplier** (*Optional*, float): Multiplying factor to correct the reported power usage. Defaults to 1.
   - All options from [Sensor](/components/sensor).
 - **humidity_setpoint** (*Optional*): The information for the humidity indoor
   sensor (experimental).

--- a/content/components/climate/midea.md
+++ b/content/components/climate/midea.md
@@ -63,6 +63,7 @@ climate:
       name: Temp
     power_usage:                # Optional. Power usage sensor (only for devices that support this feature).
       name: Power
+      power_multiplier: 1
     humidity_setpoint:          # Optional. Indoor humidity sensor (only for devices that support this feature).
       name: Humidity
 ```
@@ -91,7 +92,7 @@ climate:
   - All options from [Sensor](/components/sensor).
 - **power_usage** (*Optional*): The information for the current power consumption
   sensor.
-
+  - **power_usage** (*Optional*, float): Multiplying facotr to correct the reported power usage. Defaults to 0.
   - All options from [Sensor](/components/sensor).
 - **humidity_setpoint** (*Optional*): The information for the humidity indoor
   sensor (experimental).


### PR DESCRIPTION

## Description:

document the new power_multiplier option

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#13321

## Checklist:

  - [x ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.
