### PR TITLE
2026.1.4

### DIFF
--- a/content/changelog/2026.1.0.md
+++ b/content/changelog/2026.1.0.md
@@ -561,6 +561,22 @@ For detailed migration guides and API documentation, see the [ESPHome Developers
 
 </details>
 
+## Release 2026.1.4 - February 4
+
+<details>
+<summary></summary>
+
+- [mipi_spi] Fix log_pin() FlashStringHelper compatibility [esphome#13624](https://github.com/esphome/esphome/pull/13624) by [@J0k3r2k1](https://github.com/J0k3r2k1)
+- [max7219] Allocate buffer in constructor [esphome#13660](https://github.com/esphome/esphome/pull/13660) by [@swoboda1337](https://github.com/swoboda1337)
+- [mqtt] resolve warnings related to use of ip.str() [esphome#13719](https://github.com/esphome/esphome/pull/13719) by [@rwrozelle](https://github.com/rwrozelle)
+- [core] Add missing uint32_t ID overloads for defer() and cancel_defer() [esphome#13720](https://github.com/esphome/esphome/pull/13720) by [@bdraco](https://github.com/bdraco)
+- [http_request] Fix requests taking full timeout when response is already complete [esphome#13649](https://github.com/esphome/esphome/pull/13649) by [@bdraco](https://github.com/bdraco)
+- [cse7766] Fix power reading stuck when load switches off [esphome#13734](https://github.com/esphome/esphome/pull/13734) by [@bdraco](https://github.com/bdraco)
+- [wifi] Fix wifi.connected condition returning false in connect state listener automations [esphome#13733](https://github.com/esphome/esphome/pull/13733) by [@bdraco](https://github.com/bdraco)
+- [ultrasonic] adjust timeouts and bring the parameter back [esphome#13738](https://github.com/esphome/esphome/pull/13738) by [@ssieb](https://github.com/ssieb)
+
+</details>
+
 ## Full list of changes
 
 ### New Features

--- a/content/components/sensor/ultrasonic.md
+++ b/content/components/sensor/ultrasonic.md
@@ -15,9 +15,11 @@ to measure distances. These sensors usually can't measure anything more
 than about two meters and may sometimes make some annoying clicking
 sounds.
 
-This sensor platform expects a sensor that can be sent a **trigger
-pulse** on a specific pin and will send out an **echo pulse** once a
-measurement has been taken.
+This sensor platform expects a sensor that can be sent a **trigger pulse** on a specific pin and will send out
+an **echo pulse** while the measurement is being taken. Because sometimes (for example if no object is
+detected) the echo is never returned, this sensor has a timeout option which specifies the maximum distance
+to wait for. If you set this too long, the sensor itself will timeout and it will appear as if there was a
+valid measurement.
 
 {{< img src="ultrasonic-full.jpg" alt="Image" caption="HC-SR04 Ultrasonic Distance Sensor." width="50.0%" class="align-center" >}}
 
@@ -27,8 +29,8 @@ measurement has been taken.
 # Example configuration entry
 sensor:
   - platform: ultrasonic
-    trigger_pin: D1
-    echo_pin: D2
+    trigger_pin: GPIOXX
+    echo_pin: GPIOXX
     name: "Ultrasonic Sensor"
 ```
 
@@ -46,6 +48,9 @@ sensor:
 - All other options from [Sensor](/components/sensor).
 
 Advanced options:
+
+- **timeout** (*Optional*, float): The number of meters for the
+  timeout. Most sensors can only sense up to 2 meters. Defaults to 2 meters.
 
 - **pulse_time** (*Optional*, [Time](/guides/configuration-types#time)): The duration for which the trigger pin will be
   active. Defaults to `10us`.

--- a/content/guides/supporters.md
+++ b/content/guides/supporters.md
@@ -96,6 +96,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Alexander Leisentritt (@Alex9779)](https://github.com/Alex9779)
 - [Alex Barcelo (@alexbarcelo)](https://github.com/alexbarcelo)
 - [alexborro (@alexborro)](https://github.com/alexborro)
+- [Alex Coco (@alexcoco)](https://github.com/alexcoco)
 - [AlexCPU (@AlexCPU)](https://github.com/AlexCPU)
 - [Alexandre Danault (@AlexDanault)](https://github.com/AlexDanault)
 - [Alex Iribarren (@alexiri)](https://github.com/alexiri)
@@ -1181,6 +1182,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [klenaers (@klenaers)](https://github.com/klenaers)
 - [Kevin Lewis (@kll)](https://github.com/kll)
 - [kmoulton (@kmoulton)](https://github.com/kmoulton)
+- [Cade Parker (@Knucklesfan)](https://github.com/Knucklesfan)
 - [KNXBroker (@KNXBroker)](https://github.com/KNXBroker)
 - [KoalaBear84 (@KoalaBear84)](https://github.com/KoalaBear84)
 - [KodinLanewave (@KodinLanewave)](https://github.com/KodinLanewave)
@@ -1241,6 +1243,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [lein1013 (@lein1013)](https://github.com/lein1013)
 - [Lennart (@lennart-k)](https://github.com/lennart-k)
 - [Leo Bergolth (@leo-b)](https://github.com/leo-b)
+- [Leonardo Rivera (@leodrivera)](https://github.com/leodrivera)
 - [Leonardo La Rocca (@leoli51)](https://github.com/leoli51)
 - [leoshusar (@leoshusar)](https://github.com/leoshusar)
 - [Leo Winter (@LeoWinterDE)](https://github.com/LeoWinterDE)
@@ -1833,6 +1836,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Roeland Lutters (@Roeland54)](https://github.com/Roeland54)
 - [RoganDawes (@RoganDawes)](https://github.com/RoganDawes)
 - [Roger Busser (@rogerbusser)](https://github.com/rogerbusser)
+- [Roger Fachini (@rogerfachini)](https://github.com/rogerfachini)
 - [Roi Tagar (@roitagar)](https://github.com/roitagar)
 - [Roman Ondráček (@Roman3349)](https://github.com/Roman3349)
 - [romerod (@romerod)](https://github.com/romerod)
@@ -2330,4 +2334,4 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Christian Zufferey (@zuzu59)](https://github.com/zuzu59)
 - [Zynth-dev (@Zynth-dev)](https://github.com/Zynth-dev)
 
-*This page was last updated January 29, 2026.*
+*This page was last updated February 4, 2026.*

--- a/data/version.yaml
+++ b/data/version.yaml
@@ -1,2 +1,2 @@
-release: 2026.1.3
+release: 2026.1.4
 version: '2026.1'


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- Update water_heater Home Assistant requirements [docs#5975](https://github.com/esphome/esphome-docs/pull/5975)
- [web-api] Document SSE entity ID deprecation path with name_id field [docs#5979](https://github.com/esphome/esphome-docs/pull/5979)
- Add ir/rf proxy to ready made projects [docs#5996](https://github.com/esphome/esphome-docs/pull/5996)
- Bump docker/setup-buildx-action from 3.11.1 to 3.12.0 [docs#5810](https://github.com/esphome/esphome-docs/pull/5810)
- Bump actions/checkout from 5.0.1 to 6.0.2 [docs#5970](https://github.com/esphome/esphome-docs/pull/5970)
- Bump dessant/lock-threads from 5.0.1 to 6.0.0 [docs#5781](https://github.com/esphome/esphome-docs/pull/5781)
- Bump actions/upload-artifact from 5.0.0 to 6.0.0 [docs#5780](https://github.com/esphome/esphome-docs/pull/5780)
- Bump actions/setup-python from 6.0.0 to 6.2.0 [docs#5969](https://github.com/esphome/esphome-docs/pull/5969)
- Remove `version` from docker compose sample [docs#5988](https://github.com/esphome/esphome-docs/pull/5988)
- [key_collector] Add missing start_keys documentation [docs#5929](https://github.com/esphome/esphome-docs/pull/5929)
- Add `Legacy Hugo Shortcodes` section for AI [docs#6014](https://github.com/esphome/esphome-docs/pull/6014)
- [media_player] fix typo (`Asssistant`) [docs#6017](https://github.com/esphome/esphome-docs/pull/6017)
- fix typos in changelogs (`suppport`, `especiallly`) [docs#6016](https://github.com/esphome/esphome-docs/pull/6016)
- [binary_sensor] fix typo `excuted` [docs#6015](https://github.com/esphome/esphome-docs/pull/6015)
- [rtttl] add RTTTL format section and other smaller improvements [docs#6013](https://github.com/esphome/esphome-docs/pull/6013)
- [sx126x] fix maximal payload_length [docs#6025](https://github.com/esphome/esphome-docs/pull/6025)
- [json] Add a note reminding people to put `json:` in config to use json [docs#5397](https://github.com/esphome/esphome-docs/pull/5397)
- Add Tethercell Battery project to DIY guide [docs#6020](https://github.com/esphome/esphome-docs/pull/6020)
- [pn7150] Remove unimplemented pins from example [docs#6027](https://github.com/esphome/esphome-docs/pull/6027)
- Update status_led.md - improvements to grammar [docs#5511](https://github.com/esphome/esphome-docs/pull/5511)
- [rtttl] Fix note format to match RTTTL specification [docs#6024](https://github.com/esphome/esphome-docs/pull/6024)
- VL53L0X sensor, updated XSHUT connection instructions [docs#5932](https://github.com/esphome/esphome-docs/pull/5932)
- [lvgl] Fix LVGL horizontal and vertical equivalent layout config [docs#5687](https://github.com/esphome/esphome-docs/pull/5687)
- Update aht10.md [docs#5957](https://github.com/esphome/esphome-docs/pull/5957)
- [fan] fix on_direction_set docs example to use FanDirection enum [docs#5377](https://github.com/esphome/esphome-docs/pull/5377)
- [ultrasonic] document timeout parameter [docs#6026](https://github.com/esphome/esphome-docs/pull/6026)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
