### PR TITLE
[esp32] Document engineering_sample option for ESP32-P4

### DIFF
--- a/src/content/docs/components/esp32.mdx
+++ b/src/content/docs/components/esp32.mdx
@@ -27,6 +27,10 @@ esp32:
 > the board configuration will be automatically filled using a standard Espressif devkit board
 > suitable for that variant. Both may be specified (for backwards compatibility) but they must define the same variant.
 
+- **engineering_sample** (*Optional*, boolean): **ESP32-P4 only.** Set to `true` if your board has engineering
+  sample silicon (rev < 3.0). When using `variant: esp32p4` without specifying a `board`, a warning is logged
+  if this option is not explicitly set. Defaults to `false`.
+
 - **flash_size** (*Optional*, string): The amount of flash memory available on the ESP32 board/module. One of `2MB`,
   `4MB`, `8MB`, `16MB` or `32MB`. Defaults to `4MB`. **Warning: specifying a size larger than that available
   on your board will cause the ESP32 to fail to boot.**


### PR DESCRIPTION
## Description:

Documents the new `engineering_sample` configuration option for ESP32-P4, which allows users to indicate whether they have pre-production engineering sample silicon (pre-rev3) or production silicon (rev3+).

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#14139

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.