### PR TITLE
Fix changelog redirect to preserve URL hash fragment

### DIFF
--- a/src/components/LatestChangelog.astro
+++ b/src/components/LatestChangelog.astro
@@ -32,5 +32,5 @@ const slug = latest.entry?.data.slug ?? latest.entry?.id;
 const redirectUrl = slug ? `/${slug}/` : null;
 ---
 
-{redirectUrl && <script define:vars={{ redirectUrl }}>window.location.replace(redirectUrl);</script>}
+{redirectUrl && <script define:vars={{ redirectUrl }}>window.location.replace(redirectUrl + window.location.hash);</script>}
 {Content && <Content />}


### PR DESCRIPTION
## Description:

The `/changelog/` page redirects to the latest changelog version (e.g., `/changelog/2026.2.0/`) using `window.location.replace()`. However, it was discarding the URL hash fragment, so `/changelog/#new-features` would redirect to `/changelog/2026.2.0/` instead of `/changelog/2026.2.0/#new-features`.

Fixed by appending `window.location.hash` to the redirect URL. This is safe because `window.location.hash` is either empty string (no hash) or includes the `#` prefix.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- N/A

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.