### PR TITLE
[host][mqtt] Document experimental host MQTT support

### DIFF
--- a/content/components/host.md
+++ b/content/components/host.md
@@ -29,6 +29,25 @@ host:
   mac_address: "06:35:69:ab:f6:79"
 ```
 
+## MQTT (optional)
+
+The `host` platform can be used with the {{< docref "/components/mqtt" >}} component for development/testing.
+
+> [!NOTE]
+> Support is experimental and not all embedded-target features (for example TLS-related options) are available.
+
+If you only need MQTT for ESPHome dashboard/CLI discovery and status, it’s common to disable Home Assistant entity
+discovery while keeping device discovery enabled:
+
+```yaml
+host:
+
+mqtt:
+  broker: 127.0.0.1
+  discovery: false
+  discover_ip: true
+```
+
 ## Configuration variables
 
 - **mac_address** (*Optional*, MAC address): A dummy MAC address to use when communicating with HA.

--- a/content/components/mqtt.md
+++ b/content/components/mqtt.md
@@ -27,6 +27,10 @@ mqtt:
 > [!NOTE]
 > Support for esp-idf is still experimental. Please report issues you have with MQTT using the ESP-IDF framework.
 
+> [!NOTE]
+> The `host` platform supports MQTT for development/testing. Support is experimental and some features (for example
+> TLS-related options) are not available on `host`.
+
 ## Configuration variables
 
 - **broker** (**Required**, string): The host of your MQTT broker.


### PR DESCRIPTION
## Summary
- Document experimental MQTT support on the `host` platform.
- Add a host example showing MQTT usage for dashboard/CLI discovery and status.

## Test plan
- [ ] Preview docs build renders as expected.