### PR TITLE
[openthread] Document output_power

### DIFF
--- a/src/content/docs/components/openthread.mdx
+++ b/src/content/docs/components/openthread.mdx
@@ -48,6 +48,8 @@ openthread:
   pskc: 0xc23a76e98f1a6483639b1ac1271e2e27
   mesh_local_prefix: fd53:145f:ed22:ad81::/64
   force_dataset: true
+
+  #output_power: -3dBm   # optional: reduce power
 ```
 
 ### Configuration variables
@@ -68,6 +70,28 @@ openthread:
 
 > [!NOTE]
 > esphome.ota does not work when poll_period > 0, instead use http_request.ota, timeout and watchdog_timeout need to be tested to find the correct values.  Values greater than 100sec may be required.
+
+- **output_power** (*Optional*, integer): The amount of TX power for the Thread radio interface in dBm.
+  Allowed range depends on hardware capabilities (ESP32C5 and ESP32C6 from -15dBm to 20dBm, ESP32H2 from -24dBm to 20dBm).
+
+  Default if unset is the internal default power value of the platform. Typically this is 0dBm.
+
+  > [!WARNING]
+  > **When changing the default value built into the stack, you are responsible to comply to all local regulatories of your region.**
+  >
+  > For example, in common case of a total [EIRP](https://en.wikipedia.org/wiki/Effective_radiated_power) maximum of 20dBm/100mW for 2.4GHz frequency range:
+  > If you set an output power of 20dBm, any positive antenna gain may exceed aforementioned total EIRP limit!
+
+  > [!NOTE]
+  > Power consumption typically grows nonlinearly by increasing output power (see e.g. ESP data sheet, section "Current Consumption for 802,15,4 in Active Mode").
+  >
+  > Excessive power may also have negative spatial impact to all communicating nodes in total.
+  >
+  > Particularly for Thread as designated low-power mesh network protocol, low output power up to ca 5-7dBm are common and sufficient.
+  > Some vendors therefore even restrict their hardware to approximately this maximum, whereas Espressif with 20dBm reserves room for
+  > common EIRP regulatory maximum values, in case no further local gain (e.g. antenna) exists.
+  >
+  > Negative values also are often reasonable for extra power saving (e.g. battery powered devices), increasing data security, etc.
 
 ## Dataset TLV Configuration
 

--- a/src/content/docs/components/openthread.mdx
+++ b/src/content/docs/components/openthread.mdx
@@ -48,8 +48,6 @@ openthread:
   pskc: 0xc23a76e98f1a6483639b1ac1271e2e27
   mesh_local_prefix: fd53:145f:ed22:ad81::/64
   force_dataset: true
-
-  #output_power: -3dBm   # optional: reduce power
 ```
 
 ### Configuration variables
@@ -71,27 +69,9 @@ openthread:
 > [!NOTE]
 > esphome.ota does not work when poll_period > 0, instead use http_request.ota, timeout and watchdog_timeout need to be tested to find the correct values.  Values greater than 100sec may be required.
 
-- **output_power** (*Optional*, integer): The amount of TX power for the Thread radio interface in dBm.
-  Allowed range depends on hardware capabilities (ESP32C5 and ESP32C6 from -15dBm to 20dBm, ESP32H2 from -24dBm to 20dBm).
-
-  Default if unset is the internal default power value of the platform. Typically this is 0dBm.
-
-  > [!WARNING]
-  > **When changing the default value built into the stack, you are responsible to comply to all local regulatories of your region.**
-  >
-  > For example, in common case of a total [EIRP](https://en.wikipedia.org/wiki/Effective_radiated_power) maximum of 20dBm/100mW for 2.4GHz frequency range:
-  > If you set an output power of 20dBm, any positive antenna gain may exceed aforementioned total EIRP limit!
-
-  > [!NOTE]
-  > Power consumption typically grows nonlinearly by increasing output power (see e.g. ESP data sheet, section "Current Consumption for 802,15,4 in Active Mode").
-  >
-  > Excessive power may also have negative spatial impact to all communicating nodes in total.
-  >
-  > Particularly for Thread as designated low-power mesh network protocol, low output power up to ca 5-7dBm are common and sufficient.
-  > Some vendors therefore even restrict their hardware to approximately this maximum, whereas Espressif with 20dBm reserves room for
-  > common EIRP regulatory maximum values, in case no further local gain (e.g. antenna) exists.
-  >
-  > Negative values also are often reasonable for extra power saving (e.g. battery powered devices), increasing data security, etc.
+- **output_power** (*Optional*, integer): The amount of TX power for the Thread 802.15.4 radio in dBm.
+  Range depends on the chip variant: ESP32-C5/C6 from ``-15dBm`` to ``20dBm``, ESP32-H2 from ``-24dBm`` to ``20dBm``.
+  Defaults to the platform default (typically ``0dBm``). Ensure the configured value complies with local regulatory limits.
 
 ## Dataset TLV Configuration
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Add `output_power` to `openthread` component.

- Basically same semantic as same config key `output_power` has in other components like `wifi`.
- More focus was put into stressing the responsibility of complying to regulatory limits. Which might also be topic to mention in other components like `wifi`.
- Trivia: Some vendors like Nordic Semiconductor seem to impose much lower hardware limits like 7dBm/8dBm (except for setups with external FEM). Espressif obviously wants to leave room for making use of regulative maximum, leaving also room for risk.
- Homeassistant OTBR addon as parent/router *currently* uses default tx power of 6dB after own analysis of others to avoid "asymmetric link quality": https://github.com/home-assistant/addons/blob/master/openthread_border_router/rootfs/etc/s6-overlay/scripts/otbr-agent-configure.sh
- For wifi, also option of setting **region** at radio stack may allow to add further controls. However, for Thread / 802.15.4 did not find any radio platform implementation of `otPlatRadioSetRegion` (not ESP32 via ESP IDF nor nRF) as of now, i.e. error code `OT_ERROR_NOT_IMPLEMENTED`. Therefore, currently unreasonable to add region setting code into ESPHome.
- OpenThread API `otPlatRadioSetTransmitPower` "only" allows setting *integer* values, unlike e.g. wifi allowing float/halfsteps.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#14200

## Checklist

- [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
