### PR TITLE
Add ESPHome Bluetooth Keyboard project to DIY examples

### DIFF
--- a/src/content/docs/guides/diy.mdx
+++ b/src/content/docs/guides/diy.mdx
@@ -103,7 +103,7 @@ unless it's truly exceptional, etc.
 - [Adaptive Lighting for white/warm lights](https://github.com/mdvorak/esphome-adaptive-lighting) by [@mdvorak](https://github.com/mdvorak)
 - [Connecting the PAJ7620 gesture sensor](https://github.com/apaex/PAJ7620-ESPHome) by [@apaex](https://github.com/apaex)
 - [Dew Point Sensor using Magnus formula](https://github.com/iret33/esphome-dew-point) by [@iret33](https://github.com/iret33)
-- [ESPHome Bluetooth Keyboard for Windows] by [markusg1234] (https://github.com/markusg1234/ESPHome-espidf_ble_keyboard)
+- [ESPHome Bluetooth Keyboard for Windows](https://github.com/markusg1234/ESPHome-espidf_ble_keyboard) by [@markusg1234](https://github.com/markusg1234)
 
 ## Sample Configurations
 

--- a/src/content/docs/guides/diy.mdx
+++ b/src/content/docs/guides/diy.mdx
@@ -103,6 +103,7 @@ unless it's truly exceptional, etc.
 - [Adaptive Lighting for white/warm lights](https://github.com/mdvorak/esphome-adaptive-lighting) by [@mdvorak](https://github.com/mdvorak)
 - [Connecting the PAJ7620 gesture sensor](https://github.com/apaex/PAJ7620-ESPHome) by [@apaex](https://github.com/apaex)
 - [Dew Point Sensor using Magnus formula](https://github.com/iret33/esphome-dew-point) by [@iret33](https://github.com/iret33)
+- [ESPHome Bluetooth Keyboard for Windows] by [markusg1234] (https://github.com/markusg1234/ESPHome-espidf_ble_keyboard)
 
 ## Sample Configurations
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** Add ble keyboard to diy

**Pull request in (https://github.com/esphome/esphome-docs) with YAML changes (if applicable):**

- esphome/esphome# #6158

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.

- [ ] Link added in `/src/content/docs/guides/diy.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
