### PR TITLE
[esp32_hosted] Add configurable SDIO clock frequency

### DIFF
--- a/src/content/docs/components/esp32_hosted.mdx
+++ b/src/content/docs/components/esp32_hosted.mdx
@@ -20,6 +20,7 @@ esp32_hosted:
   d2_pin: GPIOXX
   d3_pin: GPIOXX
   active_high: true
+  sdio_frequency: 10MHz
 
 wifi:
   ssid: !secret wifi_ssid
@@ -43,6 +44,9 @@ wifi:
 - **reset_pin** (*Required*, [Pin](/guides/configuration-types#pin)): The reset pin of the co-processor.
 - **active_high** (*Required*, boolean): If enabled, the co-processor is active when reset is
   high. If disabled, the co-processor is active when reset is low.
+- **sdio_frequency** (*Optional*): Set the speed of communication between the master and
+  the slave. If you experience loss of communication, or reboots, then try reducing this value.
+  The value can be between 400KHz and 50MHz, with a default of 40MHz.
 
 ## Updating co-processor firmware
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

On some products, the master processor cannot communicate with the slave at the full 40MHz. Hence there is a requirement to be able to lower the speed of communication.

This enables the speed of the link between master and slave to be reduced from the default of 40MHz.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#14319

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.
