### PR TITLE
[ssd1306] suggest a different SPI mode to reduce visual glitching

### DIFF
--- a/src/content/docs/components/display/ssd1306.mdx
+++ b/src/content/docs/components/display/ssd1306.mdx
@@ -130,6 +130,12 @@ display:
       it.print(0, 0, id(font), "Hello World!");
 ```
 
+> [!TIP]
+> Display content might become corrupted for many reasons, including electrical or RF interference. Some people reported
+> mixing of multiple devices with a different [SPI mode](/components/spi#spi-modes) on a single bus as a contributing
+> factor. While the chip's datasheet suggests that the SSD1306 uses `MODE3`, other (non-ESPHome) drivers successfully
+> use `MODE0` for accessing the display. Using `spi_mode: MODE0` might therefore help reduce glitching.
+
 ### Configuration variables
 
 - **model** (**Required**): The model of the display. Options are:


### PR DESCRIPTION
I'm not a huge fan of these weasel words, but I have seen visual glitches on this display when combined with other SPI devices (see esphome pr 13683). On Discord, people have suggested experimenting with a different SPI mode, and indeed, that solved the problem for me.

I am not suggesting to change this chip's SPI mode (the picture in the datasheet is not 100% correct, but there are strong hints that mode3 is the intended mode). At the same time, other implementations like the Adafruit one use mode 0 successfully.

So, at a suggestion of @swoboda1337, let's at least document these findings.

## Checklist

- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.