### PR TITLE
Add `Legacy Hugo Shortcodes` section for AI

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -52,8 +52,8 @@ accurate - you are not writing a press release.
 For example instead of "Created comprehensive documentation with configuration examples and setup instructions"
 it is sufficient to say "Created documentation with examples and instructions".
 
-## Legacy Hugo Shortcuts
+## Legacy Hugo Shortcodes
 
-The following Hugo shortcuts are legacy and should be replaced when encountered:
+The following Hugo shortcodes are legacy and should be replaced when encountered:
 * `{{< docref >}}`: use standard Markdown links instead
 * `{{< img >}}`: use standard Markdown image syntax instead

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,7 +8,7 @@ Adhering to these guidelines will promote consistency and content quality.
 *   **Primary Goal:** ESPHome is a system to configure microcontrollers (like ESP32, ESP8266, RP2040, and LibreTiny-based chips)
     using simple yet powerful YAML configuration files. It generates C++ firmware that can be compiled and flashed to
     these devices, allowing users to control them remotely through home automation systems.
- 
+
     This repo is the source for the primary documentation for users of ESPHome, published on [esphome.io](https://esphome.io).
 *   **Business Domain:** Internet of Things (IoT), Home Automation.
 
@@ -52,4 +52,8 @@ accurate - you are not writing a press release.
 For example instead of "Created comprehensive documentation with configuration examples and setup instructions"
 it is sufficient to say "Created documentation with examples and instructions".
 
+## Legacy Hugo Shortcuts
 
+The following Hugo shortcuts are legacy and should be replaced when encountered:
+* `{{< docref >}}`: use standard Markdown links instead
+* `{{< img >}}`: use standard Markdown image syntax instead


### PR DESCRIPTION
## Description:

see: https://developers.esphome.io/contributing/docs/#legacy-hugo-shortcodes

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/static/images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/_index.md`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image dht22
```

</details>
