### PR TITLE
Fix schema_doc anchor resolution after Starlight migration

### DIFF
--- a/script/schema_doc.py
+++ b/script/schema_doc.py
@@ -42,8 +42,10 @@ def slugify(text: str) -> str:
     text = text.encode("ascii", "ignore").decode("ascii")
     # Lowercase
     text = text.lower()
-    # Replace non-alphanumeric sequences with hyphen
-    text = re.sub(r"[^a-z0-9]+", "-", text)
+    # Remove non-word characters (keep alphanumeric, underscores, whitespace, hyphens)
+    text = re.sub(r"[^\w\s-]", "", text)
+    # Replace whitespace and hyphens with single hyphen
+    text = re.sub(r"[-\s]+", "-", text)
     # Trim hyphens from ends
     text = text.strip("-")
     return text
@@ -166,14 +168,19 @@ def mrkdwn_lines(md_file):
 
 
 def fill_anchors(md_files):
-    REGEX_ANCHOR = r'<span\s+id="([^"]*)"'
+    REGEX_SPAN_ANCHOR = r'<span\s+id="([^"]*)"'
+    REGEX_HEADING = r"^#{1,6}\s+(.*)"
     for md_file in md_files:
         lines = mrkdwn_lines(md_file)
         for line in lines:
-            search = re.search(REGEX_ANCHOR, line)
+            search = re.search(REGEX_SPAN_ANCHOR, line)
             if search:
-                anchor = search.group(1)
-                anchors[anchor] = md_file
+                anchors[search.group(1)] = md_file
+            search = re.search(REGEX_HEADING, line)
+            if search:
+                slug = slugify(search.group(1))
+                if slug not in anchors:
+                    anchors[slug] = md_file
 
 
 def get_doc_title(md_file):


### PR DESCRIPTION
## Description

Follow-up to #6119. The schema doc generator was unable to resolve most anchor links because:

1. **`fill_anchors` only matched `<span id="">` anchors** — many docs reference heading-generated slugs via `[text](#heading-slug)` links, which were never collected. This adds heading slug extraction to `fill_anchors`, reducing missing anchors from 28 to 0.

2. **`slugify` didn't match Starlight's algorithm** — the old implementation converted underscores to hyphens (e.g. `` `on_face_scan_matched` Trigger `` → `on-face-scan-matched-trigger`), but Starlight preserves underscores (`on_face_scan_matched-trigger`). Aligned with the same algorithm used in `lint.mjs`.

**Testing:** Ran the full schema generation pipeline locally (`build_language_schema.py` + `schema_doc.py`). Results: 526 platform docs, 5421 props, 0 missing anchors (down from 28).

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.