### PR TITLE
Fix schema validation errors in climate and display docs

### DIFF
--- a/src/content/docs/components/climate/pid.mdx
+++ b/src/content/docs/components/climate/pid.mdx
@@ -375,11 +375,11 @@ on_...:
 Configuration variables:
 
 - **id** (**Required**, [ID](/guides/configuration-types#id)): ID of the PID Climate to start autotuning for.
-- **kp** (**Required**, float): The factor for the proportional term of the PID controller.
-- **ki** (*Optional*, float): The factor for the integral term of the PID controller.
+- **kp** (**Required**, float, [templatable](/automations/templates)): The factor for the proportional term of the PID controller.
+- **ki** (*Optional*, float, [templatable](/automations/templates)): The factor for the integral term of the PID controller.
   Defaults to `0`.
 
-- **kd** (*Optional*, float): The factor for the derivative term of the PID controller.
+- **kd** (*Optional*, float, [templatable](/automations/templates)): The factor for the derivative term of the PID controller.
   Defaults to `0`.
 
 ## `climate.pid.reset_integral_term` Action

--- a/src/content/docs/components/climate/thermostat.mdx
+++ b/src/content/docs/components/climate/thermostat.mdx
@@ -364,7 +364,7 @@ experience and automation.
     - `dry`
     - `fan_only`
     - `auto`
-  - **fan_mode** (*Optional*, climate fan mode): The fan mode the thermostat should switch to when this preset
+  - **fan_mode** (*Optional*, climate fan mode, [templatable](/automations/templates)): The fan mode the thermostat should switch to when this preset
     is activated. If not specified, the thermostat's fan mode will remain unchanged when the preset is activated.
     One of:
 
@@ -378,7 +378,7 @@ experience and automation.
     - `focus`
     - `diffuse`
     - `quiet`
-  - **swing_mode** (*Optional*, climate swing mode): The fan swing mode the thermostat should switch to when this
+  - **swing_mode** (*Optional*, climate swing mode, [templatable](/automations/templates)): The fan swing mode the thermostat should switch to when this
     preset is activated. If not specified, the thermostat's fan swing mode will remain unchanged when the preset
     is activated. One of:
 
@@ -429,7 +429,7 @@ climate:
 
 These configuration items determine default values the thermostat controller should use when it starts.
 
-- **default_preset** (*Optional*, string): The name of the preset to use by default. Must match a preset
+- **default_preset** (*Optional*, string, [templatable](/automations/templates)): The name of the preset to use by default. Must match a preset
   as per [preset](#thermostat-preset).
 
 - **on_boot_restore_from**: (*Optional*, on_boot_restore_from): Controls what the thermostat will do when

--- a/src/content/docs/components/display/qspi_dbi.mdx
+++ b/src/content/docs/components/display/qspi_dbi.mdx
@@ -75,7 +75,7 @@ display:
   - `AXS15231`
 
 - **init_sequence** (*Optional*, A list of byte arrays): Specifies the init sequence for the display. This is required when using the `CUSTOM` model - but may be empty. If specified for other models this data will be sent after the pre-configured sequence.
-- **cs_pin** (**Required**, [Pin Schema](/guides/configuration-types#pin-schema)): The chip select pin.
+- **cs_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The chip select pin.
 - **reset_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The RESET pin.
 - **enable_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The display enable pin.
 - **brightness** (*Optional*, int): A brightness value in the range 0-255

--- a/src/content/docs/components/display/st7789v.mdx
+++ b/src/content/docs/components/display/st7789v.mdx
@@ -74,17 +74,17 @@ If you do specify them they will override any default.
   - `Waveshare 1.47in 172X320` (round-rectangular display -- some pixels are "deleted" from corners to form rounded shape)
   - `Custom` For other displays not listed above
 
-- **height** (*Optional*, int): Sets height of display in pixels. Defaults depends `model`.
-- **width** (*Optional*, int): Sets width of display. Defaults depends `model`.
+- **height** (*Optional*, int): Sets height of display in pixels. Default depends on `model`.
+- **width** (*Optional*, int): Sets width of display. Default depends on `model`.
 - **offset_height** (*Optional*, int): When `model` is set to "Custom", use this to specify the display's vertical
-  offset in pixels. This option may not be specified when the `model` is not set to "Custom". Defaults depends `model`.
+  offset in pixels. This option may not be specified when the `model` is not set to "Custom". Default depends on `model`.
 
 - **offset_width** (*Optional*, int): When `model` is set to "Custom", use this to specify the display's horizontal
-  offset in pixels. This option may not be specified when the `model` is not set to "Custom". Defaults depends `model`.
+  offset in pixels. This option may not be specified when the `model` is not set to "Custom". Default depends on `model`.
 
-- **cs_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The CS pin. Defaults depends `model`.
-- **dc_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The DC pin. Defaults depends `model`.
-- **reset_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The RESET pin. Defaults depends `model`.
+- **cs_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The CS pin. Default depends on `model`.
+- **dc_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The DC pin. Default depends on `model`.
+- **reset_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The RESET pin. Default depends on `model`.
 - **eightbitcolor** (*Optional*, boolean): Limits the supported color depth to eight bits. May be useful on
   memory-constrained devices. Defaults to `false`.
 

--- a/src/content/docs/components/display/st7789v.mdx
+++ b/src/content/docs/components/display/st7789v.mdx
@@ -74,17 +74,17 @@ If you do specify them they will override any default.
   - `Waveshare 1.47in 172X320` (round-rectangular display -- some pixels are "deleted" from corners to form rounded shape)
   - `Custom` For other displays not listed above
 
-- **height** (**Required**, int): Sets height of display in pixels. Defaults depends `model`.
-- **width** (**Required**, int): Sets width of display. Defaults depends `model`.
-- **offset_height** (**Required**, int): When `model` is set to "Custom", use this to specify the display's vertical
+- **height** (*Optional*, int): Sets height of display in pixels. Defaults depends `model`.
+- **width** (*Optional*, int): Sets width of display. Defaults depends `model`.
+- **offset_height** (*Optional*, int): When `model` is set to "Custom", use this to specify the display's vertical
   offset in pixels. This option may not be specified when the `model` is not set to "Custom". Defaults depends `model`.
 
-- **offset_width** (**Required**, int): When `model` is set to "Custom", use this to specify the display's horizontal
+- **offset_width** (*Optional*, int): When `model` is set to "Custom", use this to specify the display's horizontal
   offset in pixels. This option may not be specified when the `model` is not set to "Custom". Defaults depends `model`.
 
-- **cs_pin** (**Required**, [Pin Schema](/guides/configuration-types#pin-schema)): The CS pin. Defaults depends `model`.
-- **dc_pin** (**Required**, [Pin Schema](/guides/configuration-types#pin-schema)): The DC pin. Defaults depends `model`.
-- **reset_pin** (**Required**, [Pin Schema](/guides/configuration-types#pin-schema)): The RESET pin. Defaults depends `model`.
+- **cs_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The CS pin. Defaults depends `model`.
+- **dc_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The DC pin. Defaults depends `model`.
+- **reset_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The RESET pin. Defaults depends `model`.
 - **eightbitcolor** (*Optional*, boolean): Limits the supported color depth to eight bits. May be useful on
   memory-constrained devices. Defaults to `false`.
 


### PR DESCRIPTION
## Summary
- **climate/pid.mdx**: Add `[templatable]` to `kp`, `ki`, `kd` in `climate.pid.set_control_parameters` action (verified against `pid/climate.py` — all three use `cv.templatable`)
- **climate/thermostat.mdx**: Add `[templatable]` to `fan_mode`, `swing_mode` in preset config and `default_preset` (verified against `thermostat/climate.py` — `PRESET_CONFIG_SCHEMA` and `CONFIG_SCHEMA`)
- **display/qspi_dbi.mdx**: Change `cs_pin` from Required to Optional (verified: `spi_device_schema(cs_pin_required=False)` in `qspi_dbi/display.py`)
- **display/st7789v.mdx**: Change `height`, `width`, `offset_height`, `offset_width`, `cs_pin`, `dc_pin`, `reset_pin` from Required to Optional (verified: all are `cv.Optional` in `st7789v/display.py`, conditionally required by validator for Custom model)

## Test plan
- [ ] Verify CI schema validation passes for the modified files
- [ ] Verify docs render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)