### PR TITLE
[esp32] Document include_builtin_idf_components advanced option

### DIFF
--- a/content/components/esp32.md
+++ b/content/components/esp32.md
@@ -257,12 +257,16 @@ The following options disable unused VFS features to save flash memory:
   endpoints. Set to `true` only if connecting to services that use uncommon Certificate Authorities. Defaults to `false`
   (CMN bundle saves ~51 KB flash).
 
-**IDF Component Inclusion:**
+**Built-in IDF Component Inclusion:**
 
-- **include_idf_components** (*Optional*, list of strings): A list of ESP-IDF component names to include in the build.
-  ESPHome excludes certain IDF components by default to reduce compile time. If you need to use an IDF component that
-  is excluded (for example, when using custom code in a lambda that requires a specific IDF library), you can explicitly
-  include it here. Example: `["esp_http_client", "mqtt"]`.
+- **include_builtin_idf_components** (*Optional*, list of strings): A list of built-in ESP-IDF component names to
+  re-enable in the build. ESPHome excludes certain built-in IDF components by default to reduce compile time. If you
+  need to use a built-in IDF component that is excluded (for example, when using custom code in a lambda that requires
+  a specific IDF library), you can explicitly include it here. Example: `["esp_http_client", "mqtt"]`.
+
+  Note: This is different from the `components` option which adds external components from the
+  [ESP Component Registry](https://components.espressif.com/). This option re-enables built-in ESP-IDF components
+  that are excluded by default.
 
 Some options can be disabled to save flash memory without affecting typical ESPHome functionality. The performance
 options (defaulting to `true`  ) improve socket operation performance but can be disabled if you need better

--- a/content/components/esp32.md
+++ b/content/components/esp32.md
@@ -262,7 +262,8 @@ The following options disable unused VFS features to save flash memory:
 - **include_idf_components** (*Optional*, list of strings): A list of ESP-IDF component names to include in the build.
   ESPHome excludes certain IDF components by default to reduce compile time. If you need to use an IDF component that
   is excluded (for example, when using custom code in a lambda that requires a specific IDF library), you can explicitly
-  include it here. Example: `["esp_http_client", "mqtt"]`.
+  include it here. Example: `["esp_http_client", "mqtt"]`. This is different from the `components` option in the "IDF Components"
+  section below, which is for adding external components (for example from the ESP Component Registry or custom sources).
 
 Some options can be disabled to save flash memory without affecting typical ESPHome functionality. The performance
 options (defaulting to `true`  ) improve socket operation performance but can be disabled if you need better

--- a/content/components/esp32.md
+++ b/content/components/esp32.md
@@ -257,6 +257,13 @@ The following options disable unused VFS features to save flash memory:
   endpoints. Set to `true` only if connecting to services that use uncommon Certificate Authorities. Defaults to `false`
   (CMN bundle saves ~51 KB flash).
 
+**IDF Component Inclusion:**
+
+- **include_idf_components** (*Optional*, list of strings): A list of ESP-IDF component names to include in the build.
+  ESPHome excludes certain IDF components by default to reduce compile time. If you need to use an IDF component that
+  is excluded (for example, when using custom code in a lambda that requires a specific IDF library), you can explicitly
+  include it here. Example: `["esp_http_client", "mqtt"]`.
+
 Some options can be disabled to save flash memory without affecting typical ESPHome functionality. The performance
 options (defaulting to `true`  ) improve socket operation performance but can be disabled if you need better
 multi-threaded scalability (which is uncommon since ESPHome uses an event loop).


### PR DESCRIPTION
## Description:

Documents the new `include_builtin_idf_components` advanced configuration option for ESP32.

This option allows users to explicitly re-enable built-in ESP-IDF components that are excluded by default to reduce compile time. This serves as an escape hatch for users who need specific built-in IDF components for custom code in lambdas or other advanced use cases.

Note: This is different from the existing `components` option which adds external components from the ESP Component Registry. This new option re-enables built-in ESP-IDF components.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#13610

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.
