### PR TITLE
[combination] Fix 'coeffecient' typo to 'coefficient'

### DIFF
--- a/src/content/docs/components/sensor/combination.mdx
+++ b/src/content/docs/components/sensor/combination.mdx
@@ -37,7 +37,7 @@ sensor:
 ```
 
 - `LINEAR` combination: This type sums all source sensors after multiplying each by
-  a configured coeffecient.
+  a configured coefficient.
 
 ```yaml
 # Example configuration entry
@@ -47,9 +47,9 @@ sensor:
     name: "Balance Power"
     sources:
       - source: total_power
-        coeffecient: 1.0
+        coefficient: 1.0
       - source: circuit_1_power
-        coeffecient: -1.0
+        coefficient: -1.0
 ```
 
 - `MAXIMUM`, `MEAN`, `MEDIAN`, `MINIMUM`, `MOST_RECENTLY_UPDATED`,
@@ -84,8 +84,8 @@ sensor:
     parameter, with low values marking accurate data. If implemented as a template, the
     measurement is in parameter `x`.
 
-  - **coeffecient** (**Required**, only for `LINEAR` type, float, [templatable](/automations/templates)):
-    The coeffecient to multiply the sensor's state by before summing all source sensor states.
+  - **coefficient** (**Required**, only for `LINEAR` type, float, [templatable](/automations/templates)):
+    The coefficient to multiply the sensor's state by before summing all source sensor states.
     If implemented as a template, the measurement is in parameter `x`.
 
 - **process_std_dev** (**Required**, only for `KALMAN` type, float): The standard deviation of the


### PR DESCRIPTION
## Description:

Fix the `coeffecient` typo (missing 'i') to the correct spelling `coefficient` in the combination sensor documentation. All 4 occurrences updated: description text, example YAML keys, and configuration variable reference.

**Related issue (if applicable):** fixes https://github.com/esphome/esphome/issues/14003

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#14004

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.