### PR TITLE
[lint] Add checks for uppercase automation names and & separator

### DIFF
--- a/lint.mjs
+++ b/lint.mjs
@@ -423,7 +423,7 @@ function checkAutomationHeadings(fname, content) {
     const upperMatch = line.match(/^#{2,4}\s+`([^`]*[A-Z][^`]*)`/);
     if (upperMatch) {
       const name = upperMatch[1];
-      if (name.match(/^[A-Za-z0-9_]+\.[A-Za-z0-9_.]+$/)) {
+      if (name.match(/^\w+\.[\w.]+$/)) {
         addError(fname, lineno, 1,
           `Action/Condition/Trigger name "\`${name}\`" contains uppercase letters. ` +
           'ESPHome automation names should be all lowercase (e.g. `component.action_name`).');
@@ -432,7 +432,7 @@ function checkAutomationHeadings(fname, content) {
 
     // Check 6: Use `/` not `&` to separate paired automation names in headings
     // e.g. ### `foo.bar` & `foo.baz` Action (should use `/`)
-    if (line.match(/^#{2,4}\s+`[^`]+`\s+&\s+`[^`]+`/)) {
+    if (line.match(/^#{2,4}\s+`\w+(\.\w+)+`\s+&\s+`\w+(\.\w+)+`/)) {
       addError(fname, lineno, 1,
         'Use `/` instead of `&` to separate paired automation names in headings ' +
         '(e.g. `foo.on` / `foo.off` Action).');

--- a/lint.mjs
+++ b/lint.mjs
@@ -420,7 +420,7 @@ function checkAutomationHeadings(fname, content) {
 
     // Check 5: Uppercase letters in backticked automation names (domain.name pattern)
     // e.g. ### `MAX7219.invert_on` Action (should be `max7219.invert_on`)
-    const upperMatch = line.match(/^#{2,4}\s+`([^`]*[A-Z][^`]*)`/);
+    const upperMatch = line.match(/^#{2,4}\s+`([\w.]*[A-Z][\w.]*)`/);
     if (upperMatch) {
       const name = upperMatch[1];
       if (name.match(/^\w+\.[\w.]+$/)) {

--- a/lint.mjs
+++ b/lint.mjs
@@ -417,6 +417,26 @@ function checkAutomationHeadings(fname, content) {
       addError(fname, lineno, 1,
         'Action/Condition suffix should be capitalized. Use "Action" or "Condition" (not lowercase).');
     }
+
+    // Check 5: Uppercase letters in backticked automation names (domain.name pattern)
+    // e.g. ### `MAX7219.invert_on` Action (should be `max7219.invert_on`)
+    const upperMatch = line.match(/^#{2,4}\s+`([^`]*[A-Z][^`]*)`/);
+    if (upperMatch) {
+      const name = upperMatch[1];
+      if (name.match(/^[A-Za-z0-9_]+\.[A-Za-z0-9_.]+$/)) {
+        addError(fname, lineno, 1,
+          `Action/Condition/Trigger name "\`${name}\`" contains uppercase letters. ` +
+          'ESPHome automation names should be all lowercase (e.g. `component.action_name`).');
+      }
+    }
+
+    // Check 6: Use `/` not `&` to separate paired automation names in headings
+    // e.g. ### `foo.bar` & `foo.baz` Action (should use `/`)
+    if (line.match(/^#{2,4}\s+`[^`]+`\s+&\s+`[^`]+`/)) {
+      addError(fname, lineno, 1,
+        'Use `/` instead of `&` to separate paired automation names in headings ' +
+        '(e.g. `foo.on` / `foo.off` Action).');
+    }
   }
 }
 

--- a/lint.mjs
+++ b/lint.mjs
@@ -420,7 +420,7 @@ function checkAutomationHeadings(fname, content) {
 
     // Check 5: Uppercase letters in backticked automation names (domain.name pattern)
     // e.g. ### `MAX7219.invert_on` Action (should be `max7219.invert_on`)
-    const upperMatch = line.match(/^#{2,4}\s+`([\w.]*[A-Z][\w.]*)`/);
+    const upperMatch = line.match(/^#{2,4}\s+.*`([\w.]*[A-Z][\w.]*)`/);
     if (upperMatch) {
       const name = upperMatch[1];
       if (name.match(/^\w+\.[\w.]+$/)) {


### PR DESCRIPTION
## Description

Add two new lint checks to `checkAutomationHeadings` in `lint.mjs` to catch issues like those found in #6131:

- **Check 5**: Flag uppercase letters in backticked automation names (e.g. `MAX7219.invert_on` should be `max7219.invert_on`). ESPHome automation names are always lowercase.
- **Check 6**: Flag `&` separator between paired automation names in headings. The convention is `/` (e.g. `foo.on` / `foo.off` Action).

Both of these would have caught the issues in the max7219digit docs before they were merged.

**Related issue (if applicable):** relates to https://github.com/esphome/esphome/issues/14154

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- N/A

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.