### PR TITLE
Logging of all received frames

### DIFF
--- a/content/components/canbus/_index.md
+++ b/content/components/canbus/_index.md
@@ -243,7 +243,7 @@ canbus:
       use_extended_id: true
       then:
         - lambda: |-
-            ESP_LOGI("CAN", "can_id: 0x%03X", can_id);
+            ESP_LOGD("CAN", "can_id: 0x%03X", can_id);
             if (x.size() > 0) {
               ESP_LOGD("CAN", "First data: 0x%02X", x[0]);
 

--- a/content/components/canbus/_index.md
+++ b/content/components/canbus/_index.md
@@ -237,6 +237,16 @@ canbus:
         - lambda: |-
             std::string b(x.begin(), x.end());
             ESP_LOGD("CAN standard ID 0x123", "%s", &b[0]);
+
+    - can_id: 0
+      can_id_mask: 0x000
+      use_extended_id: true
+      then:
+        - lambda: |-
+            ESP_LOGI("CAN", "can_id: 0x%03X", can_id);
+            if (x.size() > 0) {
+              ESP_LOGD("CAN", "First data: 0x%02X", x[0]);
+
 ```
 
 ## Binary Sensor Example


### PR DESCRIPTION
Logging of all can frames with the received frame ID and data

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/static/images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/_index.md`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image dht22
```

</details>
