### PR TITLE
[esp32_touch] Add ESP32-P4 support, document voltage_attenuation as ESP32-only

### DIFF
--- a/src/content/docs/components/binary_sensor/esp32_touch.mdx
+++ b/src/content/docs/components/binary_sensor/esp32_touch.mdx
@@ -266,7 +266,7 @@ reduce the ESP's overall performance.
 > binary_sensor:
 >   - platform: esp32_touch
 >     name: "Touch Sensor"
->     pin: GPIO1
+>     pin: GPIOXX
 >     threshold: 1000  # Adjust based on your hardware
 > ```
 

--- a/src/content/docs/components/binary_sensor/esp32_touch.mdx
+++ b/src/content/docs/components/binary_sensor/esp32_touch.mdx
@@ -8,7 +8,7 @@ import esp32TouchUiImg from './images/esp32_touch-ui.png';
 import esp32TouchFindingThresholdsImg from './images/esp32_touch-finding_thresholds.png';
 import APIRef from '@components/APIRef.astro';
 
-Capacitive touch detection is possible on ESP32, ESP32-S2 or ESP32-S3 processors.
+Capacitive touch detection is possible on ESP32, ESP32-S2, ESP32-S3 and ESP32-P4 processors.
 In ESPHome, it is configured in two parts:
 
 - [Component/Hub](#esp32-touch-component)
@@ -19,7 +19,7 @@ In ESPHome, it is configured in two parts:
 ## Component/Hub
 
 The `esp32_touch` component creates a global hub enabling (capacitive) touch detection on GPIO pins
-[supported by ESP32, ESP32-S2 or ESP32-S3 processors](#esp32-touch-pad-pins). With this enabled,
+[supported by ESP32, ESP32-S2, ESP32-S3 and ESP32-P4 processors](#esp32-touch-pad-pins). With this enabled,
 [binary sensors](#esp32-touch-binary-sensor) may then be configured to permit touch detection.
 
 ```yaml
@@ -52,14 +52,15 @@ the sensors aren't behaving as expected.
   time for all touch pads. A longer conversion time means that more charge/discharge cycles of the touch pad
   can be performed, therefore increasing accuracy. Default is about 8ms, the maximum amount.
 
+#### ESP32, ESP32-S2 and ESP32-S3 only
+
 - **low_voltage_reference** (*Optional*): The low voltage reference to use for the charge cycles. One of `0.5V`,
   `0.6V`, `0.7V`, `0.8V`. Default is `0.5V`.
 
 - **high_voltage_reference** (*Optional*): The high voltage reference to use for the charge cycles. One of `2.4V`,
   `2.5V`, `2.6V`, `2.7V`. Default is `2.7V`.
 
-- **voltage_attenuation** (*Optional*): The voltage attenuation to use for the charge cycles. One of `1.5V`, `1V`,
-  `0.5V`, `0V`. Default is `0V`.
+- **voltage_attenuation** (*Optional*, **Deprecated**): This option has no effect and will be removed in a future version.
 
 For a more detailed explanation of the parameters above, please see the
 [ESP-IDF documentation.](https://docs.espressif.com/projects/esp-idf/en/latest/api-reference/peripherals/touch_pad.html#optimization-of-measurements)
@@ -71,7 +72,7 @@ For a more detailed explanation of the parameters above, please see the
   filter should be applied to all touch pads. This can increase the accuracy of the touch pads a lot, but higher values
   decrease the response time. A good value to start with is `10ms`. By default, the IIR filter is inactive.
 
-#### ESP32-S2 and ESP32-S3 only
+#### ESP32-S2, ESP32-S3 and ESP32-P4 only
 
 **For each configuration category below, if one option is specified, all options must be specified.** The configuration
 options below do not have any default values; in other words, they are inactive by default.
@@ -79,7 +80,7 @@ options below do not have any default values; in other words, they are inactive 
 Filter configuration:
 
 - **filter_mode** (*Optional*): Sets the filter mode. Must be one of `IIR_4`, `IIR_8`, `IIR_16`,
-  `IIR_32`, `IIR_64`, `IIR_128`, `IIR_256` or `JITTER`.
+  `IIR_32`, `IIR_64`, `IIR_128`, `IIR_256` (S2/S3 only) or `JITTER`.
 
 - **debounce_count** (*Optional*, `int` range 0-7): Sets the debounce count; if the measured values continue to
   exceed the threshold for `n + 1` times, the touch sensor state changes.
@@ -94,7 +95,7 @@ Filter configuration:
 For a more detailed explanation of the filter configuration, please see the
 [ESP-IDF documentation.](https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/api-reference/peripherals/touch_pad.html#_CPPv419touch_filter_config)
 
-Denoise configuration:
+Denoise configuration (ESP32-S2 and ESP32-S3 only, not available on ESP32-P4):
 
 - **denoise_grade** (*Optional*): Sets the denoise range of the denoise channel. Determined by measuring the noise
   amplitude of the denoise channel. Must be one of `BIT12`, `BIT10`, `BIT8` or `BIT4`.
@@ -188,12 +189,12 @@ under a flexible object like a plastic mat, add the raw values, and apply a thre
 
 ## Touch Pad Pins
 
-Various pins on the ESP32, ESP32-S2 and ESP32-S3 can be used to detect touches. They are as follows (using the default
+Various pins on the ESP32, ESP32-S2, ESP32-S3 and ESP32-P4 can be used to detect touches. They are as follows (using the default
 "raw" pin names/numbers):
 
-| ESP32                                                                       | ESP32-S2       | ESP32-S3       |
-| --------------------------------------------------------------------------- | -------------- | -------------- |
-| GPIO4, GPIO0, GPIO2, GPIO15, GPIO13, GPIO12, GPIO14, GPIO27, GPIO33, GPIO32 | GPIO1 - GPIO14 | GPIO1 - GPIO14 |
+| ESP32                                                                       | ESP32-S2       | ESP32-S3       | ESP32-P4       |
+| --------------------------------------------------------------------------- | -------------- | -------------- | -------------- |
+| GPIO4, GPIO0, GPIO2, GPIO15, GPIO13, GPIO12, GPIO14, GPIO27, GPIO33, GPIO32 | GPIO1 - GPIO14 | GPIO1 - GPIO14 | GPIO2 - GPIO15 |
 
 <span id="esp32-finding-thresholds"></span>
 
@@ -239,21 +240,21 @@ reduce the ESP's overall performance.
 
 <span id="esp32-note-about-variants"></span>
 
-## S2 and S3 Variants
+## S2, S3 and P4 Variants
 
 > [!NOTE]
-> **ESP32-S2 and ESP32-S3 Touch Configuration**
+> **ESP32-S2, ESP32-S3 and ESP32-P4 Touch Configuration**
 >
 > The default `measurement_duration` and `sleep_duration` values are optimized for the original ESP32 and
-> **may not work at all on S2/S3 variants**. The S2/S3 touch hardware requires different timing settings.
+> **may not work at all on S2/S3/P4 variants**. These variants have different touch hardware requiring different timing settings.
 >
 > Key differences:
 >
 > - **Touch values increase** when touched (opposite of ESP32 which decreases)
 > - **Higher raw values** are returned compared to original ESP32
-> - **Lower measurement duration required** - the default 8ms is often too high for S2/S3
+> - **Lower measurement duration required** - the default 8ms is often too high for S2/S3/P4
 >
-> **Example settings for S2/S3:**
+> **Example settings for S2/S3/P4:**
 >
 > ```yaml
 > esp32_touch:
@@ -268,21 +269,21 @@ reduce the ESP's overall performance.
 >     threshold: 1000  # Adjust based on your hardware
 > ```
 
-If you're familiar with the ESP32 hardware and pick up an S2 or S3 variant, you're likely to notice some behavioral
+If you're familiar with the ESP32 hardware and pick up an S2, S3 or P4 variant, you're likely to notice some behavioral
 differences between them. In particular:
 
-- Raw touch sensor readings on the S2 and S3 variants will generally return larger numeric values than the original
+- Raw touch sensor readings on the S2, S3 and P4 variants will generally return larger numeric values than the original
   ESP32 hardware.
 
-- Contact with the touch sensor on the S2 and S3 variants will result in the raw sensor value reading *increasing*; on
+- Contact with the touch sensor on the S2, S3 and P4 variants will result in the raw sensor value reading *increasing*; on
   the original ESP32, contact would cause this value to *decrease*.
 
 These behavioral differences are due to changes in the hardware and software (ESP-IDF) interfaces and should be
-expected -- if you are moving your configuration from an original ESP32 to an S2 or S3 variant, expect that you'll need
+expected -- if you are moving your configuration from an original ESP32 to an S2, S3 or P4 variant, expect that you'll need
 to make some adjustments to your configuration to accommodate this behavior.
 
 Most importantly, the default `measurement_duration` of 8ms (optimized for original ESP32) is often too high for
-S2/S3 variants and can prevent touch detection from working entirely. Using a much lower value like 0.25ms has been
+S2/S3/P4 variants and can prevent touch detection from working entirely. Using a much lower value like 0.25ms has been
 found to work across many S2/S3 devices, though specific parameters may still need tuning per hardware implementation.
 
 ## See Also

--- a/src/content/docs/components/binary_sensor/esp32_touch.mdx
+++ b/src/content/docs/components/binary_sensor/esp32_touch.mdx
@@ -60,7 +60,8 @@ the sensors aren't behaving as expected.
 - **high_voltage_reference** (*Optional*): The high voltage reference to use for the charge cycles. One of `2.4V`,
   `2.5V`, `2.6V`, `2.7V`. Default is `2.7V`.
 
-- **voltage_attenuation** (*Optional*, **Deprecated**): This option has no effect and will be removed in a future version.
+- **voltage_attenuation** (*Optional*, ESP32 only): The voltage attenuation to use for the charge cycles. One of `1.5V`, `1V`,
+  `0.5V`, `0V`. Default is `0V`.
 
 For a more detailed explanation of the parameters above, please see the
 [ESP-IDF documentation.](https://docs.espressif.com/projects/esp-idf/en/latest/api-reference/peripherals/touch_pad.html#optimization-of-measurements)


### PR DESCRIPTION
## Description

Update esp32_touch documentation to reflect the driver migration in esphome/esphome#14033:

- Add ESP32-P4 as a supported processor throughout
- Add ESP32-P4 pin table (GPIO2 - GPIO15)
- Document `voltage_attenuation` as ESP32 V1 only (properly supported via the new combined high voltage enum)
- Move `low_voltage_reference` and `high_voltage_reference` under an "ESP32, ESP32-S2 and ESP32-S3 only" heading (not available on P4)
- Note that filter/waterproof options now also apply to ESP32-P4
- Note that denoise is ESP32-S2/S3 only (not available on P4)
- Note that `IIR_256` filter mode is S2/S3 only
- Update S2/S3 variants section to include P4

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#14033

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.