### PR TITLE
Add documentation for rmt_simple component

### DIFF
--- a/content/components/_index.md
+++ b/content/components/_index.md
@@ -935,6 +935,7 @@ at the {{< docref "light/fastled" "FastLED Light" >}}.
 "Modbus Output","components/output/modbus_controller","modbus.png",""
 "MY9231/MY9291","components/output/my9231","my9231.svg",""
 "PCA9685","components/output/pca9685","pca9685.jpg",""
+"RMT Simple","components/output/rmt_simple","pwm.png",""
 "Sigma-Delta Output","components/output/sigma_delta_output","sigma-delta.svg","dark-invert"
 "Slow PWM","components/output/slow_pwm","pwm.png",""
 "SM16716","components/output/sm16716","sm16716.svg",""

--- a/content/components/output/rmt_simple.md
+++ b/content/components/output/rmt_simple.md
@@ -7,14 +7,16 @@ params:
     image: pwm.png
 ---
 
-This library provides a static high-frequency, synchronised, multi-channel pulse sequence generator suitable for driving power-electronics, switched-capacitor, and timing-critical digital applications. The library uses the [RMT (Remote Control) peripheral](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/peripherals/rmt.html) to enable complementary and phase-controlled GPIO outputs with deterministic timing, and all accomplished with zero cpu overhead.
+This library provides a static high-frequency, synchronised, multi-channel pulse sequence generator suitable for driving power-electronics, switched-capacitor, and timing-critical digital applications. The library uses the [RMT (Remote Control) peripheral](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/peripherals/rmt.html) to enable complementary and phase-controlled pulse sequence outputs to GPIO pins.  The hardware peripheral ensures zero cpu overhead.
+
+The overarching aim of the library to provide an intuitive, and user-friendly way of deploying low-level rmt_word_types in pulse sequences. For this reason, the yaml input file uses rmt_word_type nomenclature for pulse sequence input.
 
 
 ## Platform variant support
 
-Different ESP32 variants support different numbers of RMT transmission channels and features:
+Advanced synchronisation hardware is enabled by default, but only available on certain chips:
 
-| Variant | Max Channels | Sync Manager | Alignment |
+| Variant | Max Transmission Channels | Sync Manager | Alignment |
 |---------|--------------|--------------|-----------|
 | ESP32    | 4 | No  | Optional |
 | ESP32-C3 | 2 | Yes | Required |
@@ -30,7 +32,7 @@ Different ESP32 variants support different numbers of RMT transmission channels 
 
 - **align_pulse_lengths** (*Optional*, boolean): When enabled, all channel pulse sequences are padded to match
   the longest pattern duration. This necessarily happens for hardware synchronisation.
-  Defaults to `true`. Can only be disabled on ESP32 - all other variants must use alignment.
+  Defaults to `true`. This feature can only be disabled for platforms lacking synchronisation hardware (ESP32).
 
 - **pin_0**, **pin_1**, **pin_2**, **pin_3** (*Optional*, [Pin](/guides/configuration-types#pin) or Object):
   GPIO pins and pulse configurations for up to 4 channels. At least one pin must be configured. Each pin
@@ -67,9 +69,9 @@ Each rmt_word_type symbol in the pulse sequence defines two level transitions:
 
 ## Understanding RMT symbols
 
-Each RMT symbol (internally `rmt_symbol_word_t`) defines **two** consecutive level transitions. This dual-transition
-structure allows compact representation of pulse patterns.  
-Each rmt_word_t symbol which is limited to 32767 ticks maximum.
+Each pulse consists of a RMT symbol (internally `rmt_symbol_word_t`) which defines **two** consecutive
+level transitions. This dual-transition structure allows compact representation of pulse patterns. Each
+rmt_word_t symbol which is limited to 32767 ticks maximum.
 
 **Example symbol breakdown:**
 ```yaml
@@ -81,9 +83,9 @@ Each rmt_word_t symbol which is limited to 32767 ticks maximum.
 
 Multiple symbols chain together to create complex patterns. The pattern repeats continuously once started.
 
-## Example configurations
+## Example configuration
 
-### Example: 2 channel square wave
+For scnchronised pulses, the frequency on each GPIO is determined both by the longest duration pulse sequence, and the number pulses per sequence on each GPIO.  In the example below pin_0 (GPIO26) is frequency limiting for both channels.
 
 ```yaml
 # Example configuration entry
@@ -96,7 +98,7 @@ rmt_simple:
   id: rmt_test
   resolution_hz: 10000000   # 10 MHz (100 ns per tick)
   pin_0:
-    gpio_number: GPIO26
+    gpio_number: GPIO26     # 400 KHz @ 5µs/sequence and 2 pulses/sequence
     pulse_sequence:
       - duration0: 10       # 1µs high
         level0: 1
@@ -104,23 +106,23 @@ rmt_simple:
         level1: 0
       - duration0: 5        # 0.5µs high
         level0: 1
-        duration1: 15       # 1.5µs low (Implied frequency of 100 KHz @ 2 pulses/cycle)
+        duration1: 15       # 1.5µs low (Implied frequency of 400 KHz at 50µs/sequence and 2 pulses/sequence)
         level1: 0
   pin_1:
-    gpio_number: GPIO16
+    gpio_number: GPIO16     # 200 KHz @ 50µs/sequence and 1 pulses/sequence
     pulse_sequence:
-      - duration0: 30
-        level0: 1
+      - duration0: 10
+        level0: 0
         duration1: 20
-        level1: 0
+        level1: 1
 ```
 
 ## Limitations and constraints
 
 - **No runtime control**: Cannot modify patterns without reflashing
 - **No Home Assistant integration**: No actions, triggers, or automations available
-- **Limited to 64 symbols per channel for EPS32**
-- **Limited to 48 symbols per channel for EPS32-XX variants**
+- **Limited to 64 symbols per channel for non-hardware synchronised variants (ESP32)**
+- **Limited to 48 symbols per channel for hardware synchronised variants**
 - **Platform-specific channel limits**: 2 synchronised channels on most variants, 4 on S3/P4
 
 ## Use cases

--- a/content/components/output/rmt_simple.md
+++ b/content/components/output/rmt_simple.md
@@ -95,6 +95,7 @@ esp32:
 rmt_simple:
   id: rmt_test
   resolution_hz: 10000000   # 10 MHz (100 ns per tick)
+  align_pulse_lengths: true  # Pad shorter patterns to match longest
   pin_0:
     gpio_number: GPIO26
     pulse_sequence:
@@ -119,8 +120,8 @@ rmt_simple:
 
 - **No runtime control**: Cannot modify patterns without reflashing
 - **No Home Assistant integration**: No actions, triggers, or automations available
-- **Limited to 64 symbols per channel for EPS32**
-- **Limited to 48 symbols per channel for EPS32-XX variants**
+- **Limited to 64 symbols per channel for EPS32 (no sync manager)**
+- **Limited to 48 symbols per channel for EPS32 variants having a sync manager**
 - **Platform-specific channel limits**: 2 synchronised channels on most variants, 4 on S3/P4
 
 ## Use cases

--- a/content/components/output/rmt_simple.md
+++ b/content/components/output/rmt_simple.md
@@ -97,13 +97,13 @@ rmt_simple:
   resolution_hz: 10000000   # 10 MHz (100 ns per tick)
   pin_0:
     gpio_number: GPIO26
-      - duration0: 10   # 1µs high
+      - duration0: 10       # 1µs high
         level0: 1
-        duration1: 20   # 2µs low
+        duration1: 20       # 2µs low
         level1: 0
-      - duration0: 5    # 0.5µs high
+      - duration0: 5        # 0.5µs high
         level0: 1
-        duration1: 15  # 1.5µs low (Implied frequency of 100 KHz @ 2 pulses/cycle)
+        duration1: 15       # 1.5µs low (Implied frequency of 100 KHz @ 2 pulses/cycle)
         level1: 0
   pin_1:
     gpio_number: GPIO16
@@ -119,7 +119,7 @@ rmt_simple:
 - **No Home Assistant integration**: No actions, triggers, or automations available
 - **Limited to 64 symbols per channel for EPS32**
 - **Limited to 48 symbols per channel for EPS32-XX variants**
-- **Platform-specific channel limits**: 2 channels on most variants, 4 on S3/P4
+- **Platform-specific channel limits**: 2 synchronised channels on most variants, 4 on S3/P4
 
 ## Use cases
 

--- a/content/components/output/rmt_simple.md
+++ b/content/components/output/rmt_simple.md
@@ -1,0 +1,141 @@
+---
+description: "Instructions for setting up RMT Simple pulse generator on ESP32"
+title: "RMT Simple Pulse Generator"
+params:
+  seo:
+    description: Instructions for setting up RMT Simple auto-start pulse generator on ESP32 variants
+    image: pwm.png
+---
+
+This library provides a static high-frequency, synchronised, multi-channel pulse sequence generator suitable for driving power-electronics, switched-capacitor, and timing-critical digital applications. The library uses the [RMT (Remote Control) peripheral](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/peripherals/rmt.html) to enable complementary and phase-controlled GPIO outputs with deterministic timing, and all accomplished with zero cpu overhead.
+
+
+## Platform variant support
+
+Different ESP32 variants support different numbers of RMT transmission channels and features:
+
+| Variant | Max Channels | Sync Manager | Alignment |
+|---------|--------------|--------------|-----------|
+| ESP32    | 4 | No  | Optional |
+| ESP32-C3 | 2 | Yes | Required |
+| ESP32-C6 | 2 | Yes | Required |
+| ESP32-S3 | 4 | Yes | Required |
+| ESP32-P4 | 4 | Yes | Required |
+
+## Configuration variables
+
+- **resolution_hz** (*Optional*, int): The default tick resolution is 1 µs, set by resolution_hz: 1000000.
+  Note: rmt_symbol_word_t only allocates 15 bits for tick encoding, so the maximum individual symbol length
+  is 32,767 ticks (≈32.8 ms at 1 MHz).
+
+- **align_pulse_lengths** (*Optional*, boolean): When enabled, all channel pulse sequences are padded to match
+  the longest pattern duration. This necessarily happens for hardware synchronisation.
+  Defaults to `true`. Can only be disabled on ESP32 - all other variants must use alignment.
+
+- **pin_0**, **pin_1**, **pin_2**, **pin_3** (*Optional*, [Pin](/guides/configuration-types#pin) or Object):
+  GPIO pins and pulse configurations for up to 4 channels. At least one pin must be configured. Each pin
+  accepts either a simple GPIO pin number or a full configuration object with pulse sequence.
+
+### Pin channel configuration
+
+- **gpio_number** (**Required**, [Pin](/guides/configuration-types#pin)): The GPIO pin to output pulses on.
+  Must be a valid output pin for your ESP32 variant.
+
+### Pulse sequence symbol configuration
+
+Each rmt_word_type symbol in the pulse sequence defines two level transitions:
+
+- **duration0** (**Required**, int): Duration of the first level in RMT ticks. 
+- **level0** (**Required**, int): State of the first level. `0` for LOW, `1` for HIGH.
+- **duration1** (**Required**, int): Duration of the second level in RMT ticks.
+- **level1** (**Required**, int): State of the second level. `0` for LOW, `1` for HIGH.
+
+**Example conversions at different resolutions:**
+
+| Resolution | Tick Duration  | Max duration (32767 ticks) |
+|------------|---------------|------------|
+| 1 MHz | 1 µs | 32.767 ms |
+| 10 MHz | 100 ns | 3.277 ms |
+| 80 MHz | 12.5 ns | 409.6 µs |
+
+**Choosing a resolution:**
+- **Lower frequency** (1 MHz): Longer maximum duration, less precision. Good for millisecond-range pulses.
+- **Higher frequency** (80 MHz): Shorter maximum duration, high precision. Good for sub-microsecond timing.
+
+> [!NOTES] 
+> Frequency can be adjusted by zero filling the longest pulse sequence. 
+
+## Understanding RMT symbols
+
+Each RMT symbol (internally `rmt_symbol_word_t`) defines **two** consecutive level transitions. This dual-transition
+structure allows compact representation of pulse patterns.  
+Each rmt_word_t symbol which is limited to 32767 ticks maximum.
+
+**Example symbol breakdown:**
+```yaml
+- duration0: 100   # Stay at level0 for 100 ticks
+  level0: 0        # First level is LOW
+  duration1: 50    # Stay at level1 for 50 ticks
+  level1: 1        # Second level is HIGH
+```
+
+Multiple symbols chain together to create complex patterns. The pattern repeats continuously once started.
+
+## Example configurations
+
+### Example: 2 channel square wave
+
+```yaml
+# Example configuration entry
+esp32:
+  board: esp32C6
+  framework:
+    type: esp-idf
+
+rmt_simple:
+  id: rmt_test
+  resolution_hz: 10000000   # 10 MHz (100 ns per tick)
+  pin_0:
+    gpio_number: GPIO26
+      - duration0: 10   # 1µs high
+        level0: 1
+        duration1: 20   # 2µs low
+        level1: 0
+      - duration0: 5    # 0.5µs high
+        level0: 1
+        duration1: 15  # 1.5µs low (Implied frequency of 100 KHz @ 2 pulses/cycle)
+        level1: 0
+  pin_1:
+    gpio_number: GPIO16
+      - duration0: 30
+        level0: 1
+        duration1: 20
+        level1: 0
+```
+
+## Limitations and constraints
+
+- **No runtime control**: Cannot modify patterns without reflashing
+- **No Home Assistant integration**: No actions, triggers, or automations available
+- **Limited to 64 symbols per channel for EPS32**
+- **Limited to 48 symbols per channel for EPS32-XX variants**
+- **Platform-specific channel limits**: 2 channels on most variants, 4 on S3/P4
+
+## Use cases
+
+**Well suited for:**
+- Charge pumps / voltage doublers
+- Synchronous DC-DC converters
+- Inverters
+- Motor control experiments
+- Fixed frequency ultrasonic signal generation
+- Software-defined pulse sequencer, similar to what one might otherwise implement
+  using a CPLD, GAL, or 555/logic glue
+
+## See Also
+
+- {{< docref "/components/output" >}}
+- {{< docref "/components/output/ledc" >}} - ESP32 PWM output (dynamic frequency control)
+- {{< docref "/components/remote_transmitter" >}} - IR transmission with RMT peripheral
+- {{< apiref "rmt_simple/rmt_simple.h" "rmt_simple/rmt_simple.h" >}}
+- [ESP-IDF RMT Documentation](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/peripherals/rmt.html)

--- a/content/components/output/rmt_simple.md
+++ b/content/components/output/rmt_simple.md
@@ -11,14 +11,13 @@ This library provides a static high-frequency, synchronised, multi-channel pulse
 
 The overarching aim of the library to provide an intuitive, and user-friendly way of deploying low-level rmt_word_types in pulse sequences. For this reason, the yaml input file uses rmt_word_type nomenclature for pulse sequence input.
 
-
 ## Platform variant support
 
 Advanced synchronisation hardware is enabled by default, but only available on certain chips:
 
 | Variant | Max Transmission Channels | Sync Manager | Alignment |
-|---------|--------------|--------------|-----------|
-| ESP32    | 4 | No  | Optional |
+| ------- | ------------------------- | ------------ | --------- |
+| ESP32 | 4 | No | Optional |
 | ESP32-C3 | 2 | Yes | Required |
 | ESP32-C6 | 2 | Yes | Required |
 | ESP32-S3 | 4 | Yes | Required |
@@ -47,25 +46,26 @@ Advanced synchronisation hardware is enabled by default, but only available on c
 
 Each rmt_word_type symbol in the pulse sequence defines two level transitions:
 
-- **duration0** (**Required**, int): Duration of the first level in RMT ticks. 
+- **duration0** (**Required**, int): Duration of the first level in RMT ticks.
 - **level0** (**Required**, int): State of the first level. `0` for LOW, `1` for HIGH.
 - **duration1** (**Required**, int): Duration of the second level in RMT ticks.
 - **level1** (**Required**, int): State of the second level. `0` for LOW, `1` for HIGH.
 
 **Example conversions at different resolutions:**
 
-| Resolution | Tick Duration  | Max duration (32767 ticks) |
-|------------|---------------|------------|
+| Resolution | Tick Duration | Max duration (32767 ticks) |
+| ---------- | ------------- | -------------------------- |
 | 1 MHz | 1 µs | 32.767 ms |
 | 10 MHz | 100 ns | 3.277 ms |
 | 80 MHz | 12.5 ns | 409.6 µs |
 
 **Choosing a resolution:**
+
 - **Lower frequency** (1 MHz): Longer maximum duration, less precision. Good for millisecond-range pulses.
 - **Higher frequency** (80 MHz): Shorter maximum duration, high precision. Good for sub-microsecond timing.
 
-> [!NOTES] 
-> Frequency can be adjusted by zero filling the longest pulse sequence. 
+> [!NOTES]
+> Frequency can be adjusted by zero filling the longest pulse sequence.
 
 ## Understanding RMT symbols
 
@@ -74,6 +74,7 @@ level transitions. This dual-transition structure allows compact representation 
 rmt_word_t symbol which is limited to 32767 ticks maximum.
 
 **Example symbol breakdown:**
+
 ```yaml
 - duration0: 100   # Stay at level0 for 100 ticks
   level0: 0        # First level is LOW
@@ -128,6 +129,7 @@ rmt_simple:
 ## Use cases
 
 **Well suited for:**
+
 - Charge pumps / voltage doublers
 - Synchronous DC-DC converters
 - Inverters

--- a/content/components/output/rmt_simple.md
+++ b/content/components/output/rmt_simple.md
@@ -97,6 +97,7 @@ rmt_simple:
   resolution_hz: 10000000   # 10 MHz (100 ns per tick)
   pin_0:
     gpio_number: GPIO26
+    pulse_sequence:
       - duration0: 10       # 1µs high
         level0: 1
         duration1: 20       # 2µs low
@@ -107,6 +108,7 @@ rmt_simple:
         level1: 0
   pin_1:
     gpio_number: GPIO16
+    pulse_sequence:
       - duration0: 30
         level0: 1
         duration1: 20

--- a/content/components/output/rmt_simple.md
+++ b/content/components/output/rmt_simple.md
@@ -9,14 +9,13 @@ params:
 
 This library provides a static high-frequency, synchronised, multi-channel pulse sequence generator suitable for driving power-electronics, switched-capacitor, and timing-critical digital applications. The library uses the [RMT (Remote Control) peripheral](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/peripherals/rmt.html) to enable complementary and phase-controlled GPIO outputs with deterministic timing, and all accomplished with zero cpu overhead.
 
-
 ## Platform variant support
 
 Different ESP32 variants support different numbers of RMT transmission channels and features:
 
 | Variant | Max Channels | Sync Manager | Alignment |
-|---------|--------------|--------------|-----------|
-| ESP32    | 4 | No  | Optional |
+| ------- | ------------ | ------------ | --------- |
+| ESP32 | 4 | No | Optional |
 | ESP32-C3 | 2 | Yes | Required |
 | ESP32-C6 | 2 | Yes | Required |
 | ESP32-S3 | 4 | Yes | Required |
@@ -45,25 +44,26 @@ Different ESP32 variants support different numbers of RMT transmission channels 
 
 Each rmt_word_type symbol in the pulse sequence defines two level transitions:
 
-- **duration0** (**Required**, int): Duration of the first level in RMT ticks. 
+- **duration0** (**Required**, int): Duration of the first level in RMT ticks.
 - **level0** (**Required**, int): State of the first level. `0` for LOW, `1` for HIGH.
 - **duration1** (**Required**, int): Duration of the second level in RMT ticks.
 - **level1** (**Required**, int): State of the second level. `0` for LOW, `1` for HIGH.
 
 **Example conversions at different resolutions:**
 
-| Resolution | Tick Duration  | Max duration (32767 ticks) |
-|------------|---------------|------------|
+| Resolution | Tick Duration | Max duration (32767 ticks) |
+| ---------- | ------------- | -------------------------- |
 | 1 MHz | 1 µs | 32.767 ms |
 | 10 MHz | 100 ns | 3.277 ms |
 | 80 MHz | 12.5 ns | 409.6 µs |
 
 **Choosing a resolution:**
+
 - **Lower frequency** (1 MHz): Longer maximum duration, less precision. Good for millisecond-range pulses.
 - **Higher frequency** (80 MHz): Shorter maximum duration, high precision. Good for sub-microsecond timing.
 
-> [!NOTES] 
-> Frequency can be adjusted by zero filling the longest pulse sequence. 
+> [!NOTES]
+> Frequency can be adjusted by zero filling the longest pulse sequence.
 
 ## Understanding RMT symbols
 
@@ -72,6 +72,7 @@ structure allows compact representation of pulse patterns.
 Each rmt_word_t symbol which is limited to 32767 ticks maximum.
 
 **Example symbol breakdown:**
+
 ```yaml
 - duration0: 100   # Stay at level0 for 100 ticks
   level0: 0        # First level is LOW
@@ -127,6 +128,7 @@ rmt_simple:
 ## Use cases
 
 **Well suited for:**
+
 - Charge pumps / voltage doublers
 - Synchronous DC-DC converters
 - Inverters


### PR DESCRIPTION
## Description:

Documents the new rmt_simple component for auto-start pulse generation. Includes oscilloscope captures demonstrating hardware synchronization precision and multi-channel operation.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#13384

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/static/images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/_index.md`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image dht22
```

</details>