### PR TITLE
[rp2040] Update docs for arduino-pico 5.5.x: RP2350 support, pin names, LED example

### DIFF
--- a/src/content/docs/components/rp2040.mdx
+++ b/src/content/docs/components/rp2040.mdx
@@ -12,8 +12,8 @@ This component contains platform-specific options for the RP2040 platform.
 > **RP2350 support is experimental.** RP2350 boards (such as the Pico 2 and Pico 2 W) can be compiled but
 > are not yet fully tested — use at your own risk.
 >
-> Pico W boards with radio module chips like ESP8285 or similar (labelled as `RP2040 Pico W-2023` etc.)
-> are not supported.
+> Boards using ESP-AT WiFi modules (such as ESP8285) are not supported. This includes Pico W clones
+> labelled as `RP2040 Pico W-2023` or similar that use an ESP radio chip instead of the CYW43439.
 >
 > Please search for or create an [issue](https://github.com/esphome/esphome/issues/new/choose) if you encounter an
 > unknown problem.

--- a/src/content/docs/components/rp2040.mdx
+++ b/src/content/docs/components/rp2040.mdx
@@ -73,6 +73,23 @@ resolved to the correct GPIO number for your board:
 > to the wireless chip rather than a standard GPIO. It is accessible as pin 64 (or the `LED` pin name)
 > and only supports output mode.
 
+### Onboard LED Example
+
+```yaml
+rp2040:
+  board: rpipicow
+
+output:
+  - platform: gpio
+    pin: LED
+    id: led_output
+
+light:
+  - platform: binary
+    name: "Onboard LED"
+    output: led_output
+```
+
 ## See Also
 
 - [ESPHome Core Configuration](/components/esphome/)

--- a/src/content/docs/components/rp2040.mdx
+++ b/src/content/docs/components/rp2040.mdx
@@ -115,7 +115,9 @@ Then connect a USB-to-serial adapter to your board's UART0 pins:
 > The `TX` and `RX` [pin names](#gpio-pin-names) resolve to the default UART0 pins for your board.
 > If your board differs from the Pico W defaults above, search for your board name (e.g. `seeed_xiao_rp2040`)
 > in [boards.py](https://github.com/esphome/esphome/blob/dev/esphome/components/rp2040/boards.py) and look
-> for the `TX` and `RX` entries in its pin map.
+> for the `TX` and `RX` entries in its pin map. Note that the GPIO numbers listed there may not match the
+> numbers silkscreened on your board — check your board's pinout diagram to find which physical pins
+> correspond to those GPIOs.
 
 Open a serial terminal at 115200 baud to view logs. This is especially useful for diagnosing boot
 failures, WiFi issues, or crashes that prevent USB from initializing.

--- a/src/content/docs/components/rp2040.mdx
+++ b/src/content/docs/components/rp2040.mdx
@@ -8,9 +8,12 @@ This component contains platform-specific options for the RP2040 platform.
 > [!NOTE]
 > Support for all aspects of ESPHome on the RP2040 is still in development.
 >
-> Only the original model of Raspberry Pi Pico W board is supported, which has the Cypress **CYW43439** chip providing
-> wireless connectivity. It can be identified by a metallic shield encapsulating the radio circuitry. Pico W boards with
-> radio module chips like ESP8285 or similar (labelled as `RP2040 Pico W-2023` etc.), are not supported.
+> The Raspberry Pi **Pico W** and boards with the Cypress **CYW43439** chip providing wireless connectivity are
+> supported and tested. RP2350 boards (such as the Pico 2 and Pico 2 W) can be compiled but are not yet
+> fully tested — use at your own risk.
+>
+> Pico W boards with radio module chips like ESP8285 or similar (labelled as `RP2040 Pico W-2023` etc.)
+> are not supported.
 >
 > Please search for or create an [issue](https://github.com/esphome/esphome/issues/new/choose) if you encounter an
 > unknown problem.
@@ -37,10 +40,51 @@ rp2040:
 
 ## Configuration variables
 
-- **board** (**Required**, string): The board type. Valid option is `rpipicow`.
+- **board** (**Required**, string): The PlatformIO board identifier. Common boards include `rpipicow`
+  (Raspberry Pi Pico W), `rpipico` (Raspberry Pi Pico), `rpipico2w` (Raspberry Pi Pico 2 W), and
+  `rpipico2` (Raspberry Pi Pico 2). Over 140 boards from the
+  [arduino-pico](https://github.com/earlephilhower/arduino-pico) framework are supported. Any board
+  supported by the framework can be used here.
 - **watchdog_timeout** (*Optional*, string): The timeout to apply to the RP2040 watchdog (in seconds or milliseconds).
   When the device hangs for that period of time, it will reboot. Defaults to `8388ms` (maximum). Set to `0s` to
   disable the watchdog entirely.
+
+## GPIO Pin Names
+
+ESPHome supports named GPIO pins for boards with known pin mappings. These names are automatically
+resolved to the correct GPIO number for your board:
+
+| Pin Name | Description             | Example (Pico W) |
+|----------|-------------------------|-------------------|
+| `LED`    | Onboard LED             | GPIO 64 (CYW43)   |
+| `SDA`    | Default I²C data        | GPIO 4             |
+| `SCL`    | Default I²C clock       | GPIO 5             |
+| `SDA1`   | Secondary I²C data      | GPIO 26            |
+| `SCL1`   | Secondary I²C clock     | GPIO 27            |
+| `MISO`   | Default SPI MISO        | GPIO 16            |
+| `MOSI`   | Default SPI MOSI        | GPIO 19            |
+| `SCK`    | Default SPI clock       | GPIO 18            |
+| `SS`     | Default SPI chip select | GPIO 17            |
+| `TX`     | Default UART TX         | GPIO 0             |
+| `RX`     | Default UART RX         | GPIO 1             |
+
+```yaml
+# Example: Using the onboard LED by name
+output:
+  - platform: gpio
+    pin: LED
+    id: led_output
+
+light:
+  - platform: binary
+    name: "Onboard LED"
+    output: led_output
+```
+
+> [!NOTE]
+> On boards with the CYW43439 wireless chip (Pico W, Pico 2 W), the onboard LED is connected
+> to the wireless chip rather than a standard GPIO. It is accessible as pin 64 (or the `LED` pin name)
+> and only supports output mode.
 
 ## See Also
 

--- a/src/content/docs/components/rp2040.mdx
+++ b/src/content/docs/components/rp2040.mdx
@@ -113,7 +113,8 @@ Then connect a USB-to-serial adapter to your board's UART0 pins:
 
 > [!TIP]
 > The `TX` and `RX` [pin names](#gpio-pin-names) resolve to the default UART0 pins for your board.
-> Check your board's pinout if they differ from the Pico W defaults above.
+> If your board differs from the Pico W defaults above, check the pin mappings in
+> [boards.py](https://github.com/esphome/esphome/blob/dev/esphome/components/rp2040/boards.py).
 
 Open a serial terminal at 115200 baud to view logs. This is especially useful for diagnosing boot
 failures, WiFi issues, or crashes that prevent USB from initializing.

--- a/src/content/docs/components/rp2040.mdx
+++ b/src/content/docs/components/rp2040.mdx
@@ -19,9 +19,39 @@ This component contains platform-specific options for the RP2040 platform.
 > unknown problem.
 
 ```yaml
-# Example configuration entry
+# Example configuration entry for Raspberry Pi Pico W
+esphome:
+  name: pico-w
+  friendly_name: Pico W
+
 rp2040:
   board: rpipicow
+
+logger:
+  hardware_uart: UART0
+  baud_rate: 115200
+
+api:
+
+ota:
+  - platform: esphome
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+
+  ap:
+    ssid: "Pico-W Fallback"
+
+output:
+  - platform: gpio
+    pin: LED
+    id: led_output
+
+light:
+  - platform: binary
+    name: "Onboard LED"
+    output: led_output
 ```
 
 > [!NOTE]
@@ -67,19 +97,6 @@ resolved to the correct GPIO number for your board:
 | `SS`     | Default SPI chip select | GPIO 17            |
 | `TX`     | Default UART TX         | GPIO 0             |
 | `RX`     | Default UART RX         | GPIO 1             |
-
-```yaml
-# Example: Using the onboard LED by name
-output:
-  - platform: gpio
-    pin: LED
-    id: led_output
-
-light:
-  - platform: binary
-    name: "Onboard LED"
-    output: led_output
-```
 
 > [!NOTE]
 > On boards with the CYW43439 wireless chip (Pico W, Pico 2 W), the onboard LED is connected

--- a/src/content/docs/components/rp2040.mdx
+++ b/src/content/docs/components/rp2040.mdx
@@ -113,8 +113,9 @@ Then connect a USB-to-serial adapter to your board's UART0 pins:
 
 > [!TIP]
 > The `TX` and `RX` [pin names](#gpio-pin-names) resolve to the default UART0 pins for your board.
-> If your board differs from the Pico W defaults above, check the pin mappings in
-> [boards.py](https://github.com/esphome/esphome/blob/dev/esphome/components/rp2040/boards.py).
+> If your board differs from the Pico W defaults above, search for your board name (e.g. `seeed_xiao_rp2040`)
+> in [boards.py](https://github.com/esphome/esphome/blob/dev/esphome/components/rp2040/boards.py) and look
+> for the `TX` and `RX` entries in its pin map.
 
 Open a serial terminal at 115200 baud to view logs. This is especially useful for diagnosing boot
 failures, WiFi issues, or crashes that prevent USB from initializing.

--- a/src/content/docs/components/rp2040.mdx
+++ b/src/content/docs/components/rp2040.mdx
@@ -90,6 +90,34 @@ light:
     output: led_output
 ```
 
+## Serial Debugging
+
+By default, ESPHome logs over USB CDC (the same USB connection used for flashing). If the device fails to
+boot or USB CDC does not come up, you can use a hardware UART to get logs via a USB-to-serial adapter.
+
+Add the following to your configuration:
+
+```yaml
+logger:
+  hardware_uart: UART0
+  baud_rate: 115200
+```
+
+Then connect a USB-to-serial adapter to your board's UART0 pins:
+
+| Signal | Pico W Pin | Connect to Adapter |
+|--------|------------|--------------------|
+| TX     | GPIO 0     | RX                 |
+| RX     | GPIO 1     | TX                 |
+| GND    | Any GND    | GND                |
+
+> [!TIP]
+> The `TX` and `RX` [pin names](#gpio-pin-names) resolve to the default UART0 pins for your board.
+> Check your board's pinout if they differ from the Pico W defaults above.
+
+Open a serial terminal at 115200 baud to view logs. This is especially useful for diagnosing boot
+failures, WiFi issues, or crashes that prevent USB from initializing.
+
 ## See Also
 
 - [ESPHome Core Configuration](/components/esphome/)

--- a/src/content/docs/components/rp2040.mdx
+++ b/src/content/docs/components/rp2040.mdx
@@ -9,8 +9,7 @@ This component contains platform-specific options for the RP2040 platform.
 > The Raspberry Pi **Pico W** and other RP2040 boards with the Cypress **CYW43439** chip providing wireless
 > connectivity are supported and tested.
 >
-> **RP2350 support is experimental.** RP2350 boards (such as the Pico 2 and Pico 2 W) can be compiled but
-> are not yet fully tested — use at your own risk.
+> **RP2350 boards** (such as the Pico 2 and Pico 2 W) are supported.
 >
 > Boards using ESP-AT WiFi modules (such as ESP8285) are not supported. This includes Pico W clones
 > labelled as `RP2040 Pico W-2023` or similar that use an ESP radio chip instead of the CYW43439.

--- a/src/content/docs/components/rp2040.mdx
+++ b/src/content/docs/components/rp2040.mdx
@@ -45,7 +45,7 @@ rp2040:
   `rpipico2` (Raspberry Pi Pico 2). Over 140 boards from the
   [arduino-pico](https://github.com/earlephilhower/arduino-pico) framework are supported. Any board
   supported by the framework can be used here.
-- **watchdog_timeout** (*Optional*, string): The timeout to apply to the RP2040 watchdog (in seconds or milliseconds).
+- **watchdog_timeout** (*Optional*, [Time](/guides/configuration-types#time)): The timeout to apply to the RP2040 watchdog.
   When the device hangs for that period of time, it will reboot. Defaults to `8388ms` (maximum). Set to `0s` to
   disable the watchdog entirely.
 

--- a/src/content/docs/components/rp2040.mdx
+++ b/src/content/docs/components/rp2040.mdx
@@ -19,39 +19,9 @@ This component contains platform-specific options for the RP2040 platform.
 > unknown problem.
 
 ```yaml
-# Example configuration entry for Raspberry Pi Pico W
-esphome:
-  name: pico-w
-  friendly_name: Pico W
-
+# Example configuration entry
 rp2040:
   board: rpipicow
-
-logger:
-  hardware_uart: UART0
-  baud_rate: 115200
-
-api:
-
-ota:
-  - platform: esphome
-
-wifi:
-  ssid: !secret wifi_ssid
-  password: !secret wifi_password
-
-  ap:
-    ssid: "Pico-W Fallback"
-
-output:
-  - platform: gpio
-    pin: LED
-    id: led_output
-
-light:
-  - platform: binary
-    name: "Onboard LED"
-    output: led_output
 ```
 
 > [!NOTE]

--- a/src/content/docs/components/rp2040.mdx
+++ b/src/content/docs/components/rp2040.mdx
@@ -6,11 +6,11 @@ title: "RP2040 Platform"
 This component contains platform-specific options for the RP2040 platform.
 
 > [!NOTE]
-> Support for all aspects of ESPHome on the RP2040 is still in development.
+> The Raspberry Pi **Pico W** and other RP2040 boards with the Cypress **CYW43439** chip providing wireless
+> connectivity are supported and tested.
 >
-> The Raspberry Pi **Pico W** and boards with the Cypress **CYW43439** chip providing wireless connectivity are
-> supported and tested. RP2350 boards (such as the Pico 2 and Pico 2 W) can be compiled but are not yet
-> fully tested — use at your own risk.
+> **RP2350 support is experimental.** RP2350 boards (such as the Pico 2 and Pico 2 W) can be compiled but
+> are not yet fully tested — use at your own risk.
 >
 > Pico W boards with radio module chips like ESP8285 or similar (labelled as `RP2040 Pico W-2023` etc.)
 > are not supported.

--- a/src/content/docs/components/rp2040.mdx
+++ b/src/content/docs/components/rp2040.mdx
@@ -115,9 +115,10 @@ Then connect a USB-to-serial adapter to your board's UART0 pins:
 > The `TX` and `RX` [pin names](#gpio-pin-names) resolve to the default UART0 pins for your board.
 > If your board differs from the Pico W defaults above, search for your board name (e.g. `seeed_xiao_rp2040`)
 > in [boards.py](https://github.com/esphome/esphome/blob/dev/esphome/components/rp2040/boards.py) and look
-> for the `TX` and `RX` entries in its pin map. Note that the GPIO numbers listed there may not match the
-> numbers silkscreened on your board — check your board's pinout diagram to find which physical pins
-> correspond to those GPIOs.
+> for the `TX` and `RX` entries in its pin map. Note that the GPIO numbers may not match the labels
+> silkscreened on your board. For example, on the
+> [Seeed XIAO RP2040](https://wiki.seeedstudio.com/XIAO-RP2040/), TX (GPIO 0) and RX (GPIO 1) are
+> labelled **D6** and **D7** on the board — check your board's pinout diagram to find the right pins.
 
 Open a serial terminal at 115200 baud to view logs. This is especially useful for diagnosing boot
 failures, WiFi issues, or crashes that prevent USB from initializing.


### PR DESCRIPTION
# What does this implement/fix?

Documentation updates for the RP2040 platform following the arduino-pico 3.9.4 → 5.5.x SDK update (esphome/esphome#14328, esphome/esphome#14500) and the board auto-generation PR (esphome/esphome#14528).

- Updated support note: RP2350 boards (Pico 2, Pico 2 W) are now supported — tested on real hardware (Pico 2 W: WiFi, debug sensors, OTA all working)
- Updated `board` config variable: 140+ boards now supported from the arduino-pico framework
- Added GPIO Pin Names table (LED, SDA, SCL, SPI, UART pin mappings)
- Added CYW43 virtual pin explanation for Pico W / Pico 2 W onboard LED (pin 64)
- Added onboard LED example configuration
- Documented `watchdog_timeout` configuration variable
- Added serial debugging guide for hardware UART

**Related PR:** esphome/esphome#14528

## Types of changes

- [ ] Bugfix
- [x] New feature
- [ ] Breaking change
- [ ] Other

## Checklist:
  - [x] Documentation changes test and look correct locally
  - [x] Hardware tested on Pico 2 W (WiFi connected, debug component working, 446KB free heap, 14ms loop time)