### PR TITLE
Update GitHub URLs

### DIFF
--- a/src/content/docs/components/sensor/xiaomi_ble.mdx
+++ b/src/content/docs/components/sensor/xiaomi_ble.mdx
@@ -1,5 +1,5 @@
 ---
-description: "Instructions for setting up Xiaomi Mi Home (Mijia) bluetooth-based sensors in ESPHome."
+description: "Instructions for setting up Xiaomi Mi Home (Mijia) Bluetooth-based sensors in ESPHome."
 title: "Xiaomi Mijia BLE Sensors"
 ---
 
@@ -23,7 +23,7 @@ import APIRef from '@components/APIRef.astro';
 The `xiaomi_ble` sensor platform lets you track the output of Xiaomi Bluetooth Low Energy devices using the [Esp32 Ble Tracker](/components/esp32_ble_tracker/). This component will track, for example, the temperature, humidity, moisture, conductivity, illuminance, formaldehyde, mosquito tablet and battery level of the device every time the sensor sends out a BLE broadcast. Contrary to other implementations, `xiaomi_ble` listens passively to advertisement packets and does not pair with the device. Hence ESPHome has no impact on battery life. Thus, if you only use such sensors, you can safely set `scan_parameters.active: false` in `esp32_ble_tracker` configuration, to save from spamming your RF environment with useless scan requests.
 
 > [!NOTE]
-> You may alternatively use ESPHome's [Bluetooth Proxy](/components/bluetooth_proxy/) component to forward sensor data to Home Assistant and have Mija devices configured using its own Mija BLE component. This should work for the devices flashed with [PVVX MiThermometer](https://github.com/pvvx/ATC_MiThermometer) custom firmware, as well as the regular, stock firmware.
+> You may alternatively use ESPHome's [Bluetooth Proxy](/components/bluetooth_proxy/) component to forward sensor data to Home Assistant and have Mijia devices configured using its own Mijia BLE component. This should work for the devices flashed with [PVVX MiThermometer](https://github.com/pvvx/ATC_MiThermometer) custom firmware, as well as the regular, stock firmware.
 
 ## Supported Devices
 
@@ -620,7 +620,7 @@ To set up an encrypted device you need to obtain the `bindkey`. The `xiaomi_ble`
   - Another option is to use a SSL packet sniffer. It can be setup on either an Android phone or the iPhone. Instructions how to obtain the
     key using Android can be found in [in this tutorial](https://github.com/ahpohl/xiaomi_lywsd03mmc) on GitHub.
     Instructions how to obtain the key using an iPhone can be found in
-    [custom-components/sensor.mitemp_bt](https://github.com/custom-components/sensor.mitemp_bt/blob/master/faq.md#my-sensors-ble-advertisements-are-encrypted-how-can-i-get-the-key)
+    [custom-components/ble_monitor](https://custom-components.github.io/ble_monitor/faq#encryption-keys)
     on GitHub. Once the traffic between the Mi Home app and the Xiaomi servers has been recorded, the bind key will show in clear text:
 
     ```text

--- a/src/content/docs/guides/diy.mdx
+++ b/src/content/docs/guides/diy.mdx
@@ -127,7 +127,7 @@ unless it's truly exceptional, etc.
 - [ESPHome configs](https://github.com/nuttytree/ESPHome-Devices) by [@nuttytree](https://github.com/nuttytree)
 - [Control LG UD79-B monitor via UART](https://github.com/kquinsland/lg-m43mu79-esp-home-bridge) by [@kquinsland](https://github.com/kquinsland)
 - [ESPHome AXA Remote 2 control](https://github.com/galagaking/espaxa/) by [@galagaking](https://github.com/galagaking)
-- [ESPHome WF-DS01 TuyaMCU based dimmable bedside touch lamp](https://github.com/davet2001/miscellaneous/blob/master/tuyamcu_ws-df01_touchlamp.yaml) by [@davet2001](https://github.com/davet2001)
+- [ESPHome WF-DS01 TuyaMCU based dimmable bedside touch lamp](https://github.com/davet2001/miscellaneous/blob/main/tuyamcu_ws-df01_touchlamp.yaml) by [@davet2001](https://github.com/davet2001)
 - [Universal menu system for devices with rotary encoder with push and SSD1306 I2C display](https://github.com/mikosoft83/pithy_screen_menu_system) by [@mikosoft83](https://github.com/mikosoft83)
 - [Show heart rate sensor values sent over Bluetooth Low Energy on a display](https://github.com/koenvervloesem/ESPHome-Heart-Rate-Display) by [@koenvervloesem](https://github.com/koenvervloesem)
 - [ESPHome floor heating controller (proportional valves)](https://github.com/nliaudat/floor-heating-controller) by [@nliaudat](https://github.com/nliaudat)


### PR DESCRIPTION
## Description:
This PR updates some GitHub URLs in the documentation
## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/static/images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/_index.md`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image dht22
```

</details>
