### PR TITLE
[web_server] add `use_legacy_id` option

### DIFF
--- a/content/components/web_server.md
+++ b/content/components/web_server.md
@@ -64,6 +64,10 @@ web_server:
   maintaining it for captive portal access. To enable OTA for web server, use the `web_server` OTA platform instead.
 
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID used for code generation.
+- **use_legacy_id** (*Optional*, boolean): Use the legacy entity ID format (`{domain}-{object_id}`) in
+  [Event Source](/web-api#api-event-source) payloads instead of the new format (`{domain}/{name}`).
+  This option is provided for compatibility with third-party integrations that rely on the previous ID format.
+  Defaults to `false`. *This option will be removed in version 2026.7.0.*
 - **local** (*Optional*, boolean): Include supporting javascript locally allowing it to work without internet access.
   Defaults to `false`.
 


### PR DESCRIPTION
Document the new `use_legacy_id` option that restores the legacy entity ID format in Event Source payloads for third-party integration compatibility.

## Description:

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#13555

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

