### PR TITLE
Fix type/templatable ordering in entity and template docs

### DIFF
--- a/src/content/docs/components/cover/template.mdx
+++ b/src/content/docs/components/cover/template.mdx
@@ -114,13 +114,13 @@ Configuration options:
 - **state** (*Optional*, [templatable](/automations/templates)):
   The state to publish. One of `OPEN`, `CLOSED`. If using a lambda, use `COVER_OPEN` or `COVER_CLOSED`.
 
-- **position** (*Optional*, [templatable](/automations/templates), float):
+- **position** (*Optional*, float, [templatable](/automations/templates)):
   The position to publish, from 0 (CLOSED) to 1.0 (OPEN)
 
-- **tilt** (*Optional*, [templatable](/automations/templates), float):
+- **tilt** (*Optional*, float, [templatable](/automations/templates)):
   The tilt position to publish, from 0 (CLOSED) to 1.0 (OPEN)
 
-- **current_operation** (*Optional*, [templatable](/automations/templates), string):
+- **current_operation** (*Optional*, string, [templatable](/automations/templates)):
   The current operation mode to publish. One of `IDLE`, `OPENING` and `CLOSING`. If using a lambda, use `COVER_OPERATION_IDLE`, `COVER_OPERATION_OPENING`, and `COVER_OPERATION_CLOSING`.
 
 > [!NOTE]

--- a/src/content/docs/components/light/index.mdx
+++ b/src/content/docs/components/light/index.mdx
@@ -49,7 +49,7 @@ light:
 - **initial_state** (*Optional*): The initial state the light should be set to on bootup. This state will be applied
   when the state is **not** restored based on `restore_mode` (below).
 
-  - **state** (*Optional*, [templatable](/automations/templates), boolean): The ON/OFF state for the light.
+  - **state** (*Optional*, boolean, [templatable](/automations/templates)): The ON/OFF state for the light.
   - All other options from [light state](#light-state_config).
 
 - **restore_mode** (*Optional*): Control how the light attempts to restore state on bootup.

--- a/src/content/docs/components/text_sensor/index.mdx
+++ b/src/content/docs/components/text_sensor/index.mdx
@@ -248,7 +248,7 @@ on_...:
 Configuration variables:
 
 - **id** (**Required**, [ID](/guides/configuration-types#id)): The text sensor ID.
-- **state** (**Required**, [templatable](/automations/templates), string): The state to compare
+- **state** (**Required**, string, [templatable](/automations/templates)): The state to compare
   to.
 
 > [!NOTE]

--- a/src/content/docs/components/valve/template.mdx
+++ b/src/content/docs/components/valve/template.mdx
@@ -104,10 +104,10 @@ Configuration options:
 - **state** (*Optional*, [templatable](/automations/templates)):
   The state to publish. One of `OPEN`, `CLOSED`. If using a lambda, use `VALVE_OPEN` or `VALVE_CLOSED`.
 
-- **position** (*Optional*, [templatable](/automations/templates), float):
+- **position** (*Optional*, float, [templatable](/automations/templates)):
   The position to publish, from 0 (CLOSED) to 1.0 (OPEN)
 
-- **current_operation** (*Optional*, [templatable](/automations/templates), string):
+- **current_operation** (*Optional*, string, [templatable](/automations/templates)):
   The current operation mode to publish. One of `IDLE`, `OPENING` and `CLOSING`. If using a lambda, use
   `VALVE_OPERATION_IDLE`, `VALVE_OPERATION_OPENING`, and `VALVE_OPERATION_CLOSING`.
 

--- a/src/content/docs/components/water_heater/template.mdx
+++ b/src/content/docs/components/water_heater/template.mdx
@@ -117,15 +117,15 @@ with the `water_heater.template.publish` action.
 Configuration options:
 
 - **id** (**Required**, [ID](/guides/configuration-types#id)): The ID of the template water heater.
-- **current_temperature** (*Optional*, [templatable](/automations/templates), float):
+- **current_temperature** (*Optional*, float, [templatable](/automations/templates)):
   The current measured temperature to publish.
-- **target_temperature** (*Optional*, [templatable](/automations/templates), float):
+- **target_temperature** (*Optional*, float, [templatable](/automations/templates)):
   The target setpoint temperature to publish.
-- **mode** (*Optional*, [templatable](/automations/templates), string):
+- **mode** (*Optional*, string, [templatable](/automations/templates)):
   The operation mode to publish. See [Water Heater Modes](/components/water_heater#water-heater-modes) for options.
-- **away** (*Optional*, [templatable](/automations/templates), boolean):
+- **away** (*Optional*, boolean, [templatable](/automations/templates)):
   The away mode state to publish.
-- **is_on** (*Optional*, [templatable](/automations/templates), boolean):
+- **is_on** (*Optional*, boolean, [templatable](/automations/templates)):
   The boolean On/Off state to publish.
 
 > [!NOTE]


### PR DESCRIPTION
## Summary
- Reorders `(templatable, type)` to `(type, templatable)` in 5 entity documentation files
- The schema validator parses `[templatable]` as the type field when it appears before the actual type, causing false "should be templatable" errors
- Convention is `type, [templatable]` (128 instances) vs `[templatable], type` (which these files used)

## Files changed
- `cover/template.mdx` — position, tilt, current_operation
- `valve/template.mdx` — position, current_operation
- `water_heater/template.mdx` — current_temperature, target_temperature, mode, away, is_on
- `light/index.mdx` — initial_state.state
- `text_sensor/index.mdx` — text_sensor.state condition

## Test plan
- [ ] Verify schema validation errors are resolved for these fields
- [ ] Verify rendered docs are unchanged (just reordering within parentheses)

🤖 Generated with [Claude Code](https://claude.com/claude-code)