### PR TITLE
[version] text sensor add option `hide_hash` to restore the pre-2026.1 behavior

### DIFF
--- a/src/content/docs/components/text_sensor/version.mdx
+++ b/src/content/docs/components/text_sensor/version.mdx
@@ -25,7 +25,7 @@ text_sensor:
 - **hide_hash** (*Optional*, boolean): Allows you to hide the config hash from the version string. Defaults to `false`.
 - All other options from [Text Sensor](/components/text_sensor#config-text_sensor).
 
-## Disabling the compilation timestamp and the config hash string
+## Disabling timestamp and hash
 
 ```yaml
 # Example configuration entry

--- a/src/content/docs/components/text_sensor/version.mdx
+++ b/src/content/docs/components/text_sensor/version.mdx
@@ -36,7 +36,7 @@ text_sensor:
     hide_hash: true
 ```
 
-This will shorten the version string like: `2026.1.0`
+This will shorten the version string to be just like: `2026.1.0`
 
 ## See Also
 

--- a/src/content/docs/components/text_sensor/version.mdx
+++ b/src/content/docs/components/text_sensor/version.mdx
@@ -22,9 +22,10 @@ text_sensor:
 ## Configuration variables
 
 - **hide_timestamp** (*Optional*, boolean): Allows you to hide the compilation timestamp from the version string. Defaults to `false`.
+- **hide_hash** (*Optional*, boolean): Allows you to hide the config hash from the version string. Defaults to `false`.
 - All other options from [Text Sensor](/components/text_sensor#config-text_sensor).
 
-## Disabling the compilation timestamp
+## Disabling the compilation timestamp and the config hash string
 
 ```yaml
 # Example configuration entry
@@ -32,11 +33,10 @@ text_sensor:
   - platform: version
     name: "ESPHome Version"
     hide_timestamp: true
+    hide_hash: true
 ```
 
-This will, for example, change the output of the sensor from:
-
-`2024.6.0-dev May 30 2024, 09:07:35` to just `2024.6.0-dev`
+This will shorten the version string like: `2026.1.0`
 
 ## See Also
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** fixes https://github.com/orgs/esphome/discussions/3492

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#14251

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
