### PR TITLE
[mipi_dsi] update transform docs

### DIFF
--- a/src/content/docs/components/display/mipi_dsi.mdx
+++ b/src/content/docs/components/display/mipi_dsi.mdx
@@ -111,8 +111,8 @@ most of the configuration will be set by default, but can be overridden if neede
   being translated to a hardware transform, otherwise the options below. Note that DSI displays do not support axis swapping so only mirroring of x and y axes
   is possible, and rotations by 90 or 270 must be handled by software.
 
-  - **swap_xy** (**Required**, boolean): If true, exchange the x and y axes.
   - **mirror_x** (**Required**, boolean): If true, mirror the x axis.
+  - **mirror_y** (**Required**, boolean): If true, mirror the y axis.
 
 - **hsync_pulse_width** (*Optional*, int): The horizontal sync pulse width.
 - **hsync_front_porch** (*Optional*, int): The horizontal front porch length.

--- a/src/content/docs/components/display/mipi_dsi.mdx
+++ b/src/content/docs/components/display/mipi_dsi.mdx
@@ -156,18 +156,13 @@ The `CUSTOM` model selection is provided for otherwise unsupported displays, and
 
 ## Using the `transform` options
 
-In most cases, the `rotation` option will be sufficient to orient the display correctly. However, some displays may require additional transformations. The `transform` option allows for these transformations to be applied in any of 8 different
-combinations. It may be necessary to experiment with different combinations to achieve the desired result. When using the `transform` option, the `rotation` option should not be set unless the display does not support axis-swapping.
-If the `swap_xy` option is set, then the `dimensions` option is required, and the `width` and `height` values should be set to reflect the final screen dimensions after rotation.
+In most cases, the `rotation` option will be sufficient to orient the display correctly. However, some displays may require additional transformations such as mirroring the x or y axes, which is accomplished with the `transform:` option..
 
 ```yaml
 transform:
-  swap_xy: true
   mirror_x: true
   mirror_y: false
-dimensions:
-  height: 480
-  width: 320
+rotation: 90
 ```
 
 ## LCD Backlights

--- a/src/content/docs/components/display/mipi_dsi.mdx
+++ b/src/content/docs/components/display/mipi_dsi.mdx
@@ -105,11 +105,14 @@ most of the configuration will be set by default, but can be overridden if neede
 
 - **invert_colors** (*Optional*, boolean): Specifies whether the display colors should be inverted. Options are `true` or `false`. Defaults to `false`.
 - **rotation** (*Optional*): Rotate the display presentation in software. Choose one of `0°`, `90°`, `180°`, or `270°`. If the driver chip supports hardware rotation for the given orientation this will be translated to the appropriate hardware command. If hardware rotation is not supported, the display will be rotated in software.
-- **transform** (*Optional*): If `rotation` is not sufficient, use this to transform the display. If this option is specified, then the `dimensions` option must also be provided. Options are:
+- **transform** (*Optional*): If `rotation` is not sufficient, use this to transform the display. If this option is
+  specified, then the `dimensions` option must also be provided. The value can either be the string `disabled` to disable hardware transform, or a dictionary.
+  For the `CUSTOM` model, use `transform: disabled` if the display does not support it, which will prevent a `rotation`
+  being translated to a hardware transform, otherwise the options below. Note that DSI displays do not support axis swapping so only mirroring of x and y axes
+  is possible, and rotations by 90 or 270 must be handled by software.
 
   - **swap_xy** (**Required**, boolean): If true, exchange the x and y axes.
   - **mirror_x** (**Required**, boolean): If true, mirror the x axis.
-  - **mirror_y** (**Required**, boolean): If true, mirror the y axis.
 
 - **hsync_pulse_width** (*Optional*, int): The horizontal sync pulse width.
 - **hsync_front_porch** (*Optional*, int): The horizontal front porch length.

--- a/src/content/docs/components/display/mipi_dsi.mdx
+++ b/src/content/docs/components/display/mipi_dsi.mdx
@@ -156,7 +156,7 @@ The `CUSTOM` model selection is provided for otherwise unsupported displays, and
 
 ## Using the `transform` options
 
-In most cases, the `rotation` option will be sufficient to orient the display correctly. However, some displays may require additional transformations such as mirroring the x or y axes, which is accomplished with the `transform:` option..
+In most cases, the `rotation` option will be sufficient to orient the display correctly. However, some displays may require additional transformations such as mirroring the x or y axes, which is accomplished with the `transform:` option.
 
 ```yaml
 transform:


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#14216

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
