### PR TITLE
[http_request] Add tls_buffer_size_rx and tls_buffer_size_tx

### DIFF
--- a/src/content/docs/components/http_request.mdx
+++ b/src/content/docs/components/http_request.mdx
@@ -45,6 +45,12 @@ http_request:
 
 **For the ESP8266:**
 
+- **tls_buffer_size_rx** (*Optional*, integer): Change TLS receive buffer size. Should be set to `16384` to fit the TLS
+  record size of modern HTTP servers. This will increase RAM usage significantly and may require removing other
+  components to free up RAM. You can check the max free heap block using the [Debug Component](/components/debug/). If
+  the server is configured to support the MFL TLS extension then this can be reduced, but most popular servers (Traefik,
+  Caddy, Cloudflare) don't support it and nginx has it disabled by default. Defaults to `512`.
+- **tls_buffer_size_tx** (*Optional*, integer): Change TLS transmit buffer size. Defaults to `512`.
 - **esp8266_disable_ssl_support** (*Optional*, boolean): Determines whether to include HTTPS/SSL support in the
   firmware binary. Excluding the SSL libraries from your build will result in a smaller binary, which may be
   necessary for memory-constrained devices (512 kB or 1 MB). If you see


### PR DESCRIPTION
## Description:

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- https://github.com/esphome/esphome/pull/14009

## Checklist:

  - [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] ~~Link added in `/components/_index.md` when creating new documents for new components or cookbook.~~