### PR TITLE
Remove media players that don't rely on Sendspin

### DIFF
--- a/themes/esphome-theme/layouts/_default/projects.html
+++ b/themes/esphome-theme/layouts/_default/projects.html
@@ -39,6 +39,7 @@
   .types input {
     position: absolute;
     left: 16px;
+    top: .5em;
   }
   .types .name {
     font-weight: bold;
@@ -144,7 +145,8 @@
     <div class="text">
       <div class="name">Media Player</div>
       <div class="description">
-        Create an internet connected smart media player.
+        Create a multi-speaker music listening experience powered by
+        <a href="https://www.sendspin-audio.com" target="_blank">Sendspin</a>.
       </div>
     </div>
   </label>
@@ -608,57 +610,9 @@
         type="radio"
         name="media-device"
         class="device-option"
-        value="raspiaudio-muse-luxe"
-        checked
-      />
-      <img
-        src="/projects/media-player/esp_muse_luxe.png"
-        alt="Raspiaudio ESP Muse Luxe"
-      />
-    </label>
-    <label>
-      <input
-        type="radio"
-        name="media-device"
-        class="device-option"
-        value="raspiaudio-muse-proto"
-      />
-      <img
-        src="/projects/media-player/esp_muse_proto.png"
-        alt="Raspiaudio ESP Muse Proto"
-      />
-    </label>
-    <label>
-      <input
-        type="radio"
-        name="media-device"
-        class="device-option"
-        value="m5stack-atom-speaker-kit"
-      />
-      <img
-        src="/projects/media-player/atom_speaker_kit.png"
-        alt="M5Stack Atom Speaker Kit"
-      />
-    </label>
-    <label>
-      <input
-        type="radio"
-        name="media-device"
-        class="device-option"
-        value="m5stack-atom-echo"
-      />
-      <img
-        src="/projects/media-player/atom_echo.png"
-        alt="M5Stack Atom Echo Development Kit"
-      />
-    </label>
-    <label>
-      <input
-        type="radio"
-        name="media-device"
-        class="device-option"
         value="home-assistant-voice"
         data-manifest-root="https://firmware.esphome.io/home-assistant-voice-pe"
+        checked
       />
       <img
         src="/projects/voice-assistant/home-assistant-voice.png"
@@ -669,96 +623,6 @@
 
   <div class="question-prompt">Start the installation:</div>
   <esp-web-install-button></esp-web-install-button>
-
-  <div class="hidden info raspiaudio-muse-luxe">
-    <h3>Raspiaudio ESP Muse Luxe</h3>
-    <p>
-      Portable speaker with two 5 Watt speakers built-in. Can run 4 hours off
-      the built-in battery or be powered by a cable.
-    </p>
-    <p>
-      This is a powerful device. If you want to use it solely as a media player,
-      we recommend to use the
-      <a href="https://raspiaudio.github.io/">Squeezelite-ESP32 firmware</a>.
-    </p>
-    <p>Buy</p>
-    <ul>
-      <li>
-        <a href="https://raspiaudio.com/produit/esp-muse-luxe">Raspiaudio</a>
-      </li>
-      <li>
-        <a
-          href="https://www.amazon.com/gp/product/B09N3S9S29/?&_encoding=UTF8&tag=homeassista0e-20&linkCode=ur2&linkId=71c80756dcd782eba9f1a80dc576c7d3&camp=1789&creative=9325"
-          >Amazon</a
-        >
-      </li>
-    </ul>
-  </div>
-
-  <div class="hidden info raspiaudio-muse-proto">
-    <h3>Raspiaudio ESP Muse Proto</h3>
-    <p>Powerful audio prototyping board to create your own smart speakers.</p>
-    <p>
-      This is a powerful device. If you want to use it solely as a media player,
-      we recommend to use the
-      <a href="https://raspiaudio.github.io/">Squeezelite-ESP32 firmware</a>.
-    </p>
-    <p>Buy</p>
-    <ul>
-      <li>
-        <a href="https://raspiaudio.com/produit/muse-proto">Raspiaudio</a>
-      </li>
-      <li>
-        <a
-          href="https://www.amazon.com/gp/product/B097F884WL/?&_encoding=UTF8&tag=homeassista0e-20&linkCode=ur2&linkId=71c80756dcd782eba9f1a80dc576c7d3&camp=1789&creative=9325"
-          >Amazon</a
-        >
-      </li>
-    </ul>
-  </div>
-
-  <div class="hidden info m5stack-atom-speaker-kit">
-    <h3>M5Stack Atom Speaker Kit</h3>
-    <p>Small ESP32 board with a built-in speaker and a headphone jack.</p>
-    <p>Buy</p>
-    <ul>
-      <li>
-        <a
-          href="https://shop.m5stack.com/products/atom-speaker-kit-ns4168?ref=NabuCasa"
-          >M5Stack Shop</a
-        >
-      </li>
-      <li>
-        <a
-          href="https://www.aliexpress.com/item/1005003297368240.html?aff_platform=portals-tool&sk=_A8G2YF&aff_trace_key=90326d2a90444b4887632f62dd533ce4-1654058373639-07963-_A8G2YF&terminal_id=c5517a8c9bb44b4fb32147398fbc2576&aff_fcid=90326d2a90444b4887632f62dd533ce4-1654058373639-07963-_A8G2YF&tt=CPS_NORMAL&aff_fsk=_A8G2YF"
-          >AliExpress</a
-        >
-      </li>
-    </ul>
-  </div>
-
-  <div class="hidden info m5stack-atom-echo">
-    <h3>M5Stack Atom Echo Development Kit</h3>
-    <p>Tiny ESP32 board with a built-in speaker.</p>
-    <p>Buy</p>
-    <ul>
-      <li>
-        <a href="https://amzn.to/47wcAx2">Amazon</a>
-      </li>
-      <li>
-        <a
-          href="https://shop.m5stack.com/collections/m5-controllers/products/atom-echo-smart-speaker-dev-kit?ref=NabuCasa"
-          >M5Stack Shop</a
-        >
-      </li>
-      <li>
-        <a
-          href="https://www.aliexpress.com/item/1005003299332198.html?aff_platform=portals-tool&sk=_A8G2YF&aff_trace_key=90326d2a90444b4887632f62dd533ce4-1654058373639-07963-_A8G2YF&terminal_id=c5517a8c9bb44b4fb32147398fbc2576&aff_fcid=90326d2a90444b4887632f62dd533ce4-1654058373639-07963-_A8G2YF&tt=CPS_NORMAL&aff_fsk=_A8G2YF"
-          >AliExpress</a
-        >
-      </li>
-    </ul>
-  </div>
 
   <div class="hidden info home-assistant-voice">
     <h3>Home Assistant Voice: Preview Edition</h3>


### PR DESCRIPTION
## Description:
Removes from ready-made projects the media players that do not rely on Sendspin.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/static/images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/_index.md`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image dht22
```

</details>
