### PR TITLE
Add example to max filter

### DIFF
--- a/src/content/docs/components/sensor/filter/max.mdx
+++ b/src/content/docs/components/sensor/filter/max.mdx
@@ -8,6 +8,17 @@ description: "Sensor filter documentation"
 A moving maximum over the last few values. A large window size will make the filter slow to
 react to input changes.
 
+```yaml
+# Example configuration entry
+- platform: ...
+  # ...
+  filters:
+    - max:
+        window_size: 7
+        send_every: 4
+        send_first_at: 3
+```
+
 Configuration variables:
 
 - **window_size** (*Optional*, int): The number of values over which to calculate the min/max


### PR DESCRIPTION
The text says "For example, in above configuration" but there were no example - so adding this one

## Description:


**Related issue (if applicable):** none

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome# none

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/static/images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/_index.md`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image dht22
```

</details>
