### PR TITLE
Fix Figure component to render markdown links in captions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@astrojs/starlight": "^0.37.6",
         "astro": "^5.17.3",
         "katex": "^0.16.33",
+        "micromark": "^4.0.2",
         "rehype-katex": "^7.0.1",
         "remark-github-blockquote-alert": "^2.0.1",
         "remark-math": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@astrojs/starlight": "^0.37.6",
     "astro": "^5.17.3",
     "katex": "^0.16.33",
+    "micromark": "^4.0.2",
     "rehype-katex": "^7.0.1",
     "remark-github-blockquote-alert": "^2.0.1",
     "remark-math": "^6.0.0",

--- a/src/components/Figure.astro
+++ b/src/components/Figure.astro
@@ -1,6 +1,7 @@
 ---
 import { Image } from 'astro:assets';
 import type { ImageMetadata } from 'astro';
+import { micromark } from 'micromark';
 
 interface Props {
   src: ImageMetadata | string;
@@ -12,7 +13,12 @@ interface Props {
   height?: number;
 }
 
-const { src, alt, caption, layout = 'constrained', style, width, height } = Astro.props;
+const { src, alt, caption: rawCaption, layout = 'constrained', style, width, height } = Astro.props;
+
+// Render caption as inline markdown (handles links, escaping, XSS)
+const caption = rawCaption
+  ? micromark(rawCaption).replace(/^<p>|<\/p>\n?$/g, '')
+  : undefined;
 
 // Check if there's slot content for caption
 const hasSlot = Astro.slots.has('caption');
@@ -29,7 +35,7 @@ const hasSlot = Astro.slots.has('caption');
   />
   {(hasSlot || caption) && (
     <figcaption>
-      {hasSlot ? <slot name="caption" /> : caption}
+      {hasSlot ? <slot name="caption" /> : <span set:html={caption} />}
     </figcaption>
   )}
 </figure>


### PR DESCRIPTION
## Description

The Figure component's `caption` prop renders markdown link syntax `[text](url)` as literal text instead of clickable links. This affects 30 captions across the docs.

Examples:
- `src/content/docs/components/sensor/hdc1080.mdx`
- `src/content/docs/components/sensor/hx711.mdx`
- `src/content/docs/components/fingerprint_grow.mdx`
- `src/content/docs/components/light/sonoff_d1.mdx`
- `src/content/docs/components/binary_sensor/cap1188.mdx`

This fix adds automatic conversion of markdown links to HTML `<a>` tags in the Figure component, so existing captions render correctly without needing to update every file.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- N/A

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.