### PR TITLE
[nrf52,zigbee] add number

### DIFF
--- a/content/components/zigbee.md
+++ b/content/components/zigbee.md
@@ -151,6 +151,37 @@ switch:
   not be exposed over Zigbee. Only specifying an `id` without a `name` will implicitly set this to true.
   Use this if you run out of Zigbee endpoints.
 
+### Number Configuration
+
+All numbers with a `name` are automatically exposed over Zigbee.
+
+```yaml
+number:
+  - platform: template
+    name: "Template_number"
+    optimistic: true
+    min_value: 2
+    max_value: 100
+    step: 1
+```
+
+#### Configuration variables
+
+- **name** (**Required**, string): The name for the number. This is exposed as the
+  Zigbee endpoint description.
+- **internal** (*Optional*, boolean): Mark this component as internal. Internal components will
+  not be exposed over Zigbee. Only specifying an `id` without a `name` will implicitly set this to true.
+  Use this if you run out of Zigbee endpoints.
+- **unit_of_measurement** (*Optional*, string): Manually set the unit. By default, values are unitless.
+  Only a limited set of units is supported. Unsupported units will revert to unitless.
+  This is exposed as the Zigbee endpoint engineering units.
+- **min_value** (**Optional**, float): The minimum value this number can be. This is exposed as the
+  Zigbee endpoint min present value.
+- **max_value** (**Optional**, float): The maximum value this number can be. This is exposed as the
+  Zigbee endpoint min present value.
+- **step** (**Optional**, float): The granularity with which the number can be set. This is exposed
+  as the Zigbee endpoint resolution.
+
 ## See Also
 
 - [Zigbee2MQTT](https://www.zigbee2mqtt.io/)

--- a/content/components/zigbee.md
+++ b/content/components/zigbee.md
@@ -158,7 +158,7 @@ All numbers with a `name` are automatically exposed over Zigbee.
 ```yaml
 number:
   - platform: template
-    name: "Template_number"
+    name: "Template Number"
     optimistic: true
     min_value: 2
     max_value: 100
@@ -178,7 +178,7 @@ number:
 - **min_value** (*Optional*, float): The minimum value this number can be. This is exposed as the
   Zigbee endpoint min present value.
 - **max_value** (*Optional*, float): The maximum value this number can be. This is exposed as the
-  Zigbee endpoint min present value.
+  Zigbee endpoint max present value.
 - **step** (*Optional*, float): The granularity with which the number can be set. This is exposed
   as the Zigbee endpoint resolution.
 

--- a/content/components/zigbee.md
+++ b/content/components/zigbee.md
@@ -175,11 +175,11 @@ number:
 - **unit_of_measurement** (*Optional*, string): Manually set the unit. By default, values are unitless.
   Only a limited set of units is supported. Unsupported units will revert to unitless.
   This is exposed as the Zigbee endpoint engineering units.
-- **min_value** (**Optional**, float): The minimum value this number can be. This is exposed as the
+- **min_value** (*Optional*, float): The minimum value this number can be. This is exposed as the
   Zigbee endpoint min present value.
-- **max_value** (**Optional**, float): The maximum value this number can be. This is exposed as the
+- **max_value** (*Optional*, float): The maximum value this number can be. This is exposed as the
   Zigbee endpoint min present value.
-- **step** (**Optional**, float): The granularity with which the number can be set. This is exposed
+- **step** (*Optional*, float): The granularity with which the number can be set. This is exposed
   as the Zigbee endpoint resolution.
 
 ## See Also


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- https://github.com/esphome/esphome/pull/13581

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/static/images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/_index.md`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image dht22
```

</details>
