### PR TITLE
[media_source] Initial platform component index

### DIFF
--- a/src/content/docs/components/index.mdx
+++ b/src/content/docs/components/index.mdx
@@ -886,6 +886,12 @@ Used for creating infrared (IR) remote control transmitters and/or receivers.
   ["Generic Output Lock", "/components/lock/output/", "upload.svg", "dark-invert"],
 ]} />
 
+## Media Source Components
+
+<ImgTable items={[
+  ["Media Source Core", "/components/media_source/", "folder-open.svg", "dark-invert"],
+]} />
+
 ## Media Player Components
 
 <ImgTable items={[

--- a/src/content/docs/components/media_source/index.mdx
+++ b/src/content/docs/components/media_source/index.mdx
@@ -1,0 +1,23 @@
+---
+description: "Instructions for setting up media sources in ESPHome."
+title: "Media Source Components"
+sidebar:
+  label: "Media Source Components"
+---
+
+The `media_source` domain contains common functionality shared across the
+media source platforms. A media source produces audio data and delivers it
+to a media player, which handles the audio output.
+
+<span id="config-media_source"></span>
+
+## Base Media Source Configuration
+
+```yaml
+media_source:
+  - platform: ...
+```
+
+## Platforms
+
+## See Also


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Basic index page for the new ``media_source`` platform component. Will add the speaker source media player under See Also once finished

**Related issue (if applicable):** not applicable

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#14417

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
