### PR TITLE
Add 3.7in Waveshare e-paper support and update model list

### DIFF
--- a/content/components/display/waveshare_epaper.md
+++ b/content/components/display/waveshare_epaper.md
@@ -140,7 +140,7 @@ lambda: |-
 - **rotation** (*Optional*): Set the rotation of the display. Everything you draw in `lambda:` will be rotated
   by this option. One of `0°` (default), `90°`, `180°`, `270°`.
 
-- **full_update_every** (**Optional**, [int](/guides/configuration-types#config-int)): E-Paper displays have two modes of switching to the next image: A partial
+- **full_update_every** (**Optional**, int): E-Paper displays have two modes of switching to the next image: A partial
   update that only changes the pixels that have changed and a full update mode that first clears the entire display
   and then re-draws the image. The former is much quicker and nicer, but every so often a full update needs to happen
   because artifacts accumulate. On the `1.54in`, `1.54inv2`, `2.13in`, `2.13inv2`, `2.13inv3`, `2.90in`,

--- a/content/components/display/waveshare_epaper.md
+++ b/content/components/display/waveshare_epaper.md
@@ -106,6 +106,7 @@ lambda: |-
   - `2.90inv2-r2` - 2.9in V2 display, but with different initialization and full/partial display refresh management than `2.90inv2`
   - `2.90in-b` - B/W rendering only
   - `2.90in-bV3` - B/W rendering only
+  - `3.70in` - 3.7in display with partial/full refresh support
   - `4.20in`
   - `4.20in-bV2` - B/W rendering only
   - `gdey042t81` - GoodDisplay GDEY042T81 4.2" B/W
@@ -139,12 +140,13 @@ lambda: |-
 - **rotation** (*Optional*): Set the rotation of the display. Everything you draw in `lambda:` will be rotated
   by this option. One of `0°` (default), `90°`, `180°`, `270°`.
 
-- **full_update_every** (*Optional*, int): E-Paper displays have two modes of switching to the next image: A partial
+- **full_update_every** (**Optional**, [int](/guides/configuration-types#config-int)): E-Paper displays have two modes of switching to the next image: A partial
   update that only changes the pixels that have changed and a full update mode that first clears the entire display
   and then re-draws the image. The former is much quicker and nicer, but every so often a full update needs to happen
-  because artifacts accumulate. On the `1.54in`, `1.54inv2`, `2.13in`, `2.13inv2`, `2.90in`, `2.90inv2`, `7.50inV2p` and `gdew029t5` models, you have the option to only
-  do a full-redraw every x-th time using this option. Defaults to `30` on the described models and a full update for
-  all other models.
+  because artifacts accumulate. On the `1.54in`, `1.54inv2`, `2.13in`, `2.13inv2`, `2.13inv3`, `2.90in`,
+  `2.90inv2`, `2.90inv2-r2`, `2.90in-dke`, `3.70in`, `7.50inV2p`, `gdew029t5`, `gdey029t94`, `gdey042t81`,
+  and `gdey0583t81` models, you have the option to only do a full-redraw every x-th time using this
+  option. Defaults to `30` on the described models and a full update for all other models.
 
 - **reset_duration** (*Optional*, [Time](/guides/configuration-types#time)): Duration for the display reset operation. Defaults to `200ms`.
   Setting this value to `2ms` may resolve issues with newer e-Paper Driver modules (e.g. Rev 2.1).


### PR DESCRIPTION
Documented the 3.7in e-paper display with refresh options. Expanded `full_update_every` to cover additional models.

## Description:


**Related issue (if applicable):** n/a

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#13437

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/static/images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/_index.md`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image dht22
```

</details>
