### PR TITLE
Fix Lilygo T5 4.7" docs

### DIFF
--- a/src/content/docs/components/touchscreen/lilygo_t5_47.mdx
+++ b/src/content/docs/components/touchscreen/lilygo_t5_47.mdx
@@ -7,7 +7,7 @@ import APIRef from '@components/APIRef.astro';
 
 The `liygo_t5_47` touchscreen platform allows using the touchscreen controller
 for the Lilygo T5 4.7" e-Paper Display with ESPHome.
-The [I²C](/components/i2c) is required to be set up in your configuration for this touchscreen to work.
+The [I²C](/components/i2c) component is required to be set up in your configuration for this touchscreen to work.
 
 ```yaml
 # Example configuration entry


### PR DESCRIPTION
## Description:
Fixes a typo in the Lilygo T5 4.7" docs.
## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/static/images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/_index.md`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image dht22
```

</details>
