### PR TITLE
Document sensor.integration.set_value action

### DIFF
--- a/src/content/docs/components/sensor/integration.mdx
+++ b/src/content/docs/components/sensor/integration.mdx
@@ -53,6 +53,19 @@ on_...:
   - sensor.integration.reset:  my_integration_sensor
 ```
 
+<span id="sensor-integration-set__value_action"></span>
+
+## `sensor.integration.set_value` Action
+
+This [Action](/automations/actions#all-actions) allows you to set the integration sensor to a specific value. For example, it can be used to set the sensor to the battery capacity when it is fully charged.
+
+```yaml
+on_...:
+  - sensor.integration.set_value:
+       id: my_integration_sensor
+       value: 100
+```
+
 ## See Also
 
 - [Sensor Filters](/components/sensor#sensor-filters)

--- a/src/content/docs/components/sensor/integration.mdx
+++ b/src/content/docs/components/sensor/integration.mdx
@@ -63,9 +63,15 @@ For example, it can be used to set the sensor to the battery capacity when it is
 ```yaml
 on_...:
   - sensor.integration.set_value:
-       id: my_integration_sensor
-       value: 100
+      id: my_integration_sensor
+      value: 100
 ```
+
+Configuration options:
+
+- **id** (**Required**, [ID](/guides/configuration-types#id)): The ID of the integration sensor.
+- **value** (**Required**, float, [templatable](/automations/templates)):
+  The value to set the integration sensor to.
 
 ## See Also
 

--- a/src/content/docs/components/sensor/integration.mdx
+++ b/src/content/docs/components/sensor/integration.mdx
@@ -53,7 +53,7 @@ on_...:
   - sensor.integration.reset:  my_integration_sensor
 ```
 
-<span id="sensor-integration-set__value_action"></span>
+<span id="sensor-integration-set_value_action"></span>
 
 ## `sensor.integration.set_value` Action
 

--- a/src/content/docs/components/sensor/integration.mdx
+++ b/src/content/docs/components/sensor/integration.mdx
@@ -57,7 +57,8 @@ on_...:
 
 ## `sensor.integration.set_value` Action
 
-This [Action](/automations/actions#all-actions) allows you to set the integration sensor to a specific value. For example, it can be used to set the sensor to the battery capacity when it is fully charged.
+This [Action](/automations/actions#all-actions) allows you to set the integration sensor to a specific value.
+For example, it can be used to set the sensor to the battery capacity when it is fully charged.
 
 ```yaml
 on_...:


### PR DESCRIPTION
Added documentation for the `sensor.integration.set_value` action, including an example of setting a specific value for the integration sensor.

<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#13316

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
