### PR TITLE
[vbus]: document DeltaSol BS/2 (DrainBack) support

### DIFF
--- a/content/components/vbus.md
+++ b/content/components/vbus.md
@@ -24,6 +24,7 @@ The following table shows the currently supported models of Vbus devices.
 | ---------------- | ---------------- | ----------- | ------------------- |
 | DeltaSol BS Plus | deltasol_bs_plus | 4221        |                     |
 | DeltaSol BS 2009 | deltasol_bs_2009 | 427B        | DeltaSol BS Plus V2 |
+| DeltaSol BS/2 (DrainBack) | deltasol_bs2 | 4278 | |
 | Dux H3214 | deltasol_bs_2009 | 427B | Pump 2 unsupported |
 | DeltaSol C | deltasol_c | 4212 | |
 | DeltaSol CS2 | deltasol_cs2 | 1121 | |
@@ -122,6 +123,7 @@ sensor:
 Supported sensors:
 
 - for **deltasol_bs_plus** and **deltasol_bs_2009**: `temperature_1`, `temperature_2`, `temperature_3`, `temperature_4`, `pump_speed_1`, `pump_speed_2`, `operating_hours_1`, `operating_hours_2`, `heat_quantity`, `time`, `version`.
+- for **deltasol_bs2**: `temperature_1`, `temperature_2`, `temperature_3`, `temperature_4`, `pump_speed_1`, `pump_speed_2`, `operating_hours_1`, `operating_hours_2`, `heat_quantity`, `version`.
 - for **deltasol_c**: `temperature_1`, `temperature_2`, `temperature_3`, `temperature_4`, `pump_speed_1`, `pump_speed_2`, `operating_hours_1`, `operating_hours_2`, `heat_quantity`, `time`.
 - for **deltasol_cs2**: `temperature_1`, `temperature_2`, `temperature_3`, `temperature_4`, `pump_speed`, `operating_hours`, `heat_quantity`, `version`.
 - for **deltasol_cs_plus**: `temperature_1`, `temperature_2`, `temperature_3`, `temperature_4`, `temperature_5`, `pump_speed_1`, `pump_speed_2`, `operating_hours_1`, `operating_hours_2`, `heat_quantity`, `time`, `version`, `flow_rate`.
@@ -173,6 +175,7 @@ binary_sensor:
 
   - **`deltasol_bs_plus`**: `relay1`, `relay2`, `sensor1_error`, `sensor2_error`, `sensor3_error`, `sensor4_error`, `collector_max`, `collector_min`, `collector_frost`, `tube_collector`, `recooling`, `hqm`.
   - **`deltasol_bs_2009`**: `sensor1_error`, `sensor2_error`, `sensor3_error`, `sensor4_error`, `frost_protection_active`.
+  - **`deltasol_bs2`**: `sensor1_error`, `sensor2_error`, `sensor3_error`, `sensor4_error`.
   - **`deltasol_c`**: `sensor1_error`, `sensor2_error`, `sensor3_error`, `sensor4_error`.
   - **`deltasol_cs2`**: `sensor1_error`, `sensor2_error`, `sensor3_error`, `sensor4_error`.
   - **`deltasol_cs_plus`**: `sensor1_error`, `sensor2_error`, `sensor3_error`, `sensor4_error`.


### PR DESCRIPTION
## Description

Documents support for the Resol DeltaSol BS/2 (DrainBack) in the vbus component: add `deltasol_bs2` to the supported models table (source address 0x4278) and list its sensors (temperatures 1–4, pump speeds 1–2, operating hours 1–2, heat quantity, version) and binary sensors (sensor 1–4 error).

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#13762

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):