### PR TITLE
Fix sensor docs formatting and required/optional mismatches

### DIFF
--- a/src/content/docs/components/sensor/bme680_bsec.mdx
+++ b/src/content/docs/components/sensor/bme680_bsec.mdx
@@ -93,65 +93,65 @@ text_sensor:
 
 Configuration variables:
 
-- **address** (_Optional_, int): Manually specify the I²C address of the sensor. Defaults to `0x76`. Another address can be `0x77`.
+- **address** (*Optional*, int): Manually specify the I²C address of the sensor. Defaults to `0x76`. Another address can be `0x77`.
 
-- **temperature_offset** (_Optional_, float): Temperature offset if device is in enclosure and reads too high. This value is subtracted
+- **temperature_offset** (*Optional*, float): Temperature offset if device is in enclosure and reads too high. This value is subtracted
   from the reading (e.g. if the sensor reads 5°C higher than expected, set this to `5`  ) and also corrects the relative humidity readings. Defaults to `0`.
 
-- **iaq_mode** (_Optional_, string): IAQ calculation mode. Default is `static` for static applications (e.g. fixed indoor devices).
+- **iaq_mode** (*Optional*, string): IAQ calculation mode. Default is `static` for static applications (e.g. fixed indoor devices).
   Can be `mobile` for mobile applications (e.g. carry-on devices).
 
-- **supply_voltage** (_Optional_, string): Supply voltage of the sensor. Default is `3.3V`.
+- **supply_voltage** (*Optional*, string): Supply voltage of the sensor. Default is `3.3V`.
   Can be set to `1.8V` if your sensor is 1.8V-powered (e.g. the Pimoroni PIM357 BME680 Breakout module).
 
-- **sample_rate** (_Optional_, string): Sample rate. Default is `lp` for low power consumption, sampling every 3 seconds.
+- **sample_rate** (*Optional*, string): Sample rate. Default is `lp` for low power consumption, sampling every 3 seconds.
   Can be `ulp` for ultra-low power, sampling every 5 minutes.
   This controls the sampling rate for gas-dependent sensors and will govern the interval at which the sensor heater is operated.
   By default, this rate will also be used for temperature, pressure, and humidity sensors but these can be overridden on a per-sensor level if required.
 
-- **state_save_interval** (_Optional_, [Time](/guides/configuration-types#time)): The minimum interval at which to save calibrated BSEC algorithm state to
+- **state_save_interval** (*Optional*, [Time](/guides/configuration-types#time)): The minimum interval at which to save calibrated BSEC algorithm state to
   flash so that calibration doesn't have to start from zero on device restart. Defaults to `6h`.
 
-- **id** (_Optional_, [ID](/guides/configuration-types#id)): Manually specify the ID used for code generation. Use this ID in the sensor section to refer to the correct BME680 if you have more than one device. This will also be used to refer to the calibrated BSEC algorithm state saved to flash.
+- **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID used for code generation. Use this ID in the sensor section to refer to the correct BME680 if you have more than one device. This will also be used to refer to the calibrated BSEC algorithm state saved to flash.
 
 ## Sensor
 
 Configuration variables:
 
-- **bme680_bsec_id** (_Optional_, [ID](/guides/configuration-types#id)): Sets the ID of the bme680_bsec component to refer to. Useful when working with multiple devices.
+- **bme680_bsec_id** (*Optional*, [ID](/guides/configuration-types#id)): Sets the ID of the bme680_bsec component to refer to. Useful when working with multiple devices.
 
-- **temperature** (_Optional_): The information for the temperature sensor.
+- **temperature** (*Optional*): The information for the temperature sensor.
 
-  - **sample_rate** (_Optional_, string): Optional sample rate override for this sensor. Can be `lp` for low power consumption, sampling every 3 seconds or `ulp` for ultra-low power, sampling every 5 minutes.
+  - **sample_rate** (*Optional*, string): Optional sample rate override for this sensor. Can be `lp` for low power consumption, sampling every 3 seconds or `ulp` for ultra-low power, sampling every 5 minutes.
   - All other options from [Sensor](/components/sensor).
 
-- **pressure** (_Optional_): The information for the pressure sensor.
+- **pressure** (*Optional*): The information for the pressure sensor.
 
-  - **sample_rate** (_Optional_, string): Optional sample rate override for this sensor. Can be `lp` for low power consumption, sampling every 3 seconds or `ulp` for ultra-low power, sampling every 5 minutes.
+  - **sample_rate** (*Optional*, string): Optional sample rate override for this sensor. Can be `lp` for low power consumption, sampling every 3 seconds or `ulp` for ultra-low power, sampling every 5 minutes.
   - All other options from [Sensor](/components/sensor).
 
-- **humidity** (_Optional_): The information for the humidity sensor.
+- **humidity** (*Optional*): The information for the humidity sensor.
 
-  - **sample_rate** (_Optional_, string): Optional sample rate override for this sensor. Can be `lp` for low power consumption, sampling every 3 seconds or `ulp` for ultra-low power, sampling every 5 minutes.
+  - **sample_rate** (*Optional*, string): Optional sample rate override for this sensor. Can be `lp` for low power consumption, sampling every 3 seconds or `ulp` for ultra-low power, sampling every 5 minutes.
   - All other options from [Sensor](/components/sensor).
 
-- **gas_resistance** (_Optional_): The information for the gas sensor.
+- **gas_resistance** (*Optional*): The information for the gas sensor.
 
   - All options from [Sensor](/components/sensor).
 
-- **iaq** (_Optional_): The information for the IAQ sensor.
+- **iaq** (*Optional*): The information for the IAQ sensor.
 
   - All options from [Sensor](/components/sensor).
 
-- **iaq_accuracy** (_Optional_): The information for the numeric IAQ accuracy sensor.
+- **iaq_accuracy** (*Optional*): The information for the numeric IAQ accuracy sensor.
 
   - All options from [Sensor](/components/sensor).
 
-- **co2_equivalent** (_Optional_): The information for the CO₂ equivalent sensor.
+- **co2_equivalent** (*Optional*): The information for the CO₂ equivalent sensor.
 
   - All options from [Sensor](/components/sensor).
 
-- **breath_voc_equivalent** (_Optional_): The information for the Breath VOC equivalent humidity sensor.
+- **breath_voc_equivalent** (*Optional*): The information for the Breath VOC equivalent humidity sensor.
 
   - All options from [Sensor](/components/sensor).
 
@@ -161,9 +161,9 @@ Accuracy can be reported in text format.
 
 Configuration variables:
 
-- **bme680_bsec_id** (_Optional_, [ID](/guides/configuration-types#id)): Sets the ID of the bme680_bsec component to refer to. Useful when working with multiple devices.
+- **bme680_bsec_id** (*Optional*, [ID](/guides/configuration-types#id)): Sets the ID of the bme680_bsec component to refer to. Useful when working with multiple devices.
 
-- **iaq_accuracy** (_Optional_): The information for the IAQ accuracy sensor. Shows: Stabilizing,
+- **iaq_accuracy** (*Optional*): The information for the IAQ accuracy sensor. Shows: Stabilizing,
   Uncertain, Calibrating, Calibrated.
 
   - All options from [TextSensor](/components/text_sensor#config-text_sensor).

--- a/src/content/docs/components/sensor/bme68x_bsec2.mdx
+++ b/src/content/docs/components/sensor/bme68x_bsec2.mdx
@@ -70,7 +70,7 @@ bme68x_bsec2_i2c:
   also be used for temperature, humidity and pressure sensors but can be overridden per-sensor if required.
 
 - **supply_voltage** (*Optional*, string): Supply voltage of the sensor. Default is `3.3V`. Can be set to `1.8V` if
-  your sensor is powerd with 1.8 volts (for example, the Pimoroni PIM357 BME680 breakout module).
+  your sensor is powered with 1.8 volts (for example, the Pimoroni PIM357 BME680 breakout module).
 
 - **temperature_offset** (*Optional*, float): Temperature offset if device is in enclosure and reads too high. This
   value is subtracted from the reading (for example, if the sensor reads 5°C higher than expected, set this to `5`  )

--- a/src/content/docs/components/sensor/bme68x_bsec2.mdx
+++ b/src/content/docs/components/sensor/bme68x_bsec2.mdx
@@ -53,33 +53,33 @@ bme68x_bsec2_i2c:
 
 ### Configuration variables
 
-- **address** (_Optional_, int): Manually specify the I²C address of the sensor. Defaults to `0x76`. The sensor can
+- **address** (*Optional*, int): Manually specify the I²C address of the sensor. Defaults to `0x76`. The sensor can
   also be configured to use `0x77`.
 
 - **i2c_id** (**Optional**, [ID](/guides/configuration-types#id)): The ID of the [I²C bus](/components/i2c) the bme68x is connected to.
-- **model** (_Required_, string): The model of the connected sensor; either `BME680` or `BME688`.
-- **algorithm_output** (_Optional_, string): The output of the BSEC2 algorithm. Either `classification` (default) or
+- **model** (**Required**, string): The model of the connected sensor; either `BME680` or `BME688`.
+- **algorithm_output** (*Optional*, string): The output of the BSEC2 algorithm. Either `classification` (default) or
   `regression`. _Only valid when model is BME688._
 
-- **operating_age** (_Optional_, string): The history BSEC2 considers for the automatic background calibration of the
+- **operating_age** (*Optional*, string): The history BSEC2 considers for the automatic background calibration of the
   IAQ in days. That means changes in this time period will influence the IAQ value. Either `4d` or `28d` (default).
 
-- **sample_rate** (_Optional_, string): Sample rate. Default is `LP` for low power consumption, sampling every 3
+- **sample_rate** (*Optional*, string): Sample rate. Default is `LP` for low power consumption, sampling every 3
   seconds. Can be `ULP` for ultra-low power, sampling every 5 minutes. This controls the sampling rate for
   gas-dependent sensors and will govern the interval at which the sensor heater is operated. By default, this rate will
   also be used for temperature, humidity and pressure sensors but can be overridden per-sensor if required.
 
-- **supply_voltage** (_Optional_, string): Supply voltage of the sensor. Default is `3.3V`. Can be set to `1.8V` if
+- **supply_voltage** (*Optional*, string): Supply voltage of the sensor. Default is `3.3V`. Can be set to `1.8V` if
   your sensor is powerd with 1.8 volts (for example, the Pimoroni PIM357 BME680 breakout module).
 
-- **temperature_offset** (_Optional_, float): Temperature offset if device is in enclosure and reads too high. This
+- **temperature_offset** (*Optional*, float): Temperature offset if device is in enclosure and reads too high. This
   value is subtracted from the reading (for example, if the sensor reads 5°C higher than expected, set this to `5`  )
   and also corrects the relative humidity readings. Defaults to `0`.
 
-- **state_save_interval** (_Optional_, [Time](/guides/configuration-types#time)): The minimum interval at which to save the calibrated BSEC2
+- **state_save_interval** (*Optional*, [Time](/guides/configuration-types#time)): The minimum interval at which to save the calibrated BSEC2
   algorithm state to flash so that calibration doesn't have to start from scratch on device restart. Defaults to `6h`.
 
-- **id** (_Optional_, [ID](/guides/configuration-types#id)): Manually specify the ID used for code generation. Use this ID in the sensor
+- **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID used for code generation. Use this ID in the sensor
   section to refer to the correct BME68x sensor if you have more than one device. This will also be used to refer to
   the calibrated BSEC2 algorithm state saved to flash.
 
@@ -105,53 +105,53 @@ sensor:
 
 ### Configuration variables
 
-- **bme68x_bsec2_id** (_Optional_, [ID](/guides/configuration-types#id)): The ID of the `bme68x_bsec2_i2c` component sensors will refer
+- **bme68x_bsec2_id** (*Optional*, [ID](/guides/configuration-types#id)): The ID of the `bme68x_bsec2_i2c` component sensors will refer
   to. Useful when multiple devices are present in your configuration.
 
-- **id** (_Optional_, [ID](/guides/configuration-types#id)): This ID has no effect other than providing a target for package management.
+- **id** (*Optional*, [ID](/guides/configuration-types#id)): This ID has no effect other than providing a target for package management.
 
-- **temperature** (_Optional_): Configuration for the temperature sensor.
+- **temperature** (*Optional*): Configuration for the temperature sensor.
 
-  - **sample_rate** (_Optional_, string): Optional sample rate override for this sensor. Can be `LP` for low power
+  - **sample_rate** (*Optional*, string): Optional sample rate override for this sensor. Can be `LP` for low power
     consumption, sampling every 3 seconds or `ULP` for ultra-low power, sampling every 5 minutes.
 
   - All other options from [Sensor](/components/sensor).
 
-- **pressure** (_Optional_): Configuration for the pressure sensor.
+- **pressure** (*Optional*): Configuration for the pressure sensor.
 
-  - **sample_rate** (_Optional_, string): Optional sample rate override for this sensor. Can be `LP` for low power
+  - **sample_rate** (*Optional*, string): Optional sample rate override for this sensor. Can be `LP` for low power
     consumption, sampling every 3 seconds or `ULP` for ultra-low power, sampling every 5 minutes.
 
   - All other options from [Sensor](/components/sensor).
 
-- **humidity** (_Optional_): Configuration for the humidity sensor.
+- **humidity** (*Optional*): Configuration for the humidity sensor.
 
-  - **sample_rate** (_Optional_, string): Optional sample rate override for this sensor. Can be `LP` for low power
+  - **sample_rate** (*Optional*, string): Optional sample rate override for this sensor. Can be `LP` for low power
     consumption, sampling every 3 seconds or `ULP` for ultra-low power, sampling every 5 minutes.
 
   - All other options from [Sensor](/components/sensor).
 
-- **gas_resistance** (_Optional_): Configuration for the gas sensor.
+- **gas_resistance** (*Optional*): Configuration for the gas sensor.
 
   - All options from [Sensor](/components/sensor).
 
-- **iaq** (_Optional_): Configuration for the IAQ sensor.
+- **iaq** (*Optional*): Configuration for the IAQ sensor.
 
   - All options from [Sensor](/components/sensor).
 
-- **iaq_static** (_Optional_): Configuration for the IAQ static sensor.
+- **iaq_static** (*Optional*): Configuration for the IAQ static sensor.
 
   - All options from [Sensor](/components/sensor).
 
-- **iaq_accuracy** (_Optional_): Configuration for the numeric IAQ accuracy sensor.
+- **iaq_accuracy** (*Optional*): Configuration for the numeric IAQ accuracy sensor.
 
   - All options from [Sensor](/components/sensor).
 
-- **co2_equivalent** (_Optional_): Configuration for the CO₂ equivalent sensor.
+- **co2_equivalent** (*Optional*): Configuration for the CO₂ equivalent sensor.
 
   - All options from [Sensor](/components/sensor).
 
-- **breath_voc_equivalent** (_Optional_): Configuration for the Breath VOC equivalent humidity sensor.
+- **breath_voc_equivalent** (*Optional*): Configuration for the Breath VOC equivalent humidity sensor.
 
   - All options from [Sensor](/components/sensor).
 
@@ -168,10 +168,10 @@ text_sensor:
 
 ### Configuration variables
 
-- **bme68x_bsec2_id** (_Optional_, [ID](/guides/configuration-types#id)): The ID of the `bme68x_bsec2_i2c` component the text sensor
+- **bme68x_bsec2_id** (*Optional*, [ID](/guides/configuration-types#id)): The ID of the `bme68x_bsec2_i2c` component the text sensor
   will refer to. Useful when multiple devices are present in your configuration.
 
-- **iaq_accuracy** (_Optional_): Configuration for the IAQ accuracy sensor. Shows: `Stabilizing`, `Uncertain`,
+- **iaq_accuracy** (*Optional*): Configuration for the IAQ accuracy sensor. Shows: `Stabilizing`, `Uncertain`,
   `Calibrating`, `Calibrated`.
 
   - All other options from [Text Sensor](/components/text_sensor#config-text_sensor).

--- a/src/content/docs/components/sensor/ltr_als_ps.mdx
+++ b/src/content/docs/components/sensor/ltr_als_ps.mdx
@@ -174,7 +174,7 @@ may simply use the shorthand syntax for the sensor. For example: `ambient_light:
 - **full_spectrum_counts** (*Optional*): Sensor counts from the sensor sensitive to both visible light and IR (_CH0_), counts.
 - **actual_gain** (*Optional*): Gain value used to measure data, multiplier. Particularly useful when "auto_mode" is selected.
 - **actual_integration_time** (*Optional*): Integration time used to measure data, ms. Particularly useful when "auto_mode" is selected.
-- **ps_counts** (*Optional*) - Raw 11-bit reading from proximity sensor, counts.
+- **ps_counts** (*Optional*): Raw 11-bit reading from proximity sensor, counts.
 
 ## See Also
 

--- a/src/content/docs/components/sensor/ltr_als_ps.mdx
+++ b/src/content/docs/components/sensor/ltr_als_ps.mdx
@@ -124,41 +124,41 @@ sensor:
 
 ## Configuration variables
 
-- **id** (_Optional_, [ID](/guides/configuration-types#id)): Manually specify the ID used for code generation.
-- **address** (_Optional_, int): Manually specify the I²C address of the sensor. Default is `0x29`.
-- **type** (_Optional_, string): The type of the sensor. Valid values are `ALS_PS` _(default)_ for
+- **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID used for code generation.
+- **address** (*Optional*, int): Manually specify the I²C address of the sensor. Default is `0x29`.
+- **type** (*Optional*, string): The type of the sensor. Valid values are `ALS_PS` _(default)_ for
   integrated sensors, `ALS` for ambient light only or `PS` for proximity only devices.
 
-- **auto_mode** (_Optional_, boolean): Automatic gain and integration time selection. Defaults to True.
-- **gain** (_Optional_, string): The gain the device will use. Higher values are better in low-light conditions.
+- **auto_mode** (*Optional*, boolean): Automatic gain and integration time selection. Defaults to True.
+- **gain** (*Optional*, string): The gain the device will use. Higher values are better in low-light conditions.
   Valid values are `1X` _(default)_, `2X`, `4X`, `8X`, `48X`, `96X`.
 
-- **integration_time** (_Optional_, [Time](/guides/configuration-types#time)):
+- **integration_time** (*Optional*, [Time](/guides/configuration-types#time)):
   The amount of time sensors are exposed. Longer means more accurate values.
   Valid values are: `50ms` _(default)_, `100ms`, `150ms`, `200ms`, `250ms`, `300ms`, `350ms`, `400ms`.
 
-- **glass_attenuation_factor** (_Optional_, float): The attenuation factor of glass if it's behind some glass
+- **glass_attenuation_factor** (*Optional*, float): The attenuation factor of glass if it's behind some glass
   or plastic facia. Default is `1.0` means `100%` transmissivity. `2` means `50%` transmissivity etc.
 
-- **update_interval** (_Optional_, [Time](/guides/configuration-types#time)): The interval for checking the sensors.
+- **update_interval** (*Optional*, [Time](/guides/configuration-types#time)): The interval for checking the sensors.
   Defaults to `60s`.
 
-- **ps_cooldown** (_Optional_, [Time](/guides/configuration-types#time)): The "cooldown" period after the proximity sensor is triggered.
+- **ps_cooldown** (*Optional*, [Time](/guides/configuration-types#time)): The "cooldown" period after the proximity sensor is triggered.
   Helps to avoid multiple calls. Defaults to `5s`.
 
-- **ps_gain** (_Optional_, string): The gain the device will use for proximity sensor. Higher values are better in low-light conditions.
+- **ps_gain** (*Optional*, string): The gain the device will use for proximity sensor. Higher values are better in low-light conditions.
   Valid values are `16X` _(default)_, `32X`, `64X`. Only for **LTR-659ALS**.
 
-- **ps_high_threshold** (_Optional_, int): The threshold for the proximity sensor to trigger on object getting closer.
+- **ps_high_threshold** (*Optional*, int): The threshold for the proximity sensor to trigger on object getting closer.
   Defaults to `65535`, which implies it will never be triggered.
 
-- **ps_low_threshold** (_Optional_, int): The threshold for the proximity sensor to trigger on object getting further away.
+- **ps_low_threshold** (*Optional*, int): The threshold for the proximity sensor to trigger on object getting further away.
   Defaults to `0`, which implies it will never be triggered.
 
-- **on_ps_high_threshold** (_Optional_): Actions to perform when the proximity sensor is triggered
+- **on_ps_high_threshold** (*Optional*): Actions to perform when the proximity sensor is triggered
   on object getting closer.
 
-- **on_ps_low_threshold** (_Optional_): Actions to perform when the proximity sensor is triggered
+- **on_ps_low_threshold** (*Optional*): Actions to perform when the proximity sensor is triggered
   on object getting further away.
 
 ### Sensors
@@ -169,12 +169,12 @@ on each `update_interval`. Each is an ESPHome [sensor](/components/sensor) and m
 accordingly; if you don't need to configure additional [sensor](/components/sensor) variables, you
 may simply use the shorthand syntax for the sensor. For example: `ambient_light: "Ambient light"`
 
-- **ambient_light** (_Optional_): Illuminance of ambient light, close to human eye spectre, lx.
-- **infrared_counts** (_Optional_): Sensor counts from the IR-sensitive sensor (_CH1_), counts.
-- **full_spectrum_counts** (_Optional_): Sensor counts from the sensor sensitive to both visible light and IR (_CH0_), counts.
-- **actual_gain** (_Optional_): Gain value used to measure data, multiplier. Particularly useful when "auto_mode" is selected.
-- **actual_integration_time** (_Optional_): Integration time used to measure data, ms. Particularly useful when "auto_mode" is selected.
-- **ps_counts** (_Optional_) - Raw 11-bit reading from proximity sensor, counts.
+- **ambient_light** (*Optional*): Illuminance of ambient light, close to human eye spectre, lx.
+- **infrared_counts** (*Optional*): Sensor counts from the IR-sensitive sensor (_CH1_), counts.
+- **full_spectrum_counts** (*Optional*): Sensor counts from the sensor sensitive to both visible light and IR (_CH0_), counts.
+- **actual_gain** (*Optional*): Gain value used to measure data, multiplier. Particularly useful when "auto_mode" is selected.
+- **actual_integration_time** (*Optional*): Integration time used to measure data, ms. Particularly useful when "auto_mode" is selected.
+- **ps_counts** (*Optional*) - Raw 11-bit reading from proximity sensor, counts.
 
 ## See Also
 

--- a/src/content/docs/components/sensor/ms8607.mdx
+++ b/src/content/docs/components/sensor/ms8607.mdx
@@ -33,29 +33,29 @@ sensor:
 
 ## Configuration variables
 
-- **temperature** (_Optional_): The information for the temperature sensor.
+- **temperature** (*Optional*): The information for the temperature sensor.
   All options from [Sensor](/components/sensor).
 
-- **pressure** (_Optional_): The information for the pressure sensor.
+- **pressure** (*Optional*): The information for the pressure sensor.
   All options from [Sensor](/components/sensor).
 
-- **humidity** (_Optional_): The information for the humidity sensor.
+- **humidity** (*Optional*): The information for the humidity sensor.
 
-  - **address** (_Optional_, int): Manually specify the I²C address of
+  - **address** (*Optional*, int): Manually specify the I²C address of
     the humidity sensor. Defaults to `0x40`.
 
-  - **i2c_id** (_Optional_, [ID](/guides/configuration-types#id)): Manually specify the ID of the [I²C Component](/components/i2c) if your
+  - **i2c_id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID of the [I²C Component](/components/i2c) if your
     configuration uses multiple I²C buses. This should match the `i2c_id` documented below.
 
   - All other options from [Sensor](/components/sensor).
 
-- **address** (_Optional_, int): Manually specify the I²C address of
+- **address** (*Optional*, int): Manually specify the I²C address of
   the temperature & pressure sensor. Defaults to `0x76`.
 
-- **i2c_id** (_Optional_, [ID](/guides/configuration-types#id)): Manually specify the ID of the [I²C Component](/components/i2c) if your
+- **i2c_id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID of the [I²C Component](/components/i2c) if your
   configuration uses multiple I²C buses. This should match the `i2c_id` inside of `humidity`, documented above.
 
-- **update_interval** (_Optional_, [Time](/guides/configuration-types#time)): The interval to check the
+- **update_interval** (*Optional*, [Time](/guides/configuration-types#time)): The interval to check the
   sensor. Defaults to `60s`.
 
 ## I²C Addresses

--- a/src/content/docs/components/sensor/sm300d2.mdx
+++ b/src/content/docs/components/sensor/sm300d2.mdx
@@ -62,31 +62,31 @@ sensor:
 
 ## Configuration variables
 
-- **co2** (**Required**): The information for the CO₂ sensor. Readings in parts per million (ppm).
+- **co2** (*Optional*): The information for the CO₂ sensor. Readings in parts per million (ppm).
 
   - All options from [Sensor](/components/sensor).
 
-- **formaldehyde** (**Required**): The information for the formaldehyde sensor. Readings in µg/m³.
+- **formaldehyde** (*Optional*): The information for the formaldehyde sensor. Readings in µg/m³.
 
   - All options from [Sensor](/components/sensor).
 
-- **tvoc** (**Required**): The information for the total volatile organic compounds (TVOC) sensor. Readings in µg/m³.
+- **tvoc** (*Optional*): The information for the total volatile organic compounds (TVOC) sensor. Readings in µg/m³.
 
   - All options from [Sensor](/components/sensor).
 
-- **pm_2_5** (**Required**): The information for the **Weight Concentration** sensor for fine particles up to 2.5μm. Readings in µg/m³.
+- **pm_2_5** (*Optional*): The information for the **Weight Concentration** sensor for fine particles up to 2.5μm. Readings in µg/m³.
 
   - All options from [Sensor](/components/sensor).
 
-- **pm_10_0** (**Required**): The information for the **Weight Concentration** sensor for coarse particles up to 10μm. Readings in µg/m³.
+- **pm_10_0** (*Optional*): The information for the **Weight Concentration** sensor for coarse particles up to 10μm. Readings in µg/m³.
 
   - All options from [Sensor](/components/sensor).
 
-- **temperature** (**Required**): The information for the temperature sensor. Readings in degrees celsius (°C).
+- **temperature** (*Optional*): The information for the temperature sensor. Readings in degrees celsius (°C).
 
   - All options from [Sensor](/components/sensor).
 
-- **humidity** (**Required**): The information for the relative humidity sensor. Readings in %.
+- **humidity** (*Optional*): The information for the relative humidity sensor. Readings in %.
 
   - All options from [Sensor](/components/sensor).
 

--- a/src/content/docs/components/sensor/tsl2591.mdx
+++ b/src/content/docs/components/sensor/tsl2591.mdx
@@ -113,15 +113,15 @@ sensor:
 
 For the TSL2591 device:
 
-- **id** (_Optional_, [ID](/guides/configuration-types#id)): Manually specify the ID used for code generation.
-- **name** (_Optional_, string): A user-friendly name for this TSL2591 device.
-- **address** (_Optional_, int): Manually specify the I²C address of the device.
+- **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID used for code generation.
+- **name** (*Optional*, string): A user-friendly name for this TSL2591 device.
+- **address** (*Optional*, int): Manually specify the I²C address of the device.
   Defaults to `0x29`.
   It is not possible to change this for this device without additional hardware.
   It also automatically uses a secondary address of `0x28` (see the datasheet),
   making that address unavailable for other devices on the same I²C bus.
 
-- **integration_time** (_Optional_, [Time](/guides/configuration-types#time)):
+- **integration_time** (*Optional*, [Time](/guides/configuration-types#time)):
   The time the device will use for each measurement. Longer means more accurate values.
   You cannot specify an arbitrary amount of time. It must be the equivalent of one of:
 
@@ -132,7 +132,7 @@ For the TSL2591 device:
   - `500ms`
   - `600ms`
 
-- **gain** (_Optional_, string): The gain the device will use. Higher values are better in low-light conditions.
+- **gain** (*Optional*, string): The gain the device will use. Higher values are better in low-light conditions.
   Multipliers here are approximate. Values below on the same line are aliases.
   You cannot specify an arbitrary gain multiplier. It must be one of:
 
@@ -142,16 +142,16 @@ For the TSL2591 device:
   - `maximum`, `max`, `9500x`
   - `auto` _(default)_
 
-- **update_interval** (_Optional_, [Time](/guides/configuration-types#time)): The interval for checking the sensors.
+- **update_interval** (*Optional*, [Time](/guides/configuration-types#time)): The interval for checking the sensors.
   Defaults to `60s`.
 
-- **power_save_mode** (_Optional_, boolean): Should the device be powered down between update intervals?
+- **power_save_mode** (*Optional*, boolean): Should the device be powered down between update intervals?
   Defaults to `True`.
 
-- **device_factor** (_Optional_, float): The default is `53.0`.
+- **device_factor** (*Optional*, float): The default is `53.0`.
   The device factor to be used as part of the lux equation for `calculated_lux`.
 
-- **glass_attenuation_factor** (_Optional_, float): The default is `7.7`.
+- **glass_attenuation_factor** (*Optional*, float): The default is `7.7`.
   The glass attenuation factor to be used as part of the lux equation for `calculated_lux`.
 
 - All other options for I²C devices described at [I²C Bus](/components/i2c).
@@ -159,23 +159,23 @@ For the TSL2591 device:
 You can configure all or any subset of the sensors described earlier.
 Each configured sensor is reported separately on each `update_interval`.
 
-- **full_spectrum** (_Optional_): The reading for the full spectrum sensor.
+- **full_spectrum** (*Optional*): The reading for the full spectrum sensor.
 
   - All options from [Sensor](/components/sensor).
 
-- **infrared** (_Optional_): The reading for the infrared sensor.
+- **infrared** (*Optional*): The reading for the infrared sensor.
 
   - All options from [Sensor](/components/sensor).
 
-- **visible** (_Optional_): The reading for visible light.
+- **visible** (*Optional*): The reading for visible light.
 
   - All options from [Sensor](/components/sensor).
 
-- **calculated_lux** (_Optional_): The value of the calculated lux.
+- **calculated_lux** (*Optional*): The value of the calculated lux.
 
   - All options from [Sensor](/components/sensor).
 
-- **actual_gain** (_Optional_): The value of gain used for reported values. Particularly useful when gain is set to "auto".
+- **actual_gain** (*Optional*): The value of gain used for reported values. Particularly useful when gain is set to "auto".
 
   - All options from [Sensor](/components/sensor).
 

--- a/src/content/docs/components/sensor/veml7700.mdx
+++ b/src/content/docs/components/sensor/veml7700.mdx
@@ -122,22 +122,22 @@ sensor:
 
 ## Configuration variables
 
-- **auto_mode** (_Optional_, boolean): Automatic gain and integration time selection. Defaults to `True`.
-- **integration_time** (_Optional_, [Time](/guides/configuration-types#time)):
+- **auto_mode** (*Optional*, boolean): Automatic gain and integration time selection. Defaults to `True`.
+- **integration_time** (*Optional*, [Time](/guides/configuration-types#time)):
   The amount of time the sensor is exposed. Valid values are `25ms`, `50ms`, `100ms` _(default)_,
   `200ms`, `400ms`, `800ms`. _In automatic mode it sets starting value_.
 
-- **gain** (_Optional_, string): The gain the device will use for the internal ADC. Valid values are
+- **gain** (*Optional*, string): The gain the device will use for the internal ADC. Valid values are
   `1/8x` _(default)_, `1/4x`, `1x`, `2x`. Higher values are better in low-light conditions.
   _In automatic mode it sets starting gain value_.
 
-- **lux_compensation** (_Optional_, boolean): Lux compensation formula is used as per manufacturer.
+- **lux_compensation** (*Optional*, boolean): Lux compensation formula is used as per manufacturer.
   Defaults to `True`.
 
-- **glass_attenuation_factor** (_Optional_): The attenuation factor of glass if it's behind some glass
+- **glass_attenuation_factor** (*Optional*): The attenuation factor of glass if it's behind some glass
   or plastic facia. Default is `1.0` means `100%` transmissivity. `2` means `50%` transmissivity etc.
 
-- **update_interval** (_Optional_, [Time](/guides/configuration-types#time)): The interval for checking the sensors.
+- **update_interval** (*Optional*, [Time](/guides/configuration-types#time)): The interval for checking the sensors.
   Defaults to `60s`.
 
 - All other options for I²C devices described at [I²C Bus](/components/i2c).
@@ -151,13 +151,13 @@ All options from [Sensor](/components/sensor) are supported.
 
 However, if you don't need any other options, you can just use shorthands like this: `ambient_light: Ambient light`.
 
-- **ambient_light** (_Optional_): Illuminance for visible light (_ALS channel_), lx.
-- **full_spectrum** (_Optional_): Illuminance for the full spectrum sensor (_WHITE channel_), lx.
-- **infrared** (_Optional_): Calculated illuminance for the Near-IR spectrum (_WHITE_ minus _ALS_), lx.
-- **ambient_light_counts** (_Optional_): The reading for visible light (_ALS channel_), counts.
-- **full_spectrum_counts** (_Optional_): The reading for the full spectrum sensor (_WHITE channel_), counts.
-- **actual_gain** (_Optional_): The value of gain used for reported values. Particularly useful when "auto_mode" is selected.
-- **actual_integration_time** (_Optional_): Integration time used for reported values, ms. Particularly useful when "auto_mode" is selected.
+- **ambient_light** (*Optional*): Illuminance for visible light (_ALS channel_), lx.
+- **full_spectrum** (*Optional*): Illuminance for the full spectrum sensor (_WHITE channel_), lx.
+- **infrared** (*Optional*): Calculated illuminance for the Near-IR spectrum (_WHITE_ minus _ALS_), lx.
+- **ambient_light_counts** (*Optional*): The reading for visible light (_ALS channel_), counts.
+- **full_spectrum_counts** (*Optional*): The reading for the full spectrum sensor (_WHITE channel_), counts.
+- **actual_gain** (*Optional*): The value of gain used for reported values. Particularly useful when "auto_mode" is selected.
+- **actual_integration_time** (*Optional*): Integration time used for reported values, ms. Particularly useful when "auto_mode" is selected.
 
 ## See Also
 


### PR DESCRIPTION
## Description

Fixes schema validation errors in sensor documentation.

### Formatting fixes (`_Optional_` → `*Optional*`)

Six sensor docs used underscores (`_Optional_`) instead of asterisks (`*Optional*`) for italic markup. Both render identically in markdown, but the schema validation script only recognizes the asterisk form. Fixed in:

- `sensor/ltr_als_ps.mdx` (18 errors)
- `sensor/bme68x_bsec2.mdx` (15 errors)
- `sensor/veml7700.mdx` (13 errors)
- `sensor/tsl2591.mdx` (13 errors)
- `sensor/ms8607.mdx` (8 errors)
- `sensor/bme680_bsec.mdx` (8 errors)

### Required/Optional fix

- `sensor/sm300d2.mdx`: All 7 sensor sub-configs (co2, formaldehyde, tvoc, pm_2_5, pm_10_0, temperature, humidity) changed from **Required** to *Optional* to match `cv.Optional` in code.

### Not addressed (validator limitations)

- GeneratedID vs Optional for `*_id` fields (ld2410, ld2450, ld2412) — this is a validator issue; documenting GeneratedID fields as Optional is the correct convention.
- `ade7880` `(instantaneous)`/`(accumulated)` annotations — these confuse the parser but are correct documentation.

## Related

Part of a series fixing docs-to-code schema mismatches identified by the esphome-schema CI validation.