### PR TITLE
[rtttl] Add hint about options order and default values

### DIFF
--- a/src/content/docs/components/rtttl.mdx
+++ b/src/content/docs/components/rtttl.mdx
@@ -139,8 +139,8 @@ name:d=4,o=5,b=120:notes
 - **b** (beats): The tempo in beats per minute (BPM). Determines how fast the melody plays. Default is 63.
 
 > [!TIP]
-> The order of the control parameters does not matter, but they must be present in the string before the notes section. The order of `d`, `o`, and `b` is just a common convention.
-> If a parameter is not specified, the default value will be used.
+> A control-parameter section (for example, `d=4,o=5,b=120`) must appear in the string before the notes section. Within this section, the order of `d`, `o`, and `b` does not matter and you may specify any subset of them.
+> Any parameter that is not specified will fall back to its default value listed above.
 
 ### Note Format
 

--- a/src/content/docs/components/rtttl.mdx
+++ b/src/content/docs/components/rtttl.mdx
@@ -138,6 +138,10 @@ name:d=4,o=5,b=120:notes
 - **o** (octave): The default octave for notes. Valid values are 4, 5, 6, or 7. Higher values produce higher-pitched sounds. Default is 6.
 - **b** (beats): The tempo in beats per minute (BPM). Determines how fast the melody plays. Default is 63.
 
+> [!TIP]
+> The order of the control parameters does not matter, but they must be present in the string before the notes section. The order of `d`, `o`, and `b` is just a common convention.
+> If a parameter is not specified, the default value will be used.
+
 ### Note Format
 
 Each note in the melody follows this pattern: `[duration][note][#][octave][.]`


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Add hint that any order of control parameters is possible and fallback to default if parameter is missing

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#14438

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
