### PR TITLE
[esp32] Document use_full_certificate_bundle advanced option

### DIFF
--- a/content/components/esp32.md
+++ b/content/components/esp32.md
@@ -249,13 +249,13 @@ The following options disable unused VFS features to save flash memory:
 
 **TLS/Certificate Options:**
 
-- **use_full_certificate_bundle** (*Optional*, boolean): Use the full certificate bundle (~69 KB) instead of the common-CAs
-  bundle (~34 KB). By default, ESPHome uses the CMN (common CAs) bundle which includes only Certificate Authorities with
+- **use_full_certificate_bundle** (*Optional*, boolean): Use the full certificate bundle instead of the common CAs
+  bundle. By default, ESPHome uses the CMN (common CAs) bundle which includes only Certificate Authorities with
   greater than 1% market share. This covers approximately 99% of websites including Let's Encrypt, DigiCert, Google Trust
   Services, Amazon Trust Services, and other major CAs. The CMN bundle is sufficient for most use cases including GitHub
   (commonly used for OTA updates via {{< docref "/components/http_request" >}}), Home Assistant Cloud, and typical HTTPS
   endpoints. Set to `true` only if connecting to services that use uncommon Certificate Authorities. Defaults to `false`
-  (CMN bundle to save ~35 KB flash).
+  (CMN bundle saves ~51 KB flash).
 
 Some options can be disabled to save flash memory without affecting typical ESPHome functionality. The performance
 options (defaulting to `true`  ) improve socket operation performance but can be disabled if you need better

--- a/content/components/esp32.md
+++ b/content/components/esp32.md
@@ -247,6 +247,16 @@ The following options disable unused VFS features to save flash memory:
   primarily at setup, not in hot loops). Set to `true` only if you have a specific use case requiring faster heap operations.
   Defaults to `false` (heap functions in flash to save IRAM).
 
+**TLS/Certificate Options:**
+
+- **use_full_certificate_bundle** (*Optional*, boolean): Use the full certificate bundle (~69 KB) instead of the common-CAs
+  bundle (~34 KB). By default, ESPHome uses the CMN (common CAs) bundle which includes only Certificate Authorities with
+  greater than 1% market share. This covers approximately 99% of websites including Let's Encrypt, DigiCert, Google Trust
+  Services, Amazon Trust Services, and other major CAs. The CMN bundle is sufficient for most use cases including GitHub
+  (commonly used for OTA updates via {{< docref "/components/http_request" >}}), Home Assistant Cloud, and typical HTTPS
+  endpoints. Set to `true` only if connecting to services that use uncommon Certificate Authorities. Defaults to `false`
+  (CMN bundle to save ~35 KB flash).
+
 Some options can be disabled to save flash memory without affecting typical ESPHome functionality. The performance
 options (defaulting to `true`  ) improve socket operation performance but can be disabled if you need better
 multi-threaded scalability (which is uncommon since ESPHome uses an event loop).
@@ -272,6 +282,9 @@ esp32:
       enable_lwip_dhcp_server: false  # Disabled by default, only needed for AP mode
       enable_lwip_mdns_queries: false  # Enabled by default, can disable if not using .local hostnames
       enable_lwip_bridge_interface: false  # Disabled by default
+
+      # TLS options
+      use_full_certificate_bundle: false  # Disabled by default, saves ~35 KB flash
 ```
 
 {{< anchor "esp32-idf_components" >}}


### PR DESCRIPTION
## Description:

Documents the new `use_full_certificate_bundle` advanced option for ESP32 ESP-IDF framework.

This is a **breaking change** in ESPHome - the default certificate bundle has been changed from FULL (~69KB) to CMN (Common CAs, ~34KB) to save approximately **51KB of flash (-5.75%)** for configurations using HTTPS.

The CMN bundle includes Certificate Authorities with >1% market share, covering ~99% of websites including:
- Let's Encrypt (most common)
- DigiCert (GitHub, many enterprise sites)
- Google Trust Services
- Amazon Trust Services

Users connecting to HTTPS services with uncommon CAs can set `use_full_certificate_bundle: true` to restore the previous behavior.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#13574

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.
