### PR TITLE
[uart][usb_uart] Document debug_prefix option

### DIFF
--- a/src/content/docs/components/uart.mdx
+++ b/src/content/docs/components/uart.mdx
@@ -139,10 +139,11 @@ uart:
   debug:
     direction: BOTH
     dummy_receiver: false
+    debug_prefix: "[MODBUS] "
     after:
       delimiter: "\n"
     sequence:
-      - lambda: UARTDebug::log_string(direction, bytes);
+      - lambda: UARTDebug::log_string(direction, bytes, debug_prefix);
 
 # Minimal configuration example, logs hex strings by default
 uart:
@@ -154,6 +155,9 @@ uart:
 
 - **direction** (*Optional*, enum): The direction of communication to debug, one of: "RX" (receive, incoming),
   "TX" (send, outgoing) or "BOTH". Defaults to "BOTH".
+
+- **debug_prefix** (*Optional*, string): A string prepended to every debug log line for this UART bus.
+  Useful when multiple UART buses have debugging enabled, to distinguish their output in the log. Defaults to "".
 
 - **dummy_receiver** (*Optional*, boolean): Whether or not to enable the dummy receiver feature. The debugger
   will only accumulate bytes that are actually read or sent by a UART device component. This feature is
@@ -176,20 +180,24 @@ uart:
 
   - **direction**: `uart::UART_DIRECTION_RX` or `uart::UART_DIRECTION_TX`
   - **bytes**: `std::vector<uint8_t>` containing the accumulated bytes
+  - **debug_prefix**: `StringRef` containing the configured prefix (empty string if not set)
 
   **Helper functions for logging**
 
   Helper functions are provided to make logging of debug data in various formats easy:
 
-  - **UARTDebug::log_hex(direction, bytes, char separator)** Log the bytes as hex values, separated by the provided
+  - **UARTDebug::log_hex(direction, bytes, char separator, debug_prefix)** Log the bytes as hex values, separated by the provided
     separator character.
 
-  - **UARTDebug::log_string(direction, bytes)** Log the bytes as string values, escaping unprintable characters.
-  - **UARTDebug::log_int(direction, bytes, char separator)** Log the bytes as integer values, separated by the provided
+  - **UARTDebug::log_string(direction, bytes, debug_prefix)** Log the bytes as string values, escaping unprintable characters.
+  - **UARTDebug::log_int(direction, bytes, char separator, debug_prefix)** Log the bytes as integer values, separated by the provided
     separator character.
 
-  - **UARTDebug::log_binary(direction, bytes, char separator)** Log the bytes as `<binary> (<hex>)` values,
+  - **UARTDebug::log_binary(direction, bytes, char separator, debug_prefix)** Log the bytes as `<binary> (<hex>)` values,
     separated by the provided separator character.
+
+  The `debug_prefix` parameter is optional in all helpers (defaults to empty). When using the default `sequence`,
+  `debug_prefix` is passed automatically.
 
   **Logger buffer size**
 

--- a/src/content/docs/components/usb_uart.mdx
+++ b/src/content/docs/components/usb_uart.mdx
@@ -51,6 +51,8 @@ Setting both `vid` and `pid` to 0 will match any device.
 - **parity** (*Optional*, string): The parity to use. One of `NONE`, `EVEN`, `ODD`, `MARK` and `SPACE`. Defaults to `NONE`.
 - **dummy_receiver** (*Optional*, boolean): If set to true, the channel will consume any data received. This is useful for debugging purposes. Defaults to false.
 - **debug** (*Optional*, boolean): If set to true, the channel will log all data sent and received. Defaults to false.
+- **debug_prefix** (*Optional*, string): A string prepended to every debug log line for this channel.
+  Useful when multiple channels have debugging enabled, to distinguish their output in the log. Defaults to "".
 
 ## Device types
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

Add documentation for new debug_prefix option in uart & usb_uart components

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#14525

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
