### PR TITLE
Add current transformer mode documentation for BL0939

### DIFF
--- a/src/content/docs/components/sensor/bl0939.mdx
+++ b/src/content/docs/components/sensor/bl0939.mdx
@@ -6,7 +6,10 @@ import APIRef from '@components/APIRef.astro';
 
 
 The `bl0939` sensor platform allows you to use your BL0939 voltage/current/power and energy
-sensors with ESPHome. This sensor is commonly found in Sonoff Dual R3 v2.
+sensors with ESPHome. This sensor supports two measurement modes:
+
+- **Direct mode** (default): Uses shunt resistor for current sensing (e.g., Sonoff Dual R3 v2)
+- **Current transformer mode**: Uses CT for current sensing (e.g., Seeed XIAO 2-Channel Wi-Fi AC Energy Meter)
 
 > [!NOTE]
 > SAFETY HAZARD: Some devices such as Sonoff POWs/Shelly/etc, have the digital GND connected directly to mains voltage so **the GPIOs become LIVE during normal operation**. Our advice is to mark these boards to prevent any use of the dangerous digital pins.
@@ -19,6 +22,7 @@ Additionally, you need to set the baud rate to 4800, parity to `NONE` and stop_b
 # Example configuration entry
 sensor:
   - platform: bl0939
+    mode: current_transformer  # Optional, defaults to 'direct'
     voltage:
       name: 'BL0939 Voltage'
     current_1:
@@ -41,6 +45,9 @@ sensor:
 > The configuration above should work for Sonoff Dual R3 v2.
 
 ## Configuration variables
+
+- **mode** (*Optional*, string): The measurement mode. One of `direct` or `current_transformer`.
+  Defaults to `direct`.
 
 - **voltage** (*Optional*): Use the voltage value of the sensor in V (RMS).
   All options from [Sensor](/components/sensor).


### PR DESCRIPTION
## Description:

BL0939 has `direct` measurement mode and `current transformer` measurement mode. The linked ESPHome PR adds support for `current transformer` measurement mode.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#13350

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.
