### PR TITLE
[sntp] Add docs for smooth_sync config option

### DIFF
--- a/content/components/time/sntp.md
+++ b/content/components/time/sntp.md
@@ -20,6 +20,9 @@ time:
 - **servers** (*Optional*, list of strings): Choose up to 3 NTP servers that are used for the clock source.
   Defaults to `0.pool.ntp.org`, `1.pool.ntp.org` and `2.pool.ntp.org`
 
+- **smooth_sync** (*Optional*, boolean): When true, updates time smoothly by gradually reducing time error. If the difference between the SNTP response time and system time is more than 35 minutes, update system time immediately.
+  Defaults to `false`, which updates system time immediately upon receiving a response from the SNTP server.
+
 - All other options from [Base Time Configuration](/components/time#base_time_config).
 
 > [!NOTE]

--- a/content/components/time/sntp.md
+++ b/content/components/time/sntp.md
@@ -20,6 +20,8 @@ time:
 - **servers** (*Optional*, list of strings): Choose up to 3 NTP servers that are used for the clock source.
   Defaults to `0.pool.ntp.org`, `1.pool.ntp.org` and `2.pool.ntp.org`
 
+**For the ESP32:**
+
 - **smooth_sync** (*Optional*, boolean): When true, updates time smoothly by gradually reducing time error. If the difference between the SNTP response time and system time is more than 35 minutes, update system time immediately.
   Defaults to `false`, which updates system time immediately upon receiving a response from the SNTP server.
 


### PR DESCRIPTION
## Description:

Updates documentation for the SNTP component to include the `smooth_sync` parameter introduced in the linked PR below

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#13630

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/static/images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/_index.md`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image dht22
```

</details>
