### PR TITLE
Add MAX31888 sensor documentation

### DIFF
--- a/content/components/sensor/max31888.md
+++ b/content/components/sensor/max31888.md
@@ -1,0 +1,38 @@
+---
+description: "Instructions for setting up Analog devices 1-Wire temperature sensors"
+title: "MAX31888 Temperature Sensor"
+params:
+  seo:
+    description: Instructions for setting up Analog devices 1-Wire temperature sensors
+---
+
+The `max31888` component allows you to use
+([datasheet](https://www.analog.com/media/en/technical-documentation/data-sheets/max31888.pdf))
+and similar 1-Wire temperature sensors. A {{< docref "/components/one_wire/index" "1-Wire bus" >}} is
+required to be set up in your configuration for this sensor to work.
+
+```yaml
+# Example configuration entries
+sensor:
+ - platform: max31888
+   name: "temperature"
+   update_interval: 1s
+```
+
+## Configuration variables
+
+- **address** (*Optional*, int): The address of the sensor. Required if there is more than one device on the bus and index is not specified.
+- **index** (*Optional*, byte): The index (0-based) of the sensor. Required if there is more than one device on the bus and address is not specified.
+  *Note this index is based on the hardware addresses of the sensors and the order can change if sensors are changed, added, or removed.*
+  
+- **update_interval** (*Optional*, [Time](/guides/configuration-types#time)): The interval that the sensors should be checked.
+  Defaults to 60 seconds.
+
+- **one_wire_id** (*Optional*, {{< docref "/components/one_wire" >}}): The ID of the 1-Wire bus to use.
+  Required if there is more than one bus.
+
+- All other options from [Sensor](/components/sensor).
+
+### See Also
+
+- {{< apiref "max31888/max31888.h" "max31888/max31888.h" >}}

--- a/content/components/sensor/max31888.md
+++ b/content/components/sensor/max31888.md
@@ -1,12 +1,12 @@
 ---
-description: "Instructions for setting up Analog devices 1-Wire temperature sensors"
+description: "Instructions for setting up Analog Devices 1-Wire temperature sensors"
 title: "MAX31888 Temperature Sensor"
 params:
   seo:
-    description: Instructions for setting up Analog devices 1-Wire temperature sensors
+    description: Instructions for setting up Analog Devices 1-Wire temperature sensors
 ---
 
-The `max31888` component allows you to use
+The `max31888` component allows you to use MAX31888
 ([datasheet](https://www.analog.com/media/en/technical-documentation/data-sheets/max31888.pdf))
 and similar 1-Wire temperature sensors. A {{< docref "/components/one_wire/index" "1-Wire bus" >}} is
 required to be set up in your configuration for this sensor to work.


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#13567

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/static/images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/_index.md`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image dht22
```

</details>
