### PR TITLE
[mipi_spi] Add docs for CYD variants

### DIFF
--- a/content/components/display/mipi_spi.md
+++ b/content/components/display/mipi_spi.md
@@ -39,9 +39,10 @@ using an octal SPI bus, so references here to parallel and octal SPI are equival
 ### Driver chips
 
 | Driver Chip | Typical Dimensions |
-| ----------- | ------------------ |
+| ----------- |--------------------|
 | RM690B0     | 320x240            |
 | ILI9341     | 320x240            |
+| ILI9342     | 240x320            |
 | ILI9481     | 320x480            |
 | ILI9486     | 320x480            |
 | ILI9488     | 320x480            |
@@ -58,31 +59,33 @@ using an octal SPI bus, so references here to parallel and octal SPI are equival
 ### Boards with integrated displays
 
 | Model                                | Manufacturer | Product Description                                               |
-| ------------------------------------ | ------------ | ----------------------------------------------------------------- |
+|--------------------------------------|--------------|-------------------------------------------------------------------|
 | ADAFRUIT-S2-TFT-FEATHER              | Adafruit     | <https://www.adafruit.com/product/6312>                           |
 | ADAFRUIT-FUNHOUSE                    | Adafruit     | <https://www.adafruit.com/product/4985>                           |
-| M5CORE                               | M5Stack      | <https://docs.m5stack.com/en/core/BASIC%20v2.6> |
-| M5CORE2                              | M5Stack      | <https://docs.m5stack.com/en/core/core2> |
-| S3BOX                                | Espressif | <https://www.espressif.com/en/products/devkits/esp32-s3-box> |
-| S3BOXLITE                            | Espressif | <https://www.espressif.com/en/products/devkits/esp32-s3-box-lite> |
-| WAVESHARE-4-TFT                      | Waveshare | <https://www.waveshare.com/4inch-tft-touch-shield.htm> |
-| PICO-RESTOUCH-LCD-3.5                | Waveshare | <https://www.waveshare.com/pico-restouch-lcd-3.5.htm> |
-| WAVESHARE-ESP32-S3-TOUCH-AMOLED-1.75 | Waveshare | <https://www.waveshare.com/esp32-s3-touch-amoled-1.75.htm> |
-| WAVESHARE-ESP32-S3-TOUCH-LCD-3.49    | Waveshare | <https://www.waveshare.com/esp32-s3-touch-lcd-3.49.htm> |
-| WT32-SC01-PLUS                       | Wireless-Tag | <https://www.wireless-tag.com/portfolio/wt32-sc01-plus/> |
-| ESP32-2432S028                       | Sunton | <https://www.espressif.com/en/products/devkits/esp32-2432s028> |
-| JC3248W535                           | Guition | <https://www.aliexpress.com/item/1005007566332450.html> |
-| JC3636W518                           | Guition | <https://www.aliexpress.com/item/1005007890666293.html> |
-| JC3636W518V2                         | Guition | <https://www.aliexpress.com/item/1005007890666293.html> |
-| JC4827W543                           | Guition | <https://www.aliexpress.com/item/1005006729377800.html> |
-| LANBON-L8                            | Lanbon | <https://www.lanbon.cn/product/lanbon-l8> |
-| T4-S3                                | Lilygo | <https://www.lilygo.cc/products/t4-s3> |
-| T-EMBED                              | Lilygo | <https://www.lilygo.cc/products/t-embed> |
-| T-DISPLAY                            | Lilygo | <https://www.lilygo.cc/products/t-display> |
-| T-DISPLAY-S3                         | Lilygo | <https://www.lilygo.cc/products/t-display-s3> |
-| T-DISPLAY-S3-PRO                     | Lilygo | <https://www.lilygo.cc/products/t-display-s3-pro> |
-| T-DISPLAY-S3-AMOLED                  | Lilygo | <https://www.lilygo.cc/products/t-display-s3-amoled> |
-| T-DISPLAY-S3-AMOLED-PLUS             | Lilygo | <https://www.lilygo.cc/products/t-display-s3-amoled-plus> |
+| M5CORE                               | M5Stack      | <https://docs.m5stack.com/en/core/BASIC%20v2.6>                   |
+| M5CORE2                              | M5Stack      | <https://docs.m5stack.com/en/core/core2>                          |
+| S3BOX                                | Espressif    | <https://www.espressif.com/en/products/devkits/esp32-s3-box>      |
+| S3BOXLITE                            | Espressif    | <https://www.espressif.com/en/products/devkits/esp32-s3-box-lite> |
+| WAVESHARE-4-TFT                      | Waveshare    | <https://www.waveshare.com/4inch-tft-touch-shield.htm>            |
+| PICO-RESTOUCH-LCD-3.5                | Waveshare    | <https://www.waveshare.com/pico-restouch-lcd-3.5.htm>             |
+| WAVESHARE-ESP32-S3-TOUCH-AMOLED-1.75 | Waveshare    | <https://www.waveshare.com/esp32-s3-touch-amoled-1.75.htm>        |
+| WAVESHARE-ESP32-S3-TOUCH-LCD-3.49    | Waveshare    | <https://www.waveshare.com/esp32-s3-touch-lcd-3.49.htm>           |
+| WT32-SC01-PLUS                       | Wireless-Tag | <https://www.wireless-tag.com/portfolio/wt32-sc01-plus/>          |
+| ESP32-2432S028                       | Sunton       | 2.8" CYD. Original micro-USB version with ILI9341 controller.     |
+| ESP32-2432S028-7789                  | Sunton       | Dual-USB version with ST7789V.                                    |
+| ESP32-2432S028-9342                  | Sunton       | Dual-USB version with ILI9342.                                    |
+| JC3248W535                           | Guition      | <https://www.aliexpress.com/item/1005007566332450.html>           |
+| JC3636W518                           | Guition      | <https://www.aliexpress.com/item/1005007890666293.html>           |
+| JC3636W518V2                         | Guition      | <https://www.aliexpress.com/item/1005007890666293.html>           |
+| JC4827W543                           | Guition      | <https://www.aliexpress.com/item/1005006729377800.html>           |
+| LANBON-L8                            | Lanbon       | <https://www.lanbon.cn/product/lanbon-l8>                         |
+| T4-S3                                | Lilygo       | <https://www.lilygo.cc/products/t4-s3>                            |
+| T-EMBED                              | Lilygo       | <https://www.lilygo.cc/products/t-embed>                          |
+| T-DISPLAY                            | Lilygo       | <https://www.lilygo.cc/products/t-display>                        |
+| T-DISPLAY-S3                         | Lilygo       | <https://www.lilygo.cc/products/t-display-s3>                     |
+| T-DISPLAY-S3-PRO                     | Lilygo       | <https://www.lilygo.cc/products/t-display-s3-pro>                 |
+| T-DISPLAY-S3-AMOLED                  | Lilygo       | <https://www.lilygo.cc/products/t-display-s3-amoled>              |
+| T-DISPLAY-S3-AMOLED-PLUS             | Lilygo       | <https://www.lilygo.cc/products/t-display-s3-amoled-plus>         |
 
 ## SPI Bus
 
@@ -128,9 +131,10 @@ most of the configuration will be set by default, but can be overridden if neede
 
 - **invert_colors** (*Optional*, boolean): Specifies whether the display colors should be inverted. Options are `true` or `false`. Defaults to `false`.
 - **rotation** (*Optional*): Rotate the display presentation in software. Choose one of `0°`, `90°`, `180°`, or `270°`. If the driver chip supports hardware rotation for the given orientation this will be translated to the appropriate hardware command. If hardware rotation is not supported, the display will be rotated in software.
-- **transform** (*Optional*): If `rotation` is not sufficient, use this to transform the display. If this option is specified, then the `dimensions` option must also be provided. The value can either be the string `disabled` to disable hardware transform, or a dictionary. Options are:
-  This option should not be used with `rotation`. For the `CUSTOM` model, use `transform: disabled`
-  if the display does not support it, which will prevent a `rotation` being translated to a hardware transform.
+- **transform** (*Optional*): If `rotation` is not sufficient, use this to transform the display. If this option is
+  specified, then the `dimensions` option must also be provided. The value can either be the string `disabled` to disable hardware transform, or a dictionary.
+  For the `CUSTOM` model, use `transform: disabled` if the display does not support it, which will prevent a `rotation`
+  being translated to a hardware transform, otherwise the options below:
 
   - **swap_xy** (**Required**, boolean): If true, exchange the x and y axes.
   - **mirror_x** (**Required**, boolean): If true, mirror the x axis.


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes https://github.com/esphome/esphome/issues/13338

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#13340

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/static/images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/_index.md`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image dht22
```

</details>
