### PR TITLE
 [ethernet] Add docs for on_connect and on_disconnect triggers

### DIFF
--- a/content/components/ethernet.md
+++ b/content/components/ethernet.md
@@ -142,6 +142,9 @@ If you are using a framework that does not support SPI-based ethernet modules wi
 
 - **mac_address** (*Optional*, MAC Address): Set the MAC address of the ethernet interface.
 
+- **on_connect** (*Optional*, [Automation](/automations)): An action to be performed when a connection is established.
+- **on_disconnect** (*Optional*, [Automation](/automations)): An action to be performed when the connection is dropped.
+
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID used for code generation.
 
 > [!NOTE]
@@ -402,6 +405,19 @@ ethernet:
 
 > [!NOTE]
 > Using a higher clock_speed, including default, might cause rx errors and dropped packets.
+
+## `on_connect` / `on_disconnect` Trigger
+
+This trigger is activated when an Ethernet connection is established or dropped.
+
+```yaml
+ethernet:
+  # ...
+  on_connect:
+    - switch.turn_on: switch1
+  on_disconnect:
+    - switch.turn_off: switch1
+```
 
 ## See Also
 


### PR DESCRIPTION
## Description:

Adds documentation for the `on_connect` and `on_disconnect` triggers in the `ethernet` component, introduced in the linked PR

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#13677

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/static/images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/_index.md`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image dht22
```

</details>
