### PR TITLE
[nrf52,zigbee] update limitations

### DIFF
--- a/content/components/zigbee.md
+++ b/content/components/zigbee.md
@@ -10,8 +10,9 @@ params:
 The `zigbee` component allows exposing supported ESPHome components over a Zigbee network to Home Assistant
 via **Zigbee2MQTT** or **ZHA**. Due to the limitations of the Zigbee protocol, only basic properties are exposed.
 Additional properties must be configured manually in Home Assistant. Each ESPHome entity consumes one Zigbee endpoint.
-Because of a limitation in Zigbee2MQTT, at least two endpoints are required. The maximum number of supported endpoints
-is eight.
+Single endpoint requires ZHA or at lease Zigbee2MQTT 2.8.0. For older versions of Zigbee2MQTT use multiple endpoints.
+Spaces in names require ZHA or at lease Zigbee2MQTT 2.8.0. For older versions of Zigbee2MQTT do not use spaces.
+The maximum number of supported endpoints is eight.
 
 Zigbee support is currently available only on `nRF52` platforms.
 

--- a/content/components/zigbee.md
+++ b/content/components/zigbee.md
@@ -10,8 +10,8 @@ params:
 The `zigbee` component allows exposing supported ESPHome components over a Zigbee network to Home Assistant
 via **Zigbee2MQTT** or **ZHA**. Due to the limitations of the Zigbee protocol, only basic properties are exposed.
 Additional properties must be configured manually in Home Assistant. Each ESPHome entity consumes one Zigbee endpoint.
-Single endpoint requires ZHA or at lease Zigbee2MQTT 2.8.0. For older versions of Zigbee2MQTT use multiple endpoints.
-Spaces in names require ZHA or at lease Zigbee2MQTT 2.8.0. For older versions of Zigbee2MQTT do not use spaces.
+Single endpoint requires ZHA or at least Zigbee2MQTT 2.8.0. For older versions of Zigbee2MQTT use multiple endpoints.
+Spaces in names require ZHA or at least Zigbee2MQTT 2.8.0. For older versions of Zigbee2MQTT do not use spaces.
 The maximum number of supported endpoints is eight.
 
 Zigbee support is currently available only on `nRF52` platforms.


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/static/images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/_index.md`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image dht22
```

</details>
