### PR TITLE
[esp32] `esp-idf` is now the default framework for all variants

### DIFF
--- a/content/components/esp32.md
+++ b/content/components/esp32.md
@@ -49,6 +49,20 @@ esp32:
 
 ESPHome supports two framework options for ESP32 chips:
 
+### ESP-IDF Framework
+
+ESP-IDF is Espressif's native development framework. It is required for ESP32-C2, ESP32-C5, ESP32-C6, ESP32-C61,
+ESP32-H2, and ESP32-P4 variants, as these are not supported by the Arduino framework. It is the default and recommended for
+all ESP32 chips when possible. See the {{< docref "/guides/esp32_arduino_to_idf" "migration guide" >}} for help transitioning from Arduino.
+
+```yaml
+# Example configuration entry
+esp32:
+  board: ...
+  framework:
+    type: esp-idf
+```
+
 ### Arduino Framework
 
 The Arduino framework is integrated as an ESP-IDF component. This provides Arduino API compatibility
@@ -62,23 +76,9 @@ esp32:
     type: arduino
 ```
 
-### ESP-IDF Framework
-
-ESP-IDF is Espressif's native development framework. It is required for ESP32-C2, ESP32-C5, ESP32-C6, ESP32-C61,
-ESP32-H2, and ESP32-P4 variants, as these are not supported by the Arduino framework. It is recommended for
-all ESP32 chips when possible. See the {{< docref "/guides/esp32_arduino_to_idf" "migration guide" >}} for help transitioning from Arduino.
-
-```yaml
-# Example configuration entry
-esp32:
-  board: ...
-  framework:
-    type: esp-idf
-```
-
 ### Configuration variables
 
-- **type** (*Optional*, string): The framework type, either `esp-idf` or `arduino`. Defaults to `arduino` for ESP32 (classic), ESP32-C3, ESP32-S2, and ESP32-S3. Defaults to `esp-idf` for ESP32-C2, ESP32-C5, ESP32-C6, ESP32-C61, ESP32-H2, and ESP32-P4 (Arduino is not supported on these variants)
+- **type** (*Optional*, string): The framework type, either `esp-idf` or `arduino`. Defaults to `esp-idf` for all ESP32 variants.
 
 - **version** (*Optional*, string): The base framework version number to use, from
   [ESP32 ESP-IDF releases](https://github.com/espressif/esp-idf/releases) or


### PR DESCRIPTION
## Description:
`esp-idf` is now the default framework for all variants

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/static/images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/_index.md`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image dht22
```

</details>
