### PR TITLE
[mipi_dsi] Shorten display text of URLs to prevent wrapping.

### DIFF
--- a/src/content/docs/components/display/mipi_dsi.mdx
+++ b/src/content/docs/components/display/mipi_dsi.mdx
@@ -48,18 +48,18 @@ specified, or a custom init sequence can be provided.
 
 ### Boards with integrated displays
 
-| Model                  | Manufacturer | Product Description                                                           |
-| ---------------------- | ------------ | ----------------------------------------------------------------------------- |
-| JC1060P470             | Guition      | [https://aliexpress.com/item/1005008328088576.html](https://aliexpress.com/item/1005008328088576.html)                           |
-| JC4880P443             | Guition      | [https://aliexpress.com/item/1005009618259341.html](https://aliexpress.com/item/1005009618259341.html)                           |
-| JC8012P4A1             | Guition      | [https://aliexpress.com/item/1005008789890066.html](https://aliexpress.com/item/1005008789890066.html)                           |
-| M5STACK-TAB5           | M5Stack      | [https://shop.m5stack.com/products/m5stack-tab5-iot-development-kit-esp32-p4](https://shop.m5stack.com/products/m5stack-tab5-iot-development-kit-esp32-p4) |
-| M5STACK-TAB5-V2        | M5Stack      | [https://shop.m5stack.com/products/m5stack-tab5-iot-development-kit-esp32-p4](https://shop.m5stack.com/products/m5stack-tab5-iot-development-kit-esp32-p4) |
-| WAVESHARE-P4-NANO-10.1 | Waveshare | [https://www.waveshare.com/esp32-p4-nano.htm?sku=29031](https://www.waveshare.com/esp32-p4-nano.htm?sku=29031) |
-| WAVESHARE-P4-86-PANEL | Waveshare | [https://www.waveshare.com/esp32-p4-wifi6-touch-lcd-4b.htm?sku=31570](https://www.waveshare.com/esp32-p4-wifi6-touch-lcd-4b.htm?sku=31570) |
-| WAVESHARE-ESP32-P4-WIFI6-TOUCH-LCD-7B | Waveshare | [https://www.waveshare.com/wiki/ESP32-P4-WIFI6-Touch-LCD-7B](https://www.waveshare.com/wiki/ESP32-P4-WIFI6-Touch-LCD-7B) |
-| WAVESHARE-ESP32-P4-WIFI6-TOUCH-LCD-3.4C | Waveshare    | [https://www.waveshare.com/wiki/ESP32-P4-WIFI6-Touch-LCD-3.4C](https://www.waveshare.com/wiki/ESP32-P4-WIFI6-Touch-LCD-3.4C)                |
-| WAVESHARE-ESP32-P4-WIFI6-TOUCH-LCD-4C   | Waveshare    | [https://www.waveshare.com/wiki/ESP32-P4-WIFI6-Touch-LCD-4C](https://www.waveshare.com/wiki/ESP32-P4-WIFI6-Touch-LCD-4C)                  |
+| Model                  | Manufacturer   | Product Description                                                                                         |
+| ---------------------- | -------------- | ----------------------------------------------------------------------------------------------------------- |
+| JC1060P470             | Guition        | [https://aliexpress.com...](https://aliexpress.com/item/1005008328088576.html)                              |
+| JC4880P443             | Guition        | [https://aliexpress.com...](https://aliexpress.com/item/1005009618259341.html)                              |
+| JC8012P4A1             | Guition        | [https://aliexpress.com...](https://aliexpress.com/item/1005008789890066.html)                              |
+| M5STACK-TAB5           | M5Stack        | [https://shop.m5stack.com...](https://shop.m5stack.com/products/m5stack-tab5-iot-development-kit-esp32-p4)  |
+| M5STACK-TAB5-V2        | M5Stack        | [https://shop.m5stack.com...](https://shop.m5stack.com/products/m5stack-tab5-iot-development-kit-esp32-p4)  |
+| WAVESHARE-P4-NANO-10.1 | Waveshare      | [https://www.waveshare.com...](https://www.waveshare.com/esp32-p4-nano.htm?sku=29031)                       |
+| WAVESHARE-P4-86-PANEL  | Waveshare      | [https://www.waveshare.com...](https://www.waveshare.com/esp32-p4-wifi6-touch-lcd-4b.htm?sku=31570)         |
+| WAVESHARE-ESP32-P4-WIFI6-TOUCH-LCD-7B   | Waveshare | [https://www.waveshare.com...](https://www.waveshare.com/wiki/ESP32-P4-WIFI6-Touch-LCD-7B)      |
+| WAVESHARE-ESP32-P4-WIFI6-TOUCH-LCD-3.4C | Waveshare | [https://www.waveshare.com...](https://www.waveshare.com/wiki/ESP32-P4-WIFI6-Touch-LCD-3.4C)    |
+| WAVESHARE-ESP32-P4-WIFI6-TOUCH-LCD-4C   | Waveshare | [https://www.waveshare.com...](https://www.waveshare.com/wiki/ESP32-P4-WIFI6-Touch-LCD-4C)      |
 
 > [!NOTE]
 The M5Stack Tab5 has two hardware revisions with different display chips requiring different model selections.


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

The change to starlight added a TOC on the right side of the pages
which has decreased the amount of space for content.  For the mipi_dsi
page, this causes unsightly wrapping of panel descriptions and URLs.
To make it look better, the URL display text has been shortened to just
`https://<host>...` leaving the link as the full URL.

**Related issue (if applicable):** fixes #6089

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
