### PR TITLE
[bthome_mithermometer] add encrypted beacon support

### DIFF
--- a/content/components/sensor/xiaomi_ble.md
+++ b/content/components/sensor/xiaomi_ble.md
@@ -178,7 +178,7 @@ Hygro thermometer, small square body, segment LCD, encrypted, broadcasts tempera
 
 {{< img src="xiaomi_lywsd03mmc.jpg" alt="Image" width="30.0%" class="align-center" >}}
 
-There are the several possibilities to operate this sensor:
+There are several ways to operate this sensor:
 
 1. Xiaomi stock firmware (requires a bindkey)
 1. Device flashed with [PVVX MiThermometer](https://github.com/pvvx/ATC_MiThermometer) custom firmware, supporting "BTHome v2", "ATC1441", "PVVX (Custom)", "MIJIA (MiHome)" advertisements

--- a/content/components/sensor/xiaomi_ble.md
+++ b/content/components/sensor/xiaomi_ble.md
@@ -25,7 +25,7 @@ Configuration example:
 ```yaml
 sensor:
   - platform: xiaomi_hhccjcy01
-    mac_address: XX:XX:XX:XX:XX:XX
+    mac_address: "XX:XX:XX:XX:XX:XX"
     temperature:
       name: "Xiaomi HHCCJCY01 Temperature"
     moisture:
@@ -53,7 +53,7 @@ Configuration example:
 ```yaml
 sensor:
   - platform: xiaomi_gcls002
-    mac_address: XX:XX:XX:XX:XX:XX
+    mac_address: "XX:XX:XX:XX:XX:XX"
     temperature:
       name: "GCLS02 Temperature"
     moisture:
@@ -75,7 +75,7 @@ Configuration example:
 ```yaml
 sensor:
   - platform: xiaomi_hhccpot002
-    mac_address: XX:XX:XX:XX:XX:XX
+    mac_address: "XX:XX:XX:XX:XX:XX"
     moisture:
       name: "HHCCPOT002 Moisture"
     conductivity:
@@ -93,7 +93,7 @@ Configuration example:
 ```yaml
 sensor:
   - platform: xiaomi_lywsdcgq
-    mac_address: XX:XX:XX:XX:XX:XX
+    mac_address: "XX:XX:XX:XX:XX:XX"
     temperature:
       name: "LYWSDCGQ Temperature"
     humidity:
@@ -115,7 +115,7 @@ Configuration example:
 ```yaml
 sensor:
   - platform: xiaomi_lywsd02
-    mac_address: XX:XX:XX:XX:XX:XX
+    mac_address: "XX:XX:XX:XX:XX:XX"
     temperature:
       name: "LYWSD02 Temperature"
     humidity:
@@ -133,7 +133,7 @@ Configuration example:
 ```yaml
 sensor:
   - platform: xiaomi_lywsd02mmc
-    mac_address: "A4:C1:38:54:5E:18"
+    mac_address: "XX:XX:XX:XX:XX:XX"
     bindkey: "2529d8e0d23150a588675cc54ad48400"
     temperature:
       name: "LYWSD02MMC Temperature"
@@ -156,7 +156,7 @@ Configuration example:
 ```yaml
 sensor:
   - platform: xiaomi_cgg1
-    mac_address: XX:XX:XX:XX:XX:XX
+    mac_address: "XX:XX:XX:XX:XX:XX"
     temperature:
       name: "CGG1 Temperature"
     humidity:
@@ -164,7 +164,7 @@ sensor:
     battery_level:
       name: "CGG1 Battery Level"
   - platform: xiaomi_cgg1
-    mac_address: XX:XX:XX:XX:XX:XX
+    mac_address: "XX:XX:XX:XX:XX:XX"
     bindkey: "00112233445566778899aabbccddeeff"
     temperature:
       name: "CGG1 (New) Temperature"
@@ -192,8 +192,8 @@ Configuration example for Xiaomi stock firmware or ATC MiThermometer firmware se
 ```yaml
 sensor:
   - platform: xiaomi_lywsd03mmc
-    mac_address: XX:XX:XX:XX:XX:XX
-    bindkey: "eef418daf699a0c188f3bfd17e4565d9"
+    mac_address: "XX:XX:XX:XX:XX:XX"
+    bindkey: "00112233445566778899aabbccddeeff"
     temperature:
       name: "LYWSD03MMC Temperature"
     humidity:
@@ -207,8 +207,8 @@ Configuration example for PVVX MiThermometer firmware set to "BTHome" advertisem
 ```yaml
 sensor:
   - platform: bthome_mithermometer
-    mac_address: AA:BB:CC:DD:EE:FF
-    bindkey: "eef418daf699a0c188f3bfd17e4565d9"
+    mac_address: "XX:XX:XX:XX:XX:XX"
+    bindkey: "00112233445566778899aabbccddeeff"
     temperature:
       name: "BTHome Temperature"
     humidity:
@@ -231,7 +231,7 @@ Configuration example for PVVX MiThermometer firmware set to "pvvx" advertisemen
 ```yaml
 sensor:
   - platform: pvvx_mithermometer
-    mac_address: XX:XX:XX:XX:XX:XX
+    mac_address: "XX:XX:XX:XX:XX:XX"
     temperature:
       name: "PVVX Temperature"
     humidity:
@@ -249,7 +249,7 @@ Configuration example for ATC MiThermometer firmware set to "Custom" advertiseme
 ```yaml
 sensor:
   - platform: atc_mithermometer
-    mac_address: XX:XX:XX:XX:XX:XX
+    mac_address: "XX:XX:XX:XX:XX:XX"
     temperature:
       name: "ATC Temperature"
     humidity:
@@ -276,8 +276,8 @@ Configuration example:
 ```yaml
 sensor:
   - platform: xiaomi_xmwsdj04mmc
-    mac_address: XX:XX:XX:XX:XX:XX
-    bindkey: "eef418daf699a0c188f3bfd17e4565d9"
+    mac_address: "XX:XX:XX:XX:XX:XX"
+    bindkey: "00112233445566778899aabbccddeeff"
     temperature:
       name: "XMWSDJ04MMC Temperature"
     humidity:
@@ -299,7 +299,7 @@ Configuration example:
 ```yaml
 sensor:
   - platform: xiaomi_mhoc303
-    mac_address: XX:XX:XX:XX:XX:XX
+    mac_address: "XX:XX:XX:XX:XX:XX"
     temperature:
       name: "MHO-C303 Climate Temperature"
     humidity:
@@ -329,8 +329,8 @@ Configuration example for Xiaomi stock firmware:
 ```yaml
 sensor:
   - platform: xiaomi_mhoc401
-    mac_address: XX:XX:XX:XX:XX:XX
-    bindkey: "eef418daf699a0c188f3bfd17e4565d9"
+    mac_address: "XX:XX:XX:XX:XX:XX"
+    bindkey: "00112233445566778899aabbccddeeff"
     temperature:
       name: "MHOC401 Temperature"
     humidity:
@@ -344,7 +344,7 @@ Configuration example for PVVX MiThermometer firmware set to "Custom" advertisem
 ```yaml
 sensor:
   - platform: pvvx_mithermometer
-    mac_address: XX:XX:XX:XX:XX:XX
+    mac_address: "XX:XX:XX:XX:XX:XX"
     temperature:
       name: "PVVX Temperature"
     humidity:
@@ -366,8 +366,8 @@ Configuration example:
 ```yaml
 sensor:
   - platform: xiaomi_cgd1
-    mac_address: XX:XX:XX:XX:XX:XX
-    bindkey: "fe39106baeedb7c801e3d63c4396f97e"
+    mac_address: "XX:XX:XX:XX:XX:XX"
+    bindkey: "00112233445566778899aabbccddeeff"
     temperature:
       name: "CGD1 Temperature"
     humidity:
@@ -388,8 +388,8 @@ Configuration example:
 ```yaml
 sensor:
   - platform: xiaomi_cgdk2
-    mac_address: XX:XX:XX:XX:XX:XX
-    bindkey: "fe39106baeedb7c801e3d63c4396f97e"
+    mac_address: "XX:XX:XX:XX:XX:XX"
+    bindkey: "00112233445566778899aabbccddeeff"
     temperature:
       name: "CGDK2 Temperature"
     humidity:
@@ -409,7 +409,7 @@ Configuration example:
 ```yaml
 sensor:
   - platform: xiaomi_jqjcy01ym
-    mac_address: XX:XX:XX:XX:XX:XX
+    mac_address: "XX:XX:XX:XX:XX:XX"
     temperature:
       name: "JQJCY01YM Temperature"
     humidity:
@@ -433,7 +433,7 @@ sensor:
 
 binary_sensor:
   - platform: xiaomi_wx08zm
-    mac_address: XX:XX:XX:XX:XX:XX
+    mac_address: "XX:XX:XX:XX:XX:XX"
     tablet:
       name: "WX08ZM Mosquito Tablet"
     battery_level:
@@ -454,7 +454,7 @@ sensor:
 binary_sensor:
   - platform: xiaomi_mue4094rt
     name: "MUE4094RT Night Light"
-    mac_address: XX:XX:XX:XX:XX:XX
+    mac_address: "XX:XX:XX:XX:XX:XX"
     timeout: "5s"
 ```
 
@@ -472,8 +472,8 @@ sensor:
 binary_sensor:
   - platform: xiaomi_mjyd02yla
     name: "MJYD02YL-A Night Light"
-    mac_address: XX:XX:XX:XX:XX:XX
-    bindkey: "48403ebe2d385db8d0c187f81e62cb64"
+    mac_address: "XX:XX:XX:XX:XX:XX"
+    bindkey: "00112233445566778899aabbccddeeff"
     idle_time:
       name: "MJYD02YL-A Idle Time"
     light:
@@ -496,8 +496,8 @@ Configuration example:
 binary_sensor:
   - platform: xiaomi_cgpr1
     name: "CGPR1 Motion detector"
-    mac_address: XX:XX:XX:XX:XX:XX
-    bindkey: "ff1ae526b23b4aebeadcaaad86f59055"
+    mac_address: "XX:XX:XX:XX:XX:XX"
+    bindkey: "00112233445566778899aabbccddeeff"
     idle_time:
       name: "CGPR1 Idle Time"
     battery_level:
@@ -518,8 +518,8 @@ Configuration example:
 ```yaml
 xiaomi_rtcgq02lm:
   - id: motion_one
-    mac_address: XX:XX:XX:XX:XX:XX
-    bindkey: fe39106baeedb7c801e3d63c4396f97e
+    mac_address: "XX:XX:XX:XX:XX:XX"
+    bindkey: 00112233445566778899aabbccddeeff
 
 binary_sensor:
   - platform: xiaomi_rtcgq02lm

--- a/content/components/sensor/xiaomi_ble.md
+++ b/content/components/sensor/xiaomi_ble.md
@@ -178,16 +178,14 @@ Hygro thermometer, small square body, segment LCD, encrypted, broadcasts tempera
 
 {{< img src="xiaomi_lywsd03mmc.jpg" alt="Image" width="30.0%" class="align-center" >}}
 
-There are the following possibilities to operate this sensor:
+There are the several possibilities to operate this sensor:
 
 1. Xiaomi stock firmware (requires a bindkey in order to decrypt the received data, see [Obtaining the Bindkey](#obtaining_the_bindkey))
-1. Device flashed with [PVVX MiThermometer](https://github.com/pvvx/ATC_MiThermometer) custom firmware
-1. Device flashed with [ATC MiThermometer](https://github.com/atc1441/ATC_MiThermometer) custom firmware
+1. Device flashed with [PVVX MiThermometer](https://github.com/pvvx/ATC_MiThermometer) custom firmware, supporting "BTHome", "pvvx", "Mi Like", "Custom" advertisements
+1. Device flashed with [ATC MiThermometer](https://github.com/atc1441/ATC_MiThermometer) custom firmware, supporting "Mi Like", "Custom" advertisements
 
-- "BTHome" advertisement (PVVX firmware default, bindkey supported)
-- "Mi Like" advertisement (dummy bindkey required)
-- "Custom" advertisement (no bindkey required)
-- "pvvx" advertisement (no bindkey required, only PVVX firmware)
+With PVVX firmware and "BTHome" advertisement, encryption with bindkey is supported, just like with Xiaomi stock firmware
+(see [Obtaining the Bindkey](#obtaining_the_bindkey)). Unencrypted communication is supported only in custom firmware, not recommended.
 
 Configuration example for Xiaomi stock firmware or ATC MiThermometer firmware set to "Mi Like" advertisement:
 

--- a/content/components/sensor/xiaomi_ble.md
+++ b/content/components/sensor/xiaomi_ble.md
@@ -223,7 +223,7 @@ sensor:
       name: "BTHome Signal"
 ```
 
-If you enable "Encrypted beacon" in the PVVX firmware, specify the `bindkey` with the value you see when you press the "Get BindKey" button in Telink Flasher ((see [Obtaining the Bindkey](#obtaining_the_bindkey)).
+If you enable "Encrypted beacon" in the PVVX firmware, specify the `bindkey` with the value you see when you press the "Get BindKey" button in Telink Flasher (see [Obtaining the Bindkey](#obtaining_the_bindkey)).
 
 > [!NOTE]
 > Once you've set a `bindkey`, the component will not accept unencrypted beacons from that `mac_address`. The mismatch will be printed in the log.

--- a/content/components/sensor/xiaomi_ble.md
+++ b/content/components/sensor/xiaomi_ble.md
@@ -205,7 +205,7 @@ sensor:
       name: "LYWSD03MMC Battery Level"
 ```
 
-Configuration example for PVVX MiThermometer firmware set to "BTHome" advertisement:
+Configuration example for PVVX MiThermometer firmware set to "BTHome v2" advertisement:
 
 ```yaml
 sensor:
@@ -582,35 +582,25 @@ It can sometimes take some time for the first BLE broadcast to be received. Once
 
 ## Obtaining the Bindkey
 
-To set up an encrypted device such as the LYWSD03MMC (with Xiaomi stock firmware) and CGD1, you first need to obtain the bind key. The `xiaomi_ble` sensor component is not able to automatically generate a bindkey so other workarounds are necessary.
-
-### LYWSD03MMC/MHO-C401
-
-If the LYWSD03MMC or MHO-C401 sensor is operated with the Xiaomi stock firmware, you can use the [TeLink flasher application](https://atc1441.github.io/TelinkFlasher.html) to easily generate a new bind key and upload the key to the device without the need to flash a new firmware (see figure). For this, you load the flasher [webpage](https://atc1441.github.io/TelinkFlasher.html) with a [supported browser](https://github.com/WebBluetoothCG/web-bluetooth/blob/master/implementation-status.md) and connect the device by pressing "Connect". After the connection is established, you press the "Do Activation" button and the new key will be shown in the "Mi Bind Key" field. The key can be copied directly into the sensor YAML configuration.
-
-{{< img src="telink_flasher.jpg" alt="Image" caption="Telink flasher application." width="100.0%" class="align-center" >}}
+To set up an encrypted device you need to obtain the `bindkey`. The `xiaomi_ble` sensor component is not able to automatically generate a bindkey so other workarounds are necessary.
 
 > [!WARNING]
-> The new bind key will work with ESPHome, but the Mi Home app will not recognise the sensor anymore once the device has been activated by the TeLink flasher application. To use the sensor again with the Xiaomi Mi Home app, the device needs to be removed and then re-added inside the Mi Home app.
+> If you keep the stock firmware, the new bind key will work with ESPHome, but the Mi Home app will not recognise the sensor anymore once the device has been activated by the TeLink flasher application.
+> To use the sensor again with the Xiaomi Mi Home app, the device needs to be removed and then re-added inside the Mi Home app.
 
-### CGDK2
+### LYWSD03MMC, CGD1 and most other encrypted devices
 
-The method to obtain a new bind key for the CGDK2 sensor is similar to the method for the LYWSD03MMC sensor, except a modified version of the flasher application is used.
-
-For this, you load the [application](https://zaluthar.github.io/TelinkFlasher.html) with a [supported browser](https://github.com/WebBluetoothCG/web-bluetooth/blob/master/implementation-status.md) and connect the device by pressing "Connect". After the connection is established, you press the "Do Activation" button and the new key will be shown in the "Mi Bind Key" field. The key can be copied directly into the sensor YAML configuration.
-
-### Other encrypted devices
-
-- The easiest method (confirmed to work for LYWSD03MMC) is to use the [Telink flasher method](https://github.com/pvvx/ATC_MiThermometer). The accompanying [video](https://www.youtube.com/watch?v=NXKzFG61lNs) shows how to wirelessly flash a LYWSD03MMC, or how to obtain the bind key of the stock firmware
+- The easiest method is to use [PVVX](https://github.com/pvvx/ATC_MiThermometer)'s [Telink flasher method](https://github.com/pvvx/ATC_MiThermometer). The accompanying
+  [video](https://www.youtube.com/watch?v=NXKzFG61lNs) shows how to wirelessly flash a LYWSD03MMC, or how to obtain the bind key of the stock firmware
   (watch till around 13:10). The custom firmware allows you to change several settings of the device, including the smiley and the advertising interval.
-  Follow the instructions on the site using Telink Flasher - best results with a Bluetooth-enabled Android phone. Note that with `pvvx` default settings
-  advertisment is set to `Custom` with no encryption. No need for `bind_key` in this case, you can just add the sensors to your ESPHome config as described above.
+  Follow the instructions on the site using Telink Flasher - best results with a Bluetooth-enabled Android phone. Note that by default there's no encryption set,
+  thus no need for `bind_key` in this case, you can just add the sensors to your ESPHome config as described above. However, if you do enable the "Encrypted beacon"
+  checkbox, scroll down to the bottom of the page press the “Get BindKey” button to see the key.
 
 - The other option is to use the original Mi Home app to add the sensor once. While adding the device, a new key is generated and uploaded into the Xiaomi cloud
-  and to the device itself. Currently a chinese server needs to be selected as the rest of the world doesn't support most of these devices yet. Once generated,
-  the key will not change again until the device is removed and re-added in the Xiaomi app.
+  and to the device itself. Once generated, the key will not change again until the device is removed and re-added in the Xiaomi app.
 
-  - The easiest method to retrieve the bindkey from the cloud is to use the
+  - To retrieve the bindkey from the cloud you can use the
     [Cloud Tokens Extractor](https://github.com/PiotrMachowski/Xiaomi-cloud-tokens-extractor), written by one of Home Assistant users.
     If you prefer to not use the executable, read [the Home Assistant Documentation](https://www.home-assistant.io/integrations/xiaomi_miio/#xiaomi-cloud-tokens-extractor).
 
@@ -628,24 +618,27 @@ For this, you load the [application](https://zaluthar.github.io/TelinkFlasher.ht
 
     The `bind_key` is the 32 digits "value" item in the above output which needs to be inserted into the config file.
 
+- If the LYWSD03MMC or MHO-C401 sensor is operated with the Xiaomi stock firmware, you can also use ATC's [TeLink flasher application](https://atc1441.github.io/TelinkFlasher.html)
+  to easily generate a new bind key and upload the key to the device without the need to flash a new firmware (see figure). For this, you load the flasher
+  [webpage](https://atc1441.github.io/TelinkFlasher.html) with a [supported browser](https://github.com/WebBluetoothCG/web-bluetooth/blob/master/implementation-status.md)
+  and connect the device by pressing "Connect". After the connection is established, you press the "Do Activation" button and the new key will be shown in the "Mi Bind Key"
+  field. The key can be copied directly into the sensor YAML configuration.
+
+{{< img src="telink_flasher.jpg" alt="Image" caption="Telink flasher application." width="100.0%" class="align-center" >}}
+
+- For CGDK2 can also load Zaluthar's [application](https://zaluthar.github.io/TelinkFlasher.html) with a [supported browser](https://github.com/WebBluetoothCG/web-bluetooth/blob/master/implementation-status.md)
+  and connect the device by pressing "Connect". After the connection is established, you press the "Do Activation" button and the new key will be shown in the "Mi Bind Key"
+  field. The key can be copied directly into the sensor YAML configuration.
+
 ## Improving reception performance
 
 Use a board with an Ethernet connection to the network, to offload ESP32's radio module from WiFi traffic, this gains performance on Bluetooth side.
-To maximize the chances of catching advertisements of the sensors, you can set `interval` equal to `window` in {{< docref "/components/esp32_ble_tracker" >}} scan parameter settings:
-
-```yaml
-esp32_ble_tracker:
-  scan_parameters:
-    interval: 5s # try with 300ms if you don't have LAN module
-    window: 5s # try with 300ms if you don't have LAN module
-    active: false
-```
 
 Avoid placing the ESP node in racks, close to routers/switches or other network equipment as EMI interference will degrade Bluetooth signal reception. For best results put as far away as possible, at least 3 meters distance from any other such equipment.
 
 ## Security considerations
 
-You should at least protect your sensors with a custom pairing PIN code. Choose a method employing bindkey in order to use encrypted communication over the air.
+You should at least protect your sensors with a custom pairing PIN code. Choose a method employing `bindkey` in order to use encrypted communication over the air, and prevent accepting spoofed messages.
 
 ## See Also
 

--- a/content/components/sensor/xiaomi_ble.md
+++ b/content/components/sensor/xiaomi_ble.md
@@ -185,7 +185,7 @@ There are the following possibilities to operate this sensor:
 1. Device flashed with [ATC MiThermometer](https://github.com/atc1441/ATC_MiThermometer) custom firmware
 
 - "BTHome" advertisement (PVVX firmware default, bindkey supported)
-- "Mi Like" advertisement (dummy bindkey required) 
+- "Mi Like" advertisement (dummy bindkey required)
 - "Custom" advertisement (no bindkey required)
 - "pvvx" advertisement (no bindkey required, only PVVX firmware)
 

--- a/content/components/sensor/xiaomi_ble.md
+++ b/content/components/sensor/xiaomi_ble.md
@@ -184,10 +184,10 @@ There are the following possibilities to operate this sensor:
 1. Device flashed with [PVVX MiThermometer](https://github.com/pvvx/ATC_MiThermometer) custom firmware
 1. Device flashed with [ATC MiThermometer](https://github.com/atc1441/ATC_MiThermometer) custom firmware
 
-- "Mi Like" advertisement (dummy bindkey required)
+- "BTHome" advertisement (PVVX firmware default, bindkey supported)
+- "Mi Like" advertisement (dummy bindkey required) 
 - "Custom" advertisement (no bindkey required)
 - "pvvx" advertisement (no bindkey required, only PVVX firmware)
-- "BTHome" advertisement (no bindkey required, PVVX firmware default)
 
 Configuration example for Xiaomi stock firmware or ATC MiThermometer firmware set to "Mi Like" advertisement:
 
@@ -210,6 +210,7 @@ Configuration example for PVVX MiThermometer firmware set to "BTHome" advertisem
 sensor:
   - platform: bthome_mithermometer
     mac_address: AA:BB:CC:DD:EE:FF
+    bindkey: eef418daf699a0c188f3bfd17e4565d9
     temperature:
       name: "BTHome Temperature"
     humidity:
@@ -221,6 +222,11 @@ sensor:
     signal_strength:
       name: "BTHome Signal"
 ```
+
+If you enable "Encrypted beacon" in the PVVX firmware, specify the `bindkey` with the value you see when you press the "Get BindKey" button in Telink Flasher ((see [Obtaining the Bindkey](#obtaining_the_bindkey)).
+
+> [!NOTE]
+> Once you've set a `bindkey`, the component will not accept unencrypted beacons from that `mac_address`. The mismatch will be printed in the log.
 
 Configuration example for PVVX MiThermometer firmware set to "pvvx" advertisement:
 
@@ -259,7 +265,7 @@ sensor:
 ```
 
 > [!NOTE]
-> PVVX firmare deprecated any other advertisment format other than "BTHome" starting with version 6.0.
+> PVVX firmare deprecated any other advertisment format other than "BTHome v2" starting with version 6.0.
 
 ### XMWSDJ04MMC
 

--- a/content/components/sensor/xiaomi_ble.md
+++ b/content/components/sensor/xiaomi_ble.md
@@ -181,11 +181,14 @@ Hygro thermometer, small square body, segment LCD, encrypted, broadcasts tempera
 There are the several possibilities to operate this sensor:
 
 1. Xiaomi stock firmware (requires a bindkey)
-1. Device flashed with [PVVX MiThermometer](https://github.com/pvvx/ATC_MiThermometer) custom firmware, supporting "BTHome", "pvvx", "Mi Like", "Custom" advertisements
+1. Device flashed with [PVVX MiThermometer](https://github.com/pvvx/ATC_MiThermometer) custom firmware, supporting "BTHome v2", "ATC1441", "PVVX (Custom)", "MIJIA (MiHome)" advertisements
 1. Device flashed with [ATC MiThermometer](https://github.com/atc1441/ATC_MiThermometer) custom firmware, supporting "Mi Like", "Custom" advertisements
 
-With PVVX firmware and "BTHome" advertisement, encryption with bindkey is supported, just like with Xiaomi stock firmware
+With PVVX firmware and "BTHome v2" advertisement, encryption with bindkey is supported, just like with Xiaomi stock firmware
 (see [Obtaining the Bindkey](#obtaining_the_bindkey)). Unencrypted communication is supported only in custom firmware, but it's not recommended for obvious security reasons.
+
+> [!NOTE]
+> PVVX firmare deprecated any other advertisment format other than "BTHome v2" starting with version 6.0.
 
 Configuration example for Xiaomi stock firmware or ATC MiThermometer firmware set to "Mi Like" advertisement:
 
@@ -226,7 +229,7 @@ If you enable "Encrypted beacon" in the PVVX firmware, specify the `bindkey` wit
 > [!NOTE]
 > Once you've set a `bindkey`, the component will not accept unencrypted beacons from that `mac_address`. The mismatch will be printed in the log.
 
-Configuration example for PVVX MiThermometer firmware set to "pvvx" advertisement:
+Configuration example for PVVX MiThermometer firmware set to "pvvx" advertisement (deprecated):
 
 ```yaml
 sensor:
@@ -244,7 +247,7 @@ sensor:
       name: "PVVX Signal"
 ```
 
-Configuration example for ATC MiThermometer firmware set to "Custom" advertisement:
+Configuration example for ATC MiThermometer firmware set to "Custom" advertisement (deprecated):
 
 ```yaml
 sensor:
@@ -261,9 +264,6 @@ sensor:
     signal_strength:
       name: "ATC Signal"
 ```
-
-> [!NOTE]
-> PVVX firmare deprecated any other advertisment format other than "BTHome v2" starting with version 6.0.
 
 ### XMWSDJ04MMC
 

--- a/content/components/sensor/xiaomi_ble.md
+++ b/content/components/sensor/xiaomi_ble.md
@@ -180,12 +180,12 @@ Hygro thermometer, small square body, segment LCD, encrypted, broadcasts tempera
 
 There are the several possibilities to operate this sensor:
 
-1. Xiaomi stock firmware (requires a bindkey in order to decrypt the received data, see [Obtaining the Bindkey](#obtaining_the_bindkey))
+1. Xiaomi stock firmware (requires a bindkey)
 1. Device flashed with [PVVX MiThermometer](https://github.com/pvvx/ATC_MiThermometer) custom firmware, supporting "BTHome", "pvvx", "Mi Like", "Custom" advertisements
 1. Device flashed with [ATC MiThermometer](https://github.com/atc1441/ATC_MiThermometer) custom firmware, supporting "Mi Like", "Custom" advertisements
 
 With PVVX firmware and "BTHome" advertisement, encryption with bindkey is supported, just like with Xiaomi stock firmware
-(see [Obtaining the Bindkey](#obtaining_the_bindkey)). Unencrypted communication is supported only in custom firmware, not recommended.
+(see [Obtaining the Bindkey](#obtaining_the_bindkey)). Unencrypted communication is supported only in custom firmware, but it's not recommended for obvious security reasons.
 
 Configuration example for Xiaomi stock firmware or ATC MiThermometer firmware set to "Mi Like" advertisement:
 

--- a/content/components/sensor/xiaomi_ble.md
+++ b/content/components/sensor/xiaomi_ble.md
@@ -208,7 +208,7 @@ Configuration example for PVVX MiThermometer firmware set to "BTHome" advertisem
 sensor:
   - platform: bthome_mithermometer
     mac_address: AA:BB:CC:DD:EE:FF
-    bindkey: eef418daf699a0c188f3bfd17e4565d9
+    bindkey: "eef418daf699a0c188f3bfd17e4565d9"
     temperature:
       name: "BTHome Temperature"
     humidity:


### PR DESCRIPTION
## Description:

SSIA

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#13428

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/static/images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/_index.md`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image dht22
```

</details>
