### PR TITLE
[remote_transmitter, remote_receiver, esp32_rmt_led_strip] Document ESP32-C2/C61 no RMT support

### DIFF
--- a/src/content/docs/components/light/esp32_rmt_led_strip.mdx
+++ b/src/content/docs/components/light/esp32_rmt_led_strip.mdx
@@ -7,6 +7,9 @@ import APIRef from '@components/APIRef.astro';
 
 This is a component using the ESP32 RMT peripheral to drive most addressable LED strips.
 
+> [!NOTE]
+> The ESP32-C2 and ESP32-C61 do not have RMT hardware and are not supported by this component.
+
 ```yaml
 light:
   - platform: esp32_rmt_led_strip
@@ -59,7 +62,6 @@ light:
 | ESP32-C3      | 96 symbols       | 48 symbols |
 | ESP32-C5      | 96 symbols       | 48 symbols |
 | ESP32-C6      | 96 symbols       | 48 symbols |
-| ESP32-C61     | 96 symbols       | 48 symbols |
 | ESP32-H2      | 96 symbols       | 48 symbols |
 | ESP32-P4      | 192 symbols      | 48 symbols |
 | ESP32-S2      | 256 symbols      | 64 symbols |

--- a/src/content/docs/components/remote_receiver.mdx
+++ b/src/content/docs/components/remote_receiver.mdx
@@ -88,16 +88,20 @@ Multiple remote receivers can be configured as a list of dict definitions within
   be considered complete. Defaults to `10ms`. The maximum allowable value is:
 
   - `65536us` on the `ESP32` and `ESP32-S2` variants
-  - `32767us` on all other ESP32 variants
-  - `4294967295us` on all other platforms
+  - `32767us` on other ESP32 variants with RMT hardware
+  - `4294967295us` on all other platforms (including ESP32-C2 and ESP32-C61 which use a software implementation)
 
-  Note: The ESP32 values listed above assume the default `clock_resolution`. If a different `clock_resolution` is used,
-  the values are scaled by 1000000 / `clock_resolution`.
+  Note: The ESP32 RMT values listed above assume the default `clock_resolution`. If a different `clock_resolution` is
+  used, the values are scaled by 1000000 / `clock_resolution`.
 
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID used for code generation. Useful when multiple
   receivers are configured on a single device.
 
-### ESP32 configuration variables
+### ESP32 RMT configuration variables
+
+> [!NOTE]
+> The following options apply only to ESP32 variants with RMT hardware. They are not available on the ESP32-C2 and
+> ESP32-C61, which use a software implementation.
 
 - **rmt_symbols** (*Optional*, int): When `use_dma` is enabled, this sets the size of the driver's internal DMA
   buffer. When DMA is disabled, it specifies how much RMT memory is allocated to the component. RMT memory is shared
@@ -110,7 +114,6 @@ Multiple remote receivers can be configured as a list of dict definitions within
 | ESP32-C3      | 96 symbols       | 48 symbols |
 | ESP32-C5      | 96 symbols       | 48 symbols |
 | ESP32-C6      | 96 symbols       | 48 symbols |
-| ESP32-C61     | 96 symbols       | 48 symbols |
 | ESP32-H2      | 96 symbols       | 48 symbols |
 | ESP32-P4      | 192 symbols      | 48 symbols |
 | ESP32-S2      | 256 symbols      | 64 symbols |

--- a/src/content/docs/components/remote_transmitter.mdx
+++ b/src/content/docs/components/remote_transmitter.mdx
@@ -16,8 +16,9 @@ The component is split into two parts:
 **See** [Setting up IR Devices](/guides/setting_up_rmt_devices#remote-setting-up-infrared) **and** [Setting up RF Devices](/guides/setting_up_rmt_devices#remote-setting-up-rf) **for details.**
 
 > [!NOTE]
-> This component performs best with an ESP32 or variant; they have a dedicated hardware peripheral which ensures
-> accurate signal timing.
+> This component performs best with an ESP32 or variant; most have a dedicated RMT hardware peripheral which ensures
+> accurate signal timing. The ESP32-C2 and ESP32-C61 lack RMT hardware and use a software (GPIO bitbang)
+> implementation instead.
 
 ```yaml
 # Example configuration entry
@@ -36,7 +37,11 @@ remote_transmitter:
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID used for code generation. Useful when multiple
   transmitters are connected to a single device.
 
-### ESP32 configuration variables
+### ESP32 RMT configuration variables
+
+> [!NOTE]
+> The following options apply only to ESP32 variants with RMT hardware. They are not available on the ESP32-C2 and
+> ESP32-C61, which use a software implementation.
 
 - **rmt_symbols** (*Optional*, int): When `use_dma` is enabled, this sets the size of the driver's internal DMA
   buffer. When DMA is disabled, it specifies how much RMT memory is allocated to the component. RMT memory is shared
@@ -49,7 +54,6 @@ remote_transmitter:
 | ESP32-C3      | 96 symbols       | 48 symbols |
 | ESP32-C5      | 96 symbols       | 48 symbols |
 | ESP32-C6      | 96 symbols       | 48 symbols |
-| ESP32-C61     | 96 symbols       | 48 symbols |
 | ESP32-H2      | 96 symbols       | 48 symbols |
 | ESP32-P4      | 192 symbols      | 48 symbols |
 | ESP32-S2      | 256 symbols      | 64 symbols |


### PR DESCRIPTION
## Description

Update documentation for ESP32-C2 and ESP32-C61 variants which lack RMT hardware:

- **esp32_rmt_led_strip**: Add note that ESP32-C2 and ESP32-C61 are not supported by this component. Remove ESP32-C61 from the RMT memory variant table.
- **remote_transmitter**: Update the note to mention C2/C61 use software (GPIO bitbang) implementation. Rename "ESP32 configuration variables" to "ESP32 RMT configuration variables" with a note that these options don't apply to C2/C61. Remove ESP32-C61 from the RMT memory variant table.
- **remote_receiver**: Same changes as remote_transmitter, plus update idle time documentation to clarify C2/C61 use software implementation and aren't subject to RMT idle limits.

**Related issue (if applicable):** fixes https://github.com/esphome/esphome/issues/13993

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#14001

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.