### PR TITLE
Fix blank guides/changelog and guides index pages

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -148,6 +148,7 @@ export default defineConfig({
   redirects: {
     "/changelog/": `/changelog/${latestChangelog}/`,
     "/changelog/index/": `/changelog/${latestChangelog}/`,
+    "/guides/changelog/": `/changelog/${latestChangelog}/`,
   },
   vite: {
     resolve: {

--- a/pagefind.yml
+++ b/pagefind.yml
@@ -5,4 +5,4 @@ exclude_selectors:
   - ".toctree-wrapper"
   - ".sphinxsidebar"
   - ".breadcrumbs"
-glob: "{changelog,components,cookbook,guides,projects,web-api}/**/*.html"
+glob: "{components,cookbook,guides,projects,web-api}/**/*.html"

--- a/pagefind.yml
+++ b/pagefind.yml
@@ -5,4 +5,4 @@ exclude_selectors:
   - ".toctree-wrapper"
   - ".sphinxsidebar"
   - ".breadcrumbs"
-glob: "{components,cookbook,guides,projects,web-api}/**/*.html"
+glob: "{changelog,components,cookbook,guides,projects,web-api}/**/*.html"

--- a/src/content/docs/changelog/index.mdx
+++ b/src/content/docs/changelog/index.mdx
@@ -1,7 +1,7 @@
 ---
 description: "ESPHome Changelog"
 title: "Changelog"
-pagefind: false
+pagefind: true
 ---
 
 Redirecting to the latest release...

--- a/src/content/docs/guides/changelog.mdx
+++ b/src/content/docs/guides/changelog.mdx
@@ -1,4 +1,0 @@
----
-description: "Changelog"
-title: "Changelog"
----

--- a/src/content/docs/guides/index.mdx
+++ b/src/content/docs/guides/index.mdx
@@ -2,3 +2,39 @@
 description: "Guides"
 title: "Guides"
 ---
+
+## Getting Started
+
+- [Getting Started with ESPHome and Home Assistant](/guides/getting_started_hassio/)
+- [Getting Started with the ESPHome Command Line](/guides/getting_started_command_line/)
+- [Installing ESPHome Manually](/guides/installing_esphome/)
+- [Physically Connecting to your Device](/guides/physical_device_connection/)
+- [Using an ESP devboard as a USB-UART bridge](/guides/devboard_as_flasher/)
+
+## Configuration
+
+- [YAML Configuration in ESPHome](/guides/yaml/)
+- [Configuration Types](/guides/configuration-types/)
+- [Command Line Interface](/guides/cli/)
+- [Frequently Asked Questions](/guides/faq/)
+- [Troubleshooting](/guides/troubleshooting/)
+- [Security Best Practices](/guides/security_best_practices/)
+
+## Migration
+
+- [Migrating from Tasmota](/guides/migrate_sonoff_tasmota/)
+- [Migrating from ESPEasy](/guides/migrate_espeasy/)
+- [Migrating from ESPurna](/guides/migrate_espurna/)
+- [ESP32 Arduino to ESP-IDF Migration Guide](/guides/esp32_arduino_to_idf/)
+
+## Projects & Community
+
+- [DIY Examples](/guides/diy/)
+- [Sharing ESPHome devices](/guides/creators/)
+- [Made for ESPHome](/guides/made_for_esphome/)
+- [Contributors](/guides/supporters/)
+
+## Advanced
+
+- [Create audio clip files for use with I²S Speakers](/guides/audio_clips_for_i2s/)
+- [Setting up RMT Devices](/guides/setting_up_rmt_devices/)


### PR DESCRIPTION
## Description

Fix blank pages and missing search results introduced during the Hugo-to-Starlight migration:

1. **`/guides/changelog/`** — The Hugo `{{< redirect url="/changelog/index.html" >}}` shortcode was stripped during migration, leaving an empty page body. Added a redirect in `astro.config.mjs` and removed the empty stub file.

2. **`/guides/`** — Hugo auto-generated section listings from child pages, but Starlight does not. The index page was blank. Populated it with categorized links to all 21 guide pages.

3. **Changelog not searchable** — The changelog index page had `pagefind: false`, making it invisible to site search. Enabled indexing so searching for "changelog" returns a result.

Note: All 66 individual changelog version pages still have `pagefind: false` in their frontmatter. This should probably be addressed separately.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- N/A

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.