### PR TITLE
Prefix APIRef links with "API Reference:"

### DIFF
--- a/src/components/APIClass.astro
+++ b/src/components/APIClass.astro
@@ -29,4 +29,4 @@ const baseUrl = 'https://api-docs.esphome.io';
 const url = `${baseUrl}/classesphome_1_1${processedPath}`;
 ---
 
-<a href={url}>{text}</a>
+<a href={url}>API Reference: {text}</a>

--- a/src/components/APIRef.astro
+++ b/src/components/APIRef.astro
@@ -31,8 +31,6 @@ processedPath = processedPath.replace(/([A-Z])/g, (match) => `_${match.toLowerCa
 const baseUrl = 'https://api-docs.esphome.io';
 const url = `${baseUrl}/${processedPath}`;
 
-// Display text defaults to "API Reference" if same as path
-const displayText = text === path ? 'API Reference' : text;
 ---
 
-<a href={url}>{displayText}</a>
+<a href={url}>API Reference: {text}</a>

--- a/src/components/APIStruct.astro
+++ b/src/components/APIStruct.astro
@@ -29,4 +29,4 @@ const baseUrl = 'https://api-docs.esphome.io';
 const url = `${baseUrl}/structesphome_1_1${processedPath}`;
 ---
 
-<a href={url}>{text}</a>
+<a href={url}>API Reference: {text}</a>


### PR DESCRIPTION
## Description

APIRef links previously displayed just the filename (e.g., `wifi_component.h`). This prefixes all APIRef links with "API Reference:" for clarity (e.g., `API Reference: wifi_component.h`).

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- N/A

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.