### PR TITLE
2026.2.1

### DIFF
--- a/data/version.yaml
+++ b/data/version.yaml
@@ -1,2 +1,2 @@
-release: 2026.2.0
+release: 2026.2.1
 version: '2026.2'

--- a/src/content/docs/changelog/2026.2.0.mdx
+++ b/src/content/docs/changelog/2026.2.0.mdx
@@ -260,6 +260,33 @@ For detailed migration guides and API documentation, see the [ESPHome Developers
 
 {/* markdownlint-disable MD013 */}
 
+## Release 2026.2.1 - February 20
+
+<details>
+<summary></summary>
+
+- [esp32_ble_server] fix infinitely large characteristic value [esphome#14011](https://github.com/esphome/esphome/pull/14011) by [@Rapsssito](https://github.com/Rapsssito)
+- [udp] Register socket consumption for CONFIG_LWIP_MAX_SOCKETS [esphome#14068](https://github.com/esphome/esphome/pull/14068) by [@bdraco](https://github.com/bdraco)
+- [web_server] Double socket allocation to prevent connection exhaustion [esphome#14067](https://github.com/esphome/esphome/pull/14067) by [@bdraco](https://github.com/bdraco)
+- [pulse_counter] Fix compilation on ESP32-C6/C5/H2/P4 [esphome#14070](https://github.com/esphome/esphome/pull/14070) by [@bdraco](https://github.com/bdraco)
+- [web_server] Fix water_heater JSON key names and move traits to DETAIL_ALL [esphome#14064](https://github.com/esphome/esphome/pull/14064) by [@bdraco](https://github.com/bdraco)
+- [ld2420] Use constexpr for compile-time constants [esphome#14079](https://github.com/esphome/esphome/pull/14079) by [@bdraco](https://github.com/bdraco)
+- [e131] Fix E1.31 on ESP8266 and RP2040 by restoring WiFiUDP support [esphome#14086](https://github.com/esphome/esphome/pull/14086) by [@bdraco](https://github.com/bdraco)
+- [socket] Fix IPv6 compilation error on host platform [esphome#14101](https://github.com/esphome/esphome/pull/14101) by [@swoboda1337](https://github.com/swoboda1337)
+- [ethernet] Improve clk_mode deprecation warning with actionable YAML [esphome#14104](https://github.com/esphome/esphome/pull/14104) by [@swoboda1337](https://github.com/swoboda1337)
+- [pulse_counter] Fix build failure when use_pcnt is false [esphome#14111](https://github.com/esphome/esphome/pull/14111) by [@swoboda1337](https://github.com/swoboda1337)
+- [esp32_ble] Enable CONFIG_BT_RELEASE_IRAM on ESP32-C2 [esphome#14109](https://github.com/esphome/esphome/pull/14109) by [@bdraco](https://github.com/bdraco)
+- [safe_mode] Log brownout as reset reason on OTA rollback [esphome#14113](https://github.com/esphome/esphome/pull/14113) by [@swoboda1337](https://github.com/swoboda1337)
+- [wifi] Sync output_power with PHY max TX power to prevent brownout [esphome#14118](https://github.com/esphome/esphome/pull/14118) by [@swoboda1337](https://github.com/swoboda1337)
+- [uart] Always call pin setup for UART0 default pins on ESP-IDF [esphome#14130](https://github.com/esphome/esphome/pull/14130) by [@bdraco](https://github.com/bdraco)
+- [pulse_counter] Fix PCNT glitch filter calculation off by 1000x [esphome#14132](https://github.com/esphome/esphome/pull/14132) by [@swoboda1337](https://github.com/swoboda1337)
+- [ld2450] Add frame header synchronization to readline_() [esphome#14135](https://github.com/esphome/esphome/pull/14135) by [@swoboda1337](https://github.com/swoboda1337)
+- [ld2410] Add frame header synchronization to readline_() [esphome#14136](https://github.com/esphome/esphome/pull/14136) by [@swoboda1337](https://github.com/swoboda1337)
+- [ld2420] Increase MAX_LINE_LENGTH to allow footer-based resync [esphome#14137](https://github.com/esphome/esphome/pull/14137) by [@swoboda1337](https://github.com/swoboda1337)
+- [ld2410/ld2450] Replace header sync with buffer size increase for frame resync [esphome#14138](https://github.com/esphome/esphome/pull/14138) by [@swoboda1337](https://github.com/swoboda1337)
+
+</details>
+
 ## Full list of changes
 
 The lists below are grouped by tag and may contain duplicates across sections.

--- a/src/content/docs/guides/faq.mdx
+++ b/src/content/docs/guides/faq.mdx
@@ -437,6 +437,30 @@ Here are some steps that may help mitigate the issue:
   may mitigate disconnections at the expense of increasing power (and possibly battery) usage of other devices also
   using power save modes.
 
+<span id="brownout-detector-was-triggered"></span>
+
+## "Brownout detector was triggered"
+
+This message means your ESP32's voltage dropped below a safe level, usually during a WiFi transmit burst where
+current can spike to 300-500mA. The most common causes:
+
+- **Inadequate power supply** -- USB ports, thin cables, or cheap adapters may not deliver enough current.
+- **Long or thin wiring** -- voltage drops over distance, especially with thin USB cables.
+- **Other peripherals drawing power** -- sensors, LEDs, or relays sharing the same supply.
+
+### Quick fixes
+
+1. **Reduce WiFi transmit power** -- this is the most effective single change:
+
+```yaml
+wifi:
+  output_power: 13dB  # default is 20dB
+```
+
+2. **Use a quality power supply** -- a dedicated 5V/2A supply with a short, thick USB cable.
+
+3. **Add a capacitor** -- a 100-1000µF electrolytic capacitor across the 3.3V and GND pins can absorb brief current spikes.
+
 ## Component states not restored after reboot
 
 Some components, such as `climate` and `switch` components, are able to restore their states following a

--- a/src/content/docs/guides/supporters.mdx
+++ b/src/content/docs/guides/supporters.mdx
@@ -881,6 +881,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Harrison Jones (@harrisonhjones)](https://github.com/harrisonhjones)
 - [HarvsG (@HarvsG)](https://github.com/HarvsG)
 - [Charles Thompson (@haryadoon)](https://github.com/haryadoon)
+- [Christopher Loessl (@hashier)](https://github.com/hashier)
 - [Ha Thach (@hathach)](https://github.com/hathach)
 - [Cong Hoang Nguyen (@HcNguyen111)](https://github.com/HcNguyen111)
 - [hcoohb (@hcoohb)](https://github.com/hcoohb)
@@ -959,6 +960,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Ingurum (@Ingurum)](https://github.com/Ingurum)
 - [Marc J (@InvncibiltyCloak)](https://github.com/InvncibiltyCloak)
 - [IoT-devices LLC (@iotdevicesdev)](https://github.com/iotdevicesdev)
+- [iret33 (@iret33)](https://github.com/iret33)
 - [irgendwienet (@irgendwienet)](https://github.com/irgendwienet)
 - [Ivo Roefs (@ironirc)](https://github.com/ironirc)
 - [irtimaled (@irtimaled)](https://github.com/irtimaled)
@@ -2338,4 +2340,4 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Christian Zufferey (@zuzu59)](https://github.com/zuzu59)
 - [Zynth-dev (@Zynth-dev)](https://github.com/Zynth-dev)
 
-*This page was last updated February 19, 2026.*
+*This page was last updated February 20, 2026.*


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- [faq] Add brownout detector troubleshooting section [docs#6122](https://github.com/esphome/esphome-docs/pull/6122)
- Restore height limit on images in component pages. [docs#6120](https://github.com/esphome/esphome-docs/pull/6120)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
