### PR TITLE
[usb_uart] baud rate is not ignored on CDC-ACM

### DIFF
--- a/src/content/docs/components/usb_uart.mdx
+++ b/src/content/docs/components/usb_uart.mdx
@@ -44,7 +44,7 @@ Setting both `vid` and `pid` to 0 will match any device.
 ## Channel configuration options
 
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): An id to assign to the channel. This id may be used anywhere a `uart` component is required.
-- **baud_rate** (**Required**, int): The baud rate to use for the channel. This is optional (and ignored) for the `stm32_vcp`, `esp_jtag` and `cdc_acm` types.
+- **baud_rate** (**Required**, int): The baud rate to use for the channel. This is optional for the `stm32_vcp`, `esp_jtag` and `cdc_acm` types.
 - **buffer_size** (*Optional*, int): The size of the buffer to use for the channel. Defaults to 256 bytes.
 - **stop_bits** (*Optional*, float): The number of stop bits to use. Defaults to 1. Other options are 1.5 and 2.
 - **data_bits** (*Optional*, int): The number of data bits to use in the range 5-8. Defaults to 8.
@@ -56,7 +56,6 @@ Setting both `vid` and `pid` to 0 will match any device.
 
 The `cdc_acm` type is a generic USB CDC ACM (Abstract Control Model) device. This is a common USB device class for serial communication.
 This driver does not strictly enforce the CDC-ACM configuration specification, so it may work with devices that do not properly implement that specification. It expects to find a single interrupt endpoint, a single bulk in endpoint, and a single bulk out endpoint.
-The `cdc_acm`, `esp_jtag` and `stm32_vcp` types do not support changing baud rate, stop bits or number of data bits, as they implement a virtual channel not typically associated with a physical UART.
 
 ## See Also
 


### PR DESCRIPTION
There are CDC-ACM devices out there which bridge an actual UART port to USB. On these devices, setting the Baud rate is definitely not a no-op, and the selected Baud rate actually affects the behavior of that serial port.

This is essentially a documentation fix for esphome/esphome#14333. Don't ask me how long I blindly trusted that sentence :).

Fixes: bc6e4165 [usb_uart] Document USB Host mode UART (#4724)
Fixes: esphome/esphome@656389f21 [usb_uart] Performance, correctness and reliability improvements (esphome/esphome#14333)
Cc: @clydebarrow @kbx81 

## Checklist

- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.