### PR TITLE
Update PID climate documentation to include level_and_direction_output option

### DIFF
--- a/src/content/docs/components/climate/pid.mdx
+++ b/src/content/docs/components/climate/pid.mdx
@@ -59,12 +59,21 @@ climate:
   for the control algorithm. This can be dynamically set in the frontend later.
 
 - **heat_output** (*Optional*, [ID](/guides/configuration-types#id)): The ID of a [float output](/components/output#config-output)
-  that increases the current temperature. At least one of `heat_output` and `cool_output` must
-  be specified.
+  that increases the current temperature. At least one of `heat_output`, `cool_output` or
+  `level_and_direction_output` must be specified. You cannot use `level_and_direction_output`
+  together with `heat_output` or `cool_output`.
 
 - **cool_output** (*Optional*, [ID](/guides/configuration-types#id)): The ID of a [float output](/components/output#config-output)
-  that decreases the current temperature. At least one of `heat_output` and `cool_output` must
-  be specified.
+  that decreases the current temperature. At least one of `heat_output`, `cool_output` or
+  `level_and_direction_output` must be specified.
+
+- **level_and_direction_output** (*Optional*): A single combined output with level and direction, for use with
+  devices such as Peltier modules or motor controllers. Mutually exclusive with `heat_output` and `cool_output`.
+  Contains:
+  - **level** (**Required**, [ID](/guides/configuration-types#id)): The ID of a [float output](/components/output#config-output)
+    for the output level (0–1), e.g. PWM.
+  - **direction** (**Required**, [ID](/guides/configuration-types#id)): The ID of a [binary output](/components/output#config-output)
+    for the direction (e.g. false = heat, true = cool).
 
 - **control_parameters** (**Required**): Control parameters of the PID controller.
 
@@ -124,6 +133,7 @@ To set up a PID climate controller, you need a couple of components:
 - A [Sensor](/components/sensor) to read the current temperature (`sensor`  ).
 - At least one [float output](/components/output#config-output) to drive for heating or cooling (or both).
   This could for example be a PWM output via [Sigma Delta Output](/components/output/sigma_delta_output/) or [Slow Pwm](/components/output/slow_pwm/) that drives a heating unit.
+  Alternatively, use **level_and_direction_output** with a float output (level) and a [binary output](/components/output#config-output) (direction) for a single device that can both heat and cool, such as a Peltier module or a motor-driven valve.
 
   Please note the output *must* be controllable with continuous value (not only ON/OFF, but any state
   in between for example 50% heating power).


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

**Related issue (if applicable): adds docs for https://github.com/esphome/esphome/pull/14419

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
