### PR TITLE
2026.2.0b3

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -55,27 +55,6 @@ function getChangelogItems() {
   }));
 }
 
-// Get the latest changelog version for redirects
-function getLatestChangelog() {
-  const changelogDir = path.join(__dirname, "src/content/docs/changelog");
-  const files = fs
-    .readdirSync(changelogDir)
-    .filter((f) => f.endsWith(".mdx") && f !== "index.mdx");
-
-  let latest = { sortValue: 0, slug: "" };
-  for (const f of files) {
-    const match = f.match(/^(\d{4})\.(\d+)\.(\d+)\.mdx$/);
-    if (match) {
-      const [, year, month, patch] = match;
-      const sortValue =
-        parseInt(year) * 10000 + parseInt(month) * 100 + parseInt(patch);
-      if (sortValue > latest.sortValue) {
-        latest = { sortValue, slug: `${year}.${month}.${patch}` };
-      }
-    }
-  }
-  return latest.slug;
-}
 
 // Generate component sidebar items with proper labels
 function getComponentItems() {
@@ -141,15 +120,8 @@ function getComponentItems() {
   return items.map(({ sort, ...item }) => item);
 }
 
-const latestChangelog = getLatestChangelog();
-
 export default defineConfig({
   site: "https://esphome.io",
-  redirects: {
-    "/changelog/": `/changelog/${latestChangelog}/`,
-    "/changelog/index/": `/changelog/${latestChangelog}/`,
-    "/guides/changelog/": `/changelog/${latestChangelog}/`,
-  },
   vite: {
     resolve: {
       alias: {

--- a/data/version.yaml
+++ b/data/version.yaml
@@ -1,2 +1,2 @@
-release: 2026.2.0b2
+release: 2026.2.0b3
 version: '2026.2'

--- a/src/components/APIClass.astro
+++ b/src/components/APIClass.astro
@@ -29,4 +29,4 @@ const baseUrl = 'https://api-docs.esphome.io';
 const url = `${baseUrl}/classesphome_1_1${processedPath}`;
 ---
 
-<a href={url}>{text}</a>
+<a href={url}>API Reference: {text}</a>

--- a/src/components/APIRef.astro
+++ b/src/components/APIRef.astro
@@ -31,8 +31,6 @@ processedPath = processedPath.replace(/([A-Z])/g, (match) => `_${match.toLowerCa
 const baseUrl = 'https://api-docs.esphome.io';
 const url = `${baseUrl}/${processedPath}`;
 
-// Display text defaults to "API Reference" if same as path
-const displayText = text === path ? 'API Reference' : text;
 ---
 
-<a href={url}>{displayText}</a>
+<a href={url}>API Reference: {text}</a>

--- a/src/components/APIStruct.astro
+++ b/src/components/APIStruct.astro
@@ -29,4 +29,4 @@ const baseUrl = 'https://api-docs.esphome.io';
 const url = `${baseUrl}/structesphome_1_1${processedPath}`;
 ---
 
-<a href={url}>{text}</a>
+<a href={url}>API Reference: {text}</a>

--- a/src/components/LatestChangelog.astro
+++ b/src/components/LatestChangelog.astro
@@ -32,5 +32,5 @@ const slug = latest.entry?.data.slug ?? latest.entry?.id;
 const redirectUrl = slug ? `/${slug}/` : null;
 ---
 
-{redirectUrl && <script define:vars={{ redirectUrl }}>window.location.replace(redirectUrl);</script>}
+{redirectUrl && <script define:vars={{ redirectUrl }}>window.location.replace(redirectUrl + window.location.hash);</script>}
 {Content && <Content />}

--- a/src/components/LatestChangelog.astro
+++ b/src/components/LatestChangelog.astro
@@ -1,0 +1,36 @@
+---
+import { getCollection, render } from "astro:content";
+
+const allDocs = await getCollection("docs");
+
+// Filter to changelog entries (excluding the index)
+const changelogs = allDocs.filter(
+  (entry) =>
+    entry.id.startsWith("changelog/") &&
+    entry.id !== "changelog/" &&
+    entry.id !== "changelog/index"
+);
+
+// Parse version and find the latest
+let latest = { sortValue: 0, entry: null as (typeof changelogs)[0] | null };
+for (const entry of changelogs) {
+  // Match 2021.x.x style IDs
+  const match = entry.id.match(/changelog\/(\d{4})\.(\d+)\.(\d+)/);
+  if (match) {
+    const [, year, month, patch] = match;
+    const sortValue =
+      parseInt(year) * 10000 + parseInt(month) * 100 + parseInt(patch);
+    if (sortValue > latest.sortValue) {
+      latest = { sortValue, entry };
+    }
+  }
+}
+
+const rendered = latest.entry ? await render(latest.entry) : null;
+const Content = rendered?.Content;
+const slug = latest.entry?.data.slug ?? latest.entry?.id;
+const redirectUrl = slug ? `/${slug}/` : null;
+---
+
+{redirectUrl && <script define:vars={{ redirectUrl }}>window.location.replace(redirectUrl);</script>}
+{Content && <Content />}

--- a/src/content/docs/changelog/2026.2.0.mdx
+++ b/src/content/docs/changelog/2026.2.0.mdx
@@ -336,6 +336,10 @@ The lists below are grouped by tag and may contain duplicates across sections.
 - [alarm_control_panel] Fix flaky integration test race condition [esphome#13964](https://github.com/esphome/esphome/pull/13964) by [@swoboda1337](https://github.com/swoboda1337)
 - [docker] Suppress git detached HEAD advice [esphome#13962](https://github.com/esphome/esphome/pull/13962) by [@swoboda1337](https://github.com/swoboda1337)
 - [api] Fix ESP8266 noise API handshake deadlock and prompt socket cleanup [esphome#13972](https://github.com/esphome/esphome/pull/13972) by [@bdraco](https://github.com/bdraco)
+- [wifi] Fix ESP8266 DHCP state corruption from premature dhcp_renew() [esphome#13983](https://github.com/esphome/esphome/pull/13983) by [@bdraco](https://github.com/bdraco)
+- [combination] Fix 'coeffecient' typo with backward-compatible deprecation [esphome#14004](https://github.com/esphome/esphome/pull/14004) by [@swoboda1337](https://github.com/swoboda1337)
+- [fan] Fix preset_mode not restored on boot [esphome#14002](https://github.com/esphome/esphome/pull/14002) by [@swoboda1337](https://github.com/swoboda1337)
+- [esp32_rmt] Handle ESP32 variants without RMT hardware [esphome#14001](https://github.com/esphome/esphome/pull/14001) by [@swoboda1337](https://github.com/swoboda1337) (new-feature)
 
 ### All changes
 
@@ -728,6 +732,17 @@ The lists below are grouped by tag and may contain duplicates across sections.
 - Allow Python 3.14 [esphome#13945](https://github.com/esphome/esphome/pull/13945) by [@swoboda1337](https://github.com/swoboda1337)
 - [wifi] Allow fast_connect without preconfigured networks [esphome#13946](https://github.com/esphome/esphome/pull/13946) by [@QRPp](https://github.com/QRPp)
 - [ethernet] Add per-PHY compile guards to eliminate unused PHY drivers [esphome#13947](https://github.com/esphome/esphome/pull/13947) by [@bdraco](https://github.com/bdraco)
+- [schema-gen] fix Windows: ensure UTF-8 encoding when reading component files [esphome#13952](https://github.com/esphome/esphome/pull/13952) by [@glmnet](https://github.com/glmnet)
+- [uart] Remove redundant mutex, fix flush race, conditional event queue [esphome#13955](https://github.com/esphome/esphome/pull/13955) by [@bdraco](https://github.com/bdraco)
+- [api] Extract cold code from APIServer::loop() hot path [esphome#13902](https://github.com/esphome/esphome/pull/13902) by [@bdraco](https://github.com/bdraco)
+- [pulse_meter] Fix early edge detection [esphome#12360](https://github.com/esphome/esphome/pull/12360) by [@LucasCZE](https://github.com/LucasCZE)
+- [alarm_control_panel] Fix flaky integration test race condition [esphome#13964](https://github.com/esphome/esphome/pull/13964) by [@swoboda1337](https://github.com/swoboda1337)
+- [docker] Suppress git detached HEAD advice [esphome#13962](https://github.com/esphome/esphome/pull/13962) by [@swoboda1337](https://github.com/swoboda1337)
+- [api] Fix ESP8266 noise API handshake deadlock and prompt socket cleanup [esphome#13972](https://github.com/esphome/esphome/pull/13972) by [@bdraco](https://github.com/bdraco)
+- [wifi] Fix ESP8266 DHCP state corruption from premature dhcp_renew() [esphome#13983](https://github.com/esphome/esphome/pull/13983) by [@bdraco](https://github.com/bdraco)
+- [combination] Fix 'coeffecient' typo with backward-compatible deprecation [esphome#14004](https://github.com/esphome/esphome/pull/14004) by [@swoboda1337](https://github.com/swoboda1337)
+- [fan] Fix preset_mode not restored on boot [esphome#14002](https://github.com/esphome/esphome/pull/14002) by [@swoboda1337](https://github.com/swoboda1337)
+- [esp32_rmt] Handle ESP32 variants without RMT hardware [esphome#14001](https://github.com/esphome/esphome/pull/14001) by [@swoboda1337](https://github.com/swoboda1337) (new-feature)
 
 </details>
 

--- a/src/content/docs/changelog/index.mdx
+++ b/src/content/docs/changelog/index.mdx
@@ -4,4 +4,6 @@ title: "Changelog"
 pagefind: true
 ---
 
-Redirecting to the latest release...
+import LatestChangelog from "@components/LatestChangelog.astro";
+
+<LatestChangelog />

--- a/src/content/docs/components/light/esp32_rmt_led_strip.mdx
+++ b/src/content/docs/components/light/esp32_rmt_led_strip.mdx
@@ -7,6 +7,9 @@ import APIRef from '@components/APIRef.astro';
 
 This is a component using the ESP32 RMT peripheral to drive most addressable LED strips.
 
+> [!NOTE]
+> The ESP32-C2 and ESP32-C61 do not have RMT hardware and are not supported by this component.
+
 ```yaml
 light:
   - platform: esp32_rmt_led_strip
@@ -59,7 +62,6 @@ light:
 | ESP32-C3      | 96 symbols       | 48 symbols |
 | ESP32-C5      | 96 symbols       | 48 symbols |
 | ESP32-C6      | 96 symbols       | 48 symbols |
-| ESP32-C61     | 96 symbols       | 48 symbols |
 | ESP32-H2      | 96 symbols       | 48 symbols |
 | ESP32-P4      | 192 symbols      | 48 symbols |
 | ESP32-S2      | 256 symbols      | 64 symbols |

--- a/src/content/docs/components/remote_receiver.mdx
+++ b/src/content/docs/components/remote_receiver.mdx
@@ -88,16 +88,20 @@ Multiple remote receivers can be configured as a list of dict definitions within
   be considered complete. Defaults to `10ms`. The maximum allowable value is:
 
   - `65536us` on the `ESP32` and `ESP32-S2` variants
-  - `32767us` on all other ESP32 variants
-  - `4294967295us` on all other platforms
+  - `32767us` on other ESP32 variants with RMT hardware
+  - `4294967295us` on all other platforms (including ESP32-C2 and ESP32-C61 which use a software implementation)
 
-  Note: The ESP32 values listed above assume the default `clock_resolution`. If a different `clock_resolution` is used,
-  the values are scaled by 1000000 / `clock_resolution`.
+  Note: The ESP32 RMT values listed above assume the default `clock_resolution`. If a different `clock_resolution` is
+  used, the values are scaled by 1000000 / `clock_resolution`.
 
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID used for code generation. Useful when multiple
   receivers are configured on a single device.
 
-### ESP32 configuration variables
+### ESP32 RMT configuration variables
+
+> [!NOTE]
+> The following options apply only to ESP32 variants with RMT hardware. They are not available on the ESP32-C2 and
+> ESP32-C61, which use a software implementation.
 
 - **rmt_symbols** (*Optional*, int): When `use_dma` is enabled, this sets the size of the driver's internal DMA
   buffer. When DMA is disabled, it specifies how much RMT memory is allocated to the component. RMT memory is shared
@@ -110,7 +114,6 @@ Multiple remote receivers can be configured as a list of dict definitions within
 | ESP32-C3      | 96 symbols       | 48 symbols |
 | ESP32-C5      | 96 symbols       | 48 symbols |
 | ESP32-C6      | 96 symbols       | 48 symbols |
-| ESP32-C61     | 96 symbols       | 48 symbols |
 | ESP32-H2      | 96 symbols       | 48 symbols |
 | ESP32-P4      | 192 symbols      | 48 symbols |
 | ESP32-S2      | 256 symbols      | 64 symbols |

--- a/src/content/docs/components/remote_transmitter.mdx
+++ b/src/content/docs/components/remote_transmitter.mdx
@@ -16,8 +16,9 @@ The component is split into two parts:
 **See** [Setting up IR Devices](/guides/setting_up_rmt_devices#remote-setting-up-infrared) **and** [Setting up RF Devices](/guides/setting_up_rmt_devices#remote-setting-up-rf) **for details.**
 
 > [!NOTE]
-> This component performs best with an ESP32 or variant; they have a dedicated hardware peripheral which ensures
-> accurate signal timing.
+> This component performs best with an ESP32 or variant; most have a dedicated RMT hardware peripheral which ensures
+> accurate signal timing. The ESP32-C2 and ESP32-C61 lack RMT hardware and use a software (GPIO bitbang)
+> implementation instead.
 
 ```yaml
 # Example configuration entry
@@ -36,7 +37,11 @@ remote_transmitter:
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID used for code generation. Useful when multiple
   transmitters are connected to a single device.
 
-### ESP32 configuration variables
+### ESP32 RMT configuration variables
+
+> [!NOTE]
+> The following options apply only to ESP32 variants with RMT hardware. They are not available on the ESP32-C2 and
+> ESP32-C61, which use a software implementation.
 
 - **rmt_symbols** (*Optional*, int): When `use_dma` is enabled, this sets the size of the driver's internal DMA
   buffer. When DMA is disabled, it specifies how much RMT memory is allocated to the component. RMT memory is shared
@@ -49,7 +54,6 @@ remote_transmitter:
 | ESP32-C3      | 96 symbols       | 48 symbols |
 | ESP32-C5      | 96 symbols       | 48 symbols |
 | ESP32-C6      | 96 symbols       | 48 symbols |
-| ESP32-C61     | 96 symbols       | 48 symbols |
 | ESP32-H2      | 96 symbols       | 48 symbols |
 | ESP32-P4      | 192 symbols      | 48 symbols |
 | ESP32-S2      | 256 symbols      | 64 symbols |

--- a/src/content/docs/components/sensor/combination.mdx
+++ b/src/content/docs/components/sensor/combination.mdx
@@ -37,7 +37,7 @@ sensor:
 ```
 
 - `LINEAR` combination: This type sums all source sensors after multiplying each by
-  a configured coeffecient.
+  a configured coefficient.
 
 ```yaml
 # Example configuration entry
@@ -47,9 +47,9 @@ sensor:
     name: "Balance Power"
     sources:
       - source: total_power
-        coeffecient: 1.0
+        coefficient: 1.0
       - source: circuit_1_power
-        coeffecient: -1.0
+        coefficient: -1.0
 ```
 
 - `MAXIMUM`, `MEAN`, `MEDIAN`, `MINIMUM`, `MOST_RECENTLY_UPDATED`,
@@ -84,8 +84,8 @@ sensor:
     parameter, with low values marking accurate data. If implemented as a template, the
     measurement is in parameter `x`.
 
-  - **coeffecient** (**Required**, only for `LINEAR` type, float, [templatable](/automations/templates)):
-    The coeffecient to multiply the sensor's state by before summing all source sensor states.
+  - **coefficient** (**Required**, only for `LINEAR` type, float, [templatable](/automations/templates)):
+    The coefficient to multiply the sensor's state by before summing all source sensor states.
     If implemented as a template, the measurement is in parameter `x`.
 
 - **process_std_dev** (**Required**, only for `KALMAN` type, float): The standard deviation of the

--- a/src/content/docs/guides/supporters.mdx
+++ b/src/content/docs/guides/supporters.mdx
@@ -2338,4 +2338,4 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Christian Zufferey (@zuzu59)](https://github.com/zuzu59)
 - [Zynth-dev (@Zynth-dev)](https://github.com/Zynth-dev)
 
-*This page was last updated February 14, 2026.*
+*This page was last updated February 17, 2026.*


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- Prefix APIRef links with "API Reference:" [docs#6081](https://github.com/esphome/esphome-docs/pull/6081)
- Make changelog index a real searchable page [docs#6083](https://github.com/esphome/esphome-docs/pull/6083)
- [remote_transmitter, remote_receiver, esp32_rmt_led_strip] Document ESP32-C2/C61 no RMT support [docs#6086](https://github.com/esphome/esphome-docs/pull/6086)
- Fix changelog redirect to preserve URL hash fragment [docs#6088](https://github.com/esphome/esphome-docs/pull/6088)
- [combination] Fix 'coeffecient' typo to 'coefficient' [docs#6087](https://github.com/esphome/esphome-docs/pull/6087)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
