### PR TITLE
2026.1.0b4

### DIFF
--- a/content/changelog/2026.1.0.md
+++ b/content/changelog/2026.1.0.md
@@ -353,10 +353,12 @@ The `esp32_camera` component received significant performance improvements ([#12
 
 ESPHome now includes a dedicated [water_heater](/components/water_heater) entity type for controlling water heaters, boilers, and similar hot water appliances ([#12498](https://github.com/esphome/esphome/pull/12498), [#12516](https://github.com/esphome/esphome/pull/12516), [#12511](https://github.com/esphome/esphome/pull/12511)).
 
-- **Native Home Assistant integration** - Proper water heater entity type in Home Assistant
 - **Template platform** - Full control via automations and lambdas
 - **Multiple operating modes** - Support for eco, gas, and custom modes
 - **Web server support** - Control and monitor via the built-in web interface
+
+> [!NOTE]
+> Home Assistant integration for water heater entities is not yet available. See [home-assistant/core#159201](https://github.com/home-assistant/core/pull/159201) for progress.
 
 ```yaml
 water_heater:

--- a/content/changelog/2026.1.0.md
+++ b/content/changelog/2026.1.0.md
@@ -1104,6 +1104,11 @@ For detailed migration guides and API documentation, see the [ESPHome Developers
 - [hmac_sha256] Replace unsafe sprintf with format_hex_to [esphome#13290](https://github.com/esphome/esphome/pull/13290) by [@bdraco](https://github.com/bdraco)
 - [hub75] Bump esp-hub75 version to 0.3.0 [esphome#13243](https://github.com/esphome/esphome/pull/13243) by [@stuartparmenter](https://github.com/stuartparmenter) (breaking-change)
 - [http_request] Unable to handle chunked responses [esphome#7884](https://github.com/esphome/esphome/pull/7884) by [@HLFCode](https://github.com/HLFCode)
+- [network] Fix IPAddress::str_to() to lowercase IPv6 hex digits [esphome#13325](https://github.com/esphome/esphome/pull/13325) by [@bdraco](https://github.com/bdraco)
+- [api] Fix truncation of Home Assistant attributes longer than 255 characters [esphome#13348](https://github.com/esphome/esphome/pull/13348) by [@bdraco](https://github.com/bdraco)
+- [core] Fix state leakage and module caching when processing multiple configurations [esphome#13368](https://github.com/esphome/esphome/pull/13368) by [@swoboda1337](https://github.com/swoboda1337)
+- [x9c] Fix potentiometer unable to decrement [esphome#13382](https://github.com/esphome/esphome/pull/13382) by [@swoboda1337](https://github.com/swoboda1337)
+- [wifi_info] Fix missing state when both IP+DNS or SSID+BSSID configure [esphome#13385](https://github.com/esphome/esphome/pull/13385) by [@bdraco](https://github.com/bdraco)
 
 </details>
 

--- a/content/components/water_heater/_index.md
+++ b/content/components/water_heater/_index.md
@@ -6,7 +6,7 @@ title: "Water Heater Component"
 The `water_heater` component is a generic representation of water heaters (boilers) in ESPHome. A water heater handles a target temperature setpoint and an operation mode (like *Eco*, *Electric*, or *Performance*).
 
 > [!NOTE]
-> To use a water heater in Home Assistant requires Home Assistant 2024.5 or later.
+> Home Assistant integration for water heater entities is not yet available. See [home-assistant/core#159201](https://github.com/home-assistant/core/pull/159201) for progress.
 
 {{< anchor "config-water-heater" >}}
 
@@ -27,8 +27,6 @@ Configuration variables:
 > [!NOTE]
 > If you have a [friendly_name](/components/esphome#esphome-configuration_variables) set for your device and you want the water heater
 > to use that name, you can set `name: None`.
-
-- **target_temperature** (*Optional*, float): The initial target temperature to set on boot.
 
 - **icon** (*Optional*, icon): Manually set the icon to use for the water heater in the frontend.
 

--- a/content/components/water_heater/_index.md
+++ b/content/components/water_heater/_index.md
@@ -147,4 +147,5 @@ Available C++ enums for modes:
 
 ## See Also
 
+- {{< docref "/components/water_heater/template" >}}
 - {{< apiref "water_heater/water_heater.h" "water_heater/water_heater.h" >}}

--- a/content/guides/supporters.md
+++ b/content/guides/supporters.md
@@ -894,6 +894,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Nate Clark (@heythisisnate)](https://github.com/heythisisnate)
 - [highground88 (@highground88)](https://github.com/highground88)
 - [hindenbugbite (@hindenbugbite)](https://github.com/hindenbugbite)
+- [Mike Ford (@HLFCode)](https://github.com/HLFCode)
 - [Henrik Fransson (@hmfhmf)](https://github.com/hmfhmf)
 - [Hmmbob (@hmmbob)](https://github.com/hmmbob)
 - [Hamish Moffatt (@hmoffatt)](https://github.com/hmoffatt)
@@ -2321,4 +2322,4 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Christian Zufferey (@zuzu59)](https://github.com/zuzu59)
 - [Zynth-dev (@Zynth-dev)](https://github.com/Zynth-dev)
 
-*This page was last updated January 16, 2026.*
+*This page was last updated January 20, 2026.*

--- a/data/version.yaml
+++ b/data/version.yaml
@@ -1,2 +1,2 @@
-release: 2026.1.0b3
+release: 2026.1.0b4
 version: '2026.1'


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- Add reference to water heater template documentation [docs#5953](https://github.com/esphome/esphome-docs/pull/5953)
- [water_heater] Fix incorrect Home Assistant integration and target_temperature documentation [docs#5949](https://github.com/esphome/esphome-docs/pull/5949)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
