### PR TITLE
[http_request] Clarify verify_ssl framework requirements

### DIFF
--- a/content/components/http_request.md
+++ b/content/components/http_request.md
@@ -29,7 +29,9 @@ http_request:
 - **verify_ssl** (*Optional*, boolean): When set to `true` (default), SSL/TLS certificates will be validated upon
   connection; if invalid, the connection will be aborted. To accomplish this, ESP-IDF's default ESP x509 certificate
   bundle is included in the build. This certificate bundle includes the complete list of root certificates from
-  Mozilla's NSS root certificate store. **Supported on ESP32 only; must be explicitly set to false on other platforms.**
+  Mozilla's NSS root certificate store. **Certificate verification is supported on ESP32 only; must be explicitly
+  set to false on other platforms. Disabling verification (`verify_ssl: false`) requires ESP-IDF framework and is
+  not supported on ESP32 Arduino.**
 
 - **watchdog_timeout** (*Optional*, [Time](/guides/configuration-types#time)): Change the watchdog timeout during connection/data transfer.
   May be useful on slow connections or connections with high latency. **Do not change this value unless you are


### PR DESCRIPTION
## Description:

Clarifies that disabling SSL verification (`verify_ssl: false`) requires ESP-IDF framework and is not supported on ESP32 Arduino.

**Related issue (if applicable):** fixes https://github.com/esphome/esphome/issues/13413

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#13422

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)