### PR TITLE
Make changelog index page searchable

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -146,8 +146,6 @@ const latestChangelog = getLatestChangelog();
 export default defineConfig({
   site: "https://esphome.io",
   redirects: {
-    "/changelog/": `/changelog/${latestChangelog}/`,
-    "/changelog/index/": `/changelog/${latestChangelog}/`,
     "/guides/changelog/": `/changelog/${latestChangelog}/`,
   },
   vite: {

--- a/src/content/docs/changelog/index.mdx
+++ b/src/content/docs/changelog/index.mdx
@@ -1,7 +1,13 @@
 ---
-description: "ESPHome Changelog"
+description: "ESPHome Changelog - release notes, breaking changes, and new features for each ESPHome version."
 title: "Changelog"
 pagefind: true
 ---
 
-Redirecting to the latest release...
+<script>{`
+  // Redirect to the latest changelog (first link in the sidebar group)
+  var link = document.querySelector('nav a[href*="/changelog/"]');
+  if (link) window.location.replace(link.href);
+`}</script>
+
+ESPHome Changelog with release notes, breaking changes, new features, bug fixes, and notable changes for each ESPHome version.


### PR DESCRIPTION
## Description

The changelog index page had `pagefind: true` but its only content was "Redirecting to the latest release..." which gave Pagefind nothing meaningful to index. This adds descriptive content (changelog, release notes, breaking changes, new features, bug fixes) so the page appears in search results. The Astro redirect in `astro.config.mjs` still sends users to the latest changelog version.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- N/A

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.