### PR TITLE
Indicate register type can only be Holding register

### DIFF
--- a/src/content/docs/components/select/modbus_controller.mdx
+++ b/src/content/docs/components/select/modbus_controller.mdx
@@ -9,7 +9,8 @@ registers.
 ## Configuration variables
 
 - **address** (**Required**, int): The start address of the first or only register
-  of the Select (can be decimal or hexadecimal).
+  of the Select (can be decimal or hexadecimal). Note that only Holding registers
+  are supported.
 
 - **optionsmap** (**Required**, Map[str, int]): Provide a mapping from options (str) of
   this Select to values (int) of the modbus register and vice versa. All options and


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** not applicable

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** not applicable

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.



As seen on [`modbus_select.h`](https://github.com/esphome/esphome/blob/74187845b7625efba82b1adf753335eb1713022a/esphome/components/modbus_controller/select/modbus_select.h) line 17, the register type can only be a Holding register. I wanted to make this explicit because somebody could assume that coils are supported (e.g. where non-zero selections mean true), or that custom registers are supported.


