### PR TITLE
[esp32] Document enable_full_printf advanced config option

### DIFF
--- a/src/content/docs/components/esp32.mdx
+++ b/src/content/docs/components/esp32.mdx
@@ -269,6 +269,16 @@ The following options disable unused VFS features to save flash memory:
   [ESP Component Registry](https://components.espressif.com/). This option re-enables built-in ESP-IDF components
   that are excluded by default.
 
+**C Library Options:**
+
+- **enable_full_printf** (*Optional*, boolean): Enable full FILE\*-based printf support. By default, ESPHome wraps
+  ``printf()``, ``vprintf()``, and ``fprintf()`` with lightweight stubs that use ``vsnprintf()`` + ``fwrite()``,
+  eliminating newlib's ``_vfprintf_r`` and saving ~11 KB of flash. ESPHome replaces the ESP-IDF log handler at
+  startup, so these libc printf functions are essentially dead code at runtime. Crash backtraces and panic output
+  are unaffected — they use ``esp_rom_printf()`` which is a ROM function and does not go through libc. Set to
+  ``true`` only if an external component needs full FILE\*-based ``fprintf()`` with output longer than 512 bytes.
+  Defaults to ``false`` (lightweight stubs to save flash).
+
 Some options can be disabled to save flash memory without affecting typical ESPHome functionality. The performance
 options (defaulting to `true`  ) improve socket operation performance but can be disabled if you need better
 multi-threaded scalability (which is uncommon since ESPHome uses an event loop).
@@ -341,6 +351,9 @@ esp32:
       use_full_certificate_bundle: false  # Saves ~51 KB flash
       disable_mbedtls_peer_cert: true  # Saves ~4 KB heap per connection
       disable_mbedtls_pkcs7: true  # Saves code size
+
+      # C library options
+      enable_full_printf: false  # Saves ~11 KB flash
 
       # Debug options (disabled by default for production)
       disable_debug_stubs: true  # Saves code size

--- a/src/content/docs/components/esp32.mdx
+++ b/src/content/docs/components/esp32.mdx
@@ -272,12 +272,12 @@ The following options disable unused VFS features to save flash memory:
 **C Library Options:**
 
 - **enable_full_printf** (*Optional*, boolean): Enable full FILE\*-based printf support. By default, ESPHome wraps
-  ``printf()``, ``vprintf()``, and ``fprintf()`` with lightweight stubs that use ``vsnprintf()`` + ``fwrite()``,
-  eliminating newlib's ``_vfprintf_r`` and saving ~11 KB of flash. ESPHome replaces the ESP-IDF log handler at
+  `printf()`, `vprintf()`, and `fprintf()` with lightweight stubs that use `vsnprintf()` + `fwrite()`,
+  eliminating newlib's `_vfprintf_r` and saving ~11 KB of flash. ESPHome replaces the ESP-IDF log handler at
   startup, so these libc printf functions are essentially dead code at runtime. Crash backtraces and panic output
-  are unaffected — they use ``esp_rom_printf()`` which is a ROM function and does not go through libc. Set to
-  ``true`` only if an external component needs full FILE\*-based ``fprintf()`` with output longer than 512 bytes.
-  Defaults to ``false`` (lightweight stubs to save flash).
+  are unaffected — they use `esp_rom_printf()` which is a ROM function and does not go through libc. Set to
+  `true` only if an external component needs full FILE\*-based `fprintf()` with output longer than 512 bytes.
+  Defaults to `false` (lightweight stubs to save flash).
 
 Some options can be disabled to save flash memory without affecting typical ESPHome functionality. The performance
 options (defaulting to `true`  ) improve socket operation performance but can be disabled if you need better

--- a/src/content/docs/components/esp32.mdx
+++ b/src/content/docs/components/esp32.mdx
@@ -280,7 +280,7 @@ The following options disable unused VFS features to save flash memory:
   Defaults to `false` (lightweight stubs to save flash).
 
 Some options can be disabled to save flash memory without affecting typical ESPHome functionality. The performance
-options (defaulting to `true`  ) improve socket operation performance but can be disabled if you need better
+options (defaulting to `true`) improve socket operation performance but can be disabled if you need better
 multi-threaded scalability (which is uncommon since ESPHome uses an event loop).
 
 - **disable_mbedtls_pkcs7** (*Optional*, boolean): Disable PKCS#7 support in mbedTLS. PKCS#7 is used for specific certificate


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Documents the new `enable_full_printf` advanced config option for the ESP32 component. This option is an escape hatch for the printf/vprintf/fprintf linker wraps that save ~11 KB of flash. It will likely never be needed, but follows the project pattern of always providing an opt-out for linker wraps.

**Related issue (if applicable):** n/a

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#14362

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.