### PR TITLE
Add navigation to logo assets

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -170,6 +170,7 @@ export default defineConfig({
       routeMiddleware: ["./src/routeData.ts"],
       components: {
         Footer: "./src/components/Footer.astro",
+        Head: "./src/components/Head.astro",
       },
       customCss: ["./src/styles/custom.css", "katex/dist/katex.min.css"],
       sidebar: [

--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -9,6 +9,6 @@ import Default from "@astrojs/starlight/components/Head.astro";
     .querySelector("a.site-title")
     ?.addEventListener("contextmenu", (e) => {
       e.preventDefault();
-      window.open("https://media.esphome.io/logo/", "_blank");
+      window.open("https://media.esphome.io/logo/", "_blank", "noopener,noreferrer");
     });
 </script>

--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -1,0 +1,14 @@
+---
+import Default from "@astrojs/starlight/components/Head.astro";
+---
+
+<Default {...Astro.props}><slot /></Default>
+
+<script>
+  document
+    .querySelector("a.site-title")
+    ?.addEventListener("contextmenu", (e) => {
+      e.preventDefault();
+      window.open("https://media.esphome.io/logo/", "_blank");
+    });
+</script>

--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -5,10 +5,12 @@ import Default from "@astrojs/starlight/components/Head.astro";
 <Default {...Astro.props}><slot /></Default>
 
 <script>
-  document
-    .querySelector("a.site-title")
-    ?.addEventListener("contextmenu", (e) => {
-      e.preventDefault();
-      window.open("https://media.esphome.io/logo/", "_blank", "noopener,noreferrer");
-    });
+  window.addEventListener("DOMContentLoaded", () => {
+    document
+      .querySelector("a.site-title")
+      ?.addEventListener("contextmenu", (e) => {
+        e.preventDefault();
+        window.open("https://media.esphome.io/logo/", "_blank");
+      });
+  });
 </script>

--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -10,7 +10,7 @@ import Default from "@astrojs/starlight/components/Head.astro";
       .querySelector("a.site-title")
       ?.addEventListener("contextmenu", (e) => {
         e.preventDefault();
-        window.open("https://media.esphome.io/logo/", "_blank");
+        window.open("https://media.esphome.io/logo/", "_blank", "noopener,noreferrer");
       });
   });
 </script>


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description
On right click of the logo, redirect to the media site

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
