### PR TITLE
Restore height limit on images in component pages.

### DIFF
--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -251,6 +251,8 @@ dialog::backdrop {
   display: block;
   margin-left: auto;
   margin-right: auto;
+  max-height: 400px;
+  object-fit: contain;
 }
 
 /* Ensure Image component wrapper centers its content */


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Some components, e.g. gps, have inline images that are rather large and push useful content down the page. This PR restores the previous limit on the height of images in content generated from Markdown to resolve this problem.

Compare https://esphome.io/components/gps with https://deploy-preview-6120--esphome.netlify.app/components/gps/


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
