### PR TITLE
[status] Document update_interval option

### DIFF
--- a/content/components/binary_sensor/status.md
+++ b/content/components/binary_sensor/status.md
@@ -1,9 +1,9 @@
 ---
-description: "Instructions for setting up MQTT status binary sensors."
+description: "Instructions for setting up status binary sensors."
 title: "Status Binary Sensor"
 params:
   seo:
-    description: Instructions for setting up MQTT status binary sensors.
+    description: Instructions for setting up status binary sensors.
     image: server-network.svg
 ---
 
@@ -21,7 +21,9 @@ binary_sensor:
 
 ## Configuration variables
 
-- All options from [Binary Sensor](/components/binary_sensor#config-binary_sensor). (Inverted mode is not supported)
+- **update_interval** (*Optional*, {{< docref "/guides/configuration-types#time" "Time" >}}): The interval
+  to check the connection status. Defaults to `1s`.
+- All other options from [Binary Sensor](/components/binary_sensor#config-binary_sensor). (Inverted mode is not supported)
 
 ## See Also
 


### PR DESCRIPTION
## Description:

Document the new `update_interval` configuration option for the status binary sensor.

The status binary sensor has been converted from a `Component` to a `PollingComponent` to reduce CPU usage. This adds the standard `update_interval` option (defaulting to `1s`) that users can configure if needed.

Also fixed the description which incorrectly mentioned "MQTT" - the status binary sensor works with both MQTT and native API.

**Related issue (if applicable):** n/a

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#13342

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.
