### PR TITLE
[cc1101] documentation of actions allowing configuration changes

### DIFF
--- a/src/content/docs/components/cc1101.mdx
+++ b/src/content/docs/components/cc1101.mdx
@@ -190,7 +190,7 @@ This [action](/automations/actions#all-actions) changes the operating frequency 
 
 #### Configuration variables
 
-- **value** (**Required**, [frequency](/guides/configuration-types/#frequency)):
+- **value** (**Required**, frequency):
   The frequency to set. Range: `300MHz` to `928MHz`.
 
 ```yaml
@@ -272,7 +272,7 @@ This [action](/automations/actions#all-actions) changes the receive filter bandw
 
 #### Configuration variables
 
-- **value** (**Required**, [frequency](/guides/configuration-types/#frequency)):
+- **value** (**Required**, frequency):
   The filter bandwidth. Range: `58kHz` to `812kHz`.
 
 ### `cc1101.set_fsk_deviation` Action
@@ -281,7 +281,7 @@ This [action](/automations/actions#all-actions) changes the FSK/GFSK frequency d
 
 #### Configuration variables
 
-- **value** (**Required**, [frequency](/guides/configuration-types/#frequency)):
+- **value** (**Required**, frequency):
   The frequency deviation. Range: `1.5kHz` to `381kHz`.
 
 ### `cc1101.set_msk_deviation` Action
@@ -306,7 +306,7 @@ This [action](/automations/actions#all-actions) changes the channel spacing at r
 
 #### Configuration variables
 
-- **value** (**Required**, [frequency](/guides/configuration-types/#frequency)):
+- **value** (**Required**, frequency):
   The spacing between channels. Range: `25kHz` to `405kHz`.
 
 ### `cc1101.set_if_frequency` Action
@@ -315,7 +315,7 @@ This [action](/automations/actions#all-actions) changes the intermediate frequen
 
 #### Configuration variables
 
-- **value** (**Required**, [frequency](/guides/configuration-types/#frequency)):
+- **value** (**Required**, frequency):
   The intermediate frequency. Range: `25kHz` to `788kHz`.
 
 ## Integration with Remote Receiver/Transmitter

--- a/src/content/docs/components/cc1101.mdx
+++ b/src/content/docs/components/cc1101.mdx
@@ -154,13 +154,6 @@ cc1101:
 
 ## Actions
 
-There are different kind of actions
-
-  * actions controlling the radio state (`begin_rx`, `begin_tx`, `set_idle`),
-  * an acion to transmit a package (`send_packet`), and
-  * actions allowing re-configuration of [general](#general-settings) and [tuner](#tuner-settings) settings on the fly
-    (all remaining `set_*` actions)
-
 ### `cc1101.begin_tx` Action
 
 This [action](/automations/actions#all-actions) puts the radio into TX mode and switches `gdo0_pin` to output mode.
@@ -193,77 +186,137 @@ on_...:
 
 ### `cc1101.set_frequency` Action
 
-This [action](/automations/actions#all-actions) allows setting the frequency.
+This [action](/automations/actions#all-actions) changes the operating frequency at runtime.
 
-### `cc1101.set_output_power` Action
+#### Configuration variables
 
-This [action](/automations/actions#all-actions) allows setting the output power.
-
-### `cc1101.set_modulation_type` Action
-
-This [action](/automations/actions#all-actions) allows setting the modulation type.
-
-Example for specifying the value directly and with a lambda:
+- **value** (**Required**, [frequency](/guides/configuration-types/#frequency)):
+  The frequency to set. Range: `300MHz` to `928MHz`.
 
 ```yaml
 on_...:
-  - cc1101.set_modulation_type: !lambda |-
-      return cc1101::Modulation::MODULATION_2_FSK;
-  - cc1101.set_modulation_type:
-      value: "4-FSK"
+  - cc1101.set_frequency: 433.92MHz
+  - cc1101.set_frequency:
+      value: !lambda "return 868.0e6;"
+```
+
+### `cc1101.set_output_power` Action
+
+This [action](/automations/actions#all-actions) changes the transmission power at runtime.
+
+#### Configuration variables
+
+- **value** (**Required**, float): The output power in dBm. Range: `-30` to `11`.
+
+### `cc1101.set_modulation_type` Action
+
+This [action](/automations/actions#all-actions) changes the modulation type at runtime.
+
+#### Configuration variables
+
+- **value** (**Required**, enum): The modulation type.
+  Options: `ASK/OOK`, `2-FSK`, `4-FSK`, `GFSK`, `MSK`.
+
+```yaml
+on_...:
   - cc1101.set_modulation_type: "GFSK"
+  - cc1101.set_modulation_type:
+      value: !lambda |-
+        return cc1101::Modulation::MODULATION_2_FSK;
 ```
 
 ### `cc1101.set_symbol_rate` Action
 
-This [action](/automations/actions#all-actions) allows setting the symbol rate.
+This [action](/automations/actions#all-actions) changes the symbol rate at runtime.
+
+#### Configuration variables
+
+- **value** (**Required**, float): The symbol rate in baud. Range: `600` to `500000`.
 
 ### `cc1101.set_rx_attenuation` Action
 
-This [action](/automations/actions#all-actions) allows setting the RX attenuation.
+This [action](/automations/actions#all-actions) changes the internal RX attenuation at runtime.
 
-Example for specifying the value directly and with a lambda:
+#### Configuration variables
+
+- **value** (**Required**, enum): The attenuation level.
+  Options: `0dB`, `6dB`, `12dB`, `18dB`.
 
 ```yaml
 on_...:
-  - cc1101.set_rx_attenuation: !lambda |-
-      return cc1101::RxAttenuation::RX_ATTENUATION_0DB;
-  - cc1101.set_rx_attenuation:
-      value: "6dB"
   - cc1101.set_rx_attenuation: "12dB"
+  - cc1101.set_rx_attenuation:
+      value: !lambda |-
+        return cc1101::RxAttenuation::RX_ATTENUATION_0DB;
 ```
 
 ### `cc1101.set_dc_blocking_filter` Action
 
-This [action](/automations/actions#all-actions) allows enabling or disabling the DC blocking filter.
+This [action](/automations/actions#all-actions) enables or disables the DC blocking filter at runtime.
+
+#### Configuration variables
+
+- **value** (**Required**, boolean): `true` to enable, `false` to disable.
 
 ### `cc1101.set_manchester` Action
 
-This [action](/automations/actions#all-actions) allows enbling or disabling manchester encoding.
+This [action](/automations/actions#all-actions) enables or disables Manchester encoding at runtime.
+
+#### Configuration variables
+
+- **value** (**Required**, boolean): `true` to enable, `false` to disable.
 
 ### `cc1101.set_filter_bandwidth` Action
 
-This [action](/automations/actions#all-actions) allows setting the filter bandwidth.
+This [action](/automations/actions#all-actions) changes the receive filter bandwidth at runtime.
+
+#### Configuration variables
+
+- **value** (**Required**, [frequency](/guides/configuration-types/#frequency)):
+  The filter bandwidth. Range: `58kHz` to `812kHz`.
 
 ### `cc1101.set_fsk_deviation` Action
 
-This [action](/automations/actions#all-actions) allows setting the FSK deviation.
+This [action](/automations/actions#all-actions) changes the FSK/GFSK frequency deviation at runtime.
+
+#### Configuration variables
+
+- **value** (**Required**, [frequency](/guides/configuration-types/#frequency)):
+  The frequency deviation. Range: `1.5kHz` to `381kHz`.
 
 ### `cc1101.set_msk_deviation` Action
 
-This [action](/automations/actions#all-actions) allows setting the MSK deviation.
+This [action](/automations/actions#all-actions) changes the MSK deviation index at runtime.
+
+#### Configuration variables
+
+- **value** (**Required**, int): The deviation index. Range: `1` to `8`.
 
 ### `cc1101.set_channel` Action
 
-This [action](/automations/actions#all-actions) allows setting the channel.
+This [action](/automations/actions#all-actions) changes the channel number at runtime.
+
+#### Configuration variables
+
+- **value** (**Required**, int): The channel number. Range: `0` to `255`.
 
 ### `cc1101.set_channel_spacing` Action
 
-This [action](/automations/actions#all-actions) allows setting the channel spacing.
+This [action](/automations/actions#all-actions) changes the channel spacing at runtime.
+
+#### Configuration variables
+
+- **value** (**Required**, [frequency](/guides/configuration-types/#frequency)):
+  The spacing between channels. Range: `25kHz` to `405kHz`.
 
 ### `cc1101.set_if_frequency` Action
 
-This [action](/automations/actions#all-actions) allows setting the intermediate frequency.
+This [action](/automations/actions#all-actions) changes the intermediate frequency at runtime.
+
+#### Configuration variables
+
+- **value** (**Required**, [frequency](/guides/configuration-types/#frequency)):
+  The intermediate frequency. Range: `25kHz` to `788kHz`.
 
 ## Integration with Remote Receiver/Transmitter
 

--- a/src/content/docs/components/cc1101.mdx
+++ b/src/content/docs/components/cc1101.mdx
@@ -154,6 +154,13 @@ cc1101:
 
 ## Actions
 
+There are different kind of actions
+
+  * actions controlling the radio state (`begin_rx`, `begin_tx`, `set_idle`),
+  * an acion to transmit a package (`send_packet`), and
+  * actions allowing re-configuration of [general](#general-settings) and [tuner](#tuner-settings) settings on the fly
+    (all remaining `set_*` actions)
+
 ### `cc1101.begin_tx` Action
 
 This [action](/automations/actions#all-actions) puts the radio into TX mode and switches `gdo0_pin` to output mode.
@@ -183,6 +190,80 @@ on_...:
   - cc1101.send_packet:
       data: [0x12, 0x34, 0x56, 0x78]
 ```
+
+### `cc1101.set_frequency` Action
+
+This [action](/automations/actions#all-actions) allows setting the frequency.
+
+### `cc1101.set_output_power` Action
+
+This [action](/automations/actions#all-actions) allows setting the output power.
+
+### `cc1101.set_modulation_type` Action
+
+This [action](/automations/actions#all-actions) allows setting the modulation type.
+
+Example for specifying the value directly and with a lambda:
+
+```yaml
+on_...:
+  - cc1101.set_modulation_type: !lambda |-
+      return cc1101::Modulation::MODULATION_2_FSK;
+  - cc1101.set_modulation_type:
+      value: "4-FSK"
+  - cc1101.set_modulation_type: "GFSK"
+```
+
+### `cc1101.set_symbol_rate` Action
+
+This [action](/automations/actions#all-actions) allows setting the symbol rate.
+
+### `cc1101.set_rx_attenuation` Action
+
+This [action](/automations/actions#all-actions) allows setting the RX attenuation.
+
+Example for specifying the value directly and with a lambda:
+
+```yaml
+on_...:
+  - cc1101.set_rx_attenuation: !lambda |-
+      return cc1101::RxAttenuation::RX_ATTENUATION_0DB;
+  - cc1101.set_rx_attenuation:
+      value: "6dB"
+  - cc1101.set_rx_attenuation: "12dB"
+```
+
+### `cc1101.set_dc_blocking_filter` Action
+
+This [action](/automations/actions#all-actions) allows enabling or disabling the DC blocking filter.
+
+### `cc1101.set_manchester` Action
+
+This [action](/automations/actions#all-actions) allows enbling or disabling manchester encoding.
+
+### `cc1101.set_filter_bandwidth` Action
+
+This [action](/automations/actions#all-actions) allows setting the filter bandwidth.
+
+### `cc1101.set_fsk_deviation` Action
+
+This [action](/automations/actions#all-actions) allows setting the FSK deviation.
+
+### `cc1101.set_msk_deviation` Action
+
+This [action](/automations/actions#all-actions) allows setting the MSK deviation.
+
+### `cc1101.set_channel` Action
+
+This [action](/automations/actions#all-actions) allows setting the channel.
+
+### `cc1101.set_channel_spacing` Action
+
+This [action](/automations/actions#all-actions) allows setting the channel spacing.
+
+### `cc1101.set_if_frequency` Action
+
+This [action](/automations/actions#all-actions) allows setting the intermediate frequency.
 
 ## Integration with Remote Receiver/Transmitter
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** fixes: none

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#14141

## Checklist

- [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
