### PR TITLE
[mipi_dsi] Add WAVESHARE-ESP32-P4-WIFI6-TOUCH-LCD 3.4C and 4C

### DIFF
--- a/content/components/display/mipi_dsi.md
+++ b/content/components/display/mipi_dsi.md
@@ -50,6 +50,8 @@ specified, or a custom init sequence can be provided.
 | WAVESHARE-P4-NANO-10.1 | Waveshare | <https://www.waveshare.com/esp32-p4-nano.htm?sku=29031> |
 | WAVESHARE-P4-86-PANEL | Waveshare | <https://www.waveshare.com/esp32-p4-wifi6-touch-lcd-4b.htm?sku=31570> |
 | WAVESHARE-ESP32-P4-WIFI6-TOUCH-LCD-7B | Waveshare | <https://www.waveshare.com/wiki/ESP32-P4-WIFI6-Touch-LCD-7B> |
+| WAVESHARE-ESP32-P4-WIFI6-TOUCH-LCD-3.4C | Waveshare | <https://www.waveshare.com/wiki/ESP32-P4-WIFI6-Touch-LCD-3.4C> |
+| WAVESHARE-ESP32-P4-WIFI6-TOUCH-LCD-4C | Waveshare | <https://www.waveshare.com/wiki/ESP32-P4-WIFI6-Touch-LCD-4C> |
 
 > [!NOTE]
 The M5Stack Tab5 has two hardware revisions with different display chips requiring different model selections.

--- a/content/components/display/mipi_dsi.md
+++ b/content/components/display/mipi_dsi.md
@@ -40,18 +40,18 @@ specified, or a custom init sequence can be provided.
 
 ### Boards with integrated displays
 
-| Model                  | Manufacturer | Product Description                                                           |
-| ---------------------- | ------------ | ----------------------------------------------------------------------------- |
-| JC1060P470             | Guition      | <https://aliexpress.com/item/1005008328088576.html>                           |
-| JC4880P443             | Guition      | <https://aliexpress.com/item/1005009618259341.html>                           |
-| JC8012P4A1             | Guition      | <https://aliexpress.com/item/1005008789890066.html>                           |
-| M5STACK-TAB5           | M5Stack      | <https://shop.m5stack.com/products/m5stack-tab5-iot-development-kit-esp32-p4> |
-| M5STACK-TAB5-V2        | M5Stack      | <https://shop.m5stack.com/products/m5stack-tab5-iot-development-kit-esp32-p4> |
-| WAVESHARE-P4-NANO-10.1 | Waveshare    | <https://www.waveshare.com/esp32-p4-nano.htm?sku=29031>                       |
-| WAVESHARE-P4-86-PANEL  | Waveshare    | <https://www.waveshare.com/esp32-p4-wifi6-touch-lcd-4b.htm?sku=31570>        |
-| WAVESHARE-ESP32-P4-WIFI6-TOUCH-LCD-7B  | Waveshare    | <https://www.waveshare.com/wiki/ESP32-P4-WIFI6-Touch-LCD-7B>                   |
-| WAVESHARE-ESP32-P4-WIFI6-TOUCH-LCD-3.4C | Waveshare    | <https://www.waveshare.com/wiki/ESP32-P4-WIFI6-Touch-LCD-3.4C>                 |
-| WAVESHARE-ESP32-P4-WIFI6-TOUCH-LCD-4C  | Waveshare    | <https://www.waveshare.com/wiki/ESP32-P4-WIFI6-Touch-LCD-4C>                   |
+| Model                                   | Manufacturer | Product Description                                                           |
+|-----------------------------------------|--------------|-------------------------------------------------------------------------------|
+| JC1060P470                              | Guition      | <https://aliexpress.com/item/1005008328088576.html>                           |
+| JC4880P443                              | Guition      | <https://aliexpress.com/item/1005009618259341.html>                           |
+| JC8012P4A1                              | Guition      | <https://aliexpress.com/item/1005008789890066.html>                           |
+| M5STACK-TAB5                            | M5Stack      | <https://shop.m5stack.com/products/m5stack-tab5-iot-development-kit-esp32-p4> |
+| M5STACK-TAB5-V2                         | M5Stack      | <https://shop.m5stack.com/products/m5stack-tab5-iot-development-kit-esp32-p4> |
+| WAVESHARE-P4-NANO-10.1                  | Waveshare    | <https://www.waveshare.com/esp32-p4-nano.htm?sku=29031>                       |
+| WAVESHARE-P4-86-PANEL                   | Waveshare    | <https://www.waveshare.com/esp32-p4-wifi6-touch-lcd-4b.htm?sku=31570>         |
+| WAVESHARE-ESP32-P4-WIFI6-TOUCH-LCD-7B   | Waveshare    | <https://www.waveshare.com/wiki/ESP32-P4-WIFI6-Touch-LCD-7B>                  |
+| WAVESHARE-ESP32-P4-WIFI6-TOUCH-LCD-3.4C | Waveshare    | <https://www.waveshare.com/wiki/ESP32-P4-WIFI6-Touch-LCD-3.4C>                |
+| WAVESHARE-ESP32-P4-WIFI6-TOUCH-LCD-4C   | Waveshare    | <https://www.waveshare.com/wiki/ESP32-P4-WIFI6-Touch-LCD-4C>                  |
 
 > [!NOTE]
 The M5Stack Tab5 has two hardware revisions with different display chips requiring different model selections.

--- a/content/components/display/mipi_dsi.md
+++ b/content/components/display/mipi_dsi.md
@@ -47,11 +47,11 @@ specified, or a custom init sequence can be provided.
 | JC8012P4A1             | Guition      | <https://aliexpress.com/item/1005008789890066.html>                           |
 | M5STACK-TAB5           | M5Stack      | <https://shop.m5stack.com/products/m5stack-tab5-iot-development-kit-esp32-p4> |
 | M5STACK-TAB5-V2        | M5Stack      | <https://shop.m5stack.com/products/m5stack-tab5-iot-development-kit-esp32-p4> |
-| WAVESHARE-P4-NANO-10.1 | Waveshare | <https://www.waveshare.com/esp32-p4-nano.htm?sku=29031> |
-| WAVESHARE-P4-86-PANEL | Waveshare | <https://www.waveshare.com/esp32-p4-wifi6-touch-lcd-4b.htm?sku=31570> |
-| WAVESHARE-ESP32-P4-WIFI6-TOUCH-LCD-7B | Waveshare | <https://www.waveshare.com/wiki/ESP32-P4-WIFI6-Touch-LCD-7B> |
-| WAVESHARE-ESP32-P4-WIFI6-TOUCH-LCD-3.4C | Waveshare | <https://www.waveshare.com/wiki/ESP32-P4-WIFI6-Touch-LCD-3.4C> |
-| WAVESHARE-ESP32-P4-WIFI6-TOUCH-LCD-4C | Waveshare | <https://www.waveshare.com/wiki/ESP32-P4-WIFI6-Touch-LCD-4C> |
+| WAVESHARE-P4-NANO-10.1 | Waveshare    | <https://www.waveshare.com/esp32-p4-nano.htm?sku=29031>                       |
+| WAVESHARE-P4-86-PANEL  | Waveshare    | <https://www.waveshare.com/esp32-p4-wifi6-touch-lcd-4b.htm?sku=31570>        |
+| WAVESHARE-ESP32-P4-WIFI6-TOUCH-LCD-7B  | Waveshare    | <https://www.waveshare.com/wiki/ESP32-P4-WIFI6-Touch-LCD-7B>                   |
+| WAVESHARE-ESP32-P4-WIFI6-TOUCH-LCD-3.4C | Waveshare    | <https://www.waveshare.com/wiki/ESP32-P4-WIFI6-Touch-LCD-3.4C>                 |
+| WAVESHARE-ESP32-P4-WIFI6-TOUCH-LCD-4C  | Waveshare    | <https://www.waveshare.com/wiki/ESP32-P4-WIFI6-Touch-LCD-4C>                   |
 
 > [!NOTE]
 The M5Stack Tab5 has two hardware revisions with different display chips requiring different model selections.


### PR DESCRIPTION
## Description:

Add WAVESHARE-ESP32-P4-WIFI6-TOUCH-LCD-3.4C 800x800 display to mipi_dsi.
https://www.waveshare.com/wiki/ESP32-P4-WIFI6-Touch-LCD-3.4C

Add WAVESHARE-ESP32-P4-WIFI6-TOUCH-LCD-4C 720x720 display to mipi_dsi.
https://www.waveshare.com/wiki/ESP32-P4-WIFI6-Touch-LCD-4C

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#13840

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/static/images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/_index.md`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image dht22
```

</details>
