### PR TITLE
[infrared] Fix example in release notes

### DIFF
--- a/content/changelog/2026.1.0.md
+++ b/content/changelog/2026.1.0.md
@@ -176,7 +176,7 @@ MD5 authentication support has been **removed** from OTA updates ([#12707](https
 > [!IMPORTANT]
 > **ESPHome versions before 2025.10.0 that use password authentication cannot OTA to devices running 2026.1.0 or later.**
 >
-> If you use multiple systems to install and/or update your ESPHome devices, be sure they're all up-to-date! If you need to downgrade to a version before 2025.10.0, downgrade to 2025.12.x first, and than OTA to an earlier version.
+> If you use multiple systems to install and/or update your ESPHome devices, be sure they're all up-to-date! If you need to downgrade to a version before 2025.10.0, downgrade to 2025.12.x first, then OTA to an earlier version.
 
 ### HMAC-SHA256 Support
 
@@ -389,11 +389,12 @@ The new [ir_rf_proxy](/components/ir_rf_proxy) component provides an API-accessi
 This component is part of a broader effort to make IR & RF easier to use from within Home Assistant. A new experimental `infrared` entity platform ([#13129](https://github.com/esphome/esphome/pull/13129)) provides the underlying infrastructure.
 
 ```yaml
-ir_rf_proxy:
-  - name: "Living Room IR Blaster"
+infrared:
+  - platform: ir_rf_proxy
+    name: IR Proxy Transmitter
     remote_transmitter_id: ir_tx
-
-  - name: "Bedroom IR Receiver"
+  - platform: ir_rf_proxy
+    name: IR Proxy Receiver
     remote_receiver_id: ir_rx
 ```
 


### PR DESCRIPTION
## Description:

The example YAML in the release notes was incorrect (from an earlier iteration of the component). This PR corrects it to be consistent with the other documentation. Also corrects a typo earlier in the document.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/static/images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/_index.md`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image dht22
```

</details>
