### PR TITLE
feat(ina226): Add alert pin control functionality

### DIFF
--- a/content/changelog/2026.1.0.md
+++ b/content/changelog/2026.1.0.md
@@ -139,6 +139,8 @@ The web server now uses entity names directly in URLs instead of sanitized `obje
 
 Old URLs using `object_id` format (e.g., `/sensor/temperature_sensor`) continue to work during a deprecation period until 2026.7.0.
 
+**SSE Entity IDs:** A deprecation path was added for SSE event entity IDs. The payload now includes a temporary `name_id` field (new format like `sensor/Temperature`) alongside `id` (legacy format like `sensor-temperature`). **Timeline:** In 2026.8.0, `name_id` will be removed and `id` will switch to the new format. Third-party integrations should prefer `name_id` now, falling back to `id` for compatibility with older firmware. Integrations requiring the legacy format after 2026.8.0 must implement their own conversion logic.
+
 **Important restrictions:**
 
 - Names may not include `/` because it is reserved as a URL path separator

--- a/content/components/sensor/ina226.md
+++ b/content/components/sensor/ina226.md
@@ -44,6 +44,23 @@ sensor:
       current: 332us
 ```
 
+```yaml
+# Example with alert pin control
+sensor:
+  - platform: ina226
+    address: 0x40
+    shunt_resistance: 0.1 ohm
+    max_current: 3.2A
+    current:
+      name: "INA226 Current"
+    alert:
+      function: bus_over
+      limit: 15.0
+      conversion_ready: false
+      active_high: true
+      latch: false
+```
+
 ## Configuration variables
 
 - **address** (*Optional*, integer): Manually specify the I²C address of the sensor. Defaults to `0x40`.
@@ -65,6 +82,27 @@ sensor:
 
 - **update_interval** (*Optional*, [Time](/guides/configuration-types#time)): The interval to check the sensor. Defaults to `60s`.
 
+- **alert** (*Optional*): Alert pin configuration for monitoring thresholds or conversion ready signal. If not specified, alert functionality is disabled.
+
+  - **function** (*Optional*, string): Alert function to trigger the alert pin. Defaults to `none`. Valid values are:
+    - `none`: No alert function, alert pin disabled
+    - `shunt_over`: Alert when shunt voltage exceeds the limit
+    - `shunt_under`: Alert when shunt voltage falls below the limit
+    - `bus_over`: Alert when bus voltage exceeds the limit
+    - `bus_under`: Alert when bus voltage falls below the limit
+    - `power_over`: Alert when power exceeds the limit
+
+  - **limit** (*Optional*, float): Threshold value for the alert function. Defaults to `0.0`. The unit depends on the alert function selected and should be specified without units:
+    - `shunt_over`, `shunt_under`: Shunt voltage threshold in Volts
+    - `bus_over`, `bus_under`: Bus voltage threshold in Volts
+    - `power_over`: Power threshold in Watts
+
+  - **conversion_ready** (*Optional*, boolean): Enable the conversion ready flag on the alert pin. When enabled, the alert pin pulses when a new measurement is ready. Can be combined with alert functions. Defaults to `false`.
+
+  - **active_high** (*Optional*, boolean): Set alert pin polarity. When `true`, alert pin is active high. When `false`, alert pin is active low. Defaults to `false`.
+
+  - **latch** (*Optional*, boolean): Enable latch mode for the alert pin. When enabled, the alert pin remains asserted until the alert register is read. Defaults to `false`.
+
 ## Sensors
 
 The component offers four sensors. You can configure all or any subset of them. Each configured sensor
@@ -75,6 +113,62 @@ All other options from [Sensor](/components/sensor).
 - **power** (*Optional*): Calculated power output, Watts.
 - **bus_voltage** (*Optional*): Bus voltage output (voltage of the high side contact), Volts.
 - **shunt_voltage** (*Optional*): Shunt voltage (voltage across the shunt resistor) value of the sensor, Volts.
+
+## Alert Pin Actions
+
+### `ina226.clear_alert` Action
+
+This action clears the alert flag on the INA226 sensor by reading the mask/enable register. This is useful in latch mode where the alert pin remains asserted until the alert register is read.
+
+```yaml
+on_...:
+  then:
+    - ina226.clear_alert: ina226_sensor
+```
+
+Configuration variables:
+
+- **id** (**Required**, [ID](/guides/configuration-types#id)): The ID of the INA226 component to clear the alert flag.
+
+## Examples
+
+### Monitor power consumption with alert
+
+The INA226 alert pin is open-drain, so GPIO must be configured with a pull-up resistor to properly detect the alert signal.
+
+```yaml
+binary_sensor:
+  - platform: gpio
+    pin:
+      number: GPIO26
+      mode:
+        input: true
+        pullup: true
+    name: "INA226 Alert"
+    id: ina226_alert_pin
+
+sensor:
+  - platform: ina226
+    address: 0x40
+    shunt_resistance: 0.1 ohm
+    max_current: 3.2 A
+    power:
+      name: "Power Consumption"
+    alert:
+      function: power_over
+      limit: 100.0
+      active_high: true
+      latch: true
+
+automation:
+  - trigger:
+      platform: gpio
+      pin: ina226_alert_pin  # INA226 Alert pin
+      mode: INPUT
+    action:
+      - logger.log: "Power limit exceeded!"
+      - ina226.clear_alert: ina226_sensor
+```
 
 ## See Also
 

--- a/content/components/water_heater/_index.md
+++ b/content/components/water_heater/_index.md
@@ -6,7 +6,7 @@ title: "Water Heater Component"
 The `water_heater` component is a generic representation of water heaters (boilers) in ESPHome. A water heater handles a target temperature setpoint and an operation mode (like *Eco*, *Electric*, or *Performance*).
 
 > [!NOTE]
-> Home Assistant integration for water heater entities is not yet available. See [home-assistant/core#159201](https://github.com/home-assistant/core/pull/159201) for progress.
+> The water heater integration is available for Home Assistant 2026.2 and later.
 
 {{< anchor "config-water-heater" >}}
 

--- a/content/web-api/_index.md
+++ b/content/web-api/_index.md
@@ -42,20 +42,35 @@ Currently, there are three types of events sent: `ping`, `state` and `log`. The 
 is repeatedly sent out to keep the connection alive. `log` events are sent every time a log
 message is triggered and is used to show the debug log on the index page. `state` is where
 the real magic happens. All events with this type have a JSON payload that describes the state
-of a component. Each of these JSON payloads have two mandatory fields: `id` and `state`. ID
-is the unique identifier of the component using the format `domain/entity_name` (for example
-`sensor/Temperature`) or `domain/device_name/entity_name` for sub-device entities. `state`
-contains a simple text-based representation of the state of the underlying component, for
-example ON/OFF or 21.4 °C. Several components also have additional fields in this payload,
-for example lights have a `brightness` attribute.
+of a component. Each of these JSON payloads has the following identifier fields:
+
+- `name_id`: **Temporary field (removed in 2026.8.0)** providing the new identifier format
+  `domain/entity_name` (for example `sensor/Temperature`) or `domain/device_name/entity_name`
+  for sub-device entities.
+- `id`: Legacy identifier using the format `domain-object_id` (for example `sensor-temperature`).
+  Provided for backward compatibility. In 2026.8.0, this field switches to the new format
+  (matching `name_id`) and `name_id` is removed.
+
+Third-party integrations **MUST** prefer `name_id` over `id` to get the new ID format,
+falling back to `id` for compatibility with older firmware and for when `name_id` is
+removed. The `id` field will switch to the new format (matching `name_id`) in ESPHome
+2026.8.0, at which point `name_id` will be removed. Third-party integrations that require
+the legacy format after 2026.8.0 must implement their own conversion logic (similar to
+`aioesphomeapi`).
+
+The `state` field contains a simple text-based representation of the state of the underlying
+component, for example ON/OFF or 21.4 °C. Several components also have additional fields in
+this payload, for example lights have a `brightness` attribute.
 
 {{< img src="event-source.png" alt="Image" caption="Example payload of the event source API." class="align-center" >}}
 
 Additionally, each time a client connects to the event source the server sends out all current
 states so that the client can catch up with reality.
 
-The payloads of these state events are also the same as the payloads of the REST API GET calls.
-I would recommend just opening the network debug panel of your web browser to see what's sent.
+The payloads of these state events are similar to the REST API GET calls, except SSE includes
+both `name_id` and `id` fields during the deprecation period (until 2026.8.0), while REST
+responses only include `id` in the new format. I would recommend just opening the network
+debug panel of your web browser to see what's sent.
 
 {{< anchor "api-rest" >}}
 


### PR DESCRIPTION
Add alert pin configuration and examples for INA226 sensor.

## Description:
Add support for INA226 alert pin control, allowing users to monitor voltage/power thresholds and conversion ready signals.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#13637

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/static/images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/_index.md`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image dht22
```

</details>
