### PR TITLE
Add Huidu HD-WF1 to display component list

### DIFF
--- a/content/components/display/hub75.md
+++ b/content/components/display/hub75.md
@@ -95,6 +95,7 @@ Board presets automatically configure all pin mappings for popular HUB75 control
 - **`adafruit-matrix-portal-s3`** - Adafruit Matrix Portal S3
 - **`apollo-automation-m1-rev4`** - Apollo Automation M1 (Rev 4)
 - **`apollo-automation-m1-rev6`** - Apollo Automation M1 (Rev 6)
+- **`huidu-hd-wf1`** - Huidu HD-WF1
 - **`huidu-hd-wf2`** - Huidu HD-WF2
 - **`esp32-trinity`** - ESP32-Trinity
 


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#13341

## Checklist:

  - [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

