### PR TITLE
Add Modbus alternative configuration and actions

### DIFF
--- a/content/components/sensor/pzemdc.md
+++ b/content/components/sensor/pzemdc.md
@@ -79,9 +79,8 @@ on_...:
 
 While its own component is great working for a basic setup, you may want to have more possibilities while using modbus controller.
 
-**Example Config**
+### Example Config
 ```yaml
-
 #Where is the modbus hardware connect to?
 uart:
   - id: modbus_uart
@@ -170,11 +169,8 @@ sensor:
 
 ```
 
-**```on_offline``` and ```on_online``` Action**
-
-**Scenario:**
-A binary sensor (id: bs_pzem_online) shall indicate if the device is off- or online.
-
+### `on_offline` and `on_online` Action
+Scenario: A binary sensor (id: bs_pzem_online) shall indicate if the device is off- or online.
 ```yaml
   on_online:
     then:
@@ -198,7 +194,6 @@ A binary sensor (id: bs_pzem_online) shall indicate if the device is off- or onl
 
 
 ## See Also
-
 - {{< docref "/components/uart" >}}
 - {{< docref "/components/modbus" >}}
 - {{< docref "/components/modbus_controller" >}}

--- a/content/components/sensor/pzemdc.md
+++ b/content/components/sensor/pzemdc.md
@@ -75,8 +75,135 @@ on_...:
     - pzemdc.reset_energy: pzemdc_1
 ```
 
+## Alternative configuration via Modbus
+
+While its own component is great working for a basic setup, you may want to have more possibilities while using modbus controller.
+
+**Example Config**
+```yaml
+
+#Where is the modbus hardware connect to?
+uart:
+  - id: modbus_uart
+    tx_pin: gpio03
+    rx_pin: gpio01
+    baud_rate: 9600
+    stop_bits: 1
+    parity: NONE
+
+#Lets define the modbus to use:
+modbus:
+  uart_id: modbus_uart
+  id: my_modbus
+
+#Lets intiate the Modbus Controller:
+modbus_controller:
+- id: pzem_hub
+  modbus_id: my_modbus
+  address: 0x01
+  setup_priority: -10
+  command_throttle: 100ms
+  update_interval: "4s"
+
+sensor:
+  - platform: modbus_controller
+    modbus_controller_id: pzem_hub
+    name: "PZEM Voltage"
+    id: pzem_dc_voltage
+    icon: "mdi:flash"
+    register_type: read
+    address: 0x0000
+    unit_of_measurement: "V"
+    value_type: U_WORD
+    accuracy_decimals: 2
+    force_update: true
+    filters:
+      - multiply: 0.01 
+
+  - platform: modbus_controller
+    modbus_controller_id: pzem_hub
+    name: "PZEM Current"
+    id: pzem_dc_current
+    icon: "mdi:current-dc"
+    register_type: read
+    address: 0x0001
+    unit_of_measurement: "A"
+    value_type: U_WORD
+    accuracy_decimals: 2
+    filters:
+      - multiply: 0.01
+      # Using delta to ignore false values in case the PZEM Device is OFF
+      - delta: 0.05
+      # Using heartbeat to send an "alive" message to HA
+      - heartbeat: 10s
+
+  - platform: modbus_controller
+    modbus_controller_id: pzem_hub
+    name: "PZEM Power"
+    id: pzem_dc_power
+    register_type: read
+    icon: "mdi:lightning-bolt"
+    address: 0x0002
+    unit_of_measurement: "W"
+    value_type: U_DWORD
+    accuracy_decimals: 2
+    filters:
+      - multiply: 0.1
+      # DELTA-Filter: Does only send a new value if the new one is different by 3 Watt 
+      - delta: 3.0
+      # Using heartbeat to send an "alive" message to HA
+      - heartbeat: 10s
+
+  - platform: total_daily_energy
+    name: "PZEM Daily Energy"
+    id: pzem_dc_energy_daily
+    icon: "mdi:counter"
+    power_id: pzem_dc_power
+    unit_of_measurement: "kWh"
+    state_class: total_increasing
+    device_class: energy
+    accuracy_decimals: 3
+    filters:
+      # Multiply to change from Watt hours to Kilo Watt hours (kwh)
+      - multiply: 0.001
+
+
+```
+
+**```on_offline``` and ```on_online``` Action**
+
+**Scenario:**
+A binary sensor (id: bs_pzem_online) shall indicate if the device is off- or online.
+
+```yaml
+  on_online:
+    then:
+      - binary_sensor.template.publish:
+          id: bs_pzem_online
+          state: ON
+
+#Also possible writing it in lambdas:
+  on_offline:
+      then:
+        - lambda: |-
+            ESP_LOGW("pzem_hub", "Controller: Device is offline, zero'ing all sensors");
+            id(bs_pzem_online).publish_state(false);
+
+            //additionally lets zero all sensors as the device is offline
+            id(pzem_dc_voltage).publish_state(0.0);
+            id(pzem_dc_current).publish_state(0.0);
+            id(pzem_dc_power).publish_state(0.0);
+
+```
+
+
 ## See Also
 
+- {{< docref "/components/uart" >}}
+- {{< docref "/components/modbus" >}}
+- {{< docref "/components/modbus_controller" >}}
+- {{< docref "/components/sensor/modbus_controller" >}}
+- {{< docref "/components/sensor/total_daily_energy" >}}
 - [Sensor Filters](/components/sensor#sensor-filters)
 - {{< docref "pzem004t/" >}}
 - {{< docref "pzemac/" >}}

--- a/content/components/sensor/pzemdc.md
+++ b/content/components/sensor/pzemdc.md
@@ -185,7 +185,7 @@ Scenario: A binary sensor (id: bs_pzem_online) shall indicate if the device is o
           id: bs_pzem_online
           state: ON
 
-#Also possible writing it in lambdas:
+`#It`'s also possible to write it in lambdas:
   on_offline:
       then:
         - lambda: |-

--- a/content/components/sensor/pzemdc.md
+++ b/content/components/sensor/pzemdc.md
@@ -85,8 +85,8 @@ While its own component is great working for a basic setup, you may want to have
 #Where is the modbus hardware connect to?
 uart:
   - id: modbus_uart
-    tx_pin: gpio03
-    rx_pin: gpio01
+    tx_pin: gpio<XX> #User-defined
+    rx_pin: gpio<XX> #User-defined
     baud_rate: 9600
     stop_bits: 1
     parity: NONE

--- a/content/components/sensor/pzemdc.md
+++ b/content/components/sensor/pzemdc.md
@@ -192,7 +192,7 @@ Scenario: A binary sensor (id: bs_pzem_online) shall indicate if the device is o
             ESP_LOGW("pzem_hub", "Controller: Device is offline, zero'ing all sensors");
             id(bs_pzem_online).publish_state(false);
 
-            //additionally lets zero all sensors as the device is offline
+            //additionally let's zero all sensors as the device is offline
             id(pzem_dc_voltage).publish_state(0.0);
             id(pzem_dc_current).publish_state(0.0);
             id(pzem_dc_power).publish_state(0.0);

--- a/content/components/sensor/pzemdc.md
+++ b/content/components/sensor/pzemdc.md
@@ -28,7 +28,7 @@ uart:
   tx_pin: D1
   rx_pin: D2
   baud_rate: 9600
-  stop_bits: 2
+  stop_bits: 1
 
 sensor:
   - platform: pzemdc
@@ -89,7 +89,6 @@ uart:
     rx_pin: gpio<XX> #User-defined
     baud_rate: 9600
     stop_bits: 1
-    parity: NONE
 
 #Lets define the modbus to use:
 modbus:
@@ -101,9 +100,8 @@ modbus_controller:
 - id: pzem_hub
   modbus_id: my_modbus
   address: 0x01
-  setup_priority: -10
   command_throttle: 100ms
-  update_interval: "4s"
+  update_interval: "4s" #a short update interval, we will throttle in the config of the sensor
 
 sensor:
   - platform: modbus_controller
@@ -132,9 +130,11 @@ sensor:
     accuracy_decimals: 2
     filters:
       - multiply: 0.01
+      #let's throttle the updates for this sensor
+      - throttle: 30s 
       # Using delta to ignore false values in case the PZEM Device is OFF
       - delta: 0.05
-      # Using heartbeat to send an "alive" message to HA
+      # Using heartbeat to send an "alive" message to HA to not have a broken line there
       - heartbeat: 10s
 
   - platform: modbus_controller
@@ -145,28 +145,33 @@ sensor:
     icon: "mdi:lightning-bolt"
     address: 0x0002
     unit_of_measurement: "W"
-    value_type: U_DWORD
-    accuracy_decimals: 2
+    value_type: U_DWORD_R
+    accuracy_decimals: 1
     filters:
       - multiply: 0.1
+      #lets throttle the updates for this sensor
+      - throttle: 30s 
       # DELTA-Filter: Does only send a new value if the new one is different by 3 Watt 
       - delta: 3.0
       # Using heartbeat to send an "alive" message to HA
       - heartbeat: 10s
 
-  - platform: total_daily_energy
+  - platform: modbus_controller
+    modbus_controller_id: pzem_hub
     name: "PZEM Daily Energy"
-    id: pzem_dc_energy_daily
-    icon: "mdi:counter"
-    power_id: pzem_dc_power
+    id: pzem_dc_energy_total
+    register_type: read
+    address: 0x0004
+    value_type: U_DWORD_R
     unit_of_measurement: "kWh"
-    state_class: total_increasing
     device_class: energy
+    state_class: total_increasing
     accuracy_decimals: 3
+    icon: "mdi:counter"
     filters:
-      # Multiply to change from Watt hours to Kilo Watt hours (kwh)
       - multiply: 0.001
-
+      #lets throttle the updates for this sensor
+      - throttle: 60s 
 ```
 
 ### `on_offline` and `on_online` Action

--- a/content/components/sensor/pzemdc.md
+++ b/content/components/sensor/pzemdc.md
@@ -80,6 +80,7 @@ on_...:
 While its own component is great working for a basic setup, you may want to have more possibilities while using modbus controller.
 
 ### Example Config
+
 ```yaml
 #Where is the modbus hardware connect to?
 uart:
@@ -166,11 +167,12 @@ sensor:
       # Multiply to change from Watt hours to Kilo Watt hours (kwh)
       - multiply: 0.001
 
-
 ```
 
 ### `on_offline` and `on_online` Action
+
 Scenario: A binary sensor (id: bs_pzem_online) shall indicate if the device is off- or online.
+
 ```yaml
   on_online:
     then:
@@ -189,11 +191,10 @@ Scenario: A binary sensor (id: bs_pzem_online) shall indicate if the device is o
             id(pzem_dc_voltage).publish_state(0.0);
             id(pzem_dc_current).publish_state(0.0);
             id(pzem_dc_power).publish_state(0.0);
-
 ```
 
-
 ## See Also
+
 - {{< docref "/components/uart" >}}
 - {{< docref "/components/modbus" >}}
 - {{< docref "/components/modbus_controller" >}}


### PR DESCRIPTION
Added alternative configuration section for Modbus usage with example YAML configuration and actions for online/offline states.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/static/images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/_index.md`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image dht22
```

</details>
