### PR TITLE
[waveshare_epaper] Update docs for WeAct 3-color e-paper displays

### DIFF
--- a/content/components/display/waveshare_epaper.md
+++ b/content/components/display/waveshare_epaper.md
@@ -134,13 +134,6 @@ lambda: |-
 > [!WARNING]
 > The BUSY pin on the `gdew0154m09`, the `Waveshare 7.30in-f` and the `Waveshare 7.50in V2` models must be inverted to prevent permanent display damage. Set the busy pin to `inverted: true` in the config.
 
-**WeAct 3-Color E-Paper Displays (2.13in, 2.90in, 4.20in)**
-
-For WeAct Studio 3-color e-paper displays, a unified driver (`WeActEPaper3C`) is used across different sizes. This single driver handles the 2.13in, 2.90in, and 4.20in models, simplifying code management and ensuring consistent behavior.
-
-> [!NOTE]
-> For these WeAct 3-color models, `full_update_every` is not configurable as they typically perform a full refresh with every display update to ensure optimal color rendering and prevent ghosting.
-
 - **busy_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The BUSY pin. Defaults to not connected.
 - **reset_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The RESET pin. Defaults to not connected.
   Make sure you pull this pin high (by connecting it to 3.3V with a resistor) if not connected to a GPIO pin.
@@ -152,9 +145,12 @@ For WeAct Studio 3-color e-paper displays, a unified driver (`WeActEPaper3C`) is
 - **full_update_every** (*Optional*, int): E-Paper displays have two modes of switching to the next image: A partial
   update that only changes the pixels that have changed and a full update mode that first clears the entire display
   and then re-draws the image. The former is much quicker and nicer, but every so often a full update needs to happen
-  because artifacts accumulate. On the `1.54in`, `1.54inv2`, `2.13in`, `2.13inv2`, `2.90in`, `2.90inv2`, `7.50inV2p`, `gdew029t5` and **WeAct 3-color displays**, you have the option to only
+  because artifacts accumulate. On the `1.54in`, `1.54inv2`, `2.13in`, `2.13inv2`, `2.90in`, `2.90inv2`, `7.50inV2p`, `gdew029t5` you have the option to only
   do a full-redraw every x-th time using this option. Defaults to `30` on the described models and a full update for
   all other models.
+
+> [!NOTE]
+> For WeAct 3-color models, `full_update_every` is not configurable as they typically perform a full refresh with every display update to ensure optimal color rendering and prevent ghosting.
 
 - **reset_duration** (*Optional*, [Time](/guides/configuration-types#time)): Duration for the display reset operation. Defaults to `200ms`.
   Setting this value to `2ms` may resolve issues with newer e-Paper Driver modules (e.g. Rev 2.1).

--- a/content/components/display/waveshare_epaper.md
+++ b/content/components/display/waveshare_epaper.md
@@ -31,12 +31,12 @@ configuration.
 | ------------------ | ----------- | ------------------ |
 | `VCC`              | `3.3V`      | N/A                |
 | `GND`              | `GND`       | N/A                |
-| `CLK`              | Any GPIO | `spi.clk_pin`      |
-| `DIN`              | Any GPIO | `spi.mosi_pin`     |
-| `CS`               | Any GPIO | `cs_pin`           |
-| `DC`               | Any GPIO | `dc_pin`           |
-| `BUSY` (Optional) | Any GPIO | `busy_pin`         |
-| `RESET` (Optional) | Any GPIO | `reset_pin`        |
+| `CLK`              | Any GPIO    | `spi.clk_pin`      |
+| `DIN`              | Any GPIO    | `spi.mosi_pin`     |
+| `CS`               | Any GPIO    | `cs_pin`           |
+| `DC`               | Any GPIO    | `dc_pin`           |
+| `BUSY` (Optional)  | Any GPIO    | `busy_pin`         |
+| `RESET` (Optional) | Any GPIO    | `reset_pin`        |
 
 {{< img src="waveshare_epaper-pins.jpg" alt="Image" width="60.0%" class="align-center" >}}
 
@@ -96,6 +96,7 @@ lambda: |-
   - `2.13in-ttgo-dke` - T5_V2.3 with DKE group display (DEPG0213BN) tested
   - `2.13inv2` - 2.13in V2 display (Pico e-Paper 2.13v2 and Cloud Module)
   - `2.13inv3` - 2.13in V3 display (Pico e-Paper 2.13v3)
+  - `2.13in3c-weact` - WeAct Studio 2.13in 3-color (Black/White/Red) e-paper display (122x250) - not tested
   - `2.70in` - currently not working with the HAT Rev 2.1 version
   - `2.70inv2`
   - `2.70in-b` - Black/White/Red
@@ -106,10 +107,12 @@ lambda: |-
   - `2.90inv2-r2` - 2.9in V2 display, but with different initialization and full/partial display refresh management than `2.90inv2`
   - `2.90in-b` - B/W rendering only
   - `2.90in-bV3` - B/W rendering only
+  - `2.90in3c-weact` - WeAct Studio 2.90in 3-color (Black/White/Red) e-paper display (128x296) - tested
   - `4.20in`
   - `4.20in-bV2` - B/W rendering only
   - `gdey042t81` - GoodDisplay GDEY042T81 4.2" B/W
   - `4.20in-bV2-bwr` - BWR rendering enabled (uses double the amount of RAM for the display buffer as B/W rendering)
+  - `4.20in3c-weact` - WeAct Studio 4.20in 3-color (Black/White/Red) e-paper display (400x300) - not tested
   - `5.83in`
   - `5.83inv2`
   - `gdey0583t81` - GoodDisplay GDEY0583T81 5.83" B/W
@@ -131,6 +134,13 @@ lambda: |-
 > [!WARNING]
 > The BUSY pin on the `gdew0154m09`, the `Waveshare 7.30in-f` and the `Waveshare 7.50in V2` models must be inverted to prevent permanent display damage. Set the busy pin to `inverted: true` in the config.
 
+**WeAct 3-Color E-Paper Displays (2.13in, 2.90in, 4.20in)**
+
+For WeAct Studio 3-color e-paper displays, a unified driver (`WeActEPaper3C`) is used across different sizes. This single driver handles the 2.13in, 2.90in, and 4.20in models, simplifying code management and ensuring consistent behavior.
+
+> [!NOTE]
+> For these WeAct 3-color models, `full_update_every` is not configurable as they typically perform a full refresh with every display update to ensure optimal color rendering and prevent ghosting.
+
 - **busy_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The BUSY pin. Defaults to not connected.
 - **reset_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The RESET pin. Defaults to not connected.
   Make sure you pull this pin high (by connecting it to 3.3V with a resistor) if not connected to a GPIO pin.
@@ -142,7 +152,7 @@ lambda: |-
 - **full_update_every** (*Optional*, int): E-Paper displays have two modes of switching to the next image: A partial
   update that only changes the pixels that have changed and a full update mode that first clears the entire display
   and then re-draws the image. The former is much quicker and nicer, but every so often a full update needs to happen
-  because artifacts accumulate. On the `1.54in`, `1.54inv2`, `2.13in`, `2.13inv2`, `2.90in`, `2.90inv2`, `7.50inV2p` and `gdew029t5` models, you have the option to only
+  because artifacts accumulate. On the `1.54in`, `1.54inv2`, `2.13in`, `2.13inv2`, `2.90in`, `2.90inv2`, `7.50inV2p`, `gdew029t5` and **WeAct 3-color displays**, you have the option to only
   do a full-redraw every x-th time using this option. Defaults to `30` on the described models and a full update for
   all other models.
 

--- a/content/components/sensor/scd4x.md
+++ b/content/components/sensor/scd4x.md
@@ -107,9 +107,9 @@ api:
       variables:
         co2_ppm: int
       then:
-      - scd4x.perform_forced_calibration:
-          value: !lambda 'return co2_ppm;'
-          id: my_scd41
+        - scd4x.perform_forced_calibration:
+            value: !lambda 'return co2_ppm;'
+            id: my_scd41
 ```
 
 {{< anchor "factory_reset_action" >}}

--- a/content/guides/diy.md
+++ b/content/guides/diy.md
@@ -105,6 +105,7 @@ unless it's truly exceptional, etc.
 - [Digoo DG-R8H and similar nexus433 sensors to MQTT component](https://github.com/FreeBear-nc/esphome-nexus433) by {{< ghuser name="FreeBear-nc" >}}
 - [Adaptive Lighting for white/warm lights](https://github.com/mdvorak/esphome-adaptive-lighting) by {{< ghuser name="mdvorak" >}}
 - [Connecting the PAJ7620 gesture sensor](https://github.com/apaex/PAJ7620-ESPHome) by {{< ghuser name="apaex" >}}
+- [Dew Point Sensor using Magnus formula](https://github.com/iret33/esphome-dew-point) by {{< ghuser name="iret33" >}}
 
 ## Sample Configurations
 


### PR DESCRIPTION
## Summary
This pull request updates the documentation for the `waveshare_epaper` component to include support for the new WeAct 3-color e-paper displays (2.13in, 2.90in, and 4.20in).
-   **New Models Documented:** Added the `2.13in3c-weact`, `2.90in3c-weact`, and `4.20in3c-weact` models to the configuration options.
-   **Unified Driver Note:** Included a note explaining that a unified `WeActEPaper3C` driver is used for these models, and that `full_update_every` is not configurable for them due to their full-refresh nature.
-   **Updated Example:** Modified the example YAML configuration to demonstrate the use of a WeAct 3-color display, including red color output.
## Related Code PR
esphome/esphome#13528
## Test Cases
-   Changes verified by local documentation build.
-   Code functionality tested locally with ESPHome `2026.1.1-dev`.
