### PR TITLE
[audio_file] Document new media source

### DIFF
--- a/src/content/docs/components/audio_file/index.mdx
+++ b/src/content/docs/components/audio_file/index.mdx
@@ -12,7 +12,7 @@ This component only works on ESP32 based chips.
 The `audio_file` component allows you to embed audio files directly into your device's firmware.
 Audio files can be sourced from local files or downloaded from a URL at compile time.
 The raw audio data is stored in flash memory and can be played back using the
-[Audio File media source](/components/media_source/audio_file) platform.
+[Audio File media source](/components/media_source/audio_file/) platform.
 
 Supported audio formats are automatically detected and include:
 
@@ -58,5 +58,5 @@ audio_file:
 ## See Also
 
 - [Media Source Components](/components/media_source/)
-- [Audio File Media Source](/components/media_source/audio_file)
+- [Audio File Media Source](/components/media_source/audio_file/)
 - <APIRef text="audio_file.h" path="esphome/components/audio_file/audio_file.h" />

--- a/src/content/docs/components/audio_file/index.mdx
+++ b/src/content/docs/components/audio_file/index.mdx
@@ -1,0 +1,60 @@
+---
+description: "Instructions for setting up audio files in ESPHome."
+title: "Audio File Component"
+sidebar:
+  label: "Audio File"
+---
+
+import APIRef from '@components/APIRef.astro';
+
+The `audio_file` component allows you to embed audio files directly into your device's firmware.
+Audio files can be sourced from local files or downloaded from a URL at compile time.
+The raw audio data is stored in flash memory and can be played back using the
+[Audio File media source](/components/media_source/audio_file) platform.
+
+Supported audio formats are automatically detected and include:
+
+- WAV
+- MP3
+- FLAC
+- Opus (in an OGG container)
+
+```yaml
+# Example configuration entry
+audio_file:
+  - id: alert_sound
+    file: "sounds/alert.wav"
+  - id: timer_sound
+    file: "https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/timer_finished.flac"
+  - id: doorbell
+    file:
+      type: local
+      path: "sounds/doorbell.mp3"
+```
+
+<span id="config-audio_file"></span>
+
+## Configuration variables
+
+- **id** (**Required**, [ID](/guides/configuration-types#id)): The ID to use for referencing this audio file. This is also used as the file identifier when playing back through a media source.
+- **file** (**Required**): The audio file to embed. Can be a simple string or a mapping with a type key:
+
+  - **Simple form**: A string value. If it starts with `http://` or `https://`, it is treated as a web URL; otherwise, it is treated as a local file path relative to the configuration file.
+
+  - **Typed form**:
+
+    - **type** (**Required**, string): Either `local` or `web`.
+
+    **Local files**:
+
+    - **path** (**Required**, string): The path (relative to the configuration file) of the audio file.
+
+    **Web files**:
+
+    - **url** (**Required**, string): The URL to download the audio file from. The file is downloaded once at compile time and cached locally.
+
+## See Also
+
+- [Media Source Components](/components/media_source/)
+- [Audio File Media Source](/components/media_source/audio_file)
+- <APIRef text="audio_file.h" path="esphome/components/audio_file/audio_file.h" />

--- a/src/content/docs/components/audio_file/index.mdx
+++ b/src/content/docs/components/audio_file/index.mdx
@@ -7,6 +7,8 @@ sidebar:
 
 import APIRef from '@components/APIRef.astro';
 
+This component only works on ESP32 based chips.
+
 The `audio_file` component allows you to embed audio files directly into your device's firmware.
 Audio files can be sourced from local files or downloaded from a URL at compile time.
 The raw audio data is stored in flash memory and can be played back using the

--- a/src/content/docs/components/index.mdx
+++ b/src/content/docs/components/index.mdx
@@ -890,7 +890,7 @@ Used for creating infrared (IR) remote control transmitters and/or receivers.
 
 <ImgTable items={[
   ["Media Source Core", "/components/media_source/", "folder-open.svg", "dark-invert"],
-  ["Audio File Media Source", "/components/media_source/audio_file", "file-document-box.svg", "dark-invert"],
+  ["Audio File Media Source", "/components/media_source/audio_file/", "file-document-box.svg", "dark-invert"],
 ]} />
 
 ## Media Player Components

--- a/src/content/docs/components/index.mdx
+++ b/src/content/docs/components/index.mdx
@@ -890,6 +890,7 @@ Used for creating infrared (IR) remote control transmitters and/or receivers.
 
 <ImgTable items={[
   ["Media Source Core", "/components/media_source/", "folder-open.svg", "dark-invert"],
+  ["Audio File Media Source", "/components/media_source/audio_file", "file-document-box.svg", "dark-invert"],
 ]} />
 
 ## Media Player Components
@@ -1089,6 +1090,7 @@ ESPHome to cellular networks. **Does not encompass Wi-Fi.**
 ## Miscellaneous Components
 
 <ImgTable items={[
+  ["Audio File", "/components/audio_file/", "file-document-box.svg", "dark-invert"],
   ["Camera Encoder", "/components/camera/camera_encoder/", "camera.svg", "dark-invert"],
   ["ESP32 Camera", "/components/esp32_camera/", "camera.svg", "dark-invert"],
   ["Exposure Notifications", "/components/exposure_notifications/", "exposure_notifications.png"],

--- a/src/content/docs/components/media_source/audio_file.mdx
+++ b/src/content/docs/components/media_source/audio_file.mdx
@@ -1,0 +1,46 @@
+---
+description: "Instructions for setting up the Audio File media source in ESPHome."
+title: "Audio File Media Source"
+---
+
+import APIRef from '@components/APIRef.astro';
+
+The `audio_file` media source platform plays audio files that have been embedded into the firmware
+using the [Audio File](/components/audio_file/) component.
+
+Files are played using the `audio-file://` URI scheme, where the URI path is the `id` of the
+audio file to play.
+
+```yaml
+# Example configuration entry
+audio_file:
+  - id: alert_sound
+    file: "sounds/alert.wav"
+  - id: timer_sound
+    file: "https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/timer_finished.flac"
+
+media_source:
+  - platform: audio_file
+    id: file_source
+```
+
+To play a file, send the media URL `audio-file://alert_sound` to a media player that uses this
+media source.
+
+<span id="config-audio_file_media_source"></span>
+
+## Configuration variables
+
+- **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID for this media source.
+- **task_stack_in_psram** (*Optional*, boolean): If `true`, the FreeRTOS decode task stack is
+  allocated in PSRAM instead of internal RAM. Requires the [psram](/components/psram/) component. Defaults to `false`.
+- All other options from [Media Source](/components/media_source/).
+
+> [!NOTE]
+> This platform is only available on ESP32.
+
+## See Also
+
+- [Audio File Component](/components/audio_file/)
+- [Media Source Components](/components/media_source/)
+- <APIRef text="audio_file_media_source.h" path="esphome/components/audio_file/media_source/audio_file_media_source.h" />

--- a/src/content/docs/components/media_source/audio_file.mdx
+++ b/src/content/docs/components/media_source/audio_file.mdx
@@ -8,8 +8,8 @@ import APIRef from '@components/APIRef.astro';
 The `audio_file` media source platform plays audio files that have been embedded into the firmware
 using the [Audio File](/components/audio_file/) component.
 
-Files are played using the `audio-file://` URI scheme, where the URI path is the `id` of the
-audio file to play.
+Files are played using the `audio-file://` URI scheme; the part after `audio-file://` is used as the
+`id` of the audio file to play.
 
 This component only works on ESP32 based chips.
 

--- a/src/content/docs/components/media_source/audio_file.mdx
+++ b/src/content/docs/components/media_source/audio_file.mdx
@@ -11,6 +11,8 @@ using the [Audio File](/components/audio_file/) component.
 Files are played using the `audio-file://` URI scheme, where the URI path is the `id` of the
 audio file to play.
 
+This component only works on ESP32 based chips.
+
 ```yaml
 # Example configuration entry
 audio_file:
@@ -35,9 +37,6 @@ media source.
 - **task_stack_in_psram** (*Optional*, boolean): If `true`, the FreeRTOS decode task stack is
   allocated in PSRAM instead of internal RAM. Requires the [psram](/components/psram/) component. Defaults to `false`.
 - All other options from [Media Source](/components/media_source/).
-
-> [!NOTE]
-> This platform is only available on ESP32.
 
 ## See Also
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Built on on top of #6201. Documents the ``audio_file`` media source component

**Related issue (if applicable):** not applicable

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#14436

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
