### PR TITLE
Update time is_valid() documentation to reflect actual logic

### DIFF
--- a/content/components/time/_index.md
+++ b/content/components/time/_index.md
@@ -270,7 +270,7 @@ created based on a given format. If you want to get the current time attributes,
 | `.year`         | Year since 0 A.C.                                             | [1970-∞[                                                                      | 2018         |
 | `.is_dst`       | Is daylight savings time                                      | false, true                                                                   | true         |
 | `.timestamp`    | Unix epoch time (seconds since UTC  Midnight January 1, 1970) | [-2147483648 - 2147483647] (negative  values for time past January 19th 2038) | 1534606002   |
-| `.is_valid()`   | Basic check if the time is valid  (i.e. not January 1st 1970) | false, true                                                                   | true         |
+| `.is_valid()`   | Basic check if the time is valid  (i.e. year 2019 or newer)   | false, true                                                                   | true         |
 
 > [!NOTE]
 > Before the ESP has connected to the internet and can get the current time the date will be January 1st 1970. So


### PR DESCRIPTION
check is not just 1970-01-01, it is 2019-01-01 or onwards per https://api-docs.esphome.io/time_8h_source#l00073

## Description:

**Related issue :** fixes https://github.com/esphome/esphome-docs/issues/6050

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

