### PR TITLE
[mipi_dsi] Add WAVESHARE-8-DSI-TOUCH-A

### DIFF
--- a/src/content/docs/components/display/mipi_dsi.mdx
+++ b/src/content/docs/components/display/mipi_dsi.mdx
@@ -60,6 +60,7 @@ specified, or a custom init sequence can be provided.
 | WAVESHARE-ESP32-P4-WIFI6-TOUCH-LCD-7B | Waveshare | [https://www.waveshare.com/wiki/ESP32-P4-WIFI6-Touch-LCD-7B](https://www.waveshare.com/wiki/ESP32-P4-WIFI6-Touch-LCD-7B) |
 | WAVESHARE-ESP32-P4-WIFI6-TOUCH-LCD-3.4C | Waveshare    | [https://www.waveshare.com/wiki/ESP32-P4-WIFI6-Touch-LCD-3.4C](https://www.waveshare.com/wiki/ESP32-P4-WIFI6-Touch-LCD-3.4C)                |
 | WAVESHARE-ESP32-P4-WIFI6-TOUCH-LCD-4C   | Waveshare    | [https://www.waveshare.com/wiki/ESP32-P4-WIFI6-Touch-LCD-4C](https://www.waveshare.com/wiki/ESP32-P4-WIFI6-Touch-LCD-4C)                  |
+| WAVESHARE-8-DSI-TOUCH-A                 | Waveshare    | [https://www.waveshare.com/wiki/8-DSI-TOUCH-A](https://www.waveshare.com/wiki/8-DSI-TOUCH-A)                                              |
 
 > [!NOTE]
 The M5Stack Tab5 has two hardware revisions with different display chips requiring different model selections.


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Add WAVESHARE-8-DSI-TOUCH-A to mipi_dsi.
https://www.waveshare.com/wiki/8-DSI-TOUCH-A


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#13990

## Checklist

- [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
