### PR TITLE
docs(aqi): clarify PM-only AQI limitation, add SEN5x to See Also

### DIFF
--- a/src/content/docs/components/sensor/aqi.mdx
+++ b/src/content/docs/components/sensor/aqi.mdx
@@ -18,12 +18,13 @@ or [Sps30](/components/sensor/sps30/).
 
 > [!WARNING]
 > The value produced by this component is a **PM-only AQI estimate**, not a full
-> US EPA Air Quality Index. The official EPA AQI considers six criteria pollutants —
-> PM2.5, PM10, ozone (O₃), carbon monoxide (CO), sulfur dioxide (SO₂), and
-> nitrogen dioxide (NO₂). Without sensors for those additional pollutants, this
-> component cannot produce a true composite AQI; the output reflects particulate
-> matter conditions only and may significantly underestimate actual air quality risk
-> when other pollutants are elevated.
+> US EPA Air Quality Index. The official EPA AQI is calculated across five pollutant
+> categories — ground-level ozone (O₃), particle pollution (PM2.5 and PM10),
+> carbon monoxide (CO), sulfur dioxide (SO₂), and nitrogen dioxide (NO₂) — and
+> reports the worst sub-index as the overall AQI. Without sensors for ozone, CO,
+> SO₂, and NO₂, this component cannot produce a true composite AQI; the output
+> reflects particulate matter conditions only and may significantly underestimate
+> actual air quality risk when other pollutants are elevated.
 >
 > Additionally, the official EPA PM2.5 AQI is defined using **24-hour averaged**
 > concentrations (or the [EPA NowCast](https://www.airnow.gov/publications/air-quality-index/technical-assistance-document-for-reporting-the-daily-aqi/)
@@ -71,8 +72,8 @@ sensor:
 
   - `AQI`: US EPA Air Quality Index breakpoint formula applied to PM2.5 and PM10
     only. Returns values from 0-500, where higher values indicate worse air quality.
-    **This is not a full EPA AQI** — the official standard also requires ozone, CO,
-    SO₂, and NO₂ measurements. Based on the
+    **This is not a full EPA AQI** — the official standard covers five pollutant
+    categories and also requires ozone, CO, SO₂, and NO₂ measurements. Based on the
     [EPA Technical Assistance Document](https://document.airnow.gov/technical-assistance-document-for-the-reporting-of-daily-air-quailty.pdf).
 
   - `CAQI`: European Common Air Quality Index. Returns values from 0 upward, where

--- a/src/content/docs/components/sensor/aqi.mdx
+++ b/src/content/docs/components/sensor/aqi.mdx
@@ -16,6 +16,24 @@ or [Sps30](/components/sensor/sps30/).
 > [HM3301](/components/sensor/hm3301) component. The standalone platform is more
 > flexible as it works with any PM sensor.
 
+> [!WARNING]
+> The value produced by this component is a **PM-only AQI estimate**, not a full
+> US EPA Air Quality Index. The official EPA AQI considers six criteria pollutants —
+> PM2.5, PM10, ozone (O₃), carbon monoxide (CO), sulfur dioxide (SO₂), and
+> nitrogen dioxide (NO₂). Without sensors for those additional pollutants, this
+> component cannot produce a true composite AQI; the output reflects particulate
+> matter conditions only and may significantly underestimate actual air quality risk
+> when other pollutants are elevated.
+>
+> Additionally, the official EPA PM2.5 AQI is defined using **24-hour averaged**
+> concentrations (or the [EPA NowCast](https://www.airnow.gov/publications/air-quality-index/technical-assistance-document-for-reporting-the-daily-aqi/)
+> algorithm for real-time hourly estimates). This component applies the AQI
+> breakpoint formula to **instantaneous** sensor readings, which produces more
+> volatile values that do not correspond to either the daily AQI or the NowCast
+> AQI used in official reporting. See the
+> [EPA Technical Assistance Document](https://document.airnow.gov/technical-assistance-document-for-the-reporting-of-daily-air-quailty.pdf)
+> for full methodology details.
+
 Two calculation types are supported:
 
 - **AQI**: US EPA Air Quality Index (0-500 scale)
@@ -51,8 +69,10 @@ sensor:
 - **calculation_type** (**Required**, enum): The AQI calculation standard to use.
   Must be one of:
 
-  - `AQI`: US EPA Air Quality Index. Returns values from 0-500, where higher values
-    indicate worse air quality. Based on the
+  - `AQI`: US EPA Air Quality Index breakpoint formula applied to PM2.5 and PM10
+    only. Returns values from 0-500, where higher values indicate worse air quality.
+    **This is not a full EPA AQI** — the official standard also requires ozone, CO,
+    SO₂, and NO₂ measurements. Based on the
     [EPA Technical Assistance Document](https://document.airnow.gov/technical-assistance-document-for-the-reporting-of-daily-air-quailty.pdf).
 
   - `CAQI`: European Common Air Quality Index. Returns values from 0 upward, where
@@ -82,6 +102,7 @@ sensor:
 
 ## See Also
 
+- [Sen5x Series Environmental Sensor](/components/sensor/sen5x/)
 - [PMSX003 Particulate Matter Sensor](/components/sensor/pmsx003/)
 - [The Grove - Laser PM2.5 Sensor (HM3301)](/components/sensor/hm3301/)
 - [SDS011 Particulate Matter Sensor](/components/sensor/sds011/)

--- a/src/content/docs/components/sensor/aqi.mdx
+++ b/src/content/docs/components/sensor/aqi.mdx
@@ -16,7 +16,7 @@ or [Sps30](/components/sensor/sps30/).
 > [HM3301](/components/sensor/hm3301) component. The standalone platform is more
 > flexible as it works with any PM sensor.
 
-> [!WARNING]
+> [!NOTE]
 > The value produced by this component is a **PM-only AQI estimate**, not a full
 > US EPA Air Quality Index. The official EPA AQI is calculated across five pollutant
 > categories — ground-level ozone (O₃), particle pollution (PM2.5 and PM10),

--- a/src/content/docs/components/sensor/aqi.mdx
+++ b/src/content/docs/components/sensor/aqi.mdx
@@ -12,11 +12,6 @@ any PM sensor source, such as [Pmsx003](/components/sensor/pmsx003/),
 or [Sps30](/components/sensor/sps30/).
 
 > [!NOTE]
-> This platform replaces the deprecated `aqi` option previously available in the
-> [HM3301](/components/sensor/hm3301) component. The standalone platform is more
-> flexible as it works with any PM sensor.
-
-> [!NOTE]
 > The value produced by this component is a **PM-only AQI estimate**, not a full
 > US EPA Air Quality Index. The official EPA AQI is calculated across five pollutant
 > categories — ground-level ozone (O₃), particle pollution (PM2.5 and PM10),
@@ -34,6 +29,11 @@ or [Sps30](/components/sensor/sps30/).
 > AQI used in official reporting. See the
 > [EPA Technical Assistance Document](https://document.airnow.gov/technical-assistance-document-for-the-reporting-of-daily-air-quailty.pdf)
 > for full methodology details.
+
+> [!NOTE]
+> This platform replaces the deprecated `aqi` option previously available in the
+> [HM3301](/components/sensor/hm3301) component. The standalone platform is more
+> flexible as it works with any PM sensor.
 
 Two calculation types are supported:
 


### PR DESCRIPTION
## Summary

- Adds a `[!WARNING]` callout making it explicit that the `aqi` component produces a **PM-only AQI estimate**, not a full US EPA AQI (which also requires ozone, CO, SO₂, and NO₂ measurements)
- Notes that this component applies AQI breakpoint math to instantaneous PM readings, which does not match the official EPA 24-hour daily AQI or the NowCast algorithm used for real-time reporting — values will be more volatile and may not correspond to officially reported AQI
- Links to the [EPA Technical Assistance Document](https://document.airnow.gov/technical-assistance-document-for-the-reporting-of-daily-air-quailty.pdf) from both the warning and the `AQI` enum description
- Clarifies the `calculation_type: AQI` description to call out the PM-only limitation inline
- Adds **Sen5x** as the first entry in the See Also section (sen5x already links back to aqi, this closes the loop)

## Motivation

Users who configure this component with a PM-only sensor (e.g. SEN55, PMSX003) may reasonably assume the output is a comprehensive AQI. In reality, a location with elevated ozone or SO₂ could read "Good" on this component while official AQI is "Unhealthy". The warning and inline clarification give users the context to make informed decisions about how to display or act on these values.

## Test plan

- [x] Verify warning callout renders correctly on the AQI docs page
- [x] Verify Sen5x link in See Also resolves correctly
- [x] Verify no broken links in the updated `calculation_type` description

🤖 Generated with [Claude Code](https://claude.com/claude-code)