### PR TITLE
Update aht10.md

### DIFF
--- a/content/components/sensor/aht10.md
+++ b/content/components/sensor/aht10.md
@@ -39,7 +39,8 @@ sensor:
   - `AHT20` - For AHT20 and AHT30 devices.
 
 > [!NOTE]
-> Even if the sensor chip housing is labeled as AHT10, it might be necessary to configure the `AHT20` variant. If the sensor is listed in the log as recognized at the configured address, but no data could be fetches, please give it a try.
+> Even if the sensor chip housing is labeled as AHT10, it may require the `AHT20` variant configuration.
+> If recognized at the address but data fetch fails, try the AHT20 variant.
 
 - **temperature** (**Required**): The information for the temperature sensor.
 

--- a/content/components/sensor/aht10.md
+++ b/content/components/sensor/aht10.md
@@ -38,6 +38,9 @@ sensor:
   - `AHT10` - For AHT10 devices.
   - `AHT20` - For AHT20 and AHT30 devices.
 
+> [!NOTE]
+> Even if the sensor chip housing is labeled as AHT10, it might be necessary to configure the `AHT20` variant. If the sensor is listed in the log as recognized at the configured address, but no data could be fetches, please give it a try.
+
 - **temperature** (**Required**): The information for the temperature sensor.
 
   - All options from [Sensor](/components/sensor).


### PR DESCRIPTION
## Description:

Add a hint to try the AHT20 protocol variant in case of an AHT10 is detected on bus, but data can't be read out.

This happens to me using a vanilla AHT10 module purchased 2025/12 at _AliExpress_. The board and event the chip housing is labeled with `AHT10`.

It take hours to find some clue at reddit for a person that did similar observations (using another software stack.)

**Related issue (if applicable):** _not found_

signup: G.Jaekel@DNB.DE