### PR TITLE
[water_heater] Fix incorrect Home Assistant integration and target_temperature documentation

### DIFF
--- a/content/changelog/2026.1.0.md
+++ b/content/changelog/2026.1.0.md
@@ -353,10 +353,12 @@ The `esp32_camera` component received significant performance improvements ([#12
 
 ESPHome now includes a dedicated [water_heater](/components/water_heater) entity type for controlling water heaters, boilers, and similar hot water appliances ([#12498](https://github.com/esphome/esphome/pull/12498), [#12516](https://github.com/esphome/esphome/pull/12516), [#12511](https://github.com/esphome/esphome/pull/12511)).
 
-- **Native Home Assistant integration** - Proper water heater entity type in Home Assistant
 - **Template platform** - Full control via automations and lambdas
 - **Multiple operating modes** - Support for eco, gas, and custom modes
 - **Web server support** - Control and monitor via the built-in web interface
+
+> [!NOTE]
+> Home Assistant integration is not yet available. See [home-assistant/core#159201](https://github.com/home-assistant/core/pull/159201) for progress.
 
 ```yaml
 water_heater:

--- a/content/changelog/2026.1.0.md
+++ b/content/changelog/2026.1.0.md
@@ -358,7 +358,7 @@ ESPHome now includes a dedicated [water_heater](/components/water_heater) entity
 - **Web server support** - Control and monitor via the built-in web interface
 
 > [!NOTE]
-> Home Assistant integration is not yet available. See [home-assistant/core#159201](https://github.com/home-assistant/core/pull/159201) for progress.
+> Home Assistant integration for water heater entities is not yet available. See [home-assistant/core#159201](https://github.com/home-assistant/core/pull/159201) for progress.
 
 ```yaml
 water_heater:

--- a/content/components/water_heater/_index.md
+++ b/content/components/water_heater/_index.md
@@ -6,7 +6,7 @@ title: "Water Heater Component"
 The `water_heater` component is a generic representation of water heaters (boilers) in ESPHome. A water heater handles a target temperature setpoint and an operation mode (like *Eco*, *Electric*, or *Performance*).
 
 > [!NOTE]
-> To use a water heater in Home Assistant requires Home Assistant 2024.5 or later.
+> Home Assistant integration for water heater entities is not yet available. See [home-assistant/core#159201](https://github.com/home-assistant/core/pull/159201) for progress.
 
 {{< anchor "config-water-heater" >}}
 
@@ -27,8 +27,6 @@ Configuration variables:
 > [!NOTE]
 > If you have a [friendly_name](/components/esphome#esphome-configuration_variables) set for your device and you want the water heater
 > to use that name, you can set `name: None`.
-
-- **target_temperature** (*Optional*, float): The initial target temperature to set on boot.
 
 - **icon** (*Optional*, icon): Manually set the icon to use for the water heater in the frontend.
 


### PR DESCRIPTION
## Description:

Fix incorrect water_heater documentation that was cargo-culted from an earlier 2024 implementation attempt.

**Changes:**

1. **Removed undocumented `target_temperature` config option** - The base water_heater docs claimed this was a valid configuration option for setting initial temperature on boot, but it was never implemented in the template platform. Users attempting to use it receive: `"[target_temperature] is an invalid option for [water_heater.template]"`

2. **Fixed Home Assistant integration status** - The docs incorrectly stated "To use a water heater in Home Assistant requires Home Assistant 2024.5 or later." In reality, Home Assistant integration is not yet available - the PR is still pending at home-assistant/core#159201. Updated to accurately reflect this.

3. **Updated 2026.1.0 release notes** - Removed the false "Native Home Assistant integration" bullet point and added a note clarifying HA integration is pending.

**Related issue (if applicable):** fixes https://github.com/esphome/esphome/issues/13355

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- N/A (documentation-only fix)

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [x] Link added in `/components/_index.md` when creating new documents for new components or cookbook.
    - N/A - no new components

