### PR TITLE
Add Nexus protocol docs

### DIFF
--- a/content/components/remote_receiver.md
+++ b/content/components/remote_receiver.md
@@ -55,6 +55,7 @@ Multiple remote receivers can be configured as a list of dict definitions within
   - **midea**: Decode and dump Midea infrared codes.
   - **nec**: Decode and dump NEC infrared codes.
   - **nexa**: Decode and dump Nexa (RF) codes.
+  - **nexus**: Decode and dump Nexus temperature & humidity sensor RF codes.
   - **panasonic**: Decode and dump Panasonic infrared codes.
   - **pioneer**: Decode and dump Pioneer infrared codes.
   - **pronto**: Print remote code in Pronto form. Useful for using arbitrary protocols.
@@ -228,6 +229,10 @@ To enable signal demodulation, configure the signal carrier frequency and duty c
 
 - **on_nexa** (*Optional*, [Automation](/automations)): An automation to perform when a
   Nexa RF code has been decoded. A variable `x` of type {{< apistruct "remote_base::NexaData" "remote_base::NexaData" >}}
+  is passed to the automation for use in lambdas.
+
+- **on_nexus** (*Optional*, :ref:`Automation <automation>`): An automation to perform when a
+  Nexus remote code has been decoded. A variable ``x`` of type :apistruct:`remote_base::NexusData`
   is passed to the automation for use in lambdas.
 
 - **on_panasonic** (*Optional*, [Automation](/automations)): An automation to perform when a
@@ -488,6 +493,11 @@ Remote code selection (exactly one of these has to be included):
   - **state** (**Required**, int): The Nexa state code to trigger on, see dumper output for more info.
   - **channel** (**Required**, int): The Nexa channel code to trigger on, see dumper output for more info.
   - **level** (**Required**, int): The Nexa level code to trigger on, see dumper output for more info.
+
+- **nexus**: Trigger on a decoded Nexus remote code with the given data.
+
+  - **channel** (**Required**, int): The channel to trigger on, see dumper output for more info.
+  - **address** (**Required**, int): The address to trigger on, see dumper output for more info.
 
 - **panasonic**: Trigger on a decoded Panasonic remote code with the given data.
 

--- a/content/components/remote_receiver.md
+++ b/content/components/remote_receiver.md
@@ -232,7 +232,7 @@ To enable signal demodulation, configure the signal carrier frequency and duty c
   is passed to the automation for use in lambdas.
 
 - **on_nexus** (*Optional*, :ref:`Automation <automation>`): An automation to perform when a
-  Nexus remote code has been decoded. A variable ``x`` of type :apistruct:`remote_base::NexusData`
+  Nexus remote code has been decoded. A variable `x` of type {{< apistruct "remote_base::NexusData" "remote_base::NexusData" >}}
   is passed to the automation for use in lambdas.
 
 - **on_panasonic** (*Optional*, [Automation](/automations)): An automation to perform when a

--- a/content/components/remote_receiver.md
+++ b/content/components/remote_receiver.md
@@ -231,7 +231,7 @@ To enable signal demodulation, configure the signal carrier frequency and duty c
   Nexa RF code has been decoded. A variable `x` of type {{< apistruct "remote_base::NexaData" "remote_base::NexaData" >}}
   is passed to the automation for use in lambdas.
 
-- **on_nexus** (*Optional*, :ref:`Automation <automation>`): An automation to perform when a
+- **on_nexus** (*Optional*, [Automation](/automations)): An automation to perform when a
   Nexus remote code has been decoded. A variable `x` of type {{< apistruct "remote_base::NexusData" "remote_base::NexusData" >}}
   is passed to the automation for use in lambdas.
 

--- a/content/components/remote_transmitter.md
+++ b/content/components/remote_transmitter.md
@@ -621,6 +621,31 @@ on_...:
 
 {{< anchor "remote_transmitter-transmit_panasonic" >}}
 
+### ``remote_transmitter.transmit_nexus`` **Action**
+
+This [action](config-action) sends a 36-bit Nexus code to a remote transmitter.
+
+```yaml
+on_...:
+  - remote_transmitter.transmit_nexus:
+      channel: 1
+      address: 42
+      temperature: 34.5
+      humidity: 51
+      battery_level: true
+      force_update: false
+```
+
+Configuration variables:
+
+- **channel** (**Required**, int): The 2-bit channel to send, between 1 and 4 inclusive.
+- **address** (**Required**, int): The 8-bit address (sensor ID) to send, between 0 and 255 inclusive. Each sensor has a unique one.
+- **temperature** (**Optional**, float): The 12-bit temperature to send, between -204.8 and 204.7 inclusive. Defaults to ``25.5``.
+- **humidity** (**Optional**, int): The 8-bit humidity to send, between 0 and 255 inclusive. Defaults to ``42``.
+- **battery_level** (**Optional**, boolean): The battery level normal flag bit to send, ``false`` means the battery level is low, ``true`` means normal. Defaults to ``true``.
+- **force_update** (**Optional**, boolean): The force update flag bit to send, ``false`` means the transmission is normal, ``true`` means forced. Defaults to ``false``.
+- All other options from :ref:`remote_transmitter-transmit_action`.
+
 ### `remote_transmitter.transmit_panasonic` **Action**
 
 This [action](/automations/actions#all-actions) sends a Panasonic infrared remote code to a remote transmitter.


### PR DESCRIPTION
Docs from https://github.com/esphome/esphome-docs/pull/4407/files, brought up to date.

## Description:

Bring https://github.com/esphome/esphome-docs/pull/4407/files up to date, to go with 

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#13577

## Checklist:

  - [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/static/images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/_index.md`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image dht22
```

</details>
