### PR TITLE
Update PN7160/PN7161 docs: add health check, auto-recovery, and I2C f…

### DIFF
--- a/src/content/docs/components/binary_sensor/nfc.mdx
+++ b/src/content/docs/components/binary_sensor/nfc.mdx
@@ -41,7 +41,10 @@ binary_sensor:
   not be used with `ndef_contains` and/or `uid`.
 
 - **uid** (*Optional*, string): The unique ID of the NFC tag. This is a hyphen-separated list of hexadecimal values.
-  For example: `74-10-37-94`. May not be used with `ndef_contains` and/or `tag_id` (above).
+  For example: `74-10-37-94`. Colon-separated values (e.g., `74:10:37:94`) are also accepted. May not be used with
+  `ndef_contains` and/or `tag_id` (above).
+
+- **pn7160_id** (*Optional*, [ID](/guides/configuration-types#id)): The ID of the PN7160 hub to use.
 
 - All other options from [Binary Sensor](/components/binary_sensor#config-binary_sensor).
 

--- a/src/content/docs/components/index.mdx
+++ b/src/content/docs/components/index.mdx
@@ -593,7 +593,7 @@ Often known as "tag" or "card" readers within the community.
   ["NFC Tag", "/components/binary_sensor/nfc/", "nfc.png", "dark-invert"],
   ["PN532", "/components/binary_sensor/pn532/", "pn532.jpg"],
   ["PN7150", "/components/pn7150/", "pn7150.jpg"],
-  ["PN716X", "/components/pn7160/", "pn716x.jpg"],
+  ["PN7160 / PN7161", "/components/pn7160/", "pn716x.jpg"],
   ["RC522", "/components/binary_sensor/rc522/", "rc522.jpg"],
   ["RDM6300", "/components/binary_sensor/rdm6300/", "rdm6300.jpg"],
   ["Wiegand Reader", "/components/wiegand/", "wiegand.jpg"],

--- a/src/content/docs/components/index.mdx
+++ b/src/content/docs/components/index.mdx
@@ -593,7 +593,7 @@ Often known as "tag" or "card" readers within the community.
   ["NFC Tag", "/components/binary_sensor/nfc/", "nfc.png", "dark-invert"],
   ["PN532", "/components/binary_sensor/pn532/", "pn532.jpg"],
   ["PN7150", "/components/pn7150/", "pn7150.jpg"],
-  ["PN7160 / PN7161", "/components/pn7160/", "pn716x.jpg"],
+  ["PN716X", "/components/pn7160/", "pn716x.jpg"],
   ["RC522", "/components/binary_sensor/rc522/", "rc522.jpg"],
   ["RDM6300", "/components/binary_sensor/rdm6300/", "rdm6300.jpg"],
   ["Wiegand Reader", "/components/wiegand/", "wiegand.jpg"],

--- a/src/content/docs/components/pn7160.mdx
+++ b/src/content/docs/components/pn7160.mdx
@@ -1,6 +1,6 @@
 ---
-description: "Instructions for setting up PN7160/PN7161 NFC tag readers and tags in ESPHome"
-title: "PN7160/PN7161 NFC"
+description: "Instructions for setting up PN716X NFC tag readers and tags in ESPHome"
+title: "PN716X NFC"
 ---
 
 import { Image } from 'astro:assets';
@@ -11,12 +11,12 @@ import APIRef from '@components/APIRef.astro';
 
 ## Component/Hub
 
-The `pn7160` component allows you to use PN7160/PN7161 NFC controllers with ESPHome. This component is a global hub that
-establishes a connection to the PN7160/PN7161 via [SPI](/components/spi) or [I²C](/components/i2c).
+The `pn7160` component allows you to use PN716X NFC controllers with ESPHome. This component is a global hub that
+establishes a connection to the PN716X via [SPI](/components/spi) or [I²C](/components/i2c).
 
 <Image src={pn716xFullImg} layout="constrained" alt="" />
 
-Within ESPHome, the PN7160/PN7161 can be configured to use either the SPI **or** I²C protocol for data communication.
+Within ESPHome, the PN716X can be configured to use either the SPI **or** I²C protocol for data communication.
 Note that there are different versions of the IC for each bus type, each with a different part number; in other
 words, **the bus type cannot be changed by jumpers/switches as it is determed at the time of manufacture.**
 
@@ -34,8 +34,8 @@ In addition, the [Nfc](/components/binary_sensor/nfc/) platform may be used to q
 
 ## Stability and Health Check
 
-This component includes several enhancements to improve reliability and address common issues found in PN7160/PN7161 implementations:
-- **I2C Frequency Validation:** PN7160/PN7161 requires an I2C frequency of 100kHz or higher; configuring a lower frequency will trigger a validation warning to prevent startup IRQ timeouts (ESPHome issue [#6339](https://github.com/esphome/issues/issues/6339)).
+This component includes several enhancements to improve reliability and address common issues found in PN716X implementations:
+- **I2C Frequency Validation:** PN716X requires an I2C frequency of 100kHz or higher; configuring a lower frequency will trigger a validation warning to prevent startup IRQ timeouts (ESPHome issue [#6339](https://github.com/esphome/issues/issues/6339)).
 - **IRQ Handling:** Addresses issues where the IRQ line could become "stuck" high after several reads, blocking further communication.
 - **Health Check with Auto-Recovery:** Periodically validates NCI communication and the internal state machine. If the component becomes unresponsive or stuck in an initialization state, it can perform an automatic hard reset by toggling the `ven_pin`.
 
@@ -43,7 +43,7 @@ This component includes several enhancements to improve reliability and address 
 
 ## Over SPI
 
-The `pn7160_spi` component allows you to use [SPI-equipped](/components/spi) PN7160/PN7161 NFC controllers with ESPHome.
+The `pn7160_spi` component allows you to use [SPI-equipped](/components/spi) PN716X NFC controllers with ESPHome.
 
 ```yaml
 pn7160_spi:
@@ -62,22 +62,22 @@ pn7160_spi:
 
 ### Configuration variables
 
-- **cs_pin** (**Required**, [Pin Schema](/guides/configuration-types#pin-schema)): The pin connected to the PN7160's `NSS` (chip
+- **cs_pin** (**Required**, [Pin Schema](/guides/configuration-types#pin-schema)): The pin connected to the PN716X's `NSS` (chip
   select) line.
 
-- **dwl_req_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The pin connected to the PN7160's
-  `DWL_REQ` line. Used to invoke the PN7160's firmware update mode; may be used in a future release.
+- **dwl_req_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The pin connected to the PN716X's
+  `DWL_REQ` line. Used to invoke the PN716X's firmware update mode; may be used in a future release.
 
-- **irq_pin** (**Required**, [Pin Schema](/guides/configuration-types#pin-schema)): The pin connected to the PN7160's `IRQ` line.
-- **ven_pin** (**Required**, [Pin Schema](/guides/configuration-types#pin-schema)): The pin connected to the PN7160's `VEN` line.
-- **wkup_req_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The pin connected to the PN7160's
+- **irq_pin** (**Required**, [Pin Schema](/guides/configuration-types#pin-schema)): The pin connected to the PN716X's `IRQ` line.
+- **ven_pin** (**Required**, [Pin Schema](/guides/configuration-types#pin-schema)): The pin connected to the PN716X's `VEN` line.
+- **wkup_req_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The pin connected to the PN716X's
   `WKUP_REQ` line. May be used to improve power management in a future release.
 
 - **emulation_message** (*Optional*, string): When scanned by another NFC card/tag reader (such as a smartphone), this
-  string is used as the content for an NDEF-formatted response. This allows the PN7160 to act as a tag in addition to a
+  string is used as the content for an NDEF-formatted response. This allows the PN716X to act as a tag in addition to a
   tag reader/writer.
 
-- **tag_ttl** (*Optional*, [Time](/guides/configuration-types#time)): The duration that must elapse after the PN7160 is no longer able to
+- **tag_ttl** (*Optional*, [Time](/guides/configuration-types#time)): The duration that must elapse after the PN716X is no longer able to
   "see" a tag before it is considered to have been removed from the reader.
 
 - **health_check_enabled** (*Optional*, boolean): Enable periodic health checks. Defaults to `true`.
@@ -94,7 +94,7 @@ pn7160_spi:
 - **on_tag_removed** (*Optional*, [Automation](/automations)): An automation to perform after a tag is removed. See
   [`on_tag_removed` Trigger](#pn7160-on_tag_removed).
 
-- **on_emulated_tag_scan** (*Optional*, [Automation](/automations)): An automation to perform when the PN7160 is
+- **on_emulated_tag_scan** (*Optional*, [Automation](/automations)): An automation to perform when the PN716X is
   scanned by another tag reader (such as a smartphone). See [`on_emulated_tag_scan` Trigger](#pn7160-on_emulated_tag_scan).
 
 - **spi_id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID of the [SPI Component](/components/spi) if you want
@@ -106,10 +106,10 @@ pn7160_spi:
 
 ## Over I²C
 
-The `pn7160_i2c` component allows you to use [I²C-equipped](/components/i2c) PN7160/PN7161 NFC controllers with ESPHome.
+The `pn7160_i2c` component allows you to use [I²C-equipped](/components/i2c) PN716X NFC controllers with ESPHome.
 
 ```yaml
-# CRITICAL: PN7160/PN7161 requires I2C frequency >= 100kHz
+# CRITICAL: PN716X requires I2C frequency >= 100kHz
 # ESPHome's default 50kHz will cause IRQ timeouts
 i2c:
   sda: GPIO21
@@ -130,24 +130,24 @@ pn7160_i2c:
 ```
 
 :::caution
-Your `i2c:` config **must** specify `frequency: 100kHz` or higher. The ESPHome default of 50kHz will cause IRQ timeouts (see bug [#6339](https://github.com/esphome/issues/issues/6339)). This requirement applies to both PN7160 and PN7161.
+Your `i2c:` config **must** specify `frequency: 100kHz` or higher. The ESPHome default of 50kHz will cause IRQ timeouts (see bug [#6339](https://github.com/esphome/issues/issues/6339)). This requirement applies to both PN716X and PN7161.
 :::
 
 ### Configuration variables
 
-- **dwl_req_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The pin connected to the PN7160's
-  `DWL_REQ` line. Used to invoke the PN7160's firmware update mode; may be used in a future release.
+- **dwl_req_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The pin connected to the PN716X's
+  `DWL_REQ` line. Used to invoke the PN716X's firmware update mode; may be used in a future release.
 
-- **irq_pin** (**Required**, [Pin Schema](/guides/configuration-types#pin-schema)): The pin connected to the PN7160's `IRQ` line.
-- **ven_pin** (**Required**, [Pin Schema](/guides/configuration-types#pin-schema)): The pin connected to the PN7160's `VEN` line.
-- **wkup_req_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The pin connected to the PN7160's
+- **irq_pin** (**Required**, [Pin Schema](/guides/configuration-types#pin-schema)): The pin connected to the PN716X's `IRQ` line.
+- **ven_pin** (**Required**, [Pin Schema](/guides/configuration-types#pin-schema)): The pin connected to the PN716X's `VEN` line.
+- **wkup_req_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The pin connected to the PN716X's
   `WKUP_REQ` line. May be used to improve power management in a future release.
 
 - **emulation_message** (*Optional*, string): When scanned by another NFC card/tag reader (such as a smartphone), this
-  string is used as the content for an NDEF-formatted response. This allows the PN7160 to act as a tag in addition to a
+  string is used as the content for an NDEF-formatted response. This allows the PN716X to act as a tag in addition to a
   tag reader/writer.
 
-- **tag_ttl** (*Optional*, [Time](/guides/configuration-types#time)): The duration that must elapse after the PN7160 is no longer able to
+- **tag_ttl** (*Optional*, [Time](/guides/configuration-types#time)): The duration that must elapse after the PN716X is no longer able to
   "see" a tag before it is considered to have been removed from the reader.
 
 - **health_check_enabled** (*Optional*, boolean): Enable periodic health checks. Defaults to `true`.
@@ -164,7 +164,7 @@ Your `i2c:` config **must** specify `frequency: 100kHz` or higher. The ESPHome d
 - **on_tag_removed** (*Optional*, [Automation](/automations)): An automation to perform after a tag is removed. See
   [`on_tag_removed` Trigger](#pn7160-on_tag_removed).
 
-- **on_emulated_tag_scan** (*Optional*, [Automation](/automations)): An automation to perform when the PN7160 is
+- **on_emulated_tag_scan** (*Optional*, [Automation](/automations)): An automation to perform when the PN716X is
   scanned by another tag reader (such as a smartphone). See [`on_emulated_tag_scan` Trigger](#pn7160-on_emulated_tag_scan).
 
 - **i2c_id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID of the [I²C Component](/components/i2c) if you need
@@ -180,7 +180,7 @@ Your `i2c:` config **must** specify `frequency: 100kHz` or higher. The ESPHome d
 
 ### `tag.set_clean_mode` Action
 
-Use this action to invoke "clean mode" -- the next tag presented to the PN7160 will be "cleaned", removing all data
+Use this action to invoke "clean mode" -- the next tag presented to the PN716X will be "cleaned", removing all data
 from the tag.
 
 ```yaml
@@ -193,7 +193,7 @@ on_...:
 
 ### `tag.set_format_mode` Action
 
-Use this action to invoke "format mode" -- the next tag presented to the PN7160 will be "formatted", leaving only an
+Use this action to invoke "format mode" -- the next tag presented to the PN716X will be "formatted", leaving only an
 empty NDEF message structure on the tag.
 
 ```yaml
@@ -206,7 +206,7 @@ on_...:
 
 ### `tag.set_read_mode` Action
 
-Use this action to invoke "read mode" -- the next tag presented to the PN7160 will be read. This is the default mode
+Use this action to invoke "read mode" -- the next tag presented to the PN716X will be read. This is the default mode
 that the component operates in.
 
 ```yaml
@@ -239,7 +239,7 @@ on_...:
 
 ### `tag.set_write_mode` Action
 
-Use this action to invoke "write mode" -- the next tag presented to the PN7160 will have its NDEF message set to the
+Use this action to invoke "write mode" -- the next tag presented to the PN716X will have its NDEF message set to the
 message defined by the `tag.set_write_message` action (see above). **Note that a message must be set before this mode
 may be invoked.**
 
@@ -273,7 +273,7 @@ on_...:
 
 ### `tag.emulation_off` Action
 
-Use this action to disable card (tag) emulation mode. The PN7160 will no longer respond to requests from other readers,
+Use this action to disable card (tag) emulation mode. The PN716X will no longer respond to requests from other readers,
 such as smartphones.
 
 ```yaml
@@ -286,12 +286,12 @@ on_...:
 
 ### `tag.emulation_on` Action
 
-Use this action to enable card (tag) emulation mode. The PN7160 will respond to requests from other readers, such as
+Use this action to enable card (tag) emulation mode. The PN716X will respond to requests from other readers, such as
 smartphones.
 
 **Note:** when card/tag emulation is enabled, polling (detecting a nearby card/tag) frequency is decreased; this
-typically results in slightly slower detection of cards/tags presented to the PN7160. This behavior is normal and should
-be expected; it is the result of the PN7160 toggling between polling and listening modes to support both functions.
+typically results in slightly slower detection of cards/tags presented to the PN716X. This behavior is normal and should
+be expected; it is the result of the PN716X toggling between polling and listening modes to support both functions.
 
 ```yaml
 on_...:
@@ -303,7 +303,7 @@ on_...:
 
 ### `tag.polling_off` Action
 
-Use this action to disable card (tag) reading/writing. The PN7160 will no longer read or write cards/tags.
+Use this action to disable card (tag) reading/writing. The PN716X will no longer read or write cards/tags.
 
 ```yaml
 on_...:
@@ -315,7 +315,7 @@ on_...:
 
 ### `tag.polling_on` Action
 
-Use this action to enable card (tag) reading/writing. The PN7160 will read or write cards/tags.
+Use this action to enable card (tag) reading/writing. The PN716X will read or write cards/tags.
 
 ```yaml
 on_...:
@@ -347,7 +347,7 @@ if:
 
 ### `on_tag` Trigger
 
-This automation will be triggered immediately after the PN7160 module identifies a tag and reads its NDEF
+This automation will be triggered immediately after the PN716X module identifies a tag and reads its NDEF
 message (if one is present).
 
 The parameter `x` this trigger provides is of type `std::string` and is the tag UID in the format
@@ -397,7 +397,7 @@ text_sensor:
 
 ### `on_tag_removed` Trigger
 
-This automation will be triggered after the `tag_ttl` interval (see above) when the PN7160 no longer "sees" a
+This automation will be triggered after the `tag_ttl` interval (see above) when the PN716X no longer "sees" a
 previously scanned tag.
 
 The parameter `x` this trigger provides is of type `std::string` and is the removed tag UID in the format
@@ -418,8 +418,8 @@ pn7160_...:
 ### `on_emulated_tag_scan` Trigger
 
 If card/tag emulation is enabled, this automation will be triggered when another reader (such as a smartphone) scans
-the PN7160 and reads the NDEF message it responds with. No parameters are available to this action because data is only
-sent *from* the PN7160 *to* the scanning device.
+the PN716X and reads the NDEF message it responds with. No parameters are available to this action because data is only
+sent *from* the PN716X *to* the scanning device.
 
 ```yaml
 pn7160_...:
@@ -447,7 +447,7 @@ pn7160_...:
 
 ## Health Check
 
-The PN7160 component includes a health check mechanism to ensure the chip remains responsive:
+The PN716X component includes a health check mechanism to ensure the chip remains responsive:
 - It periodically validates the internal state machine.
 - It detects if the chip is stuck in transient initialization states (RESET, INIT, CONFIG, etc.).
 - It monitors for "stuck" IRQ states where the chip fails to progress.
@@ -457,7 +457,7 @@ The PN7160 component includes a health check mechanism to ensure the chip remain
 
 ## NDEF
 
-The PN7160 supports reading NDEF messages from and writing NDEF messages to cards/tags.
+The PN716X supports reading NDEF messages from and writing NDEF messages to cards/tags.
 
 <span id="pn7160-ndef_reading"></span>
 
@@ -481,7 +481,7 @@ pn7160_...:
 
 ### NDEF Writing
 
-The examples below illustrate how NDEF messages may be written to cards/tags via the PN7160. Note that a
+The examples below illustrate how NDEF messages may be written to cards/tags via the PN716X. Note that a
 [button](/components/button/) is a great mechanism to use to trigger these actions.
 
 The first example will write a simple, fixed NDEF message to a tag.

--- a/src/content/docs/components/pn7160.mdx
+++ b/src/content/docs/components/pn7160.mdx
@@ -1,6 +1,6 @@
 ---
-description: "Instructions for setting up PN7160 NFC tag readers and tags in ESPHome"
-title: "PN7160 NFC"
+description: "Instructions for setting up PN7160/PN7161 NFC tag readers and tags in ESPHome"
+title: "PN7160/PN7161 NFC"
 ---
 
 import { Image } from 'astro:assets';
@@ -11,12 +11,12 @@ import APIRef from '@components/APIRef.astro';
 
 ## Component/Hub
 
-The `pn7160` component allows you to use PN7160 NFC controllers with ESPHome. This component is a global hub that
-establishes a connection to the PN7160 via [SPI](/components/spi) or [I²C](/components/i2c).
+The `pn7160` component allows you to use PN7160/PN7161 NFC controllers with ESPHome. This component is a global hub that
+establishes a connection to the PN7160/PN7161 via [SPI](/components/spi) or [I²C](/components/i2c).
 
 <Image src={pn716xFullImg} layout="constrained" alt="" />
 
-Within ESPHome, the PN7160 can be configured to use either the SPI **or** I²C protocol for data communication.
+Within ESPHome, the PN7160/PN7161 can be configured to use either the SPI **or** I²C protocol for data communication.
 Note that there are different versions of the IC for each bus type, each with a different part number; in other
 words, **the bus type cannot be changed by jumpers/switches as it is determed at the time of manufacture.**
 
@@ -30,11 +30,20 @@ independently enabled and disabled by using the corresponding [Actions](#pn7160-
 
 In addition, the [Nfc](/components/binary_sensor/nfc/) platform may be used to quickly and easily identify tags presented to the reader.
 
+<span id="pn7160-stability_health_check"></span>
+
+## Stability and Health Check
+
+This component includes several enhancements to improve reliability and address common issues found in PN7160/PN7161 implementations:
+- **I2C Frequency Validation:** PN7160/PN7161 requires an I2C frequency of 100kHz or higher; configuring a lower frequency will trigger a validation warning to prevent startup IRQ timeouts (ESPHome issue [#6339](https://github.com/esphome/issues/issues/6339)).
+- **IRQ Handling:** Addresses issues where the IRQ line could become "stuck" high after several reads, blocking further communication.
+- **Health Check with Auto-Recovery:** Periodically validates NCI communication and the internal state machine. If the component becomes unresponsive or stuck in an initialization state, it can perform an automatic hard reset by toggling the `ven_pin`.
+
 <span id="pn7160-spi"></span>
 
 ## Over SPI
 
-The `pn7160_spi` component allows you to use [SPI-equipped](/components/spi) PN7160 NFC controllers with ESPHome.
+The `pn7160_spi` component allows you to use [SPI-equipped](/components/spi) PN7160/PN7161 NFC controllers with ESPHome.
 
 ```yaml
 pn7160_spi:
@@ -45,6 +54,10 @@ pn7160_spi:
   wkup_req_pin: GPIOXX
   emulation_message: https://www.home-assistant.io/tag/pulse_ce
   tag_ttl: 1000ms
+  health_check_enabled: true
+  health_check_interval: 30s
+  max_failed_checks: 3
+  auto_reset_on_failure: true
 ```
 
 ### Configuration variables
@@ -67,6 +80,14 @@ pn7160_spi:
 - **tag_ttl** (*Optional*, [Time](/guides/configuration-types#time)): The duration that must elapse after the PN7160 is no longer able to
   "see" a tag before it is considered to have been removed from the reader.
 
+- **health_check_enabled** (*Optional*, boolean): Enable periodic health checks. Defaults to `true`.
+
+- **health_check_interval** (*Optional*, [Time](/guides/configuration-types#time)): The health check frequency. Defaults to `60s`.
+
+- **max_failed_checks** (*Optional*, integer): The number of consecutive health check failures allowed before declaring the component unhealthy. Defaults to `3`.
+
+- **auto_reset_on_failure** (*Optional*, boolean): Whether to perform a hard reset via the `ven_pin` when the health check fails. Defaults to `true`.
+
 - **on_tag** (*Optional*, [Automation](/automations)): An automation to perform when a tag is first read. See
   [`on_tag` Trigger](#pn7160-on_tag).
 
@@ -85,9 +106,16 @@ pn7160_spi:
 
 ## Over I²C
 
-The `pn7160_i2c` component allows you to use [I²C-equipped](/components/i2c) PN7160 NFC controllers with ESPHome.
+The `pn7160_i2c` component allows you to use [I²C-equipped](/components/i2c) PN7160/PN7161 NFC controllers with ESPHome.
 
 ```yaml
+# CRITICAL: PN7160/PN7161 requires I2C frequency >= 100kHz
+# ESPHome's default 50kHz will cause IRQ timeouts
+i2c:
+  sda: GPIO21
+  scl: GPIO22
+  frequency: 400kHz  # Must be >= 100kHz
+
 pn7160_i2c:
   dwl_req_pin: GPIOXX
   irq_pin: GPIOXX
@@ -95,7 +123,15 @@ pn7160_i2c:
   wkup_req_pin: GPIOXX
   emulation_message: https://www.home-assistant.io/tag/pulse_ce
   tag_ttl: 1000ms
+  health_check_enabled: true
+  health_check_interval: 30s
+  max_failed_checks: 3
+  auto_reset_on_failure: true
 ```
+
+:::caution
+Your `i2c:` config **must** specify `frequency: 100kHz` or higher. The ESPHome default of 50kHz will cause IRQ timeouts (see bug [#6339](https://github.com/esphome/issues/issues/6339)). This requirement applies to both PN7160 and PN7161.
+:::
 
 ### Configuration variables
 
@@ -113,6 +149,14 @@ pn7160_i2c:
 
 - **tag_ttl** (*Optional*, [Time](/guides/configuration-types#time)): The duration that must elapse after the PN7160 is no longer able to
   "see" a tag before it is considered to have been removed from the reader.
+
+- **health_check_enabled** (*Optional*, boolean): Enable periodic health checks. Defaults to `true`.
+
+- **health_check_interval** (*Optional*, [Time](/guides/configuration-types#time)): The health check frequency. Defaults to `60s`.
+
+- **max_failed_checks** (*Optional*, integer): The number of consecutive health check failures allowed before declaring the component unhealthy. Defaults to `3`.
+
+- **auto_reset_on_failure** (*Optional*, boolean): Whether to perform a hard reset via the `ven_pin` when the health check fails. Defaults to `true`.
 
 - **on_tag** (*Optional*, [Automation](/automations)): An automation to perform when a tag is first read. See
   [`on_tag` Trigger](#pn7160-on_tag).
@@ -279,6 +323,24 @@ on_...:
     - tag.polling_on: my_pn7160_id
 ```
 
+<span id="pn7160-conditions"></span>
+
+## Conditions
+
+<span id="pn7160-is_writing"></span>
+
+### `pn7160.is_writing` Condition
+
+This condition returns `true` if the component is currently waiting for a tag to be presented so it can write to it.
+
+```yaml
+if:
+  condition:
+    pn7160.is_writing: my_pn7160_id
+  then:
+    - logger.log: "Waiting for tag to write..."
+```
+
 ## Triggers
 
 <span id="pn7160-on_tag"></span>
@@ -366,6 +428,30 @@ pn7160_...:
     then:
       - rtttl.play: "alert:d=32,o=5,b=160:e6,p,e6,p,e6"
 ```
+
+<span id="pn7160-on_finished_write"></span>
+
+### `on_finished_write` Trigger
+
+This automation will be triggered when a tag write operation completes.
+
+```yaml
+pn7160_...:
+  # ...
+  on_finished_write:
+    then:
+      - logger.log: "Tag write complete!"
+```
+
+<span id="pn7160-health_check"></span>
+
+## Health Check
+
+The PN7160 component includes a health check mechanism to ensure the chip remains responsive:
+- It periodically validates the internal state machine.
+- It detects if the chip is stuck in transient initialization states (RESET, INIT, CONFIG, etc.).
+- It monitors for "stuck" IRQ states where the chip fails to progress.
+- If failures exceed `max_failed_checks`, it can perform a hard reset by toggling the `ven_pin` (if `auto_reset_on_failure` is enabled).
 
 <span id="pn7160-ndef"></span>
 


### PR DESCRIPTION
## Description

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#14504

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.
