### PR TITLE
Fix schema annotations in misc component docs

### DIFF
--- a/src/content/docs/components/binary_sensor/analog_threshold.mdx
+++ b/src/content/docs/components/binary_sensor/analog_threshold.mdx
@@ -53,12 +53,12 @@ binary_sensor:
 ## Configuration variables
 
 - **sensor_id** (**Required**, [ID](/guides/configuration-types#id)): The ID of the source sensor.
-- **threshold** (**Required**, float [templatable](/automations/templates) or mapping): Configures the reference for comparison. Accepts either a shorthand
+- **threshold** (**Required**, float, [templatable](/automations/templates) or mapping): Configures the reference for comparison. Accepts either a shorthand
    float number that will be used as both upper/lower threshold, or a mapping to define different values for each (to
    use hysteresis).
 
-  - **upper** (**Required**, float [templatable](/automations/templates)): Upper threshold, that needs to be crossed to transition from `low` to `high` states.
-  - **lower** (**Required**, float [templatable](/automations/templates)): Lower threshold, that needs to be crossed to transition from `high` to `low` states.
+  - **upper** (**Required**, float, [templatable](/automations/templates)): Upper threshold, that needs to be crossed to transition from `low` to `high` states.
+  - **lower** (**Required**, float, [templatable](/automations/templates)): Lower threshold, that needs to be crossed to transition from `high` to `low` states.
 - All other options from [Binary Sensor](/components/binary_sensor#config-binary_sensor).
 
 ## See Also

--- a/src/content/docs/components/output/sigma_delta_output.mdx
+++ b/src/content/docs/components/output/sigma_delta_output.mdx
@@ -59,7 +59,7 @@ output:
 
 Configuration variables:
 
-- **update_interval** (**Required**, [Time](/guides/configuration-types#time)): The cycle interval at which the output is recalculated.
+- **update_interval** (*Optional*, [Time](/guides/configuration-types#time)): The cycle interval at which the output is recalculated. Defaults to `60s`.
 - **pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The pin to pulse.
 - **state_change_action** (*Optional*, [Automation](/automations)): An automation to perform when the load is switched. If a lambda is used the boolean `state` parameter holds the new status.
 - **turn_on_action** (*Optional*, [Automation](/automations)): An automation to perform when the load is turned on. Can be used to control for example a switch or output component.

--- a/src/content/docs/components/text_sensor/nextion.mdx
+++ b/src/content/docs/components/text_sensor/nextion.mdx
@@ -32,7 +32,7 @@ text_sensor:
 ## Configuration variables
 
 - **nextion_id** (*Optional*, [ID](/guides/configuration-types#id)): The ID of the Nextion display.
-- **component_name** (*Optional*, string): The name of the Nextion component.
+- **component_name** (**Required**, string): The name of the Nextion component.
 - **update_interval** (*Optional*, [Time](/guides/configuration-types#time)): The duration to update the sensor. If using a [Nextion Custom Text Sensor Protocol](#nextion_custom_text_sensor_protocol) this should not be used
 - **background_color** (*Optional*, [Color](/components/display#config-color)): The background color
 - **foreground_color** (*Optional*, [Color](/components/display#config-color)): The foreground color

--- a/src/content/docs/components/time/bm8563.mdx
+++ b/src/content/docs/components/time/bm8563.mdx
@@ -74,7 +74,7 @@ on_...:
 
 Configuration options:
 
-- **duration** (**Required**, [Time](/guides/configuration-types#config-time)): The time duration for the timer.
+- **duration** (**Required**, [Time](/guides/configuration-types#config-time), [templatable](/automations/templates)): The time duration for the timer.
 - **id** (*Optional*, [ID](/guides/configuration-types#config-id)): Manually specify the ID of the BM8563 component if you have multiple components.
 
 <span id="bm8563-config_example"></span>

--- a/src/content/docs/components/touchscreen/ektf2232.mdx
+++ b/src/content/docs/components/touchscreen/ektf2232.mdx
@@ -20,8 +20,8 @@ touchscreen:
 ## Configuration variables
 
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually set the ID of this touchscreen.
-- **reset_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The reset pin of the controller.
-- **interrupt_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The touch detection pin.
+- **reset_pin** (**Required**, [Pin Schema](/guides/configuration-types#pin-schema)): The reset pin of the controller.
+- **interrupt_pin** (**Required**, [Pin Schema](/guides/configuration-types#pin-schema)): The touch detection pin.
 
 - All other options from [Base Touchscreen Configuration](/components/touchscreen#config-touchscreen).
 

--- a/src/content/docs/components/touchscreen/lilygo_t5_47.mdx
+++ b/src/content/docs/components/touchscreen/lilygo_t5_47.mdx
@@ -19,7 +19,7 @@ touchscreen:
 ## Configuration variables
 
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually set the ID of this touchscreen.
-- **interrupt_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The touch detection pin. Must be `GPIO13`.
+- **interrupt_pin** (**Required**, [Pin Schema](/guides/configuration-types#pin-schema)): The touch detection pin. Must be `GPIO13`.
 - All other options from [Base Touchscreen Configuration](/components/touchscreen#config-touchscreen).
 
 ## See Also

--- a/src/content/docs/components/touchscreen/tt21100.mdx
+++ b/src/content/docs/components/touchscreen/tt21100.mdx
@@ -42,7 +42,7 @@ touchscreen:
 ### Configuration variables
 
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually set the ID of this touchscreen.
-- **interrupt_pin** (**Required**, [Pin Schema](/guides/configuration-types#pin-schema)): The touch detection pin.
+- **interrupt_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The touch detection pin.
 - **reset_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The reset pin of the controller.
 
 - All other options from [Touchscreen](/components/touchscreen#config-touchscreen).


### PR DESCRIPTION
## Summary
Fixes templatable formatting and Required/Optional mismatches across 7 component documentation files, verified against ESPHome Python source code.

### Templatable fixes
- `binary_sensor/analog_threshold.mdx` — add missing comma before `[templatable]` on threshold, upper, lower (validator parsed `float [templatable]` as a single type token)
- `time/bm8563.mdx` — add missing `[templatable]` to timer duration

### Required/Optional fixes
- `text_sensor/nextion.mdx` — `component_name`: Optional → Required (source: `nextion/base_component.py`)
- `touchscreen/ektf2232.mdx` — `reset_pin`, `interrupt_pin`: Optional → Required
- `touchscreen/lilygo_t5_47.mdx` — `interrupt_pin`: Optional → Required
- `touchscreen/tt21100.mdx` — `interrupt_pin`: Required → Optional
- `output/sigma_delta_output.mdx` — `update_interval`: Required → Optional (default 60s, from `polling_component_schema`)

## Test plan
- [ ] Verify schema validation errors are resolved for these files
- [ ] Verify rendered docs accurately reflect the source code requirements

🤖 Generated with [Claude Code](https://claude.com/claude-code)