### PR TITLE
Link domain names to component pages in automation lists

### DIFF
--- a/src/components/AutomationList.astro
+++ b/src/components/AutomationList.astro
@@ -48,8 +48,8 @@ const headingPatternGlobal = new RegExp(
 // Extract individual backticked names from a heading line
 const namePattern = /`([a-z_][a-z0-9_.]*\.[a-z_][a-z0-9_]*)`/g;
 
-// Map: domain -> Set of action/condition names
-const domainMap = new Map<string, Set<string>>();
+// Map: domain -> { names: Set of action/condition names, filePath: source file }
+const domainMap = new Map<string, { names: Set<string>; filePath: string }>();
 
 for (const filePath of collectMdxFiles(docsDir)) {
   const content = fs.readFileSync(filePath, "utf-8");
@@ -62,27 +62,35 @@ for (const filePath of collectMdxFiles(docsDir)) {
       const domain = fullName.substring(0, lastDot);
       const name = fullName.substring(lastDot + 1);
       if (!domainMap.has(domain)) {
-        domainMap.set(domain, new Set());
+        domainMap.set(domain, { names: new Set(), filePath });
       }
-      domainMap.get(domain)!.add(name);
+      domainMap.get(domain)!.names.add(name);
     }
   }
+}
+
+// Convert a docs file path to a site URL
+function filePathToUrl(filePath: string): string {
+  let rel = path.relative(docsDir, filePath);
+  rel = rel.replace(/index\.mdx$/, "").replace(/\.mdx$/, "");
+  return "/" + rel.replace(/\/$/, "") + "/";
 }
 
 // Sort domains alphabetically, and names within each domain
 const sorted = [...domainMap.entries()]
   .sort(([a], [b]) => a.localeCompare(b))
-  .map(([domain, names]) => ({
+  .map(([domain, { names, filePath }]) => ({
     domain,
     names: [...names].sort((a, b) => a.localeCompare(b)),
+    url: filePathToUrl(filePath),
   }));
 ---
 
 {/* markdownlint-disable MD013 */}
 <ul>
-  {sorted.map(({ domain, names }) => (
+  {sorted.map(({ domain, names, url }) => (
     <li>
-      <strong>{domain}:</strong>{" "}
+      <strong><a href={url}>{domain}</a>:</strong>{" "}
       {names.map((name, i) => (
         <>
           <code>{name}</code>{i < names.length - 1 ? ", " : ""}


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

The auto-generated All Actions/Conditions lists (from #6107) rendered domain names as plain bold text. The original docs had these as clickable links to the component documentation pages. This tracks the source file path for each domain and converts it to a site URL so domain names link to their docs.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- N/A

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.