### PR TITLE
docs(whirlpool): :memo: new model DG11J1-39

### DIFF
--- a/content/components/climate/climate_ir.md
+++ b/content/components/climate/climate_ir.md
@@ -288,6 +288,7 @@ climate:
 
   - `DG11J1-3A`  : Temperature range is from 18 to 32 (default)
   - `DG11J1-91`  : Temperature range is from 16 to 30
+  - `DG11J1-39`  : Temperature range is from 18 to 32
 
 {{< anchor "whynter" >}}
 

--- a/content/components/climate/climate_ir.md
+++ b/content/components/climate/climate_ir.md
@@ -284,7 +284,7 @@ climate:
 
 ### `whirlpool`
 
-- **model** (*Optional*, string): There are two valid models to choose from:
+- **model** (*Optional*, string): There are three valid models to choose from:
 
   - `DG11J1-3A`  : Temperature range is from 18 to 32 (default)
   - `DG11J1-91`  : Temperature range is from 16 to 30


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#13718

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/static/images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/_index.md`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image dht22
```

</details>
