### PR TITLE
[http_request] Add warning about GitHub releases URL buffer limit

### DIFF
--- a/content/components/update/http_request.md
+++ b/content/components/update/http_request.md
@@ -33,6 +33,13 @@ update:
 
 - All other options from [Update](/components/update#config-update).
 
+> [!WARNING]
+> GitHub releases URLs (e.g., `https://github.com/<user>/<repo>/releases/latest/download/manifest.json`) redirect
+> to very long URLs that may exceed the default 512-byte buffer limit of the [HTTP Request](/components/http_request)
+> component, causing update checks to fail with an "Out of buffer" error.
+>
+> Use GitHub Pages URLs instead (e.g., `https://<user>.github.io/<repo>/firmware/manifest.json`) which do not redirect, or increase the buffer size.
+
 {{< anchor "update_http_request-manifest_format" >}}
 
 ## Update Manifest Format


### PR DESCRIPTION
## Description:

Add a warning to the HTTP Request update component documentation about GitHub releases URLs redirecting to very long URLs that exceed the default 512-byte buffer limit.

**Related issue (if applicable):** fixes https://github.com/esphome/esphome/issues/13786

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- N/A

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)