### PR TITLE
[sx126x] fix maximal payload_length

### DIFF
--- a/content/components/sx126x.md
+++ b/content/components/sx126x.md
@@ -70,7 +70,7 @@ sx126x:
 
 - **payload_length** (**Optional**, int): If greater than zero implicit header mode is enabled and the
   packet size is fixed. If not configured explicit header mode is enabled and variable packet sizes can
-  be used. Maximum length is 256. Must be greater than zero when using a spreading_factor of 6.
+  be used. Maximum length is 255. Must be greater than zero when using a spreading_factor of 6.
 
 - **crc_enable** (**Optional**, bool): Enables a payload CRC calculation/check.
 - **preamble_size** (**Optional**, int): Length of the preamble in symbols, minimum of 6. Defaults to 8.
@@ -89,7 +89,7 @@ sx126x:
   `78_2kHz`, `93_8kHz`, `117_3kHz`, `156_2kHz`, `187_2kHz`, `234_3kHz`, `312_0kHz`,
   `373_6kHz` or `467_0kHz`.
 
-- **payload_length** (**Optional**, int): Length of the packet. Maximum length is 256.
+- **payload_length** (**Optional**, int): Length of the packet. Maximum length is 255.
 - **crc_enable** (**Optional**, bool): Enables a 16 bit CRC calculation/check. Defaults to `false`.
 - **crc_inverted** (**Optional**, bool): Inverts the CRC if enabled. Defaults to `true`.
 - **crc_size** (**Optional**, int): Size of the CRC in bytes, either 1 or 2. Defaults to 2.


### PR DESCRIPTION
## Description:

The maximal packet length on SX126x is 255 bytes, not 256. The code  is correct (it's using an uint8_t already), but the config validator allowed specifying 256, and the docs reflected that.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#13723

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.
