### PR TITLE
Schema gen support starlight migration

### DIFF
--- a/script/schema_doc.py
+++ b/script/schema_doc.py
@@ -72,7 +72,8 @@ class SeeAlso:
         self.set_title_slug(title)
 
     def md(self):
-        url_path = "/" + "/".join(list(self.file.parts[1:-1]))
+        relative = self.file.relative_to(DOCS_ROOT)
+        url_path = "/" + "/".join(relative.parts[:-1])
         if self.file.stem != "index":
             url_path += f"/{self.file.stem}"
         if self.doc_slug_title:

--- a/script/schema_doc.py
+++ b/script/schema_doc.py
@@ -73,7 +73,7 @@ class SeeAlso:
 
     def md(self):
         url_path = "/" + "/".join(list(self.file.parts[1:-1]))
-        if self.file.stem != "_index":
+        if self.file.stem != "index":
             url_path += f"/{self.file.stem}"
         if self.doc_slug_title:
             url_path += self.doc_slug_title
@@ -407,7 +407,7 @@ def get_md_file_ref(md_file, ref):
     ref_md_path = md_parent / (ref + ".mdx")
     if ref_md_path.exists():
         return ref_md_path
-    ref_md_default = md_parent / ref / "_index.mdx"
+    ref_md_default = md_parent / ref / "index.mdx"
     if ref_md_default.exists():
         return ref_md_default
     ref_md_default = DOCS_ROOT / "components" / (ref + ".mdx")
@@ -784,7 +784,7 @@ if __name__ == "__main__":
         # so for the root component (in core) we need to use the one in root, and ignore the one in subfolder,
         # that one will be used in e.g. sensors.json (platform)
 
-        if file_name == "_index" and content_folder == "components":
+        if file_name == "index" and content_folder == "components":
             continue  # nothing here
 
         if file_name in core["components"]:
@@ -793,7 +793,7 @@ if __name__ == "__main__":
             if is_component:
                 config_component = file_name
         elif content_folder != "content" and content_folder in core["platforms"]:
-            if file_name == "_index":
+            if file_name == "index":
                 # fill core platform docs, from _index files in platforms folders
                 index, docs = md_get_paragraph(lines, index)
                 core["platforms"][content_folder][JSON_DOCS] = (
@@ -842,7 +842,7 @@ if __name__ == "__main__":
                 component_name = f"{file_name}_i2c"
             elif (
                 # Handle Platform titles, e.g. Sensor, Switch titles
-                file_name != "_index"
+                file_name != "index"
                 and get_platform_from_title(title, config_component or file_name)
                 is not None
             ):

--- a/script/schema_doc.py
+++ b/script/schema_doc.py
@@ -4,7 +4,6 @@ import json
 import os
 import re
 import unicodedata
-import string
 from pathlib import Path
 from pprint import pprint
 from inspect import getmembers
@@ -301,7 +300,7 @@ def json_save():
 
 
 def make_doc_with_see_also(md_file, index, docs):
-    docs = convert_links_and_shortcodes(md_file, index, docs)
+    docs = convert_links(md_file, index, docs)
     return f"{docs}\n\n{see_also.md()}"
 
 
@@ -375,49 +374,7 @@ def find_schema_prop(schema, prop_name):
     return None
 
 
-DOXYGEN_LOOKUP = {}
-for s in string.ascii_lowercase + string.digits:
-    DOXYGEN_LOOKUP[s] = s
-for s in string.ascii_uppercase:
-    DOXYGEN_LOOKUP[s] = "_{}".format(s.lower())
-DOXYGEN_LOOKUP[":"] = "_1"
-DOXYGEN_LOOKUP["_"] = "__"
-DOXYGEN_LOOKUP["."] = "_8"
-
-
-def encode_doxygen(value):
-    value = value.split("/")[-1]
-    try:
-        return "".join(DOXYGEN_LOOKUP[s] for s in value)
-    except KeyError as exc:
-        raise ValueError(
-            "Unknown character in doxygen string! '{}'".format(value)
-        ) from exc
-
-
-def get_md_file_ref(md_file, ref):
-    # This should mimic the docref short code, see /themes/esphome-theme/layouts/shortcodes/docref.html
-    if ref.startswith("/"):
-        md_parent = DOCS_ROOT
-        ref = ref[1:]
-    else:
-        md_parent = md_file.parent
-    if ref.endswith("/"):
-        ref = ref[:-1]
-
-    ref_md_path = md_parent / (ref + ".mdx")
-    if ref_md_path.exists():
-        return ref_md_path
-    ref_md_default = md_parent / ref / "index.mdx"
-    if ref_md_default.exists():
-        return ref_md_default
-    ref_md_default = DOCS_ROOT / "components" / (ref + ".mdx")
-    if ref_md_default.exists():
-        return ref_md_default
-    return md_file  # go nowhere
-
-
-def convert_links_and_shortcodes(md_file, index, docs):
+def convert_links(md_file, index, docs):
     if docs is None:
         return None
 
@@ -437,34 +394,7 @@ def convert_links_and_shortcodes(md_file, index, docs):
 
         return f"[{title}]({url})"
 
-    docs = re.sub(REGEX_LOCAL_LINK, replacer_local, docs)
-
-    # Matches {{ shortcode-group-1 "group-2" "group-3" }}
-    REGEX_SHORTCODE = r"{{<\s([^\s]*)\s\"([^\"]*)\"(?:\s\"([^\"]*)\")?\s>}}"
-
-    def replacer_shortcode(match):
-        if match.group(1) == "docref":
-            ref = match.group(2)
-            md_file_ref = get_md_file_ref(md_file, ref)
-            title = match.group(3) or get_doc_title(md_file_ref)
-            if ref.startswith("/"):
-                url = args.deploy_url + ref
-            else:
-                url = args.deploy_url + "/" + "/".join(md_file.parts[1:-1]) + "/" + ref
-            if url.endswith("/index"):
-                url = url[: -(len("/index"))]
-        elif match.group(1) == "apistruct":
-            title = match.group(2)
-            url = f"{args.api_docs_url}/structesphome_1_1{encode_doxygen(match.group(3))}.html"
-        elif match.group(1) == "apiclass":
-            title = match.group(2)
-            url = f"{args.api_docs_url}/classesphome_1_1{encode_doxygen(match.group(3))}.html"
-        else:
-            print(f"{md_file}:{index} unknown shortcode '{match.group(1)}'")
-
-        return f"[{title}]({url})"
-
-    return re.sub(REGEX_SHORTCODE, replacer_shortcode, docs)
+    return re.sub(REGEX_LOCAL_LINK, replacer_local, docs)
 
 
 def set_schema_doc(md_file, index, schema, prop_name, prop_types, doc):
@@ -496,7 +426,7 @@ def set_schema_doc(md_file, index, schema, prop_name, prop_types, doc):
 
             # Document with type information, unless the type just says templatable
             if len(type_parts) > 1 and type_parts[1] != TYPE_TEMPLATABLE:
-                prop_type = convert_links_and_shortcodes(md_file, index, type_parts[1])
+                prop_type = convert_links(md_file, index, type_parts[1])
                 matched_config[JSON_DOCS] = f"**{prop_type}**: {converted_doc}"
                 stats.props += 1
                 return matched_config
@@ -651,7 +581,7 @@ def process_config(md_file, lines, index, config_var, indent=0, parent_schema=No
                 values = config_var.get("values", {})
                 if enum_value in values:
                     values[enum_value] = values.get(enum_value) or {}
-                    values[enum_value][JSON_DOCS] = convert_links_and_shortcodes(
+                    values[enum_value][JSON_DOCS] = convert_links(
                         md_file, index, enum_desc
                     )
                     stats.enum_docs += 1
@@ -663,7 +593,7 @@ def process_config(md_file, lines, index, config_var, indent=0, parent_schema=No
                     values = config_var.get("values", {})
                     if enum_value in values:
                         values[enum_value] = values.get(enum_value) or {}
-                        values[enum_value][JSON_DOCS] = convert_links_and_shortcodes(
+                        values[enum_value][JSON_DOCS] = convert_links(
                             md_file, index, enum_desc
                         )
                         stats.enum_docs += 1
@@ -797,8 +727,8 @@ if __name__ == "__main__":
             if file_name == "index":
                 # fill core platform docs, from _index files in platforms folders
                 index, docs = md_get_paragraph(lines, index)
-                core["platforms"][content_folder][JSON_DOCS] = (
-                    convert_links_and_shortcodes(md_file, index, docs)
+                core["platforms"][content_folder][JSON_DOCS] = convert_links(
+                    md_file, index, docs
                 )
                 stats.core_platform_docs += 1
                 is_platform = True
@@ -901,9 +831,7 @@ if __name__ == "__main__":
 
                 if title_config_vars is not None:
                     index, docs = md_get_paragraph(lines, index)
-                    title_config_vars[JSON_DOCS] = convert_links_and_shortcodes(
-                        md_file, index, docs
-                    )
+                    title_config_vars[JSON_DOCS] = convert_links(md_file, index, docs)
                     if config_type == "action":
                         stats.action_docs += 1
                     elif config_type == "condition":

--- a/script/schema_doc.py
+++ b/script/schema_doc.py
@@ -9,7 +9,7 @@ from pprint import pprint
 from inspect import getmembers
 from types import FunctionType
 
-# cspell:ignore Clockless fastled apiclass apistruct classesphome dfrobot docref structesphome templatable
+# cspell:ignore Clockless fastled dfrobot templatable
 
 DOC_CONFIGURATION_VARIABLES = "Configuration variables:"
 DOC_CONFIGURATION_OPTIONS = "Configuration options:"
@@ -36,7 +36,7 @@ def is_configuration_variables_title_alike(title):
     return re.search(REGEX_CONFIGURATION_VARIABLES_TITLE, title, re.IGNORECASE)
 
 
-def hugo_slugify(text: str) -> str:
+def slugify(text: str) -> str:
     # Normalize Unicode to ASCII (e.g., é → e)
     text = unicodedata.normalize("NFKD", text)
     text = text.encode("ascii", "ignore").decode("ascii")
@@ -65,7 +65,7 @@ class SeeAlso:
 
     def set_title_slug(self, title):
         # TODO: if setting same title, the slug actually gets appended -1, -2 etc.
-        self.doc_slug_title = f"#{hugo_slugify(title)}"
+        self.doc_slug_title = f"#{slugify(title)}"
 
     def set_title(self, title):
         self.set_title_slug(title)
@@ -92,7 +92,10 @@ class Stats:
     enum_docs = 0
     action_docs = 0
     condition_docs = 0
-    missing_anchors = []
+    missing_anchors: list = None
+
+    def __init__(self):
+        self.missing_anchors = []
 
 
 stats = Stats()
@@ -163,11 +166,11 @@ def mrkdwn_lines(md_file):
 
 
 def fill_anchors(md_files):
-    REGEX_ANCHOR = r"^{{<\sanchor\s\"([^\"]*)\"\s>}}"
+    REGEX_ANCHOR = r'<span\s+id="([^"]*)"'
     for md_file in md_files:
         lines = mrkdwn_lines(md_file)
         for line in lines:
-            search = re.search(REGEX_ANCHOR, line, re.IGNORECASE)
+            search = re.search(REGEX_ANCHOR, line)
             if search:
                 anchor = search.group(1)
                 anchors[anchor] = md_file
@@ -190,8 +193,9 @@ def md_get_paragraph(lines, index):
         not lines[index].strip()
         or (  # whitespace
             lines[index].strip().startswith("{{")
-            and lines[index].strip().endswith("}}")  # anchors
+            and lines[index].strip().endswith("}}")  # legacy anchors
         )
+        or lines[index].strip().startswith('<span id="')  # anchors
         or (is_title(lines[index]))  # titles
     ):
         index += 1
@@ -208,7 +212,7 @@ def md_get_paragraph(lines, index):
     return index, paragraph.strip()
 
 
-def md_get_next_title(lines, index):
+def md_get_next_title(md_file, lines, index):
     while True:
         if index >= len(lines):
             return index, None
@@ -390,7 +394,11 @@ def convert_links(md_file, index, docs):
             url = anchor
         else:
             anchor_file = anchors[anchor]
-            url = f"{args.deploy_url}/{'/'.join(anchor_file.parts[1:-1])}/{anchor_file.stem}#{anchor}"
+            relative = anchor_file.relative_to(DOCS_ROOT)
+            url_path = "/" + "/".join(relative.parts[:-1])
+            if anchor_file.stem != "index":
+                url_path += f"/{anchor_file.stem}"
+            url = f"{args.deploy_url}{url_path}#{anchor}"
 
         return f"[{title}]({url})"
 
@@ -711,7 +719,7 @@ if __name__ == "__main__":
         config_component = None
         json_config = None
         # component docs:
-        # some components have .md files on folders, e.g. http_request
+        # some components have .mdx files in folders, e.g. http_request
         # so for the root component (in core) we need to use the one in root, and ignore the one in subfolder,
         # that one will be used in e.g. sensors.json (platform)
 
@@ -725,7 +733,7 @@ if __name__ == "__main__":
                 config_component = file_name
         elif content_folder != "content" and content_folder in core["platforms"]:
             if file_name == "index":
-                # fill core platform docs, from _index files in platforms folders
+                # fill core platform docs, from index files in platforms folders
                 index, docs = md_get_paragraph(lines, index)
                 core["platforms"][content_folder][JSON_DOCS] = convert_links(
                     md_file, index, docs
@@ -748,7 +756,7 @@ if __name__ == "__main__":
         title_config_vars = None
 
         while True:
-            index, title = md_get_next_title(lines, index)
+            index, title = md_get_next_title(md_file, lines, index)
             if not title:
                 break
             component_name = None

--- a/script/schema_doc.py
+++ b/script/schema_doc.py
@@ -26,6 +26,8 @@ JSON_CV_TYPE = "type"
 JSON_CV_TYPE_SCHEMA = "schema"
 JSON_ACTION = "action"
 
+DOCS_ROOT = Path(".") / "src" / "content" / "docs"
+
 args = None
 
 
@@ -395,20 +397,20 @@ def encode_doxygen(value):
 def get_md_file_ref(md_file, ref):
     # This should mimic the docref short code, see /themes/esphome-theme/layouts/shortcodes/docref.html
     if ref.startswith("/"):
-        md_parent = Path(".") / "content"
+        md_parent = DOCS_ROOT
         ref = ref[1:]
     else:
         md_parent = md_file.parent
     if ref.endswith("/"):
         ref = ref[:-1]
 
-    ref_md_path = md_parent / (ref + ".md")
+    ref_md_path = md_parent / (ref + ".mdx")
     if ref_md_path.exists():
         return ref_md_path
-    ref_md_default = md_parent / ref / "_index.md"
+    ref_md_default = md_parent / ref / "_index.mdx"
     if ref_md_default.exists():
         return ref_md_default
-    ref_md_default = Path(".") / "content" / "components" / (ref + ".md")
+    ref_md_default = DOCS_ROOT / "components" / (ref + ".mdx")
     if ref_md_default.exists():
         return ref_md_default
     return md_file  # go nowhere
@@ -745,22 +747,22 @@ if __name__ == "__main__":
     core = esphome_json["core"]
 
     md_files = []
-    for root, _, files in os.walk(Path(".") / "content" / "components"):
+    for root, _, files in os.walk(DOCS_ROOT / "components"):
         for file in files:
-            if file.endswith(".md"):
+            if file.endswith(".mdx"):
                 fullpath = Path(root, file)
                 md_files.append(fullpath)
-    md_files.append(Path(".") / "content" / "automations" / "actions.md")
+    md_files.append(DOCS_ROOT / "automations" / "actions.mdx")
 
     fill_anchors(
         md_files
         + [
             # config-lambda, config-templatable
-            Path(".") / "content" / "automations" / "templates.md",
+            DOCS_ROOT / "automations" / "templates.mdx",
             # config-id, config-pin_schema
-            Path(".") / "content" / "guides" / "configuration-types.md",
+            DOCS_ROOT / "guides" / "configuration-types.mdx",
             # api-rest
-            Path(".") / "content" / "web-api" / "_index.md",
+            DOCS_ROOT / "web-api" / "index.mdx",
         ]
     )
 
@@ -953,10 +955,14 @@ if __name__ == "__main__":
                             schema = json_config[config_component]["schemas"].get(
                                 f"{platform_name.upper()}_SCHEMA"
                             )
-                        else:
+                        elif platform_name:
                             schema = json_config[f"{config_component}.{platform_name}"][
                                 "schemas"
                             ].get("CONFIG_SCHEMA")
+                        else:
+                            print(
+                                f"{md_file}:{index} {config_component} unknown component type"
+                            )
                     else:
                         schema = None
                 if schema:


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Quick fix to get schema filled with docs from the new path and mdx extension.
Parser might need updates but with this will fix the schema gen action on https://github.com/esphome/esphome-schema/actions and get most of docs back there.
 
## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.