### PR TITLE
[lvgl] Fix some indentation

### DIFF
--- a/src/content/docs/components/lvgl/layouts.mdx
+++ b/src/content/docs/components/lvgl/layouts.mdx
@@ -86,14 +86,15 @@ handle growing the layout to make the item(s) fill the remaining space with resp
 **Configuration variables:**
 
 - **flex_flow** (*Optional*, string): Select the arrangement of the children widgets:
-- `ROW`  : place the children in a row without wrapping.
-- `COLUMN`  : place the children in a column without wrapping.
-- `ROW_WRAP`  : place the children in a row with wrapping (default).
-- `COLUMN_WRAP`  : place the children in a column with wrapping.
-- `ROW_REVERSE`  : place the children in a row without wrapping but in reversed order.
-- `COLUMN_REVERSE`  : place the children in a column without wrapping but in reversed order.
-- `ROW_WRAP_REVERSE`  : place the children in a row with wrapping but in reversed order.
-- `COLUMN_WRAP_REVERSE`  : place the children in a column with wrapping but in reversed order.
+
+  - `ROW`  : place the children in a row without wrapping.
+  - `COLUMN`  : place the children in a column without wrapping.
+  - `ROW_WRAP`  : place the children in a row with wrapping (default).
+  - `COLUMN_WRAP`  : place the children in a column with wrapping.
+  - `ROW_REVERSE`  : place the children in a row without wrapping but in reversed order.
+  - `COLUMN_REVERSE`  : place the children in a column without wrapping but in reversed order.
+  - `ROW_WRAP_REVERSE`  : place the children in a row with wrapping but in reversed order.
+  - `COLUMN_WRAP_REVERSE`  : place the children in a column with wrapping but in reversed order.
 
 - **flex_align_main** (*Optional*, string): Determines how to distribute the items in their track on the *main* axis.
   For example, flush the items to the right on with `flex_flow: ROW_WRAP` (known as *justify-content* in CSS). Possible
@@ -107,17 +108,17 @@ handle growing the layout to make the item(s) fill the remaining space with resp
 
   Values for use with `flex_align_main`, `flex_align_cross`, `flex_align_track`  :
 
-- `START`  : means left horizontally and top vertically (default).
-- `END`  : means right horizontally and bottom vertically.
-- `CENTER`  : simply center.
-- `SPACE_EVENLY`  : items are distributed so that the spacing between any two items (and the space to the edges) is
-  equal. Does not apply to `flex_align_track`.
-- `SPACE_AROUND`  : items are evenly distributed in the track with equal space around them. Note that visually the
-  spaces aren't equal, since all the items have equal space on both sides. The first item will have one unit of space
-  against the container edge, but two units of space between the next item because that next item has its own spacing
-  that applies. Does not apply to `flex_align_track`.
-- `SPACE_BETWEEN`  : items are evenly distributed in the track: first item is on the start line, last item on the end
-  line. Does not apply to `flex_align_track`.
+  - `START`  : means left horizontally and top vertically (default).
+  - `END`  : means right horizontally and bottom vertically.
+  - `CENTER`  : simply center.
+  - `SPACE_EVENLY`  : items are distributed so that the spacing between any two items (and the space to the edges) is
+    equal. Does not apply to `flex_align_track`.
+  - `SPACE_AROUND`  : items are evenly distributed in the track with equal space around them. Note that visually the
+    spaces aren't equal, since all the items have equal space on both sides. The first item will have one unit of space
+    against the container edge, but two units of space between the next item because that next item has its own spacing
+    that applies. Does not apply to `flex_align_track`.
+  - `SPACE_BETWEEN`  : items are evenly distributed in the track: first item is on the start line, last item on the end
+    line. Does not apply to `flex_align_track`.
 
 The `flex_align_cross` option may also take the argument `STRETCH` which will cause the items to fill the available
 space on the cross axis. This is achieved by setting the default height or width of each item to 100%. An explicit


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/static/images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/_index.md`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image dht22
```

</details>
