### PR TITLE
Mention `OTA` as argument to `--device`

### DIFF
--- a/src/content/docs/guides/cli.mdx
+++ b/src/content/docs/guides/cli.mdx
@@ -67,9 +67,10 @@ The `esphome run <CONFIG>` command is the most common command for ESPHome. It
 
 #### Options
 
-**`--device UPLOAD_PORT`**
-: Manually specify the upload port/IP to use. For example `/dev/cu.SLAB_USBtoUART`, or `192.168.1.176`
-to perform an OTA.
+**`--device DEVICE`**
+: Manually specify the port/IP to use for upload and logging. For example `/dev/cu.SLAB_USBtoUART`, or `192.168.1.176`
+to perform an OTA. You can also specify `OTA` to resolve the address from MQTT, DNS or mDNS.
+This prevents the interactive prompt when multiple options exist.
 
 Multiple `--device` options can be specified to provide fallback addresses. ESPHome will
 try each address in order until one succeeds. This is particularly useful for devices with
@@ -137,9 +138,10 @@ The `esphome upload <CONFIG>` validates the configuration and uploads the most r
 
 #### Options
 
-**`--device UPLOAD_PORT`**
+**`--device DEVICE`**
 : Manually specify the upload port/IP address to use. For example `/dev/cu.SLAB_USBtoUART`, or `192.168.1.176`
-to perform an OTA.
+to perform an OTA. You can also specify `OTA` to resolve the address from MQTT, DNS or mDNS.
+This prevents the interactive prompt when multiple options exist.
 
 Multiple `--device` options can be specified to provide fallback addresses. ESPHome will
 try each address in order until one succeeds.
@@ -275,8 +277,10 @@ The `esphome logs <CONFIG>` command validates the configuration and shows all lo
 : Manually set the client id.
 
 
-**`--device SERIAL_PORT`**
+**`--device DEVICE`**
 : Manually specify a serial port/IP to use. For example `/dev/cu.SLAB_USBtoUART`.
+You can also specify `OTA` to resolve the address from MQTT, DNS or mDNS.
+This prevents the interactive prompt when multiple options exist.
 
 Multiple `--device` options can be specified to provide fallback addresses. When using the
 native API for logs, all addresses are passed to the API client which uses the Happy Eyeballs


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

This adds mention of `OTA` that can be passed for `--device` such that the interactive prompt does not appear and the first of MQTT, DNS or mDNS IP resolution is used.

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.
