### PR TITLE
Add target temperature lambda to water heater template

### DIFF
--- a/content/components/water_heater/template.md
+++ b/content/components/water_heater/template.md
@@ -20,6 +20,9 @@ water_heater:
     # Lambda to read the current temperature (e.g. from a sensor)
     current_temperature: !lambda 'return id(my_sensor).state;'
 
+    # Lambda to read the target temperature (optional)
+    target_temperature: !lambda 'return id(my_target_temp_sensor).state;'
+
     # Lambda to read the current operation mode (optional)
     mode: !lambda 'return water_heater::WATER_HEATER_MODE_ECO;'
     optimistic: true
@@ -43,12 +46,16 @@ water_heater:
 Possible return values for the lambdas:
 
 - `current_temperature`: Returns a `float` (e.g. `42.5`).
+- `target_temperature`: Returns a `float` (e.g. `60.0`).
 - `mode`: Returns a `WaterHeaterMode` enum (e.g. `water_heater::WATER_HEATER_MODE_ECO`).
 
 ## Configuration variables
 
 - **current_temperature** (*Optional*, [lambda](/automations/templates#config-lambda)):
   Lambda to be evaluated repeatedly to get the current temperature of the water. Expects a float return value.
+
+- **target_temperature** (*Optional*, [lambda](/automations/templates#config-lambda)):
+  Lambda to be evaluated repeatedly to get the target temperature of the water. Expects a float return value.
 
 - **mode** (*Optional*, [lambda](/automations/templates#config-lambda)):
   Lambda to be evaluated repeatedly to get the current operation mode. Expects a `WaterHeaterMode` enum return value.


### PR DESCRIPTION
## Description:
Add target temperature lambda to water heater template

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#13661

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/static/images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/_index.md`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image dht22
```

</details>
