### PR TITLE
[bl0942] Update references to match esphome PR#12867

### DIFF
--- a/content/components/sensor/bl0942.md
+++ b/content/components/sensor/bl0942.md
@@ -54,10 +54,10 @@ sensor:
 - **line_frequency** (*Optional*, string): The nominal AC line frequency of the supply voltage. One of `50Hz`, `60Hz`. Defaults to `50Hz`.
 - **address** (*Optional*, int): The address of the BL0942 from its strapping pins. Defaults to `0`.
 - **reset** (*Optional*, boolean): Whether to reset the BL0942 chip on startup, resetting all internal counters. Defaults to `true`.
-- **current_reference** (*Optional*, float): The calibration parameter for current readings. Defaults to `251213.46469622`.
-- **voltage_reference** (*Optional*, float): The calibration parameter for voltage readings. Defaults to `15873.35944299`.
-- **power_reference** (*Optional*, float): The calibration parameter for power readings. Defaults to `596.0` unless either `current_reference` or `voltage_reference` are explicitly set, in which case it is calculated. See [Calibration](#bl0942-calibration) for more details.
-- **energy_reference** (*Optional*, float): The calibration parameter for cumulative energy readings. Defaults to `3304.61127328` unless any of `current_reference`, `voltage_reference` or `power_reference` are explicitly set, in which case it is calculated. See [Calibration](#bl0942-calibration) for more details.
+- **current_reference** (*Optional*, float): The calibration parameter for current readings. Defaults to `251065.6814`.
+- **voltage_reference** (*Optional*, float): The calibration parameter for voltage readings. Defaults to `15883.34116`.
+- **power_reference** (*Optional*, float): The calibration parameter for power readings. Defaults to `623.3937992` unless either `current_reference` or `voltage_reference` are explicitly set, in which case it is calculated. See [Calibration](#bl0942-calibration) for more details.
+- **energy_reference** (*Optional*, float): The calibration parameter for cumulative energy readings. Defaults to `5350.631898` unless any of `current_reference`, `voltage_reference` or `power_reference` are explicitly set, in which case it is calculated. See [Calibration](#bl0942-calibration) for more details.
 
 {{< anchor "bl0942-calibration" >}}
 
@@ -68,7 +68,7 @@ These can be determined by using an accurate voltage and current meter with a si
 more resolution to the measurement than smaller ones. Consider the largest load your device can support for this procedure. Example
 resistive loads to consider: space heater, toaster, incandescent light bulb(s), etc.
 
-The default value of `voltage_reference` is `15873.35944299` and for `current_reference` it is `251213.46469622`. Flash the
+The default value of `voltage_reference` is `15883.34116` and for `current_reference` it is `251065.6814`. Flash the
 device with these values and then measure the voltage and current of the load while comparing it to the value reported in ESPHome.
 The formula to determine the correct reference value is `new_reference = reported_value * default_reference / actual_value`.
 (If the reported value is low, the reference value should decrease, and vice versa.) This procedure can be repeated several

--- a/content/components/sensor/bl0942.md
+++ b/content/components/sensor/bl0942.md
@@ -18,6 +18,11 @@ to some pins on your board and the baud rate set to 4800 with 1 stop bit.
 # Example configuration entry
 sensor:
   - platform: bl0942
+    line_frequency: 50Hz
+    voltage_reference: 15883.34116
+    current_reference: 251065.6814
+    power_reference: 623.3937992
+    energy_reference: 5350.631898
     voltage:
       name: 'BL0942 Voltage'
     current:
@@ -78,7 +83,20 @@ The `power_reference` value can be derived from those, and will be roughly `volt
 
 The `energy_reference` value can be derived as roughly `power_reference` * 3600000 / 419430.4.
 
-For compatibility with existing configurations, if no reference values are set then the original defaults will be used, despite the power and energy calibration not being entirely consistent.
+### ⚠️ Important Note About Reference Defaults
+
+While nominal reference values are documented above, **`power_reference` and `energy_reference` are not fixed defaults**.
+
+If these values are not explicitly provided in the YAML configuration, they are **calculated at runtime** based on the supplied
+(or default) voltage and/or current reference values. Due to floating-point precision, the calculated values may differ slightly
+from the documented nominal values.
+
+For the most consistent and reproducible behavior—especially when comparing energy accumulation across restarts—it is recommended
+to explicitly specify **all four reference values** (`voltage_reference`, `current_reference`, `power_reference`,
+and `energy_reference`) in the configuration, using the documented nominal values as a starting point.
+
+For backward compatibility, if **no reference values are provided at all**, the original legacy defaults are used, even though
+power and energy calibration may not be fully consistent in that case.
 
 If converting Tuya devices, the factory calibration values can often be obtained from the original firmware. For example, they may be found in DPS parameters 22-25, or the `voltage_coe` and related options.
 

--- a/content/components/sensor/bl0942.md
+++ b/content/components/sensor/bl0942.md
@@ -18,11 +18,6 @@ to some pins on your board and the baud rate set to 4800 with 1 stop bit.
 # Example configuration entry
 sensor:
   - platform: bl0942
-    line_frequency: 50Hz
-    voltage_reference: 15883.34116
-    current_reference: 251065.6814
-    power_reference: 623.3937992
-    energy_reference: 5350.631898
     voltage:
       name: 'BL0942 Voltage'
     current:
@@ -83,20 +78,7 @@ The `power_reference` value can be derived from those, and will be roughly `volt
 
 The `energy_reference` value can be derived as roughly `power_reference` * 3600000 / 419430.4.
 
-### ⚠️ Important Note About Reference Defaults
-
-While nominal reference values are documented above, **`power_reference` and `energy_reference` are not fixed defaults**.
-
-If these values are not explicitly provided in the YAML configuration, they are **calculated at runtime** based on the supplied
-(or default) voltage and/or current reference values. Due to floating-point precision, the calculated values may differ slightly
-from the documented nominal values.
-
-For the most consistent and reproducible behavior—especially when comparing energy accumulation across restarts—it is recommended
-to explicitly specify **all four reference values** (`voltage_reference`, `current_reference`, `power_reference`,
-and `energy_reference`) in the configuration, using the documented nominal values as a starting point.
-
-For backward compatibility, if **no reference values are provided at all**, the original legacy defaults are used, even though
-power and energy calibration may not be fully consistent in that case.
+For compatibility with existing configurations, if no reference values are set then the original defaults will be used, despite the power and energy calibration not being entirely consistent.
 
 If converting Tuya devices, the factory calibration values can often be obtained from the original firmware. For example, they may be found in DPS parameters 22-25, or the `voltage_coe` and related options.
 

--- a/content/components/sensor/bl0942.md
+++ b/content/components/sensor/bl0942.md
@@ -56,8 +56,8 @@ sensor:
 - **reset** (*Optional*, boolean): Whether to reset the BL0942 chip on startup, resetting all internal counters. Defaults to `true`.
 - **current_reference** (*Optional*, float): The calibration parameter for current readings. Defaults to `251065.6814`.
 - **voltage_reference** (*Optional*, float): The calibration parameter for voltage readings. Defaults to `15883.34116`.
-- **power_reference** (*Optional*, float): The calibration parameter for power readings. Defaults to `623.3937992` unless either `current_reference` or `voltage_reference` are explicitly set, in which case it is calculated. See [Calibration](#bl0942-calibration) for more details.
-- **energy_reference** (*Optional*, float): The calibration parameter for cumulative energy readings. Defaults to `5350.631898` unless any of `current_reference`, `voltage_reference` or `power_reference` are explicitly set, in which case it is calculated. See [Calibration](#bl0942-calibration) for more details.
+- **power_reference** (*Optional*, float): The calibration parameter for power readings. Defaults to `623.0270705` unless either `current_reference` or `voltage_reference` are explicitly set, in which case it is calculated. See [Calibration](#bl0942-calibration) for more details.
+- **energy_reference** (*Optional*, float): The calibration parameter for cumulative energy readings. Defaults to `5347.484240` unless any of `current_reference`, `voltage_reference` or `power_reference` are explicitly set, in which case it is calculated. See [Calibration](#bl0942-calibration) for more details.
 
 {{< anchor "bl0942-calibration" >}}
 

--- a/content/components/sensor/bl0942.md
+++ b/content/components/sensor/bl0942.md
@@ -85,13 +85,13 @@ The `energy_reference` value can be derived as roughly `power_reference` * 36000
 
 ### ⚠️ Important Note About Reference Defaults
 
-While nominal reference values are documented above, **`power_reference` and `energy_reference` are not fixed defaults**.
+While nominal reference values are documented above, **`power_reference` and `energy_reference` are calculated estimates unless explicitly specified in the YAML**.
 
 If these values are not explicitly provided in the YAML configuration, they are **calculated at runtime** based on the supplied
 (or default) voltage and/or current reference values. Due to floating-point precision, the calculated values may differ slightly
 from the documented nominal values.
 
-For the most consistent and reproducible behavior—especially when comparing energy accumulation across restarts—it is recommended
+For the most consistent and reproducible behavior it is recommended
 to explicitly specify **all four reference values** (`voltage_reference`, `current_reference`, `power_reference`,
 and `energy_reference`) in the configuration, using the documented nominal values as a starting point.
 

--- a/content/components/sensor/bl0942.md
+++ b/content/components/sensor/bl0942.md
@@ -85,13 +85,13 @@ The `energy_reference` value can be derived as roughly `power_reference` * 36000
 
 ### ⚠️ Important Note About Reference Defaults
 
-While nominal reference values are documented above, **`power_reference` and `energy_reference` are calculated estimates unless explicitly specified in the YAML**.
+While nominal reference values are documented above, **`power_reference` and `energy_reference` are not fixed defaults**.
 
 If these values are not explicitly provided in the YAML configuration, they are **calculated at runtime** based on the supplied
 (or default) voltage and/or current reference values. Due to floating-point precision, the calculated values may differ slightly
 from the documented nominal values.
 
-For the most consistent and reproducible behavior it is recommended
+For the most consistent and reproducible behavior—especially when comparing energy accumulation across restarts—it is recommended
 to explicitly specify **all four reference values** (`voltage_reference`, `current_reference`, `power_reference`,
 and `energy_reference`) in the configuration, using the documented nominal values as a starting point.
 


### PR DESCRIPTION
## Description:

This is follow-up of https://github.com/esphome/esphome-docs/pull/5853

Change made in https://github.com/esphome/esphome/commit/f4481dbedfae0919847bbbbdc8757758411c0eb9 was not documented, this fixes it.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#12867

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/static/images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/_index.md`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image dht22
```

</details>
