### PR TITLE
[rtttl] add RTTTL format section and other smaller improvements

### DIFF
--- a/content/components/rtttl.md
+++ b/content/components/rtttl.md
@@ -122,8 +122,8 @@ name:d=4,o=5,b=120:notes
 ```
 
 1. **Name**: A short identifier for the melody (max 10 characters)
-2. **Control Parameters**: Control section with `d`, `o`, and `b` parameters
-3. **Notes**: The actual melody encoded as note data
+1. **Control Parameters**: Control section with `d`, `o`, and `b` parameters
+1. **Notes**: The actual melody encoded as note data
 
 ### Control Parameters
 

--- a/content/components/rtttl.md
+++ b/content/components/rtttl.md
@@ -1,26 +1,26 @@
 ---
-description: "Instructions for setting up a buzzer to play tones and rtttl songs with ESPHome."
-title: "Rtttl Buzzer"
+description: "Instructions for setting up a buzzer to play tones and RTTTL songs with ESPHome."
+title: "RTTTL Buzzer"
 params:
   seo:
-    description: Instructions for setting up a buzzer to play tones and rtttl songs with ESPHome.
+    description: Instructions for setting up a buzzer to play tones and RTTTL songs with ESPHome.
     image: buzzer.jpg
 ---
 
 The `rtttl`, component allows you to easily connect a passive piezo buzzer to your microcontroller
-and play monophonic songs. It accepts the Ring Tone Text Transfer Language, rtttl format
+and play monophonic songs. It accepts the Ring Tone Text Transfer Language, RTTTL format
 ([Wikipedia](https://en.wikipedia.org/wiki/Ring_Tone_Transfer_Language)) which allows to store simple melodies.
 
 {{< img src="buzzer.jpg" alt="Image" caption="Buzzer Module" width="50.0%" class="align-center" >}}
 
-## Overview Using a passive buzzer
+## Overview Using a Passive Buzzer
 
 It's important that your buzzer is a **passive** one, if it beeps when you feed it with 3.3V then it is not
 a passive one and this library will not work properly.
 
 The tone generator needs a PWM capable output to work with, currently only the
-{{< docref "output/esp8266_pwm" "ESP8266 Software PWM Output" >}} and
-{{< docref "output/ledc" "ESP32 LEDC Output" >}} are supported.
+[ESP8266 Software PWM Output](/component/output/esp8266_pwm) and
+[ESP32 LEDC Output](/component/output/ledc) are supported.
 
 ```yaml
 # Example configuration entry
@@ -35,9 +35,9 @@ rtttl:
   gain: 60%
 ```
 
-## Overview Using the I2S speaker
+## Overview Using a Speaker
 
-The tone generator can instead be used with a {{< docref "/components/speaker/index" "Speaker" >}} to output the audio.
+The tone generator can instead be used with a [Speaker](/components/speaker) to output the audio.
 
 ```yaml
 # Example configuration entry
@@ -52,22 +52,27 @@ rtttl:
   gain: 0.8
 ```
 
-## Configuration variables
+## Configuration Variables
 
-- **output** (**Exclusive**, [ID](/guides/configuration-types#id)): The id of the [float output](/components/output#output) to use for
+- **output** (**Exclusive**, [ID](/guides/configuration-types#id)): The id of the [float output](/components/output) to use for
   this buzzer.
 
-- **speaker** (**Exclusive**, [ID](/guides/configuration-types#id)): The id of the [speaker](/components/i2s_audio#i2s_audio) to play the song on.
+- **speaker** (**Exclusive**, [ID](/guides/configuration-types#id)): The id of the [Speaker](/components/speaker) to play the song on.
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID used for code generation.
 - **gain** (*Optional*, Percentage): With this value you can set the volume of the sound.
 - **on_finished_playback** (*Optional*, [Automation](/automations)): An action to be
   performed when playback is finished.
 
-Note: You can only use the **output** or **speaker** variable, not both at the same time.
+> [!NOTE]
+> You can only use the **output** or **speaker** variable, not both at the same time.
 
-## `rtttl.play` Action
+## All Actions and Conditions
 
-Plays an rtttl tone.
+- **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID of the RTTTL if you have multiple components.
+
+### `rtttl.play` Action
+
+Plays an RTTTL tone.
 
 ```yaml
 on_...:
@@ -77,13 +82,14 @@ on_...:
 
 Configuration options:
 
-- **rtttl** (**Required**, string, [templatable](/automations/templates)): The rtttl string.
+- **rtttl** (**Required**, string, [templatable](/automations/templates)): The RTTTL string.
 
-You can find many rtttl strings online on the web, they must start with a name, then a colon: `:` symbol
-and more codes of the song itself. Tip: you can try playing with the values of d=16,o=6,b=95 and make the
-song play at a different pace or pitch, e.g. setting o=7 instead will cause the song to play on a higher pitch.
+> [!NOTE]
+> If a melody is currently playing, you must call the `rtttl.stop` action before starting a new melody.
 
-## `rtttl.stop` Action
+You can find many RTTTL strings online on the web. You can test melodies using the [RTTTL Online Player](https://adamonsoon.github.io/rtttl-play/) before adding them to your configuration. See the format description below for details.
+
+### `rtttl.stop` Action
 
 Stops playback.
 
@@ -93,11 +99,7 @@ on_...:
     - rtttl.stop
 ```
 
-## All actions
-
-- **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID of the rtttl if you have multiple components.
-
-## `rtttl.is_playing` Condition
+### `rtttl.is_playing` Condition
 
 This Condition returns true while playback is active.
 
@@ -111,7 +113,45 @@ on_...:
       logger.log: 'Playback is active!'
 ```
 
-## Common beeps
+
+## RTTTL Format
+
+An RTTTL string consists of three parts separated by colons (`:`):
+
+```text
+name:d=4,o=5,b=120:notes
+```
+
+1. **Name**: A short identifier for the melody (max 10 characters)
+2. **Control Parameters**: Control section with `d`, `o`, and `b` parameters
+3. **Notes**: The actual melody encoded as note data
+
+### Control Parameters
+
+- **d** (duration): The default note duration. Valid values are 1 (whole note), 2 (half note), 4 (quarter note), 8 (eighth note), 16 (sixteenth note), and 32 (thirty-second note). Default is 4.
+- **o** (octave): The default octave for notes. Valid values are 4, 5, 6, or 7. Higher values produce higher pitched sounds. Default is 6.
+- **b** (beats): The tempo in beats per minute (BPM). Determines how fast the melody plays. Default is 63.
+
+### Note Format
+
+Each note in the melody follows this pattern: `[duration][note][#][.][octave]`
+
+- **duration** (optional): Overrides the default duration (1, 2, 4, 8, 16, 32)
+- **note**: The note name: `c`, `d`, `e`, `f`, `g`, `a`, `b`, or `p` for pause
+- **#** (optional): Sharp modifier, raises the note by a half step
+- **. (dot)** (optional): Dotted note, extends duration by 50%
+- **octave** (optional): Overrides the default octave (4-7)
+
+### Examples
+
+- `8e6` - Eighth note E in octave 6
+- `4c#5` - Quarter note C-sharp in octave 5
+- `2g.` - Dotted half note G in the default octave
+- `16p` - Sixteenth note pause
+
+Tip: You can experiment with the control values to change how a song sounds. For example, increasing `b` makes the song play faster, while changing `o` shifts the pitch higher or lower.
+
+## Common Beeps
 
 You can do your own beep patterns too! Here's a short collection so you can just use right away or tweak them to your like:
 
@@ -125,7 +165,7 @@ mission_imp:d=16,o=6,b=95:32d,32d#,32d,32d#,32d,32d#,32d,32d#,32d,32d,32d#,32e,3
 mario:d=4,o=5,b=100:16e6,16e6,32p,8e6,16c6,8e6,8g6,8p,8g,8p,8c6,16p,8g,16p,8e,16p,8a,8b,16a#,8a,16g.,16e6,16g6,8a6,16f6,8g6,8e6,16c6,16d6,8b,16p,8c6,16p,8g,16p,8e,16p,8a,8b,16a#,8a,16g.,16e6,16g6,8a6,16f6,8g6,8e6,16c6,16d6,8b,8p,16g6,16f#6,16f6,16d#6,16p,16e6,16p,16g#,16a,16c6,16p,16a,16c6,16d6,8p,16g6,16f#6,16f6,16d#6,16p,16e6,16p,16c7,16p,16c7,16c7,p,16g6,16f#6,16f6,16d#6,16p,16e6,16p,16g#,16a,16c6,16p,16a,16c6,16d6,8p,16d#6,8p,16d6,8p,16c6
 ```
 
-## Test setup
+## Test Setup
 
 With the following code you can quickly setup a node and use Home Assistant's service in the developer tools.
 E.g. for calling `rtttl.play` select the service `esphome.test_esp8266_rtttl_play` and in service data enter
@@ -169,7 +209,7 @@ api:
 
 ## See Also
 
-- {{< docref "/components/output/esp8266_pwm" >}}
-- {{< docref "/components/output/ledc" >}}
-- {{< docref "/components/speaker" >}}
+- [ESP8266 Software PWM Output](/components/output/esp8266_pwm)
+- [ESP32 LEDC Output](/components/output/ledc)
+- [Speaker Components](/components/speaker)
 - {{< apiref "rtttl/rtttl.h" "rtttl/rtttl.h" >}}

--- a/content/components/rtttl.md
+++ b/content/components/rtttl.md
@@ -18,9 +18,9 @@ and play monophonic songs. It accepts the Ring Tone Text Transfer Language, RTTT
 It's important that your buzzer is a **passive** one, if it beeps when you feed it with 3.3V then it is not
 a passive one and this library will not work properly.
 
-The tone generator needs a PWM capable output to work with, currently only the
-[ESP8266 Software PWM Output](/component/output/esp8266_pwm) and
-[ESP32 LEDC Output](/component/output/ledc) are supported.
+The tone generator needs a PWM-capable output to work with, currently only the
+[ESP8266 Software PWM Output](/components/output/esp8266_pwm) and
+[ESP32 LEDC Output](/components/output/ledc) are supported.
 
 ```yaml
 # Example configuration entry
@@ -113,7 +113,6 @@ on_...:
       logger.log: 'Playback is active!'
 ```
 
-
 ## RTTTL Format
 
 An RTTTL string consists of three parts separated by colons (`:`):
@@ -129,7 +128,7 @@ name:d=4,o=5,b=120:notes
 ### Control Parameters
 
 - **d** (duration): The default note duration. Valid values are 1 (whole note), 2 (half note), 4 (quarter note), 8 (eighth note), 16 (sixteenth note), and 32 (thirty-second note). Default is 4.
-- **o** (octave): The default octave for notes. Valid values are 4, 5, 6, or 7. Higher values produce higher pitched sounds. Default is 6.
+- **o** (octave): The default octave for notes. Valid values are 4, 5, 6, or 7. Higher values produce higher-pitched sounds. Default is 6.
 - **b** (beats): The tempo in beats per minute (BPM). Determines how fast the melody plays. Default is 63.
 
 ### Note Format

--- a/content/components/rtttl.md
+++ b/content/components/rtttl.md
@@ -7,7 +7,7 @@ params:
     image: buzzer.jpg
 ---
 
-The `rtttl`, component allows you to easily connect a passive piezo buzzer to your microcontroller
+The `rtttl` component allows you to easily connect a passive piezo buzzer to your microcontroller
 and play monophonic songs. It accepts the Ring Tone Text Transfer Language, RTTTL format
 ([Wikipedia](https://en.wikipedia.org/wiki/Ring_Tone_Transfer_Language)) which allows to store simple melodies.
 


### PR DESCRIPTION
## Description:

- Unify lower/upper case
- Convert to Markdown Links
- add RTTTL Format section
- add Online Player link for testing
- Group Actions and Conditions together (share the id param)
- Add hint about stopping before play again while playing

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/static/images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/_index.md`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image dht22
```

</details>
