### PR TITLE
[web_server][captive_portal] Document RP2040 platform support

### DIFF
--- a/content/components/captive_portal.md
+++ b/content/components/captive_portal.md
@@ -10,6 +10,8 @@ params:
 The captive portal component in ESPHome is a fallback mechanism for when connecting to the
 configured {{< docref "wifi" "WiFi" >}} fails.
 
+This component is available on ESP32, ESP8266, RP2040, and LibreTiny platforms.
+
 After 1 minute of unsuccessful WiFi connection attempts, the ESP will start a WiFi hotspot
 (with the credentials from your configuration)
 

--- a/content/components/web_server.md
+++ b/content/components/web_server.md
@@ -11,6 +11,8 @@ The `web_server` component creates a simple web server on the node that can be a
 through any browser and a simple [REST API](/web-api#api-rest). Please note that enabling this component
 will take up *a lot* of memory and may decrease stability, especially on ESP8266.
 
+This component is available on ESP32, ESP8266, RP2040, and LibreTiny platforms.
+
 {{< img src="web_server.png" alt="Image" caption="Web server version 1" width="86.0%" class="align-center" >}}
 
 {{< img src="web_server-v2.png" alt="Image" caption="Web server version 2" width="86.0%" class="align-center" >}}


### PR DESCRIPTION
## Description:

Documents RP2040 (Raspberry Pi Pico W) platform support for `web_server` and `captive_portal` components.

Added platform availability notes to both component pages indicating they now work on ESP32, ESP8266, RP2040, and LibreTiny platforms.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#13522

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.
