### PR TITLE
fix typos in changelogs (`suppport`, `especiallly`)

### DIFF
--- a/content/changelog/2023.7.0.md
+++ b/content/changelog/2023.7.0.md
@@ -53,7 +53,7 @@ if someone has not already commented for that specific component.
 - Add Zio Ultrasonic Distance Sensor Component {{< pr number="5059" repo="esphome" >}} by {{< ghuser name="kahrendt" >}} (new-integration)
 - Add Alpha3 pump component {{< pr number="3787" repo="esphome" >}} by {{< ghuser name="jan-hofmeier" >}} (new-integration)
 - RTC implementation of pcf8563 {{< pr number="4998" repo="esphome" >}} by {{< ghuser name="KoenBreeman" >}} (new-integration)
-- web server esp idf suppport {{< pr number="3500" repo="esphome" >}} by {{< ghuser name="dentra" >}} (new-integration)
+- web server esp idf support {{< pr number="3500" repo="esphome" >}} by {{< ghuser name="dentra" >}} (new-integration)
 - Add TT21100 touchscreen component {{< pr number="4793" repo="esphome" >}} by {{< ghuser name="kroimon" >}} (new-integration)
 - Add support for Grove tb6612 fng {{< pr number="4797" repo="esphome" >}} by {{< ghuser name="max246" >}} (new-integration)
 - Add support for ATM90E26 {{< pr number="4366" repo="esphome" >}} by {{< ghuser name="danieltwagner" >}} (new-integration)
@@ -142,7 +142,7 @@ if someone has not already commented for that specific component.
 - Add Zio Ultrasonic Distance Sensor Component {{< pr number="5059" repo="esphome" >}} by {{< ghuser name="kahrendt" >}} (new-integration)
 - Add Alpha3 pump component {{< pr number="3787" repo="esphome" >}} by {{< ghuser name="jan-hofmeier" >}} (new-integration)
 - RTC implementation of pcf8563 {{< pr number="4998" repo="esphome" >}} by {{< ghuser name="KoenBreeman" >}} (new-integration)
-- web server esp idf suppport {{< pr number="3500" repo="esphome" >}} by {{< ghuser name="dentra" >}} (new-integration)
+- web server esp idf support {{< pr number="3500" repo="esphome" >}} by {{< ghuser name="dentra" >}} (new-integration)
 - Add TT21100 touchscreen component {{< pr number="4793" repo="esphome" >}} by {{< ghuser name="kroimon" >}} (new-integration)
 - tuya_light: fix float->int conversion while setting color temperature {{< pr number="5067" repo="esphome" >}} by {{< ghuser name="kswt" >}}
 - Fix typo in mpu6050.cpp {{< pr number="5086" repo="esphome" >}} by {{< ghuser name="stefanklug" >}}

--- a/content/changelog/2024.11.0.md
+++ b/content/changelog/2024.11.0.md
@@ -38,7 +38,7 @@ This release brings {{< docref "/components/opentherm" >}} support to ESPHome. P
 We will be retiring ESPHome's Docker support for `armv7` hardware in the February 2025 release.
 
 This is due to both waning support as it relates to tooling and performance reasons. We strongly recommend moving to a
-more modern architecture, especiallly if you're using the ESPHome Device Compiler to build/compile firmware for your
+more modern architecture, especially if you're using the ESPHome Device Compiler to build/compile firmware for your
 devices.
 
 <!-- markdownlint-disable MD013 -->


### PR DESCRIPTION
## Description:

fix typos in changelogs (`suppport`, `especiallly`)

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/static/images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/_index.md`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image dht22
```

</details>
