### PR TITLE
[mqtt] Remove broken ESP8266 ssl_fingerprints documentation

### DIFF
--- a/src/content/docs/components/mqtt.mdx
+++ b/src/content/docs/components/mqtt.mdx
@@ -93,10 +93,6 @@ mqtt:
 - **shutdown_message** (*Optional*, [MQTTMessage](#mqtt-message)): The message to send when
   the node shuts down and the connection is closed cleanly. See [Last Will And Birth Messages](#mqtt-last_will_birth) for more information.
 
-- **ssl_fingerprints** (*Optional*, list): Only on ESP8266. A list of SHA1 hashes used
-  for verifying SSL connections. See [SSL Fingerprints](#mqtt-ssl_fingerprints).
-  for more information.
-
 - **certificate_authority** (*Optional*, string): Only on ESP32. CA certificate in PEM format. See
   [TLS (ESP32)](#mqtt-tls-idf) for more information.
 
@@ -357,33 +353,6 @@ mqtt:
 If the birth message and last will message have empty topics or topics
 that are different from each other, availability reporting will be
 disabled.
-
-<span id="mqtt-ssl_fingerprints"></span>
-
-## SSL Fingerprints
-
-On the ESP8266 you have the option to use SSL connections for MQTT. This feature
-will get expanded to the ESP32 once the base library, AsyncTCP, supports it. Please
-note that the SSL feature only checks the SHA1 hash of the SSL certificate to verify
-the integrity of the connection, so every time the certificate changes, you'll have to
-update the fingerprints variable. Additionally, SHA1 is known to be partially insecure
-and with some computing power the fingerprint can be faked.
-
-To get this fingerprint, first put the broker and port options in the configuration and
-then run the `mqtt-fingerprint` script of ESPHome to get the certificate:
-
-```bash
-esphome mqtt-fingerprint livingroom.yaml
-> SHA1 Fingerprint: a502ff13999f8b398ef1834f1123650b3236fc07
-> Copy above string into mqtt.ssl_fingerprints section of livingroom.yaml
-```
-
-```yaml
-mqtt:
-  # ...
-  ssl_fingerprints:
-    - a502ff13999f8b398ef1834f1123650b3236fc07
-```
 
 <span id="mqtt-tls-idf"></span>
 

--- a/src/content/docs/guides/cli.mdx
+++ b/src/content/docs/guides/cli.mdx
@@ -189,11 +189,6 @@ node).
 
 The `esphome wizard <CONFIG>` command starts the ESPHome configuration creation wizard.
 
-### `mqtt-fingerprint` Command
-
-The `esphome mqtt-fingerprint <CONFIG>` command shows the MQTT SSL fingerprints of the remote used
-for SSL MQTT connections. See [SSL Fingerprints](/components/mqtt#mqtt-ssl_fingerprints).
-
 ### `version` Command
 
 The `esphome version` command shows the current ESPHome version and exits.

--- a/src/content/docs/guides/security_best_practices.mdx
+++ b/src/content/docs/guides/security_best_practices.mdx
@@ -420,9 +420,6 @@ mqtt:
   broker: !secret mqtt_broker
   username: !secret mqtt_username
   password: !secret mqtt_password
-  # For ESP8266: Use TLS with SSL fingerprints
-  # ssl_fingerprints:
-  #   - "SHA1_FINGERPRINT_HERE"
   # For ESP32 with esp-idf: Use TLS with certificate authority
   # certificate_authority: ca_cert.pem
 


### PR DESCRIPTION
# What does this implement/fix?

Remove documentation for the `ssl_fingerprints` MQTT configuration option, the `mqtt-fingerprint` CLI command, and related references in the security best practices guide.

This accompanies esphome/esphome#14182 which removes the code. The feature has been non-functional since the ESP8266 Arduino Core dropped axTLS in favor of BearSSL.

The intent here isn't to remove SSL fingerprint support because we don't want it. it's to stop misleading users. Right now the option is documented and accepted in config, but it has never worked with any recent Arduino Core. Users spend hours trying to get it working only to hit a wall of compilation errors. Removing it from the config and docs saves people that frustration and makes it clear what the actual state of things is.

If someone wants to champion updating the underlying libraries (ESPAsyncTCP would need its SSL layer rewritten for BearSSL), we'd happily accept a PR to add this back.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- esphome/esphome#14182

## Checklist:
  - [x] The documentation has been tested and renders correctly.