### PR TITLE
[ble_nus] add uart doc

### DIFF
--- a/src/content/docs/components/ble_nus.mdx
+++ b/src/content/docs/components/ble_nus.mdx
@@ -15,7 +15,7 @@ ble_nus:
 ## Configuration variables
 
 - **type** (*Optional*, string): Mode of operation. One of `logs` or `uart`.
-  `logs` streams ESPHome logs over the BLE UART. `uart` can be used as uart over BLE.
+  `logs` streams ESPHome logs. `uart` provides two direction communication. Defaults to `logs`.
 - **rx_buffer_size** (*Optional*, int): Size of the receive buffer in bytes. Range: 160-8192. Defaults to `512`.
   Valid only for mode `uart`.
 - **tx_buffer_size** (*Optional*, int): Size of the transmit buffer in bytes. Range: 160-8192. Defaults to `512`.

--- a/src/content/docs/components/ble_nus.mdx
+++ b/src/content/docs/components/ble_nus.mdx
@@ -14,7 +14,12 @@ ble_nus:
 
 ## Configuration variables
 
-- **type** (*Optional*, string): Mode of operation. Must be set to ``logs`` to stream ESPHome logs over the BLE UART.
+- **type** (*Optional*, string): Mode of operation. One of `logs` or `uart`.
+  `logs` streams ESPHome logs over the BLE UART. `uart` can be used as uart over BLE.
+- **rx_buffer_size** (*Optional*, int): Size of the receive buffer in bytes. Range: 160-8192. Defaults to `512`.
+  Valid only for mode `uart`.
+- **tx_buffer_size** (*Optional*, int): Size of the transmit buffer in bytes. Range: 160-8192. Defaults to `512`.
+- **debug** (*Optional*, mapping): Options for debugging communication on the UART hub, see [Debugging](#uart-debugging).
 
 ## Usage
 
@@ -30,6 +35,9 @@ Or connect to a specific BLE address:
 esphome logs d.yaml --device 00:11:22:33:44:55
 ```
 
+`uart` can be used with python BLE Serial
+
 ## See Also
 
-- Nordic UART Service [https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/libraries/bluetooth/services/nus.html](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/libraries/bluetooth/services/nus.html)
+- [Nordic UART Service](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/libraries/bluetooth/services/nus.html)
+- [BLE Serial](https://pypi.org/project/ble-serial)

--- a/src/content/docs/components/ble_nus.mdx
+++ b/src/content/docs/components/ble_nus.mdx
@@ -19,7 +19,7 @@ ble_nus:
 - **rx_buffer_size** (*Optional*, int): Size of the receive buffer in bytes. Range: 160-8192. Defaults to `512`.
   Valid only for mode `uart`.
 - **tx_buffer_size** (*Optional*, int): Size of the transmit buffer in bytes. Range: 160-8192. Defaults to `512`.
-- **debug** (*Optional*, mapping): Options for debugging communication on the UART hub, see [Debugging](#uart-debugging).
+- **debug** (*Optional*, mapping): Options for debugging communication on the UART hub, see [Debugging](/components/uart#uart-debugging).
 
 ## Usage
 

--- a/src/content/docs/components/ble_nus.mdx
+++ b/src/content/docs/components/ble_nus.mdx
@@ -15,7 +15,7 @@ ble_nus:
 ## Configuration variables
 
 - **type** (*Optional*, string): Mode of operation. One of `logs` or `uart`.
-  `logs` streams ESPHome logs. `uart` provides two direction communication. Defaults to `logs`.
+  `logs` streams ESPHome logs. `uart` provides bi-directional communication. Defaults to `logs`.
 - **rx_buffer_size** (*Optional*, int): Size of the receive buffer in bytes. Range: 160-8192. Defaults to `512`.
   Valid only for mode `uart`.
 - **tx_buffer_size** (*Optional*, int): Size of the transmit buffer in bytes. Range: 160-8192. Defaults to `512`.


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- https://github.com/esphome/esphome/pull/14320

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
