### PR TITLE
Make changelog index a real searchable page

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -55,27 +55,6 @@ function getChangelogItems() {
   }));
 }
 
-// Get the latest changelog version for redirects
-function getLatestChangelog() {
-  const changelogDir = path.join(__dirname, "src/content/docs/changelog");
-  const files = fs
-    .readdirSync(changelogDir)
-    .filter((f) => f.endsWith(".mdx") && f !== "index.mdx");
-
-  let latest = { sortValue: 0, slug: "" };
-  for (const f of files) {
-    const match = f.match(/^(\d{4})\.(\d+)\.(\d+)\.mdx$/);
-    if (match) {
-      const [, year, month, patch] = match;
-      const sortValue =
-        parseInt(year) * 10000 + parseInt(month) * 100 + parseInt(patch);
-      if (sortValue > latest.sortValue) {
-        latest = { sortValue, slug: `${year}.${month}.${patch}` };
-      }
-    }
-  }
-  return latest.slug;
-}
 
 // Generate component sidebar items with proper labels
 function getComponentItems() {
@@ -141,15 +120,8 @@ function getComponentItems() {
   return items.map(({ sort, ...item }) => item);
 }
 
-const latestChangelog = getLatestChangelog();
-
 export default defineConfig({
   site: "https://esphome.io",
-  redirects: {
-    "/changelog/": `/changelog/${latestChangelog}/`,
-    "/changelog/index/": `/changelog/${latestChangelog}/`,
-    "/guides/changelog/": `/changelog/${latestChangelog}/`,
-  },
   vite: {
     resolve: {
       alias: {

--- a/src/components/LatestChangelog.astro
+++ b/src/components/LatestChangelog.astro
@@ -28,6 +28,9 @@ for (const entry of changelogs) {
 
 const rendered = latest.entry ? await render(latest.entry) : null;
 const Content = rendered?.Content;
+const slug = latest.entry?.data.slug ?? latest.entry?.id;
+const redirectUrl = slug ? `/${slug}/` : null;
 ---
 
+{redirectUrl && <script define:vars={{ redirectUrl }}>window.location.replace(redirectUrl);</script>}
 {Content && <Content />}

--- a/src/components/LatestChangelog.astro
+++ b/src/components/LatestChangelog.astro
@@ -1,0 +1,33 @@
+---
+import { getCollection, render } from "astro:content";
+
+const allDocs = await getCollection("docs");
+
+// Filter to changelog entries (excluding the index)
+const changelogs = allDocs.filter(
+  (entry) =>
+    entry.id.startsWith("changelog/") &&
+    entry.id !== "changelog/" &&
+    entry.id !== "changelog/index"
+);
+
+// Parse version and find the latest
+let latest = { sortValue: 0, entry: null as (typeof changelogs)[0] | null };
+for (const entry of changelogs) {
+  // Match 2021.x.x style IDs
+  const match = entry.id.match(/changelog\/(\d{4})\.(\d+)\.(\d+)/);
+  if (match) {
+    const [, year, month, patch] = match;
+    const sortValue =
+      parseInt(year) * 10000 + parseInt(month) * 100 + parseInt(patch);
+    if (sortValue > latest.sortValue) {
+      latest = { sortValue, entry };
+    }
+  }
+}
+
+const rendered = latest.entry ? await render(latest.entry) : null;
+const Content = rendered?.Content;
+---
+
+{Content && <Content />}

--- a/src/content/docs/changelog/index.mdx
+++ b/src/content/docs/changelog/index.mdx
@@ -4,4 +4,6 @@ title: "Changelog"
 pagefind: true
 ---
 
-Redirecting to the latest release...
+import LatestChangelog from "@components/LatestChangelog.astro";
+
+<LatestChangelog />

--- a/src/content/docs/changelog/index.mdx
+++ b/src/content/docs/changelog/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: "ESPHome Changelog - release notes, new components, breaking changes, and upgrade guides for every ESPHome version."
+description: "ESPHome Changelog"
 title: "Changelog"
 pagefind: true
 ---

--- a/src/content/docs/changelog/index.mdx
+++ b/src/content/docs/changelog/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: "ESPHome Changelog"
+description: "ESPHome Changelog - release notes, new components, breaking changes, and upgrade guides for every ESPHome version."
 title: "Changelog"
 pagefind: true
 ---


### PR DESCRIPTION
## Description

Replace the `/changelog/` redirect with a `LatestChangelog` Astro component that dynamically renders the latest changelog content at build time. This makes the changelog index page discoverable by pagefind search while still displaying the latest release content directly.

The previous Astro server-side redirect caused a flash of unstyled content (FOUC) — a momentary white page with "Redirecting to the latest release..." text before navigating to the actual changelog. The new approach uses a client-side redirect within the rendered page, avoiding this visual glitch while also making the changelog content searchable.

**Changes:**
- Add `LatestChangelog.astro` component that queries the docs collection, finds the latest changelog by version number, and renders it inline
- Update `changelog/index.mdx` to use the new component instead of placeholder redirect text
- Remove the `/changelog/` redirects and unused `getLatestChangelog()` function from `astro.config.mjs`
- Client-side JS redirect ensures visitors still land on the dedicated changelog page

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- N/A

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.