### PR TITLE
[nrf52,deep_sleep, zigbee] add deep sleep support with zigbee wakeup

### DIFF
--- a/src/content/docs/components/deep_sleep.mdx
+++ b/src/content/docs/components/deep_sleep.mdx
@@ -8,7 +8,7 @@ import APIRef from '@components/APIRef.astro';
 <span id="deep_sleep-component"></span>
 
 The `deep_sleep` component can be used to automatically enter a deep sleep mode on the
-ESP8266/ESP32/BK72xx after a certain amount of time. This is especially useful with nodes that operate
+ESP8266/ESP32/BK72xx/nRF52 after a certain amount of time. This is especially useful with nodes that operate
 on batteries and therefore need to conserve as much energy as possible.
 
 To use `deep_sleep` first specify how long the node should be active, i.e. how long it should
@@ -138,6 +138,11 @@ The following integers are the wakeup causes:
 - **10** - `ESP_SLEEP_WAKEUP_COCPU`  : Wakeup caused by COCPU int
 - **11** - `ESP_SLEEP_WAKEUP_COCPU_TRAP_TRIG`  : Wakeup caused by COCPU crash
 - **12** - `ESP_SLEEP_WAKEUP_BT`  : Wakeup caused by BT (light sleep only)
+
+## nRF52
+
+When `sleep_duration` is configured or Zigbee is used, the nRF52 resumes normal operation after waking up.
+Otherwise, the nRF52 performs a full reset instead of continuing execution.
 
 <span id="deep_sleep-enter_action"></span>
 

--- a/src/content/docs/components/zigbee.mdx
+++ b/src/content/docs/components/zigbee.mdx
@@ -56,6 +56,9 @@ binary_sensor:
 > [!WARNING]
 > Overusing `random` may exhaust memory in the Zigbee coordinator by creating many "ghost" devices.
 
+- **sleepy** (*Optional*, boolean): Disable RX during idle to reduce power consumption for battery-powered devices.
+  It may cause stability problems with the Zigbee connection. Defaults to `false`.
+
 ## Actions
 
 ### `zigbee.factory_reset` Action

--- a/src/content/docs/components/zigbee.mdx
+++ b/src/content/docs/components/zigbee.mdx
@@ -96,6 +96,7 @@ Only on `ESP32`:
 - **router** (*Optional*, boolean): If true the Zigbee role will be `router` instead of `end device` and it will
   forward Zigbee packets from other devices. Don't use this for battery-powered devices. Defaults to `false`.
 
+
 ## Actions
 
 ### `zigbee.factory_reset` Action


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- https://github.com/esphome/esphome/pull/13950

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/static/images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/_index.md`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image dht22
```

</details>
