### PR TITLE
[web-api] Document SSE entity ID deprecation path with name_id field

### DIFF
--- a/content/changelog/2026.1.0.md
+++ b/content/changelog/2026.1.0.md
@@ -139,7 +139,7 @@ The web server now uses entity names directly in URLs instead of sanitized `obje
 
 Old URLs using `object_id` format (e.g., `/sensor/temperature_sensor`) continue to work during a deprecation period until 2026.7.0.
 
-**SSE Entity IDs (added in 2026.1.3):** A deprecation path was added for SSE event entity IDs. The payload now includes both `name_id` (new format like `sensor/Temperature`) and `id` (legacy format like `sensor-temperature`). Third-party integrations should migrate to `name_id`. In 2026.8.0, `id` will switch to the new format and `name_id` will be removed.
+**SSE Entity IDs (added in 2026.1.3):** A deprecation path was added for SSE event entity IDs. The payload now includes both `name_id` (new format like `sensor/Temperature`) and `id` (legacy format like `sensor-temperature`). Third-party integrations **MUST** prefer `name_id` to get the new ID format, falling back to `id` for compatibility with older firmware and for when `name_id` is removed. In 2026.8.0, `id` will switch to the new format and `name_id` will be removed. Third-party integrations requiring the legacy format after 2026.8.0 must implement their own conversion logic.
 
 **Important restrictions:**
 

--- a/content/changelog/2026.1.0.md
+++ b/content/changelog/2026.1.0.md
@@ -139,7 +139,7 @@ The web server now uses entity names directly in URLs instead of sanitized `obje
 
 Old URLs using `object_id` format (e.g., `/sensor/temperature_sensor`) continue to work during a deprecation period until 2026.7.0.
 
-**SSE Entity IDs (added in 2026.1.3):** A deprecation path was added for SSE event entity IDs. The payload now includes both `name_id` (new format like `sensor/Temperature`) and `id` (legacy format like `sensor-temperature`). Third-party integrations **MUST** prefer `name_id` to get the new ID format, falling back to `id` for compatibility with older firmware and for when `name_id` is removed. In 2026.8.0, `id` will switch to the new format and `name_id` will be removed. Third-party integrations requiring the legacy format after 2026.8.0 must implement their own conversion logic.
+**SSE Entity IDs:** A deprecation path was added for SSE event entity IDs. The payload now includes a temporary `name_id` field (new format like `sensor/Temperature`) alongside `id` (legacy format like `sensor-temperature`). **Timeline:** In 2026.8.0, `name_id` will be removed and `id` will switch to the new format. Third-party integrations should prefer `name_id` now, falling back to `id` for compatibility with older firmware. Integrations requiring the legacy format after 2026.8.0 must implement their own conversion logic.
 
 **Important restrictions:**
 

--- a/content/changelog/2026.1.0.md
+++ b/content/changelog/2026.1.0.md
@@ -139,6 +139,8 @@ The web server now uses entity names directly in URLs instead of sanitized `obje
 
 Old URLs using `object_id` format (e.g., `/sensor/temperature_sensor`) continue to work during a deprecation period until 2026.7.0.
 
+**SSE Entity IDs (added in 2026.1.3):** A deprecation path was added for SSE event entity IDs. The payload now includes both `name_id` (new format like `sensor/Temperature`) and `id` (legacy format like `sensor-temperature`). Third-party integrations should migrate to `name_id`. In 2026.8.0, `id` will switch to the new format and `name_id` will be removed.
+
 **Important restrictions:**
 
 - Names may not include `/` because it is reserved as a URL path separator

--- a/content/web-api/_index.md
+++ b/content/web-api/_index.md
@@ -49,8 +49,12 @@ of a component. Each of these JSON payloads have the following identifier fields
 - `id`: Legacy identifier using the format `domain-object_id` (for example `sensor-temperature`).
   Provided for backward compatibility with existing integrations.
 
-New integrations should use `name_id`. The `id` field will switch to the new format
-(matching `name_id`) in ESPHome 2026.8.0, at which point `name_id` will be removed.
+Third-party integrations **MUST** prefer `name_id` over `id` to get the new ID format,
+falling back to `id` for compatibility with older firmware and for when `name_id` is
+removed. The `id` field will switch to the new format (matching `name_id`) in ESPHome
+2026.8.0, at which point `name_id` will be removed. Third-party integrations that require
+the legacy format after 2026.8.0 must implement their own conversion logic (similar to
+`aioesphomeapi`).
 
 The `state` field contains a simple text-based representation of the state of the underlying
 component, for example ON/OFF or 21.4 °C. Several components also have additional fields in

--- a/content/web-api/_index.md
+++ b/content/web-api/_index.md
@@ -42,12 +42,19 @@ Currently, there are three types of events sent: `ping`, `state` and `log`. The 
 is repeatedly sent out to keep the connection alive. `log` events are sent every time a log
 message is triggered and is used to show the debug log on the index page. `state` is where
 the real magic happens. All events with this type have a JSON payload that describes the state
-of a component. Each of these JSON payloads have two mandatory fields: `id` and `state`. ID
-is the unique identifier of the component using the format `domain/entity_name` (for example
-`sensor/Temperature`) or `domain/device_name/entity_name` for sub-device entities. `state`
-contains a simple text-based representation of the state of the underlying component, for
-example ON/OFF or 21.4 °C. Several components also have additional fields in this payload,
-for example lights have a `brightness` attribute.
+of a component. Each of these JSON payloads have the following identifier fields:
+
+- `name_id`: The preferred identifier using the format `domain/entity_name` (for example
+  `sensor/Temperature`) or `domain/device_name/entity_name` for sub-device entities.
+- `id`: Legacy identifier using the format `domain-object_id` (for example `sensor-temperature`).
+  Provided for backward compatibility with existing integrations.
+
+New integrations should use `name_id`. The `id` field will switch to the new format
+(matching `name_id`) in ESPHome 2026.8.0, at which point `name_id` will be removed.
+
+The `state` field contains a simple text-based representation of the state of the underlying
+component, for example ON/OFF or 21.4 °C. Several components also have additional fields in
+this payload, for example lights have a `brightness` attribute.
 
 {{< img src="event-source.png" alt="Image" caption="Example payload of the event source API." class="align-center" >}}
 

--- a/content/web-api/_index.md
+++ b/content/web-api/_index.md
@@ -42,12 +42,14 @@ Currently, there are three types of events sent: `ping`, `state` and `log`. The 
 is repeatedly sent out to keep the connection alive. `log` events are sent every time a log
 message is triggered and is used to show the debug log on the index page. `state` is where
 the real magic happens. All events with this type have a JSON payload that describes the state
-of a component. Each of these JSON payloads have the following identifier fields:
+of a component. Each of these JSON payloads has the following identifier fields:
 
-- `name_id`: The preferred identifier using the format `domain/entity_name` (for example
-  `sensor/Temperature`) or `domain/device_name/entity_name` for sub-device entities.
+- `name_id`: **Temporary field (removed in 2026.8.0)** providing the new identifier format
+  `domain/entity_name` (for example `sensor/Temperature`) or `domain/device_name/entity_name`
+  for sub-device entities.
 - `id`: Legacy identifier using the format `domain-object_id` (for example `sensor-temperature`).
-  Provided for backward compatibility with existing integrations.
+  Provided for backward compatibility. In 2026.8.0, this field switches to the new format
+  (matching `name_id`) and `name_id` is removed.
 
 Third-party integrations **MUST** prefer `name_id` over `id` to get the new ID format,
 falling back to `id` for compatibility with older firmware and for when `name_id` is
@@ -65,8 +67,10 @@ this payload, for example lights have a `brightness` attribute.
 Additionally, each time a client connects to the event source the server sends out all current
 states so that the client can catch up with reality.
 
-The payloads of these state events are also the same as the payloads of the REST API GET calls.
-I would recommend just opening the network debug panel of your web browser to see what's sent.
+The payloads of these state events are similar to the REST API GET calls, except SSE includes
+both `name_id` and `id` fields during the deprecation period (until 2026.8.0), while REST
+responses only include `id` in the new format. I would recommend just opening the network
+debug panel of your web browser to see what's sent.
 
 {{< anchor "api-rest" >}}
 


### PR DESCRIPTION
## Description:

Documents the SSE entity ID deprecation path:

- `name_id`: preferred identifier (new format `domain/entity_name`)
- `id`: legacy identifier (old format `domain-object_id`) for backward compatibility

Timeline: `id` switches to new format in 2026.8.0, `name_id` removed.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- https://github.com/esphome/esphome/pull/13535

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.
