### PR TITLE
[http_request] Document ca_certificate_path for ESP32

### DIFF
--- a/content/components/http_request.md
+++ b/content/components/http_request.md
@@ -40,6 +40,10 @@ http_request:
 
 - **buffer_size_rx** (*Optional*, integer): Change HTTP receive buffer size. Defaults to `512`.
 - **buffer_size_tx** (*Optional*, integer): Change HTTP transmit buffer size. Defaults to `512`.
+- **ca_certificate_path** (*Optional*, file path): Path to a PEM-encoded CA certificate file. Use this to verify
+  connections to servers using self-signed or custom CA certificates while keeping `verify_ssl` enabled. The
+  certificate is embedded in the firmware at compile time. When specified, the default certificate bundle is not
+  included, reducing firmware size.
 
 **For the ESP8266:**
 
@@ -60,9 +64,11 @@ http_request:
 >
 > To maximize security, do not set `verify_ssl` to `false` *unless:*
 >
-> - a custom CA/self-signed certificate is used,
 > - the Arduino framework on a non-ESP32 device is used, or
 > - the device does not have sufficient memory to store the certificate bundle
+>
+> If you need to connect to a server using a self-signed or custom CA certificate on ESP32, use the
+> `ca_certificate_path` option instead of disabling `verify_ssl`.
 >
 > **We strongly recommend using hardware which properly supports TLS/SSL.**
 


### PR DESCRIPTION
## Description:

Documents the new `ca_certificate_path` option for ESP32, which allows users to specify a custom CA certificate for SSL verification instead of disabling `verify_ssl` entirely. This enables secure HTTPS connections to servers using self-signed or custom CA certificates.

**Related issue (if applicable):** fixes https://github.com/esphome/esphome/issues/13551

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#13552

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.