### PR TITLE
Dew point component

### DIFF
--- a/src/content/docs/components/index.mdx
+++ b/src/content/docs/components/index.mdx
@@ -365,7 +365,6 @@ Sensors are organized into categories; if a given sensor fits into more than one
 
 <ImgTable items={[
   ["Absolute Humidity", "/components/sensor/absolute_humidity/", "water-drop.svg", "dark-invert"],
-  ["Dew Point", "/components/sensor/dew_point/", "water-drop.svg", "dark-invert"],
   ["AHT10 / AHT20 / AHT21 / DHT20", "/components/sensor/aht10/", "aht10.jpg", "Temperature & Humidity"],
   ["AirThings BLE", "/components/sensor/airthings_ble/", "airthings_logo.png", "Temperature & Humidity & Pressure"],
   ["AM2315C", "/components/sensor/am2315c/", "am2315c.jpg", "Temperature & Humidity"],
@@ -381,6 +380,7 @@ Sensors are organized into categories; if a given sensor fits into more than one
   ["BMP388 and BMP390", "/components/sensor/bmp3xx/", "bmp388.jpg", "Temperature & Pressure"],
   ["BMP581", "/components/sensor/bmp581/", "bmp581.jpg", "Temperature & Pressure"],
   ["Dallas DS18B20", "/components/sensor/dallas_temp/", "dallas.jpg", "Temperature"],
+  ["Dew Point", "/components/sensor/dew_point/", "water-drop.svg", "dark-invert"],
   ["DHT", "/components/sensor/dht/", "dht.jpg", "Temperature & Humidity"],
   ["DHT12", "/components/sensor/dht12/", "dht12.jpg", "Temperature & Humidity"],
   ["DPS310", "/components/sensor/dps310/", "dps310.jpg", "Temperature & Pressure"],

--- a/src/content/docs/components/index.mdx
+++ b/src/content/docs/components/index.mdx
@@ -487,6 +487,7 @@ Sensors are organized into categories; if a given sensor fits into more than one
   ["b-parasite", "/components/sensor/b_parasite/", "b_parasite.jpg", "Moisture & Temperature & Humidity & Light"],
   ["Binary Sensor Map", "/components/sensor/binary_sensor_map/", "binary_sensor_map.jpg", "Map binary to value"],
   ["Combination", "/components/sensor/combination/", "function.svg", "dark-invert"],
+  ["Dew Point", "/components/sensor/dew_point/", "water-drop.svg", "dark-invert"],
   ["Duty Time", "/components/sensor/duty_time/", "timer-play-outline.svg", "dark-invert"],
   ["EZO sensor circuits", "/components/sensor/ezo/", "ezo-ph-circuit.png", "(pH)"],
   ["FS3000", "/components/sensor/fs3000/", "fs3000.jpg", "Air velocity"],

--- a/src/content/docs/components/index.mdx
+++ b/src/content/docs/components/index.mdx
@@ -365,6 +365,7 @@ Sensors are organized into categories; if a given sensor fits into more than one
 
 <ImgTable items={[
   ["Absolute Humidity", "/components/sensor/absolute_humidity/", "water-drop.svg", "dark-invert"],
+  ["Dew Point", "/components/sensor/dew_point/", "water-drop.svg", "dark-invert"],
   ["AHT10 / AHT20 / AHT21 / DHT20", "/components/sensor/aht10/", "aht10.jpg", "Temperature & Humidity"],
   ["AirThings BLE", "/components/sensor/airthings_ble/", "airthings_logo.png", "Temperature & Humidity & Pressure"],
   ["AM2315C", "/components/sensor/am2315c/", "am2315c.jpg", "Temperature & Humidity"],
@@ -487,7 +488,6 @@ Sensors are organized into categories; if a given sensor fits into more than one
   ["b-parasite", "/components/sensor/b_parasite/", "b_parasite.jpg", "Moisture & Temperature & Humidity & Light"],
   ["Binary Sensor Map", "/components/sensor/binary_sensor_map/", "binary_sensor_map.jpg", "Map binary to value"],
   ["Combination", "/components/sensor/combination/", "function.svg", "dark-invert"],
-  ["Dew Point", "/components/sensor/dew_point/", "water-drop.svg", "dark-invert"],
   ["Duty Time", "/components/sensor/duty_time/", "timer-play-outline.svg", "dark-invert"],
   ["EZO sensor circuits", "/components/sensor/ezo/", "ezo-ph-circuit.png", "(pH)"],
   ["FS3000", "/components/sensor/fs3000/", "fs3000.jpg", "Air velocity"],

--- a/src/content/docs/components/sensor/dew_point.mdx
+++ b/src/content/docs/components/sensor/dew_point.mdx
@@ -38,6 +38,7 @@ sensor:
 
 ## See Also
 
+- [Absolute Humidity](/components/sensor/absolute_humidity/)
 - [Sensor Filters](/components/sensor#sensor-filters)
 - [Dew point on Wikipedia](https://en.wikipedia.org/wiki/Dew_point)
 - <APIRef text="dew_point.h" path="dew_point/dew_point.h" />

--- a/src/content/docs/components/sensor/dew_point.mdx
+++ b/src/content/docs/components/sensor/dew_point.mdx
@@ -1,0 +1,43 @@
+---
+description: "Instructions for setting up dew point calculation"
+title: "Dew Point"
+---
+import APIRef from '@components/APIRef.astro';
+
+
+The `dew_point` platform allows you to calculate the dew point from air temperature and relative humidity.
+For the calculation the Magnus formula approximation is used.
+
+See the links at the bottom of the page for details on dew point equations and the Magnus formula.
+
+```yaml
+# Example configuration entry
+sensor:
+  - platform: dew_point
+    name: "Dew point"
+    temperature: temperature
+    humidity: humidity
+
+  # Use any temperature and relative humidity source, e.g. a BME280:
+  - platform: bme280_i2c
+    temperature:
+      name: "BME280 Temperature"
+      id: temperature
+    pressure:
+      name: "BME280 Pressure"
+    humidity:
+      name: "BME280 Humidity"
+      id: humidity
+```
+
+## Configuration variables
+
+- **temperature** (**Required**, [ID](/guides/configuration-types#id)): The sensor that is used to measure the current temperature, in °C.
+- **humidity** (**Required**, [ID](/guides/configuration-types#id)): The sensor that is used to measure the current relative humidity, in %.
+- All other options from [Sensor](/components/sensor).
+
+## See Also
+
+- [Sensor Filters](/components/sensor#sensor-filters)
+- [Dew point on Wikipedia](https://en.wikipedia.org/wiki/Dew_point)
+- <APIRef text="dew_point.h" path="dew_point/dew_point.h" />


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** n/a
**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#14441

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
