### PR TITLE
[max7219digit] Fix incorrect action names in documentation

### DIFF
--- a/src/content/docs/components/display/max7219digit.mdx
+++ b/src/content/docs/components/display/max7219digit.mdx
@@ -85,25 +85,25 @@ display:
 
 The following actions are replicas of the LAMBDA functions shown in the next section.
 
-### `MAX7219.invert_on` & `MAX7219.invert_off` Action
+### `max7219digit.invert_on` / `max7219digit.invert_off` Action
 
-This action `MAX7219.invert_on` will invert the display. So background pixels are on and texts pixels are
-off. `MAX7219.invert_off` sets the display back to normal. The background pixels are only set at the next update, the pixels drawn in
-the various function like print, line, etc. are directly influenced by the invert command.
+This action `max7219digit.invert_on` will invert the display. So background pixels are on and text pixels are
+off. `max7219digit.invert_off` sets the display back to normal. The background pixels are only set at the next update, the pixels drawn in
+the various functions like print, line, etc. are directly influenced by the invert command.
 
-### `MAX7219.turn_on` & `MAX7219.turn_off` Action
+### `max7219digit.turn_on` / `max7219digit.turn_off` Action
 
-The display can be switched on and off "dynamically" with the actions `MAX7219.turn_on` & `MAX7219.turn_off`.
+The display can be switched on and off "dynamically" with the actions `max7219digit.turn_on` / `max7219digit.turn_off`.
 
-## `MAX7219.reverse_on` & `MAX7219.reverse_off` Action
+### `max7219digit.reverse_on` / `max7219digit.reverse_off` Action
 
-With this actions you can reverse the display direction from left to right to right to left.
+With these actions you can reverse the display direction from left-to-right to right-to-left.
 
-## `MAX7219.intensity` Action
+### `max7219digit.intensity` Action
 
-The intensity of the screen can be set "dynamically" within the lambda code with the following command: it.intensity(`0` .. `15`  ).
+The intensity of the screen can be set "dynamically" with this action.
 
-- **intensity** (int): The intensity with which the MAX7219 should drive the outputs. Range is
+- **intensity** (*Optional*, int): The intensity with which the MAX7219 should drive the outputs. Range is
   from `0`, least intense to `15` the brightest. Defaults to `15`.
 
 <span id="display-max7219digit_lambda"></span>


### PR DESCRIPTION
## Description

The documented action names for the max7219digit component incorrectly used the `MAX7219.*` prefix (e.g. `MAX7219.reverse_on`, `MAX7219.invert_on`). The actual registered action names use the `max7219digit.*` prefix (e.g. `max7219digit.reverse_on`, `max7219digit.invert_on`).

This also fixes the heading levels for the `reverse` and `intensity` action sections which were `##` instead of `###` like the other action headings.

**Related issue (if applicable):** fixes https://github.com/esphome/esphome/issues/14154

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- N/A (note: there is also a typo in the code where actions are registered as `max7129digit.*` instead of `max7219digit.*` — that will need a separate esphome PR)

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.