### PR TITLE
[nRF52] Small wording adjustment for MCUBoot flashing

### DIFF
--- a/src/content/docs/components/nrf52.mdx
+++ b/src/content/docs/components/nrf52.mdx
@@ -30,9 +30,22 @@ The nRF52840 requires a bootloader, with two supported options: `MCUboot` and `A
 
 Examples of low power [nRF52840 boards](https://github.com/joric/nrfmicro/wiki).
 
+## Flashing with MCUboot
+
+Flashing with MCUboot requires an SWD connection, for which a programmer is necessary. A cheap ST-Link V2 can be utilized.
+
+1. Connect the board to the PC via SWD.
+1. Run `esphome upload yourfile.yaml --device PYOCD`.
+
+```yaml
+# Example configuration entry
+nrf52:
+  board: adafruit_feather_nrf52840
+```
+
 ## Flashing with Adafruit nRF52 Bootloader
 
-For Adafruit, ProMicro nRF52840, Seeed Studio XIAO BLE boards flashing via a flash drive.
+For flashing via a flash drive.
 
 1. Connect the board to the PC via USB.
 1. Quickly short the reset pin to ground twice.
@@ -48,19 +61,6 @@ This bootloader supports updates over USB CDC.
 # Example configuration entry
 nrf52:
   board: adafruit_itsybitsy_nrf52840
-```
-
-## Flashing with MCUboot
-
-Flashing this bootloader requires an SWD connection, for which a programmer is necessary. A cheap ST-Link V2 can be utilized.
-
-1. Connect the board to the PC via SWD.
-1. Run `esphome upload yourfile.yaml --device PYOCD`.
-
-```yaml
-# Example configuration entry
-nrf52:
-  board: adafruit_feather_nrf52840
 ```
 
 ## GPIO Pin Numbering

--- a/src/content/docs/components/nrf52.mdx
+++ b/src/content/docs/components/nrf52.mdx
@@ -32,7 +32,7 @@ Examples of low power [nRF52840 boards](https://github.com/joric/nrfmicro/wiki).
 
 ## Flashing with Adafruit nRF52 Bootloader
 
-For flashing via a flash drive.
+For Adafruit, ProMicro nRF52840, Seeed Studio XIAO BLE boards flashing via a flash drive.
 
 1. Connect the board to the PC via USB.
 1. Quickly short the reset pin to ground twice.

--- a/src/content/docs/components/nrf52.mdx
+++ b/src/content/docs/components/nrf52.mdx
@@ -30,19 +30,6 @@ The nRF52840 requires a bootloader, with two supported options: `MCUboot` and `A
 
 Examples of low power [nRF52840 boards](https://github.com/joric/nrfmicro/wiki).
 
-## Flashing with MCUboot
-
-Flashing this bootloader requires an SWD connection, for which a programmer is necessary. A cheap ST-Link V2 can be utilized.
-
-1. Connect the board to the PC via SWD.
-1. Run `esphome upload yourfile.yaml --device PYOCD`.
-
-```yaml
-# Example configuration entry
-nrf52:
-  board: adafruit_feather_nrf52840
-```
-
 ## Flashing with Adafruit nRF52 Bootloader
 
 For flashing via a flash drive.
@@ -61,6 +48,19 @@ This bootloader supports updates over USB CDC.
 # Example configuration entry
 nrf52:
   board: adafruit_itsybitsy_nrf52840
+```
+
+## Flashing with MCUboot
+
+Flashing this bootloader requires an SWD connection, for which a programmer is necessary. A cheap ST-Link V2 can be utilized.
+
+1. Connect the board to the PC via SWD.
+1. Run `esphome upload yourfile.yaml --device PYOCD`.
+
+```yaml
+# Example configuration entry
+nrf52:
+  board: adafruit_feather_nrf52840
 ```
 
 ## GPIO Pin Numbering


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

[nRF52] Put the most common case first (Adafruit bootloader). Users who purchase a board will find themselves in this situation.
Replace https://github.com/esphome/esphome-docs/pull/5549

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
