### PR TITLE
2026.1.3

### DIFF
--- a/content/changelog/2026.1.0.md
+++ b/content/changelog/2026.1.0.md
@@ -542,6 +542,23 @@ For detailed migration guides and API documentation, see the [ESPHome Developers
 
 </details>
 
+## Release 2026.1.3 - January 29
+
+<details>
+<summary></summary>
+
+- Update webserver local assets to 20260122-204614 [esphome#13455](https://github.com/esphome/esphome/pull/13455) by [@esphomebot](https://github.com/esphomebot)
+- [mhz19] Fix Uninitialized var warning message [esphome#13526](https://github.com/esphome/esphome/pull/13526) by [@sebcaps](https://github.com/sebcaps)
+- [ota] Improve error message when device closes connection without responding [esphome#13562](https://github.com/esphome/esphome/pull/13562) by [@bdraco](https://github.com/bdraco)
+- [socket] ESP8266: call delay(0) instead of esp_delay(0, cb) for zero timeout [esphome#13530](https://github.com/esphome/esphome/pull/13530) by [@bdraco](https://github.com/bdraco)
+- [web_server] Add name_id to SSE for entity ID format migration [esphome#13535](https://github.com/esphome/esphome/pull/13535) by [@bdraco](https://github.com/bdraco)
+- Update webserver local assets to 20260127-190637 [esphome#13573](https://github.com/esphome/esphome/pull/13573) by [@esphomebot](https://github.com/esphomebot)
+- [ld2450] preserve precision of angle [esphome#13600](https://github.com/esphome/esphome/pull/13600) by [@ccutrer](https://github.com/ccutrer)
+- [wifi] Fix ESP8266 yield panic when WiFi scan fails [esphome#13603](https://github.com/esphome/esphome/pull/13603) by [@bdraco](https://github.com/bdraco)
+- [http_request] Fix empty body for chunked transfer encoding responses [esphome#13599](https://github.com/esphome/esphome/pull/13599) by [@bdraco](https://github.com/bdraco)
+
+</details>
+
 ## Full list of changes
 
 ### New Features

--- a/content/guides/supporters.md
+++ b/content/guides/supporters.md
@@ -2330,4 +2330,4 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Christian Zufferey (@zuzu59)](https://github.com/zuzu59)
 - [Zynth-dev (@Zynth-dev)](https://github.com/Zynth-dev)
 
-*This page was last updated January 25, 2026.*
+*This page was last updated January 29, 2026.*

--- a/data/version.yaml
+++ b/data/version.yaml
@@ -1,2 +1,2 @@
-release: 2026.1.2
+release: 2026.1.3
 version: '2026.1'


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- Bump docker/login-action from 3.6.0 to 3.7.0 [docs#6000](https://github.com/esphome/esphome-docs/pull/6000)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
