### PR TITLE
Added Panasonic SN GCJA5 sensor to AQI list

### DIFF
--- a/content/components/sensor/aqi.md
+++ b/content/components/sensor/aqi.md
@@ -9,7 +9,8 @@ params:
 The `aqi` sensor platform allows you to compute an Air Quality Index from
 PM2.5 and PM10 particulate matter sensor readings. This sensor works with
 any PM sensor source, such as {{< docref "/components/sensor/pmsx003" >}},
-{{< docref "/components/sensor/hm3301" >}}, {{< docref "/components/sensor/sds011" >}},
+{{< docref "/components/sensor/hm3301" >}}, {{< docref "/components/sensor/sds011" >}}, 
+{{< docref "/components/sensor/gcja5" >}}
 or {{< docref "/components/sensor/sps30" >}}.
 
 > [!NOTE]
@@ -86,5 +87,6 @@ sensor:
 - {{< docref "/components/sensor/pmsx003" >}}
 - {{< docref "/components/sensor/hm3301" >}}
 - {{< docref "/components/sensor/sds011" >}}
+- {{< docref "/components/sensor/gcja5" >}}
 - {{< docref "/components/sensor/sps30" >}}
 - {{< apiref "aqi/aqi_sensor.h" "aqi/aqi_sensor.h" >}}

--- a/content/components/sensor/aqi.md
+++ b/content/components/sensor/aqi.md
@@ -9,7 +9,7 @@ params:
 The `aqi` sensor platform allows you to compute an Air Quality Index from
 PM2.5 and PM10 particulate matter sensor readings. This sensor works with
 any PM sensor source, such as {{< docref "/components/sensor/pmsx003" >}},
-{{< docref "/components/sensor/hm3301" >}}, {{< docref "/components/sensor/sds011" >}}, 
+{{< docref "/components/sensor/hm3301" >}}, {{< docref "/components/sensor/sds011" >}},  
 {{< docref "/components/sensor/gcja5" >}}
 or {{< docref "/components/sensor/sps30" >}}.
 
@@ -90,3 +90,4 @@ sensor:
 - {{< docref "/components/sensor/gcja5" >}}
 - {{< docref "/components/sensor/sps30" >}}
 - {{< apiref "aqi/aqi_sensor.h" "aqi/aqi_sensor.h" >}}
+

--- a/content/components/sensor/aqi.md
+++ b/content/components/sensor/aqi.md
@@ -90,4 +90,3 @@ sensor:
 - {{< docref "/components/sensor/gcja5" >}}
 - {{< docref "/components/sensor/sps30" >}}
 - {{< apiref "aqi/aqi_sensor.h" "aqi/aqi_sensor.h" >}}
-


### PR DESCRIPTION
## Description:
Added Panasonic SN GCJA5 sensor to AQI list of possible sensors to choose from. It makes it easier for new users to see that this sensor is also available for use with the AQI sensor component.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/static/images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/_index.md`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image dht22
```

</details>
