### PR TITLE
[esp32_ble_beacon] Document tx_power unavailable on ESP-Hosted

### DIFF
--- a/content/components/esp32_ble_beacon.md
+++ b/content/components/esp32_ble_beacon.md
@@ -56,7 +56,7 @@ Advanced options:
   under the heading *Calibrating iBeacon*. Between -128 to 0. Defaults to `-59`.
 
 - **tx_power** (*Optional*, int): The transmit power of the iBeacon in dBm.
-  One of -12, -9, -6, -3, 0, 3, 6, 9. Defaults to `3dBm`.
+  One of -12, -9, -6, -3, 0, 3, 6, 9. Defaults to `3dBm`. Not available on ESP-Hosted platforms (e.g., ESP32-P4).
 
 ## Setting Up
 


### PR DESCRIPTION
## Description:

Document that the `tx_power` configuration option is not available on ESP-Hosted platforms (e.g., ESP32-P4) since they don't have native Bluetooth and the `esp_power_level_t` enum is not available.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#13787

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)