### PR TITLE
[pylontech] Document SOH, cycle count, and capacity sensors

### DIFF
--- a/content/components/pylontech.md
+++ b/content/components/pylontech.md
@@ -72,6 +72,14 @@ sensor:
       name: "Battery1 Current"
     coulomb:
       name: "Battery1 State of Charge"
+    state_of_health:
+      name: "Battery1 State of Health"
+    cycle_count:
+      name: "Battery1 Cycle Count"
+    design_capacity:
+      name: "Battery1 Design Capacity"
+    remaining_capacity:
+      name: "Battery1 Remaining Capacity"
 ```
 
 ### Configuration variables
@@ -87,6 +95,10 @@ sensor:
 - **voltage_low** (*Optional*): Voltage of the lowest cell. All options from [Sensor](/components/sensor).
 - **voltage_high** (*Optional*): Voltage of the highest cell. All options from [Sensor](/components/sensor).
 - **mos_temperature** (*Optional*): Temperature of the mosfets. All options from [Sensor](/components/sensor).
+- **state_of_health** (*Optional*): State of Health in percent. Obtained via the ``soh`` console command. All options from [Sensor](/components/sensor).
+- **cycle_count** (*Optional*): Number of charge/discharge cycles. Obtained via the ``soh`` console command. All options from [Sensor](/components/sensor).
+- **design_capacity** (*Optional*): Design capacity in Ah. Obtained via the ``soh`` console command. All options from [Sensor](/components/sensor).
+- **remaining_capacity** (*Optional*): Remaining capacity in Ah. Obtained via the ``soh`` console command. All options from [Sensor](/components/sensor).
 
 ## Text Sensor
 


### PR DESCRIPTION
## Description:

Add documentation for four new sensors in the Pylontech component, obtained via the `soh` console command:

- **state_of_health** - State of Health in percent
- **cycle_count** - Number of charge/discharge cycles
- **design_capacity** - Design capacity in Ah
- **remaining_capacity** - Remaining capacity in Ah

**Related issue (if applicable):** fixes https://github.com/esphome/feature-requests/issues/2544

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#13772

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.