### PR TITLE
[sensor] Add filter headings to table of contents

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -168,6 +168,7 @@ export default defineConfig({
       editLink: {
         baseUrl: "https://github.com/esphome/esphome-docs/edit/current/",
       },
+      routeMiddleware: ["./src/routeData.ts"],
       components: {
         Footer: "./src/components/Footer.astro",
       },

--- a/src/routeData.ts
+++ b/src/routeData.ts
@@ -1,0 +1,44 @@
+import { defineRouteMiddleware } from "@astrojs/starlight/route-data";
+import GithubSlugger from "github-slugger";
+
+// Eagerly import all sensor filter MDX files to extract their headings.
+const filterModules = import.meta.glob(
+  "./content/docs/components/sensor/filter/*.mdx",
+  { eager: true },
+);
+
+// Build the list of filter TOC entries once at module load time.
+const slugger = new GithubSlugger();
+const filterTocEntries = Object.entries(filterModules)
+  .sort(([a], [b]) => a.localeCompare(b))
+  .map(([, module]) => {
+    const title = (module as any).frontmatter?.title as string | undefined;
+    if (!title) return null;
+    return {
+      depth: 3 as const,
+      slug: slugger.slug(title),
+      text: title,
+      children: [],
+    };
+  })
+  .filter(Boolean);
+
+export const onRequest = defineRouteMiddleware(async (context, next) => {
+  // Let Starlight generate the default route data first.
+  await next();
+
+  const route = context.locals.starlightRoute;
+  if (!route.toc) return;
+
+  // Find the "Sensor Filters" heading in the TOC — only present on the sensor index page.
+  const sensorFiltersEntry = route.toc.items.find(
+    (item) => item.slug === "sensor-filters",
+  );
+  if (!sensorFiltersEntry || sensorFiltersEntry.children.length > 0) return;
+
+  // Inject filter headings as children of the "Sensor Filters" TOC entry.
+  sensorFiltersEntry.children = filterTocEntries.map((entry) => ({
+    ...entry!,
+    children: [],
+  }));
+});


### PR DESCRIPTION
## Description

The sensor index page uses a `<FilterList />` component to dynamically render 26 filter MDX files. Because these headings are rendered at runtime rather than being static MDX content, Starlight's TOC generation didn't include them — the "Sensor Filters" section in the table of contents had no children.

This adds a Starlight route middleware (`src/routeData.ts`) that:
- Eagerly imports all sensor filter MDX files at build time
- Extracts heading titles from their frontmatter
- Generates matching slugs using `github-slugger`
- Injects the 26 filter headings as children of the "Sensor Filters" TOC entry

**Before:** The TOC only showed top-level sections with no filter sub-entries.
**After:** All 26 filter names appear nested under "Sensor Filters" in the TOC.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- N/A

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.