### PR TITLE
2026.1.5

### DIFF
--- a/content/changelog/2026.1.0.md
+++ b/content/changelog/2026.1.0.md
@@ -577,6 +577,22 @@ For detailed migration guides and API documentation, see the [ESPHome Developers
 
 </details>
 
+## Release 2026.1.5 - February 11
+
+<details>
+<summary></summary>
+
+- [rd03d] Revert incorrect field order swap [esphome#13769](https://github.com/esphome/esphome/pull/13769) by [@jasstrong](https://github.com/jasstrong)
+- [core] Add capacity check to register_component_ [esphome#13778](https://github.com/esphome/esphome/pull/13778) by [@swoboda1337](https://github.com/swoboda1337)
+- [ota] Fix CLI upload option shown when only http_request platform configured [esphome#13784](https://github.com/esphome/esphome/pull/13784) by [@swoboda1337](https://github.com/swoboda1337)
+- [dashboard] Close WebSocket after process exit to prevent zombie connections [esphome#13834](https://github.com/esphome/esphome/pull/13834) by [@bdraco](https://github.com/bdraco)
+- [nrf52,logger] fix printk [esphome#13874](https://github.com/esphome/esphome/pull/13874) by [@tomaszduda23](https://github.com/tomaszduda23)
+- [lvgl] Fix crash with unconfigured `top_layer` [esphome#13846](https://github.com/esphome/esphome/pull/13846) by [@clydebarrow](https://github.com/clydebarrow)
+- [esp32] Set UV_CACHE_DIR inside data dir so Clean All clears it [esphome#13888](https://github.com/esphome/esphome/pull/13888) by [@swoboda1337](https://github.com/swoboda1337)
+- [aqi] Fix AQI calculation for specific pm2.5 or pm10 readings [esphome#13770](https://github.com/esphome/esphome/pull/13770) by [@xconverge](https://github.com/xconverge)
+
+</details>
+
 ## Full list of changes
 
 ### New Features

--- a/content/guides/supporters.md
+++ b/content/guides/supporters.md
@@ -111,6 +111,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Alessandro Ranellucci (@alranel)](https://github.com/alranel)
 - [Maxime Gauduin (@alucryd)](https://github.com/alucryd)
 - [alva (@alva-seal)](https://github.com/alva-seal)
+- [Aljaz Ogrin (@aly-fly)](https://github.com/aly-fly)
 - [Amaery (@Amaery)](https://github.com/Amaery)
 - [Andreas Mandel (@amandel)](https://github.com/amandel)
 - [Aman kumar (@amankrokx)](https://github.com/amankrokx)
@@ -576,6 +577,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [djwlindenaar (@djwlindenaar)](https://github.com/djwlindenaar)
 - [Marcos Pérez Ferro (@djwmarcx)](https://github.com/djwmarcx)
 - [Dmitry Ketov (@dketov)](https://github.com/dketov)
+- [Daniel Kukula (@dkuku)](https://github.com/dkuku)
 - [Darsey Litzenberger (@dlitz)](https://github.com/dlitz)
 - [Dan Mannock (@dmannock)](https://github.com/dmannock)
 - [Dmitriy Lopatko (@dmitriy5181)](https://github.com/dmitriy5181)
@@ -973,6 +975,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Ivan Lisenkov (@ivlis)](https://github.com/ivlis)
 - [Ivo-tje (@Ivo-tje)](https://github.com/Ivo-tje)
 - [Jouni Paulus (@j-paulus)](https://github.com/j-paulus)
+- [J0k3r2k1 (@J0k3r2k1)](https://github.com/J0k3r2k1)
 - [J0RD4N300 (@J0RD4N300)](https://github.com/J0RD4N300)
 - [Jeff Brown (@j9brown)](https://github.com/j9brown)
 - [Tonye Jack (@jackton1)](https://github.com/jackton1)
@@ -1710,6 +1713,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Marcus Kempe (@plopp)](https://github.com/plopp)
 - [Jan Pluskal (@pluskal)](https://github.com/pluskal)
 - [Peter (@pmannk)](https://github.com/pmannk)
+- [PolarGoose (@PolarGoose)](https://github.com/PolarGoose)
 - [DK (@poldim)](https://github.com/poldim)
 - [poloswiss (@poloswiss)](https://github.com/poloswiss)
 - [polyfaces (@polyfaces)](https://github.com/polyfaces)
@@ -1901,6 +1905,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [scaiper (@scaiper)](https://github.com/scaiper)
 - [scamiv (@scamiv)](https://github.com/scamiv)
 - [Sascha (@Scarbous)](https://github.com/Scarbous)
+- [schrob (@schdro)](https://github.com/schdro)
 - [Matthew Schinckel (@schinckel)](https://github.com/schinckel)
 - [Lukas Schulte (@Schluggi)](https://github.com/Schluggi)
 - [Nils Schulte (@schnili)](https://github.com/schnili)
@@ -2334,4 +2339,4 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Christian Zufferey (@zuzu59)](https://github.com/zuzu59)
 - [Zynth-dev (@Zynth-dev)](https://github.com/Zynth-dev)
 
-*This page was last updated February 4, 2026.*
+*This page was last updated February 11, 2026.*

--- a/data/version.yaml
+++ b/data/version.yaml
@@ -1,2 +1,2 @@
-release: 2026.1.4
+release: 2026.1.5
 version: '2026.1'


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- [nrf52,zigbee] update limitations [docs#6039](https://github.com/esphome/esphome-docs/pull/6039)
- [http_request] Add warning about GitHub releases URL buffer limit [docs#6041](https://github.com/esphome/esphome-docs/pull/6041)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
