### PR TITLE
[http_request] Document the new media source

### DIFF
--- a/src/content/docs/components/index.mdx
+++ b/src/content/docs/components/index.mdx
@@ -890,6 +890,7 @@ Used for creating infrared (IR) remote control transmitters and/or receivers.
 
 <ImgTable items={[
   ["Media Source Core", "/components/media_source/", "folder-open.svg", "dark-invert"],
+  ["HTTP Request Media Source", "/components/media_source/http_request/", "connection.svg", "dark-invert"],
 ]} />
 
 ## Media Player Components

--- a/src/content/docs/components/media_source/http_request.mdx
+++ b/src/content/docs/components/media_source/http_request.mdx
@@ -1,0 +1,43 @@
+---
+description: "Instructions for setting up the HTTP Request media source in ESPHome."
+title: "HTTP Request Media Source"
+---
+
+import APIRef from '@components/APIRef.astro';
+
+The `http_request` media source platform plays audio streamed from HTTP and HTTPS URLs using the
+[HTTP Request](/components/http_request/) component. Audio is fetched over the network and decoded
+on the device.
+
+Files are played using the `http://` or `https://` URI scheme.
+
+This component only works on ESP32 based chips.
+
+```yaml
+# Example configuration entry
+http_request:
+
+media_source:
+  - platform: http_request
+    id: http_source
+```
+
+To play a file, send a media URL like `https://example.com/audio/alert.mp3` to a media player that
+uses this media source.
+
+<span id="config-http_request_media_source"></span>
+
+## Configuration variables
+
+- **buffer_size** (*Optional*, int): The size of the ring buffer in bytes used to transfer data
+  between the HTTP reader and the audio decoder. Minimum is `8192`, maximum is `512000`. Defaults
+  to `51200`.
+- **task_stack_in_psram** (*Optional*, boolean): If `true`, the FreeRTOS decode task stack is
+  allocated in PSRAM instead of internal RAM. Requires the [psram](/components/psram/) component. Defaults to `false`.
+- All other options from [Media Source](/components/media_source/).
+
+## See Also
+
+- [HTTP Request Component](/components/http_request/)
+- [Media Source Components](/components/media_source/)
+- <APIRef text="http_request_media_source.h" path="esphome/components/http_request/media_source/http_request_media_source.h" />

--- a/src/content/docs/components/media_source/index.mdx
+++ b/src/content/docs/components/media_source/index.mdx
@@ -20,4 +20,6 @@ media_source:
 
 ## Platforms
 
+- [HTTP Request Media Source](/components/media_source/http_request/)
+
 ## See Also


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Documents the new `http_request` media source component.

**Related issue (if applicable):** not applicable

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#14510

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [x] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
