### PR TITLE
[pn7150] Remove unimplemented pins from example

### DIFF
--- a/content/components/pn7150.md
+++ b/content/components/pn7150.md
@@ -27,10 +27,8 @@ In addition, the {{< docref "binary_sensor/nfc" >}} platform may be used to quic
 
 ```yaml
 pn7150_i2c:
-  dwl_req_pin: GPIOXX
   irq_pin: GPIOXX
   ven_pin: GPIOXX
-  wkup_req_pin: GPIOXX
   emulation_message: https://www.home-assistant.io/tag/pulse_ce
   tag_ttl: 1000ms
 ```


### PR DESCRIPTION
## Description:

Remove `dwl_req_pin` and `wkup_req_pin` from the pn7150 configuration example as these options are documented as "may be used in a future release" but are not actually implemented, causing validation errors when users copy the example.

**Related issue (if applicable):** fixes https://github.com/esphome/esphome/issues/13641

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- N/A

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.