### PR TITLE
Add on and away state lambdas to water heater template

### DIFF
--- a/content/components/water_heater/template.md
+++ b/content/components/water_heater/template.md
@@ -24,7 +24,7 @@ water_heater:
     target_temperature: !lambda 'return id(my_target_temp_sensor).state;'
 
     # Lambda to read the work state (on/off) (optional)
-    on: !lambda "return id(my_switch).state;"
+    "on": !lambda "return id(my_switch).state;"
 
     # Lambda to read the away mode state (optional)
     away: !lambda "return id(vacation_mode).state;"
@@ -111,7 +111,7 @@ with the `water_heater.template.publish` action.
     current_temperature: 55.0
     target_temperature: 60.0
     mode: ECO
-    on: true
+    "on": true
     away: false
 ```
 

--- a/content/components/water_heater/template.md
+++ b/content/components/water_heater/template.md
@@ -23,6 +23,12 @@ water_heater:
     # Lambda to read the target temperature (optional)
     target_temperature: !lambda 'return id(my_target_temp_sensor).state;'
 
+    # Lambda to read the work state (on/off) (optional)
+    on: !lambda "return id(my_switch).state;"
+
+    # Lambda to read the away mode state (optional)
+    away: !lambda "return id(vacation_mode).state;"
+
     # Lambda to read the current operation mode (optional)
     mode: !lambda 'return water_heater::WATER_HEATER_MODE_ECO;'
     optimistic: true
@@ -41,6 +47,8 @@ water_heater:
     set_action:
       - lambda: |-
           ESP_LOGI("boiler", "New mode: %d", id(my_boiler).get_mode());
+          ESP_LOGI("boiler", "New target temperature: %.1f", id(my_boiler).get_target_temperature());
+          ESP_LOGI("boiler", "On: %s, Away: %s", YESNO(id(my_boiler).is_on()), YESNO(id(my_boiler).is_away()));
 ```
 
 Possible return values for the lambdas:
@@ -48,6 +56,8 @@ Possible return values for the lambdas:
 - `current_temperature`: Returns a `float` (e.g. `42.5`).
 - `target_temperature`: Returns a `float` (e.g. `60.0`).
 - `mode`: Returns a `WaterHeaterMode` enum (e.g. `water_heater::WATER_HEATER_MODE_ECO`).
+- `on`: Returns a `bool` (e.g. `true`).
+- `away`: Returns a `bool` (e.g. `true`).
 
 ## Configuration variables
 
@@ -59,6 +69,12 @@ Possible return values for the lambdas:
 
 - **mode** (*Optional*, [lambda](/automations/templates#config-lambda)):
   Lambda to be evaluated repeatedly to get the current operation mode. Expects a `WaterHeaterMode` enum return value.
+
+- **on** (*Optional*, [lambda](/automations/templates#config-lambda)):
+  Lambda to be evaluated repeatedly to get the current on/off state. Expects a boolean return value.
+
+- **away** (*Optional*, [lambda](/automations/templates#config-lambda)):
+  Lambda to be evaluated repeatedly to get the current away mode state. Expects a boolean return value.
 
 - **optimistic** (*Optional*, boolean): Whether to operate in optimistic mode - when in this mode, any command sent to
   the template water heater will immediately update the reported state. Defaults to `true`.
@@ -95,6 +111,8 @@ with the `water_heater.template.publish` action.
     current_temperature: 55.0
     target_temperature: 60.0
     mode: ECO
+    on: true
+    away: false
 ```
 
 Configuration options:
@@ -106,6 +124,10 @@ Configuration options:
   The target setpoint temperature to publish.
 - **mode** (*Optional*, [templatable](/automations/templates), string):
   The operation mode to publish. See [Water Heater Modes](/components/water_heater#water-heater-modes) for options.
+- **on** (*Optional*, [templatable](/automations/templates), boolean):
+  The current on/off state to publish.
+- **away** (*Optional*, [templatable](/automations/templates), boolean):
+  The current away mode state to publish.
 
 > [!NOTE]
 > This action can also be written in lambdas:
@@ -113,6 +135,11 @@ Configuration options:
 > ```cpp
 > id(my_boiler).set_current_temperature(55.0);
 > id(my_boiler).publish_state();
+> // Or with state updates
+> auto call = id(my_boiler).make_call();
+> call.set_on(true);
+> call.set_away(false);
+> call.perform();
 > ```
 
 ## See Also

--- a/content/components/water_heater/template.md
+++ b/content/components/water_heater/template.md
@@ -23,14 +23,15 @@ water_heater:
     # Lambda to read the target temperature (optional)
     target_temperature: !lambda 'return id(my_target_temp_sensor).state;'
 
-    # Lambda to read the work state (on/off) (optional)
-    "on": !lambda "return id(my_switch).state;"
+    # Lambda to read the current operation mode (optional)
+    mode: !lambda 'return water_heater::WATER_HEATER_MODE_ECO;'
 
     # Lambda to read the away mode state (optional)
     away: !lambda "return id(vacation_mode).state;"
 
-    # Lambda to read the current operation mode (optional)
-    mode: !lambda 'return water_heater::WATER_HEATER_MODE_ECO;'
+    # Lambda to read the current On/Off state (optional)
+    is_on: !lambda 'return id(my_relay).state;'
+
     optimistic: true
 
     # List of modes to show in the UI (optional)
@@ -56,8 +57,8 @@ Possible return values for the lambdas:
 - `current_temperature`: Returns a `float` (e.g. `42.5`).
 - `target_temperature`: Returns a `float` (e.g. `60.0`).
 - `mode`: Returns a `WaterHeaterMode` enum (e.g. `water_heater::WATER_HEATER_MODE_ECO`).
-- `on`: Returns a `bool` (e.g. `true`).
-- `away`: Returns a `bool` (e.g. `true`).
+- `away`: Returns a `bool` (e.g. `false`).
+- `is_on`: Returns a `bool` (e.g. `true`).
 
 ## Configuration variables
 
@@ -70,17 +71,17 @@ Possible return values for the lambdas:
 - **mode** (*Optional*, [lambda](/automations/templates#config-lambda)):
   Lambda to be evaluated repeatedly to get the current operation mode. Expects a `WaterHeaterMode` enum return value.
 
-- **on** (*Optional*, [lambda](/automations/templates#config-lambda)):
-  Lambda to be evaluated repeatedly to get the current on/off state. Expects a boolean return value.
-
 - **away** (*Optional*, [lambda](/automations/templates#config-lambda)):
   Lambda to be evaluated repeatedly to get the current away mode state. Expects a boolean return value.
+
+- **is_on** (*Optional*, [lambda](/automations/templates#config-lambda)):
+  Lambda to be evaluated repeatedly to get the current On/Off state. Expects a boolean return value.
 
 - **optimistic** (*Optional*, boolean): Whether to operate in optimistic mode - when in this mode, any command sent to
   the template water heater will immediately update the reported state. Defaults to `true`.
 
 - **set_action** (*Optional*, [Action](/automations/actions#all-actions)):
-  The action to perform when the water heater receives a command (mode change, target temperature change, etc.).
+  The action to perform when the water heater receives a command (mode change, target temperature change, away, on/off, etc.).
   This is where you implement the actual control logic for your water heater.
 
 - **supported_modes** (*Optional*, list):
@@ -111,8 +112,8 @@ with the `water_heater.template.publish` action.
     current_temperature: 55.0
     target_temperature: 60.0
     mode: ECO
-    "on": true
     away: false
+    is_on: true
 ```
 
 Configuration options:
@@ -124,10 +125,10 @@ Configuration options:
   The target setpoint temperature to publish.
 - **mode** (*Optional*, [templatable](/automations/templates), string):
   The operation mode to publish. See [Water Heater Modes](/components/water_heater#water-heater-modes) for options.
-- **on** (*Optional*, [templatable](/automations/templates), boolean):
-  The current on/off state to publish.
 - **away** (*Optional*, [templatable](/automations/templates), boolean):
-  The current away mode state to publish.
+  The away mode state to publish.
+- **is_on** (*Optional*, [templatable](/automations/templates), boolean):
+  The boolean On/Off state to publish.
 
 > [!NOTE]
 > This action can also be written in lambdas:
@@ -135,11 +136,6 @@ Configuration options:
 > ```cpp
 > id(my_boiler).set_current_temperature(55.0);
 > id(my_boiler).publish_state();
-> // Or with state updates
-> auto call = id(my_boiler).make_call();
-> call.set_on(true);
-> call.set_away(false);
-> call.perform();
 > ```
 
 ## See Also


### PR DESCRIPTION
## Description:

Added instructions for the new 'is_on' and 'away' configuration variables.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#13839

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/static/images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/_index.md`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image dht22
```

</details>
