### PR TITLE
Fix sensor docs schema mismatches (batch 2)

### DIFF
--- a/src/content/docs/components/sensor/ags10.mdx
+++ b/src/content/docs/components/sensor/ags10.mdx
@@ -35,7 +35,7 @@ sensor:
 
 ## Configuration variables
 
-- **tvoc** (**Required**): The information for the total Volatile Organic Compounds sensor.
+- **tvoc** (*Optional*): The information for the total Volatile Organic Compounds sensor.
   All options from [Sensor](/components/sensor).
 
 - **address** (*Optional*, int): Manually specify the I²C address of
@@ -109,7 +109,7 @@ on_...:
 Configuration options:
 
 - **id** (**Required**, [ID](/guides/configuration-types#id)): The ID of the AGS10 sensor.
-- **address** (**Required**, int): New I2C address.
+- **address** (**Required**, int, [templatable](/automations/templates)): New I2C address.
 
 ## See Also
 

--- a/src/content/docs/components/sensor/aht10.mdx
+++ b/src/content/docs/components/sensor/aht10.mdx
@@ -49,11 +49,11 @@ sensor:
 > Even if the sensor chip housing is labeled as AHT10, it may require the `AHT20` variant configuration.
 > If recognized at the address but data fetch fails, try the AHT20 variant.
 
-- **temperature** (**Required**): The information for the temperature sensor.
+- **temperature** (*Optional*): The information for the temperature sensor.
 
   - All options from [Sensor](/components/sensor).
 
-- **humidity** (**Required**): The information for the humidity sensor
+- **humidity** (*Optional*): The information for the humidity sensor
 
   - All options from [Sensor](/components/sensor).
 

--- a/src/content/docs/components/sensor/am2320.mdx
+++ b/src/content/docs/components/sensor/am2320.mdx
@@ -39,11 +39,11 @@ sensor:
 
 ## Configuration variables
 
-- **temperature** (**Required**): The information for the temperature sensor.
+- **temperature** (*Optional*): The information for the temperature sensor.
 
   - All options from [Sensor](/components/sensor).
 
-- **humidity** (**Required**): The information for the humidity sensor
+- **humidity** (*Optional*): The information for the humidity sensor
 
   - All options from [Sensor](/components/sensor).
 

--- a/src/content/docs/components/sensor/combination.mdx
+++ b/src/content/docs/components/sensor/combination.mdx
@@ -84,7 +84,7 @@ sensor:
     parameter, with low values marking accurate data. If implemented as a template, the
     measurement is in parameter `x`.
 
-  - **coefficient** (**Required**, only for `LINEAR` type, float, [templatable](/automations/templates)):
+  - **coefficient** (*Optional*, only for `LINEAR` type, float, [templatable](/automations/templates)):
     The coefficient to multiply the sensor's state by before summing all source sensor states.
     If implemented as a template, the measurement is in parameter `x`.
 

--- a/src/content/docs/components/sensor/dht.mdx
+++ b/src/content/docs/components/sensor/dht.mdx
@@ -48,11 +48,11 @@ sensor:
 ## Configuration variables
 
 - **pin** (**Required**, [Pin](/guides/configuration-types#pin)): The pin where the DHT bus is connected.
-- **temperature** (**Required**): The information for the temperature sensor.
+- **temperature** (*Optional*): The information for the temperature sensor.
 
   - All options from [Sensor](/components/sensor).
 
-- **humidity** (**Required**): The information for the humidity sensor
+- **humidity** (*Optional*): The information for the humidity sensor
 
   - All options from [Sensor](/components/sensor).
 

--- a/src/content/docs/components/sensor/dht12.mdx
+++ b/src/content/docs/components/sensor/dht12.mdx
@@ -35,11 +35,11 @@ sensor:
 
 ## Configuration variables
 
-- **temperature** (**Required**): The information for the temperature sensor.
+- **temperature** (*Optional*): The information for the temperature sensor.
 
   - All options from [Sensor](/components/sensor).
 
-- **humidity** (**Required**): The information for the humidity sensor
+- **humidity** (*Optional*): The information for the humidity sensor
 
   - All options from [Sensor](/components/sensor).
 

--- a/src/content/docs/components/sensor/duty_cycle.mdx
+++ b/src/content/docs/components/sensor/duty_cycle.mdx
@@ -25,7 +25,7 @@ sensor:
 
 ## Configuration variables
 
-- **pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The pin to observe for the duty
+- **pin** (**Required**, [Pin Schema](/guides/configuration-types#pin-schema)): The pin to observe for the duty
   cycle.
 
 - **update_interval** (*Optional*, [Time](/guides/configuration-types#time)): The interval to check the sensor. Defaults to `60s`.

--- a/src/content/docs/components/sensor/ens210.mdx
+++ b/src/content/docs/components/sensor/ens210.mdx
@@ -35,11 +35,11 @@ sensor:
 
 ## Configuration variables
 
-- **temperature** (**Required**): The information for the temperature sensor.
+- **temperature** (*Optional*): The information for the temperature sensor.
 
   - All options from [Sensor](/components/sensor).
 
-- **humidity** (**Required**): The information for the humidity sensor
+- **humidity** (*Optional*): The information for the humidity sensor
 
   - All options from [Sensor](/components/sensor).
 

--- a/src/content/docs/components/sensor/grove_gas_mc_v2.mdx
+++ b/src/content/docs/components/sensor/grove_gas_mc_v2.mdx
@@ -45,16 +45,16 @@ sensor:
 
 ## Configuration variables
 
-- **nitrogen_dioxide** (**Required**): The Nitrogen Dioxide sensor data.
+- **nitrogen_dioxide** (*Optional*): The Nitrogen Dioxide sensor data.
   All options from [Sensor](/components/sensor).
 
-- **ethanol** (**Required**): The Ethanol (C2H5OH) sensor data.
+- **ethanol** (*Optional*): The Ethanol (C2H5OH) sensor data.
   All options from [Sensor](/components/sensor).
 
-- **carbon_monoxide** (**Required**): The Carbon Monoxide sensor data.
+- **carbon_monoxide** (*Optional*): The Carbon Monoxide sensor data.
   All options from [Sensor](/components/sensor).
 
-- **tvoc** (**Required**): The Total Volatile Organic Compounds (TVOC) sensor data.
+- **tvoc** (*Optional*): The Total Volatile Organic Compounds (TVOC) sensor data.
   All options from [Sensor](/components/sensor).
 
 - **update_interval** (*Optional*, [Time](/guides/configuration-types#time)): The interval to check the

--- a/src/content/docs/components/sensor/hdc1080.mdx
+++ b/src/content/docs/components/sensor/hdc1080.mdx
@@ -37,11 +37,11 @@ sensor:
 
 ## Configuration variables
 
-- **temperature** (**Required**): The information for the temperature sensor.
+- **temperature** (*Optional*): The information for the temperature sensor.
 
   - All options from [Sensor](/components/sensor).
 
-- **humidity** (**Required**): The information for the humidity sensor
+- **humidity** (*Optional*): The information for the humidity sensor
 
   - All options from [Sensor](/components/sensor).
 

--- a/src/content/docs/components/sensor/hdc2010.mdx
+++ b/src/content/docs/components/sensor/hdc2010.mdx
@@ -37,11 +37,11 @@ sensor:
 
 ## Configuration variables
 
-- **temperature** (**Required**): The information for the temperature sensor.
+- **temperature** (*Optional*): The information for the temperature sensor.
 
   - All options from [Sensor](/components/sensor/).
 
-- **humidity** (**Required**): The information for the humidity sensor
+- **humidity** (*Optional*): The information for the humidity sensor
 
   - All options from [Sensor](/components/sensor/).
 

--- a/src/content/docs/components/sensor/honeywell_hih_i2c.mdx
+++ b/src/content/docs/components/sensor/honeywell_hih_i2c.mdx
@@ -23,10 +23,10 @@ sensor:
 
 ## Configuration variables
 
-- **temperature** (**Required**): The information for the temperature sensor.
+- **temperature** (*Optional*): The information for the temperature sensor.
   All options from [Sensor](/components/sensor).
 
-- **humidity** (**Required**): The information for the humidity sensor.
+- **humidity** (*Optional*): The information for the humidity sensor.
   All options from [Sensor](/components/sensor).
 
 - **update_interval** (*Optional*, [Time](/guides/configuration-types#time)): The interval to check the sensor. Defaults to `60s`.

--- a/src/content/docs/components/sensor/ld2420.mdx
+++ b/src/content/docs/components/sensor/ld2420.mdx
@@ -257,7 +257,7 @@ Four button components are available enabling configuration controls for editing
 
 ### Configuration variables
 
-- **apply_config** (*Optional*): Saves both manual config tuning or the auto calibrate still and move threshold config
+- **apply_config** (**Required**): Saves both manual config tuning or the auto calibrate still and move threshold config
   settings. May contain any options from [Button](/components/button#config-button).
 
 - **restart_module** (*Optional*): Reboots the LD2420 modules. May contain any options from [Button](/components/button#config-button).

--- a/src/content/docs/components/sensor/mmc5983.mdx
+++ b/src/content/docs/components/sensor/mmc5983.mdx
@@ -41,16 +41,16 @@ sensor:
 
 ## Configuration variables
 
-- **field_strength_x** (_Optional_): The information for the X-axis field sensor. All options from
+- **field_strength_x** (*Optional*): The information for the X-axis field sensor. All options from
   [Sensor](/components/sensor).
 
-- **field_strength_y** (_Optional_): The information for the Y-axis field sensor. All options from
+- **field_strength_y** (*Optional*): The information for the Y-axis field sensor. All options from
   [Sensor](/components/sensor).
 
-- **field_strength_z** (_Optional_): The information for the Z-axis field sensor. All options from
+- **field_strength_z** (*Optional*): The information for the Z-axis field sensor. All options from
   [Sensor](/components/sensor).
 
-- **update_interval** (_Optional_, [Time](/guides/configuration-types#time)): The interval to check the sensor. Defaults to `60s`.
+- **update_interval** (*Optional*, [Time](/guides/configuration-types#time)): The interval to check the sensor. Defaults to `60s`.
 
 ## See Also
 

--- a/src/content/docs/components/sensor/opt3001.mdx
+++ b/src/content/docs/components/sensor/opt3001.mdx
@@ -33,7 +33,7 @@ sensor:
 
 ## Configuration variables
 
-- **name** (**Required**, string): The name for the sensor.
+- **name** (*Optional*, string): The name for the sensor.
 - **address** (*Optional*, int): Manually specify the I²C address of the sensor.
   Defaults to `0x44` (address if address pin is pulled low). If the address pin is pulled high,
   the address is `0x45`. If the address pin is connected to SDA, the address is `0x46`. If the

--- a/src/content/docs/components/sensor/pmwcs3.mdx
+++ b/src/content/docs/components/sensor/pmwcs3.mdx
@@ -127,7 +127,7 @@ on_...:
 Configuration options:
 
 - **id** (**Required**, [ID](/guides/configuration-types#id)): The ID of the pmwcs3 sensor.
-- **address** (**Required**, int): New I2C address.
+- **address** (**Required**, int, [templatable](/automations/templates)): New I2C address.
 
 ## See Also
 

--- a/src/content/docs/components/sensor/pulse_counter.mdx
+++ b/src/content/docs/components/sensor/pulse_counter.mdx
@@ -31,11 +31,9 @@ sensor:
 
   - **rising_edge** (**Required**): What to do when a rising edge is
     detected. One of `DISABLE`, `INCREMENT` and `DECREMENT`.
-    Defaults to `INCREMENT`.
 
   - **falling_edge** (**Required**): What to do when a falling edge is
     detected. One of `DISABLE`, `INCREMENT` and `DECREMENT`.
-    Defaults to `DISABLE`.
 
 - **use_pcnt** (*Optional*, boolean): Use hardware `PCNT` pulse counter. Only supported on ESP32. Defaults to `true`.
 - **internal_filter** (*Optional*, [Time](/guides/configuration-types#time)): If a pulse shorter than this

--- a/src/content/docs/components/sensor/pulse_counter.mdx
+++ b/src/content/docs/components/sensor/pulse_counter.mdx
@@ -29,11 +29,11 @@ sensor:
 - **count_mode** (*Optional*): Configure how the counter should behave
   on a detected rising edge/falling edge.
 
-  - **rising_edge** (*Optional*): What to do when a rising edge is
+  - **rising_edge** (**Required**): What to do when a rising edge is
     detected. One of `DISABLE`, `INCREMENT` and `DECREMENT`.
     Defaults to `INCREMENT`.
 
-  - **falling_edge** (*Optional*): What to do when a falling edge is
+  - **falling_edge** (**Required**): What to do when a falling edge is
     detected. One of `DISABLE`, `INCREMENT` and `DECREMENT`.
     Defaults to `DISABLE`.
 

--- a/src/content/docs/components/sensor/pulse_width.mdx
+++ b/src/content/docs/components/sensor/pulse_width.mdx
@@ -23,7 +23,7 @@ sensor:
 
 ## Configuration variables
 
-- **pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The pin to observe for the
+- **pin** (**Required**, [Pin Schema](/guides/configuration-types#pin-schema)): The pin to observe for the
   pulse width.
 
 - **update_interval** (*Optional*, [Time](/guides/configuration-types#time)): The interval to check the sensor.

--- a/src/content/docs/components/sensor/sgp30.mdx
+++ b/src/content/docs/components/sensor/sgp30.mdx
@@ -60,10 +60,10 @@ Advanced:
 
 - **compensation** (*Optional*): The block containing sensors used for compensation. Both values must be supplied in order to be able to generate the absolute humidity to be reported to the sensor.
 
-  - **temperature_source** (*Optional*, [ID](/guides/configuration-types#id)): Give an external temperature sensor ID
+  - **temperature_source** (**Required**, [ID](/guides/configuration-types#id)): Give an external temperature sensor ID
     here. The data must be in Celsius. This can improve the sensor's internal calculations.
 
-  - **humidity_source** (*Optional*, [ID](/guides/configuration-types#id)): Give an external relative humidity sensor ID
+  - **humidity_source** (**Required**, [ID](/guides/configuration-types#id)): Give an external relative humidity sensor ID
     here. This can improve the sensor's internal calculations.
 
 <span id="sgp30-calibrating"></span>

--- a/src/content/docs/components/sensor/sgp4x.mdx
+++ b/src/content/docs/components/sensor/sgp4x.mdx
@@ -64,10 +64,10 @@ sensor:
 
 - **compensation** (*Optional*): The block containing sensors used for compensation. If not set defaults will be used.
 
-  - **temperature_source** (*Optional*, [ID](/guides/configuration-types#id)): Give an external temperature sensor ID
+  - **temperature_source** (**Required**, [ID](/guides/configuration-types#id)): Give an external temperature sensor ID
     here. This can improve the sensor's internal calculations. Defaults to `25`
 
-  - **humidity_source** (*Optional*, [ID](/guides/configuration-types#id)): Give an external humidity sensor ID
+  - **humidity_source** (**Required**, [ID](/guides/configuration-types#id)): Give an external humidity sensor ID
     here. This can improve the sensor's internal calculations. Defaults to `50`
 
 ## Example With Compensation

--- a/src/content/docs/components/sensor/sgp4x.mdx
+++ b/src/content/docs/components/sensor/sgp4x.mdx
@@ -65,10 +65,10 @@ sensor:
 - **compensation** (*Optional*): The block containing sensors used for compensation. If not set defaults will be used.
 
   - **temperature_source** (**Required**, [ID](/guides/configuration-types#id)): Give an external temperature sensor ID
-    here. This can improve the sensor's internal calculations. Defaults to `25`
+    here. This can improve the sensor's internal calculations.
 
   - **humidity_source** (**Required**, [ID](/guides/configuration-types#id)): Give an external humidity sensor ID
-    here. This can improve the sensor's internal calculations. Defaults to `50`
+    here. This can improve the sensor's internal calculations.
 
 ## Example With Compensation
 

--- a/src/content/docs/components/sensor/sht3xd.mdx
+++ b/src/content/docs/components/sensor/sht3xd.mdx
@@ -29,21 +29,21 @@ sensor:
 
 ## Configuration variables
 
-- **temperature** (_Optional_): The information for the temperature sensor.
+- **temperature** (*Optional*): The information for the temperature sensor.
 
   - All options from [Sensor](/components/sensor).
 
-- **humidity** (_Optional_): The information for the humidity sensor.
+- **humidity** (*Optional*): The information for the humidity sensor.
 
   - All options from [Sensor](/components/sensor).
 
-- **address** (_Optional_, int): Manually specify the I²C address of the sensor.
+- **address** (*Optional*, int): Manually specify the I²C address of the sensor.
   Defaults to `0x44`. For SHT3x, an alternate address can be `0x45` while SHT85 supports only address `0x44`
 
-- **update_interval** (_Optional_, [Time](/guides/configuration-types#time)): The interval to check the
+- **update_interval** (*Optional*, [Time](/guides/configuration-types#time)): The interval to check the
   sensor. Defaults to `60s`.
 
-- **heater_enabled** (_Optional_, bool): Turn on/off heater at boot.
+- **heater_enabled** (*Optional*, bool): Turn on/off heater at boot.
   This may help provide [more accurate readings in condensing conditions](https://forum.arduino.cc/t/atmospheric-sensors-in-condensing-conditions/412167),
   but can also increase temperature readings and decrease humidity readings as a side effect.
   Defaults to `false`.

--- a/src/content/docs/components/sensor/sound_level.mdx
+++ b/src/content/docs/components/sensor/sound_level.mdx
@@ -27,7 +27,7 @@ sensor:
 
 ## Configuration variables
 
-- **microphone** (**Required**, [Microphone Source Configuration](/components/microphone#config-microphone-source)): The [microphone](/components/microphone/) settings to use for input. Multiple channels may be selected.
+- **microphone** (*Optional*, [Microphone Source Configuration](/components/microphone#config-microphone-source)): The [microphone](/components/microphone/) settings to use for input. Multiple channels may be selected.
 - **measurement_duration** (*Optional*, [Time](/guides/configuration-types#time)): The time duration for each sound level measurement. Ranges from `50ms` to `60s`. Defaults to `1000ms`.
 - **passive** (**Required**, boolean). Whether passive mode is enabled. See [Passive Mode](#sound_level-passive).
 - **peak** (*Optional*): The information for the peak loudness sensor.

--- a/src/content/docs/components/sensor/sound_level.mdx
+++ b/src/content/docs/components/sensor/sound_level.mdx
@@ -29,7 +29,7 @@ sensor:
 
 - **microphone** (*Optional*, [Microphone Source Configuration](/components/microphone#config-microphone-source)): The [microphone](/components/microphone/) settings to use for input. Multiple channels may be selected.
 - **measurement_duration** (*Optional*, [Time](/guides/configuration-types#time)): The time duration for each sound level measurement. Ranges from `50ms` to `60s`. Defaults to `1000ms`.
-- **passive** (**Required**, boolean). Whether passive mode is enabled. See [Passive Mode](#sound_level-passive).
+- **passive** (**Required**, boolean): Whether passive mode is enabled. See [Passive Mode](#sound_level-passive).
 - **peak** (*Optional*): The information for the peak loudness sensor.
 
   - All options from [Sensor](/components/sensor).

--- a/src/content/docs/components/sensor/tx20.mdx
+++ b/src/content/docs/components/sensor/tx20.mdx
@@ -39,10 +39,10 @@ sensor:
 
 ## Configuration variables
 
-- **wind_speed** (**Required**): The information for the wind speed sensor.
+- **wind_speed** (*Optional*): The information for the wind speed sensor.
   All options from [Sensor](/components/sensor).
 
-- **wind_direction_degrees** (**Required**): The information for the direction
+- **wind_direction_degrees** (*Optional*): The information for the direction
   in degrees sensor.
   All options from [Sensor](/components/sensor).
 

--- a/src/content/docs/components/sensor/ufire_ec.mdx
+++ b/src/content/docs/components/sensor/ufire_ec.mdx
@@ -69,8 +69,8 @@ on_...:
 Configuration options:
 
 - **id** (**Required**, [ID](/guides/configuration-types#id)): The ID of the ufire EC sensor.
-- **solution** (**Required**, float): Solution reference EC value.
-- **temperature** (**Required**, float): Solution current temperature.
+- **solution** (**Required**, float, [templatable](/automations/templates)): Solution reference EC value.
+- **temperature** (**Required**, float, [templatable](/automations/templates)): Solution current temperature.
 
 <span id="sensor-ufire_ec-reset_action"></span>
 

--- a/src/content/docs/components/sensor/ufire_ise.mdx
+++ b/src/content/docs/components/sensor/ufire_ise.mdx
@@ -65,7 +65,7 @@ on_...:
 Configuration options:
 
 - **id** (**Required**, [ID](/guides/configuration-types#id)): The ID of the ufire pH sensor.
-- **solution** (**Required**, float): Solution reference pH value.
+- **solution** (**Required**, float, [templatable](/automations/templates)): Solution reference pH value.
 
 <span id="sensor-ufire_ise-calibrate_probe_low_action"></span>
 
@@ -92,7 +92,7 @@ on_...:
 Configuration options:
 
 - **id** (**Required**, [ID](/guides/configuration-types#id)): The ID of the ufire pH sensor.
-- **solution** (**Required**, float): Solution reference pH value.
+- **solution** (**Required**, float, [templatable](/automations/templates)): Solution reference pH value.
 
 <span id="sensor-ufire_ise-reset_action"></span>
 

--- a/src/content/docs/components/sensor/ufire_ise.mdx
+++ b/src/content/docs/components/sensor/ufire_ise.mdx
@@ -44,7 +44,7 @@ sensor:
 
 ## `ufire_ise.calibrate_probe_high` Action
 
-The pH probe have to be calibrated. For this you need know the pH reference value and temperature
+The pH probe have to be calibrated. For this you need to know the pH reference value
 of the calibration high solution.
 
 ```yaml
@@ -59,7 +59,6 @@ on_...:
   - sensor.ufire_ise_board.calibrate_probe_high:
       id: ufire_ise_board
       solution: 7.0
-      temperature: !lambda "return id(temperature_liquid).state;"
 ```
 
 Configuration options:
@@ -71,7 +70,7 @@ Configuration options:
 
 ## `ufire_ise.calibrate_probe_low` Action
 
-The pH probe have to be calibrated. For this you need know the pH reference value and temperature
+The pH probe have to be calibrated. For this you need to know the pH reference value
 of the calibration low solution.
 
 ```yaml
@@ -86,7 +85,6 @@ on_...:
   - sensor.ufire_ise_board.calibrate_probe_low:
       id: ufire_ise_board
       solution: 4.0
-      temperature: !lambda "return id(temperature_liquid).state;"
 ```
 
 Configuration options:


### PR DESCRIPTION
## Summary
- Fix Required/Optional, formatting, and templatable annotation mismatches between docs and ESPHome code across 25 sensor component files
- All changes verified against the ESPHome Python source schemas

### Changes by category

**Format (`_Optional_` → `*Optional*`):**
- sht3xd, mmc5983

**Optional in code, Required in docs (changed to Optional):**
- aht10, am2320, dht, dht12, ens210, grove_gas_mc_v2, hdc1080, hdc2010, honeywell_hih_i2c, tx20: temperature/humidity sub-sensors
- ags10: tvoc
- combination: coefficient
- opt3001: name
- sound_level: microphone

**Required in code, Optional in docs (changed to Required):**
- duty_cycle, pulse_width: pin
- pulse_counter: rising_edge, falling_edge
- sgp30, sgp4x: temperature_source, humidity_source (Required within Optional compensation block)
- ld2420: apply_config

**Add missing templatable annotation:**
- ags10, pmwcs3: address in new_i2c_address action
- ufire_ec: solution, temperature in calibrate_probe action
- ufire_ise: solution in calibrate_probe/calibrate_probe_low actions

## Test plan
- [ ] Verify changed pages render correctly
- [ ] Run schema validation to confirm mismatches are resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)