### PR TITLE
[openthread] Docs for static log level code quality improvement

### DIFF
--- a/src/content/docs/components/openthread.mdx
+++ b/src/content/docs/components/openthread.mdx
@@ -99,11 +99,19 @@ See [https://openthread.io/guides/thread-primer/node-roles-and-types](https://op
 The Poll Period makes the device behave as a SED.  Follow on work is needed utilizing Power Management and/or Light Sleep capability in esp-idf.
 If the device is always awake, the API timeout is 60 seconds, so a ping request will force interaction with the parent when the poll period is greater than 60 seconds.
 
-## Logging Within ESP-IDF Openthread Component
+## OpenThread ESP-IDF Logging
 
-The logging within the ESP-IDF Openthread component is controlled by the log_level setting in framework and statically set using
-sdkconfig compile-time configuration macros.
-see [CONFIG_OPENTHREAD_LOG_LEVEL](https://docs.espressif.com/projects/esp-idf/en/v5.0.1/esp32/api-reference/kconfig.html#config-openthread-log-level)
+The OpenThread log level is controlled by the ``log_level`` setting in the ESP-IDF framework configuration.
+The ESP-IDF log levels are mapped to OpenThread log levels as follows:
+
+| ESP-IDF Level | OpenThread Level |
+|---------------|------------------|
+| NONE          | NONE             |
+| ERROR         | CRIT             |
+| WARN          | WARN             |
+| INFO          | NOTE             |
+| DEBUG         | INFO             |
+| VERBOSE       | DEBG             |
 
 ```yaml
 # Example ESP-IDF framework log_level setting
@@ -113,19 +121,10 @@ esp32:
     log_level: INFO
 ```
 
-The ESP-IDF log_levels are mapped as follows to Openthread log levels:
-
-* 0 NONE -> NONE
-* 1 ERROR -> CRIT
-* 2 WARN -> WARN
-* 3 INFO -> NOTE
-* 4 DEBUG -> INFO
-* 5 VERBOSE -> DEBG
-
 ## See Also
 
 - [OpenThread Info Text Sensor](/components/text_sensor/openthread_info/)
-- [ESP32 Platform](/components/esp32/)
 - [Network component](/components/network/)
+- [ESP32 Platform](/components/esp32/)
 - [https://openthread.io/](https://openthread.io/)
 - <APIRef text="openthread.h" path="openthread/openthread.h" />

--- a/src/content/docs/components/openthread.mdx
+++ b/src/content/docs/components/openthread.mdx
@@ -108,7 +108,6 @@ see [CONFIG_OPENTHREAD_LOG_LEVEL](https://docs.espressif.com/projects/esp-idf/en
 ```yaml
 # Example ESP-IDF framework log_level setting
 esp32:
-  board: esp32-c6-devkitm-1
   framework:
     type: esp-idf
     log_level: INFO

--- a/src/content/docs/components/openthread.mdx
+++ b/src/content/docs/components/openthread.mdx
@@ -111,7 +111,7 @@ esp32:
   board: esp32-c6-devkitm-1
   framework:
     type: esp-idf
-	log_level: INFO
+    log_level: INFO
 ```
 
 The ESP-IDF log_levels are mapped as follows to Openthread log levels:

--- a/src/content/docs/components/openthread.mdx
+++ b/src/content/docs/components/openthread.mdx
@@ -99,9 +99,34 @@ See [https://openthread.io/guides/thread-primer/node-roles-and-types](https://op
 The Poll Period makes the device behave as a SED.  Follow on work is needed utilizing Power Management and/or Light Sleep capability in esp-idf.
 If the device is always awake, the API timeout is 60 seconds, so a ping request will force interaction with the parent when the poll period is greater than 60 seconds.
 
+## Logging Within ESP-IDF Openthread Component
+
+The logging within the ESP-IDF Openthread component is controlled by the log_level setting in framework and statically set using
+sdkconfig compile-time configuration macros.
+see [CONFIG_OPENTHREAD_LOG_LEVEL] (https://docs.espressif.com/projects/esp-idf/en/v5.0.1/esp32/api-reference/kconfig.html#config-openthread-log-level)
+
+```yaml
+# Example ESP-IDF framework log_level setting
+esp32:
+  board: esp32-c6-devkitm-1
+  framework:
+    type: esp-idf
+	log_level: INFO
+```
+
+The ESP-IDF log_levels are mapped as follows to Openthread log levels:
+
+* 0 NONE -> NONE
+* 1 ERROR -> CRIT
+* 2 WARN -> WARN
+* 3 INFO -> NOTE
+* 4 DEBUG -> INFO
+* 5 VERBOSE -> DEBG
+
 ## See Also
 
 - [OpenThread Info Text Sensor](/components/text_sensor/openthread_info/)
+- [ESP32 Platform](/components/esp32/)
 - [Network component](/components/network/)
 - [https://openthread.io/](https://openthread.io/)
 - <APIRef text="openthread.h" path="openthread/openthread.h" />

--- a/src/content/docs/components/openthread.mdx
+++ b/src/content/docs/components/openthread.mdx
@@ -103,7 +103,7 @@ If the device is always awake, the API timeout is 60 seconds, so a ping request 
 
 The logging within the ESP-IDF Openthread component is controlled by the log_level setting in framework and statically set using
 sdkconfig compile-time configuration macros.
-see [CONFIG_OPENTHREAD_LOG_LEVEL] (https://docs.espressif.com/projects/esp-idf/en/v5.0.1/esp32/api-reference/kconfig.html#config-openthread-log-level)
+see [CONFIG_OPENTHREAD_LOG_LEVEL](https://docs.espressif.com/projects/esp-idf/en/v5.0.1/esp32/api-reference/kconfig.html#config-openthread-log-level)
 
 ```yaml
 # Example ESP-IDF framework log_level setting


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description
Documentation for changes to the internal logging of the openthread task from dynamic to static using CONFIG_OPENTHREAD_LOG_LEVEL_ setting.
The OpenThread log level is now controlled by the esp32.framework.log_level setting. The ESP-IDF log level labels are mapped to OpenThread log levels:

0 NONE -> NONE
1 ERROR -> CRIT
2 WARN -> WARN
3 INFO -> NOTE
4 DEBUG -> INFO
5 VERBOSE -> DEBG
This is a breaking change because the OpenThread log level was previously dynamic and is now statically set based on the framework log level.
**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#14456

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
