### PR TITLE
Document esp32_ble_server max_clients option

### DIFF
--- a/src/content/docs/components/esp32_ble_server.mdx
+++ b/src/content/docs/components/esp32_ble_server.mdx
@@ -41,7 +41,7 @@ esp32_ble_server:
 - **max_clients** (*Optional*, int): The maximum number of simultaneous BLE client connections the server will
   accept. When set to a value greater than 1, the server resumes advertising after a client connects so that
   additional clients can discover and connect, up to this limit. Must not exceed the `max_connections` value
-  configured in the [ESP32 BLE](/components/esp32_ble) component. Defaults to `1`. Range: 1-9.
+  configured in the [ESP32 BLE](/components/esp32_ble) component. Defaults to `1`. Range: 1 to 9.
 
 - **on_connect** (*Optional*, [Automation](/automations)): An action to be performed when a client connects to the BLE server. It provides the `id` variable which contains the ID of the client that connected.
 - **on_disconnect** (*Optional*, [Automation](/automations)): An action to be performed when a client disconnects from the BLE server. It provides the `id` variable which contains the ID of the client that disconnected.

--- a/src/content/docs/components/esp32_ble_server.mdx
+++ b/src/content/docs/components/esp32_ble_server.mdx
@@ -38,6 +38,10 @@ esp32_ble_server:
 - **manufacturer_data** (*Optional*, list of bytes): The manufacturer-specific data to include in the advertising
   packet. Should be a list of bytes, where the first two are the little-endian representation of the 16-bit
   manufacturer ID as assigned by the Bluetooth SIG.
+- **max_clients** (*Optional*, int): The maximum number of simultaneous BLE client connections the server will
+  accept. When set to a value greater than 1, the server resumes advertising after a client connects so that
+  additional clients can discover and connect, up to this limit. Must not exceed the `max_connections` value
+  configured in the [ESP32 BLE](/components/esp32_ble) component. Defaults to `1`. Range: 1-9.
 
 - **on_connect** (*Optional*, [Automation](/automations)): An action to be performed when a client connects to the BLE server. It provides the `id` variable which contains the ID of the client that connected.
 - **on_disconnect** (*Optional*, [Automation](/automations)): An action to be performed when a client disconnects from the BLE server. It provides the `id` variable which contains the ID of the client that disconnected.


### PR DESCRIPTION
## What does this implement/fix?

Documents the new `max_clients` configuration option for `esp32_ble_server`, added in esphome/esphome#14239.

## Description

Adds a documentation entry for the `max_clients` option which controls how many simultaneous BLE client connections the server will accept. When set to a value greater than 1, the server resumes advertising after a client connects, allowing additional clients to discover and connect up to the configured limit.

## Related PR

esphome/esphome#14239