### PR TITLE
Docs/pre build feature

### DIFF
--- a/src/content/docs/guides/cli.mdx
+++ b/src/content/docs/guides/cli.mdx
@@ -231,6 +231,19 @@ for those parameters will be ignored. Cannot be used along with `--systemd-socke
 `--socket`.
 
 
+#### Automatic Firmware Pre-build
+
+When the dashboard starts, it automatically checks all configured devices and compiles firmware for any device whose
+stored ESPHome version does not match the currently running version. This means firmware binaries are ready before you
+manually trigger an update, so OTA flashing can happen immediately without waiting for a compile.
+
+Devices are compiled one at a time in the background. The dashboard remains fully usable while pre-builds are in
+progress -- a snackbar notification at the bottom of the screen shows the current progress and a summary when all
+builds are complete.
+
+If a pre-build fails for a particular device, the error is logged and the dashboard moves on to the next device. Failed
+devices will still show as having an update available so you can retry manually.
+
 ### `analyze-memory` Command
 
 > [!NOTE]

--- a/src/content/docs/guides/cli.mdx
+++ b/src/content/docs/guides/cli.mdx
@@ -231,6 +231,12 @@ for those parameters will be ignored. Cannot be used along with `--systemd-socke
 `--socket`.
 
 
+**`--no-auto-build`**
+: Disable automatic firmware pre-build on startup. When set, the dashboard will not compile firmware for out-of-date
+devices automatically. You can also disable this via the `ESPHOME_DASHBOARD_AUTO_BUILD` environment variable (set to
+`false` or `0`). The CLI flag takes precedence over the environment variable. Pre-build is enabled by default.
+
+
 #### Automatic Firmware Pre-build
 
 When the dashboard starts, it automatically checks all configured devices and compiles firmware for any device whose
@@ -243,6 +249,18 @@ builds are complete.
 
 If a pre-build fails for a particular device, the error is logged and the dashboard moves on to the next device. Failed
 devices will still show as having an update available so you can retry manually.
+
+To disable automatic pre-building, use the `--no-auto-build` flag:
+
+```bash
+esphome dashboard config/ --no-auto-build
+```
+
+Or set the environment variable:
+
+```bash
+ESPHOME_DASHBOARD_AUTO_BUILD=false esphome dashboard config/
+```
 
 ### `analyze-memory` Command
 

--- a/src/content/docs/guides/cli.mdx
+++ b/src/content/docs/guides/cli.mdx
@@ -245,7 +245,8 @@ manually trigger an update, so OTA flashing can happen immediately without waiti
 
 Devices are compiled one at a time in the background. The dashboard remains fully usable while pre-builds are in
 progress -- a snackbar notification at the bottom of the screen shows the current progress and a summary when all
-builds are complete.
+builds are complete. After each successful compile, the previous firmware binary is automatically removed if the new
+build produced a binary at a different path, keeping storage usage in check.
 
 If a pre-build fails for a particular device, the error is logged and the dashboard moves on to the next device. Failed
 devices will still show as having an update available so you can retry manually.

--- a/src/content/docs/guides/getting_started_command_line.mdx
+++ b/src/content/docs/guides/getting_started_command_line.mdx
@@ -238,6 +238,10 @@ docker run --rm -p 6052:6052 -e ESPHOME_DASHBOARD_USE_PING=true -v "${PWD}":/con
 
 After that, you will be able to access the ESPHome Device Builder at `localhost:6052`.
 
+When the dashboard starts, it automatically pre-builds firmware for any device whose ESPHome version is out of date.
+This runs in the background so the dashboard is immediately usable, and a snackbar notification tracks progress. Once
+pre-builds are complete, clicking UPDATE on a device will flash immediately without waiting for a compile.
+
 Logging level can be set with the env var `ESPHOME_LOG_LEVEL` (default is `INFO`).
 
 <Image src={dashboardStatesImg} layout="constrained" alt="" />

--- a/src/content/docs/guides/getting_started_command_line.mdx
+++ b/src/content/docs/guides/getting_started_command_line.mdx
@@ -240,7 +240,8 @@ After that, you will be able to access the ESPHome Device Builder at `localhost:
 
 When the dashboard starts, it automatically pre-builds firmware for any device whose ESPHome version is out of date.
 This runs in the background so the dashboard is immediately usable, and a snackbar notification tracks progress. Once
-pre-builds are complete, clicking UPDATE on a device will flash immediately without waiting for a compile.
+pre-builds are complete, clicking UPDATE on a device will flash immediately without waiting for a compile. To disable
+this behavior, pass `--no-auto-build` or set `ESPHOME_DASHBOARD_AUTO_BUILD=false`.
 
 Logging level can be set with the env var `ESPHOME_LOG_LEVEL` (default is `INFO`).
 

--- a/src/content/docs/guides/getting_started_hassio.mdx
+++ b/src/content/docs/guides/getting_started_hassio.mdx
@@ -90,7 +90,8 @@ The main page displays a list of all configuration files for nodes you've create
 actions you can perform:
 
 - **UPDATE**: This button appears when the device is running an ESPHome version which is older than that available in
-  the ESPHome Device Builder add-on.
+  the ESPHome Device Builder add-on. When the dashboard starts, it automatically pre-builds firmware for all
+  out-of-date devices in the background, so clicking UPDATE will often flash immediately without waiting for a compile.
 
 - **EDIT**: This will open the configuration editor.
 - **LOGS**: This allows you to view logs emitted by the device. If a device is connected via USB, you can choose to use


### PR DESCRIPTION
  Documents the automatic firmware pre-build feature on dashboard startup. When the dashboard starts, it automatically compiles firmware for any device whose stored ESPHome version    
  doesn't match the currently running version. This PR documents the feature across three pages:
                                                                                                                                                                                        
  - CLI reference (cli.mdx): Added --no-auto-build option under the dashboard command, documented the ESPHOME_DASHBOARD_AUTO_BUILD environment variable, and added a dedicated        
  "Automatic Firmware Pre-build" section with usage examples.
  - Getting Started - Command Line (getting_started_command_line.mdx): Added description of automatic pre-build behavior in the Device Builder section, with a note on how to disable
  it.
  - Getting Started - Home Assistant (getting_started_hassio.mdx): Added a note to the UPDATE button description mentioning that pre-builds happen automatically on startup.

[Related discussion](https://github.com/orgs/esphome/discussions/3540)

  Related issue (if applicable): N/A

https://github.com/esphome/dashboard/pull/877
https://github.com/esphome/esphome/pull/14337

  - esphome/esphome#

  Checklist

  - I am merging into next because this is new documentation that has a matching pull-request in https://github.com/esphome/esphome as linked above.
  or