### PR TITLE
Add DS2482 (DS2482-100/DS2482-800) documentation

### DIFF
--- a/content/components/one_wire/_index.md
+++ b/content/components/one_wire/_index.md
@@ -18,7 +18,8 @@ work fine as well, provided you don't have unusually long wires.
 ## Platforms
 
 - [**GPIO**](/components/one_wire/gpio/) Create a 1-Wire bus on a GPIO pin
-- [**DS2484**](/components/one_wire/ds2484/) An I2C-to-1-Wire bridge device
+- [**DS2482**](/components/one_wire/ds2482/) I2C-to-1-Wire bridge (DS2482-100 single-channel or DS2482-800 8-channel)
+- [**DS2484**](/components/one_wire/ds2484/) I2C-to-1-Wire bridge (single-channel)
 
 ## Obtaining Sensor IDs
 

--- a/content/components/one_wire/ds2482.md
+++ b/content/components/one_wire/ds2482.md
@@ -1,0 +1,165 @@
+---
+description: "Instructions for setting up a Dallas (Analog Devices) 1-Wire bus via a DS2482 IC to communicate with 1-wire devices in ESPHome"
+title: "1-Wire Bus via DS2482"
+params:
+  seo:
+    description: Instructions for setting up a Dallas (Analog Devices) 1-Wire bus via a DS2482 IC to communicate with 1-wire devices in ESPHome
+    image: one-wire.svg
+---
+
+The `ds2482` platform provides access to 1-Wire busses via DS2482 I2C-to-1-Wire bridge chips using the [I²C Bus](/components/i2c) for communication.
+
+This platform supports both variants:
+- **DS2482-800**: 8-channel device with independent 1-Wire channels (IO0-IO7)
+- **DS2482-100**: Single-channel device
+
+The platform automatically detects which variant is connected. The DS2482-800 provides 8 independent 1-Wire channels on a single I2C device. Each channel is configured as a separate `one_wire` platform instance in ESPHome, allowing you to connect up to 8 independent 1-Wire busses to a single microcontroller.
+
+```yaml
+# Example configuration entry for DS2482-100 (single-channel)
+one_wire:
+  - platform: ds2482
+    active_pullup: true
+
+# Example configuration entry for DS2482-800 (multi-channel)
+one_wire:
+  - platform: ds2482
+    id: onewire_ch0
+    channel: 0
+    active_pullup: true
+
+  - platform: ds2482
+    id: onewire_ch1
+    channel: 1
+    active_pullup: true
+```
+
+## Configuration variables
+
+- **channel** (*Optional*, int, defaults to `0`): The 1-Wire channel to use (0-7). Corresponds to IO0-IO7 pins on the DS2482-800. For DS2482-100, this should be 0 or omitted.
+- **active_pullup** (*Optional*, defaults to `false`): Enables DS2482 active pullup (1.5kΩ pullup resistor).
+- **strong_pullup** (*Optional*, defaults to `false`): Enables DS2482 strong pullup (for powering parasitic devices).
+- **address** (*Optional*, int): The I²C address of the device. Defaults to `0x18`. See [I2C Address Selection](#i2c-address-selection) below.
+- **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID used for code generation. Required if you have multiple 1-Wire busses.
+- **i2c_id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID of the {{< docref "/components/i2c" >}}. Required if you have configured multiple I2C busses.
+
+{{< note >}}
+All channels on the same DS2482-800 chip must use identical `active_pullup` and `strong_pullup` settings. ESPHome will validate this at configuration time and produce an error if the settings differ.
+{{< /note >}}
+
+## I2C Address Selection
+
+The DS2482-800 I2C address is configurable via the AD0 and AD1 pins:
+
+| AD1 | AD0 | I²C Address |
+|-----|-----|-------------|
+| GND | GND | 0x18 (default) |
+| GND | VCC | 0x19 |
+| VCC | GND | 0x1A |
+| VCC | VCC | 0x1B |
+
+Connect AD0 and AD1 to GND or VCC to select the desired address. Multiple DS2482-800 devices can be used on the same I²C bus by configuring different addresses.
+
+## Example Configurations
+
+### Multiple Channels on Single Chip
+
+Connect different 1-Wire devices to different channels:
+
+```yaml
+i2c:
+  sda: GPIO21
+  scl: GPIO22
+
+one_wire:
+  - platform: ds2482
+    id: indoor_bus
+    channel: 0
+    active_pullup: true
+
+  - platform: ds2482
+    id: outdoor_bus
+    channel: 1
+    active_pullup: true
+
+  - platform: ds2482
+    id: basement_bus
+    channel: 2
+    active_pullup: true
+
+sensor:
+  - platform: dallas_temp
+    one_wire_id: indoor_bus
+    name: "Indoor Temperature"
+
+  - platform: dallas_temp
+    one_wire_id: outdoor_bus
+    name: "Outdoor Temperature"
+
+  - platform: dallas_temp
+    one_wire_id: basement_bus
+    name: "Basement Temperature"
+```
+
+### Multiple DS2482 Chips
+
+Use multiple DS2482-800 devices for more than 8 channels:
+
+```yaml
+i2c:
+  sda: GPIO21
+  scl: GPIO22
+
+one_wire:
+  # First chip at address 0x18
+  - platform: ds2482
+    id: chip1_ch0
+    address: 0x18
+    channel: 0
+
+  - platform: ds2482
+    id: chip1_ch1
+    address: 0x18
+    channel: 1
+
+  # Second chip at address 0x19 (AD0=VCC, AD1=GND)
+  - platform: ds2482
+    id: chip2_ch0
+    address: 0x19
+    channel: 0
+
+  - platform: ds2482
+    id: chip2_ch1
+    address: 0x19
+    channel: 1
+```
+
+## Migration from DS2484
+
+The DS2482-800 is software-compatible with the DS2484, with the addition of channel selection. To migrate from DS2484:
+
+1. Change `platform: ds2484` to `platform: ds2482`
+2. Add the `channel: 0` parameter (the DS2484 is equivalent to channel 0)
+
+```yaml
+# Before (DS2484)
+one_wire:
+  - platform: ds2484
+    active_pullup: true
+
+# After (DS2482-800)
+one_wire:
+  - platform: ds2482
+    channel: 0
+    active_pullup: true
+```
+
+All 1-Wire devices (Dallas temperature sensors, iButton readers, etc.) work identically with both platforms.
+
+### See Also
+
+- {{< docref "index/" >}}
+- {{< docref "ds2484/" >}} - Single-channel DS2484 platform
+- {{< apiref "one_wire/one_wire_bus.h" "one_wire/one_wire_bus.h" >}}
+- [DS2482-800 Datasheet](https://www.analog.com/media/en/technical-documentation/data-sheets/ds2482-800.pdf)
+- [Guidelines for Reliable Long Line 1-Wire Networks](https://www.analog.com/en/technical-articles/guidelines-for-reliable-long-line-1wire-networks.html)


### PR DESCRIPTION
# What does this implement/fix?

Add comprehensive documentation for the DS2482 I2C-to-1-Wire bridge component, supporting both DS2482-100 (single-channel) and DS2482-800 (8-channel) variants.

## Changes

- Created new `ds2482.md` documentation page
- Updated `one_wire/_index.md` to include DS2482 in platform list
- Documented automatic variant detection feature
- Provided configuration examples for both DS2482-100 and DS2482-800
- I2C address selection table (AD0/AD1 pin configuration)
- Migration guide from DS2484
- Notes about pullup configuration validation

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Related code PR in [esphome](https://github.com/esphome/esphome):**
- esphome/esphome#13534

## Checklist:
  - [x] Documentation follows ESPHome style guide
  - [x] All configuration variables documented
  - [x] Example configurations provided and tested
  - [x] Links to related components included
  - [x] Datasheet reference included

## Additional Notes

This documentation corresponds to the DS2482 component implementation that adds support for:
- DS2482-800 (8-channel I2C-to-1-Wire bridge)
- DS2482-100 (single-channel I2C-to-1-Wire bridge)

The component automatically detects which variant is connected and adjusts behavior accordingly. Each DS2482-800 channel can be configured as an independent 1-Wire bus.
