### PR TITLE
[wifi] Add band_mode documentation for ESP32-C5 dual-band WiFi

### DIFF
--- a/src/content/docs/components/wifi.mdx
+++ b/src/content/docs/components/wifi.mdx
@@ -128,6 +128,10 @@ wifi:
 - **enable_btm** (*Optional*, bool): Only on `esp32`. Enable 802.11v BSS Transition Management support.
 - **enable_rrm** (*Optional*, bool): Only on `esp32`. Enable 802.11k Radio Resource Management support.
 
+- **band_mode** (*Optional*, string): Only on ESP32-C5. Controls which WiFi frequency band the device uses.
+  Possible values are `AUTO` (use both 2.4 GHz and 5 GHz), `2.4GHZ` (2.4 GHz only), and `5GHZ` (5 GHz only).
+  If not specified, the device uses the ESP-IDF default behavior.
+
 - **post_connect_roaming** (*Optional*, bool): Enable basic post-connect
   roaming for stationary devices. After connecting to a non-hidden network,
   the device will periodically check for better access points with the same

--- a/src/content/docs/components/wifi.mdx
+++ b/src/content/docs/components/wifi.mdx
@@ -128,7 +128,7 @@ wifi:
 - **enable_btm** (*Optional*, bool): Only on `esp32`. Enable 802.11v BSS Transition Management support.
 - **enable_rrm** (*Optional*, bool): Only on `esp32`. Enable 802.11k Radio Resource Management support.
 
-- **band_mode** (*Optional*, string): Only on ESP32-C5. Controls which WiFi frequency band the device uses.
+- **band_mode** (*Optional*, string): Only on `esp32-c5`. Controls which WiFi frequency band the device uses.
   Possible values are `AUTO` (use both 2.4 GHz and 5 GHz), `2.4GHZ` (2.4 GHz only), and `5GHZ` (5 GHz only).
   If not specified, the device uses the ESP-IDF default behavior.
 

--- a/src/content/docs/components/wifi.mdx
+++ b/src/content/docs/components/wifi.mdx
@@ -130,7 +130,7 @@ wifi:
 
 - **band_mode** (*Optional*, string): Only on `esp32-c5`. Controls which WiFi frequency band the device uses.
   Possible values are `AUTO` (use both 2.4 GHz and 5 GHz), `2.4GHZ` (2.4 GHz only), and `5GHZ` (5 GHz only).
-  If not specified, the defaults to `AUTO`.
+  If not specified, it defaults to `AUTO`.
 
 - **post_connect_roaming** (*Optional*, bool): Enable basic post-connect
   roaming for stationary devices. After connecting to a non-hidden network,

--- a/src/content/docs/components/wifi.mdx
+++ b/src/content/docs/components/wifi.mdx
@@ -130,7 +130,7 @@ wifi:
 
 - **band_mode** (*Optional*, string): Only on `esp32-c5`. Controls which WiFi frequency band the device uses.
   Possible values are `AUTO` (use both 2.4 GHz and 5 GHz), `2.4GHZ` (2.4 GHz only), and `5GHZ` (5 GHz only).
-  If not specified, the device uses the ESP-IDF default behavior.
+  If not specified, the defaults to `AUTO`.
 
 - **post_connect_roaming** (*Optional*, bool): Enable basic post-connect
   roaming for stationary devices. After connecting to a non-hidden network,


### PR DESCRIPTION
## Description

Add documentation for the new `band_mode` configuration option on the WiFi component, which allows ESP32-C5 users to control WiFi frequency band selection (`AUTO`, `2.4GHZ`, `5GHZ`).

**Related issue (if applicable):** fixes https://github.com/esphome/esphome/issues/13389

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#14148

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.