### PR TITLE
[dps310] Document DPS368 as fully supported drop-in replacement

### DIFF
--- a/src/content/docs/components/index.mdx
+++ b/src/content/docs/components/index.mdx
@@ -381,7 +381,7 @@ Sensors are organized into categories; if a given sensor fits into more than one
   ["Dallas DS18B20", "/components/sensor/dallas_temp/", "dallas.jpg", "Temperature"],
   ["DHT", "/components/sensor/dht/", "dht.jpg", "Temperature & Humidity"],
   ["DHT12", "/components/sensor/dht12/", "dht12.jpg", "Temperature & Humidity"],
-  ["DPS310", "/components/sensor/dps310/", "dps310.jpg", "Temperature & Pressure"],
+  ["DPS310/DPS368", "/components/sensor/dps310/", "dps310.jpg", "Temperature & Pressure"],
   ["EMC2101", "/components/emc2101/", "emc2101.jpg", "Temperature"],
   ["ENS160", "/components/sensor/ens160/", "ens160.jpg", "CO2 & Air Quality"],
   ["ENS210", "/components/sensor/ens210/", "ens210.jpg", "Temperature & Humidity"],

--- a/src/content/docs/components/sensor/dps310.mdx
+++ b/src/content/docs/components/sensor/dps310.mdx
@@ -13,10 +13,11 @@ your DPS310 or DPS368 atmospheric pressure sensor
 ([Adafruit](https://www.adafruit.com/product/4494)) with ESPHome.
 The [I²C](/components/i2c) component is required to be set up in your configuration.
 
-**Note:** The Infineon DPS368 is a drop-in replacement for the discontinued DPS310 and is fully
-supported by this component. The two sensors share identical register maps, I²C addresses, and
-calibration procedures — no configuration changes are needed. If you are designing a new project,
-Infineon recommends the DPS368.
+> [!NOTE]
+> The Infineon DPS368 is a drop-in replacement for the discontinued DPS310 and is fully
+> supported by this component. The two sensors share identical register maps, I²C addresses, and
+> calibration procedures - no configuration changes are needed. If you are designing a new project,
+> Infineon recommends the DPS368.
 
 <Figure
   src={dps310FullImg}

--- a/src/content/docs/components/sensor/dps310.mdx
+++ b/src/content/docs/components/sensor/dps310.mdx
@@ -1,6 +1,6 @@
 ---
-description: "Instructions for setting up DPS310 atmospheric pressure sensors"
-title: "DPS310 Atmospheric Pressure Sensor"
+description: "Instructions for setting up DPS310/DPS368 atmospheric pressure sensors"
+title: "DPS310/DPS368 Atmospheric Pressure Sensor"
 ---
 
 import { Image } from 'astro:assets';
@@ -9,8 +9,14 @@ import dps310FullImg from './images/dps310-full.jpg';
 import APIRef from '@components/APIRef.astro';
 
 The `dps310` sensor platform allows you to use both the temperature and pressure sensors on
-your DPS310 atmospheric pressure sensor ([Adafruit](https://www.adafruit.com/product/4494))
-with ESPHome. The [I²C](/components/i2c) component is required to be set up in your configuration.
+your DPS310 or DPS368 atmospheric pressure sensor
+([Adafruit](https://www.adafruit.com/product/4494)) with ESPHome.
+The [I²C](/components/i2c) component is required to be set up in your configuration.
+
+**Note:** The Infineon DPS368 is a drop-in replacement for the discontinued DPS310 and is fully
+supported by this component. The two sensors share identical register maps, I²C addresses, and
+calibration procedures — no configuration changes are needed. If you are designing a new project,
+Infineon recommends the DPS368.
 
 <Figure
   src={dps310FullImg}


### PR DESCRIPTION
## Description

The Infineon DPS310 barometric pressure sensor is discontinued ("Not for New Design"). The DPS368 is its drop-in successor with identical register maps, I²C addresses (0x77/0x76), and calibration procedures. The existing `dps310` ESPHome component works with the DPS368 without any configuration changes, but the documentation doesn't mention this.

This PR updates the DPS310 docs page to:
- Include DPS368 in the title and description
- Add a note explaining DPS368 is fully supported
- Mention the DPS310 is discontinued and Infineon recommends the DPS368

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.