### PR TITLE
[pylontech] Document cell voltage and temperature sensors

### DIFF
--- a/src/content/docs/components/pylontech.mdx
+++ b/src/content/docs/components/pylontech.mdx
@@ -104,9 +104,8 @@ sensor:
   - **voltage** (*Optional*): Cell voltage in V. All options from [Sensor](/components/sensor).
   - **temperature** (*Optional*): Cell temperature in °C. All options from [Sensor](/components/sensor).
 
-:::note
+[!NOTE]
 When any cell sensor is configured, the component automatically sends `bat N` commands after the `pwr` command to retrieve cell-level data. This increases the UART traffic per update cycle. It is recommended to set `rx_buffer_size: 2048` on the UART bus when using cell sensors.
-:::
 
 ### Cell Sensor Example
 

--- a/src/content/docs/components/pylontech.mdx
+++ b/src/content/docs/components/pylontech.mdx
@@ -99,8 +99,10 @@ sensor:
 - **voltage_low** (*Optional*): Voltage of the lowest cell. All options from [Sensor](/components/sensor).
 - **voltage_high** (*Optional*): Voltage of the highest cell. All options from [Sensor](/components/sensor).
 - **mos_temperature** (*Optional*): Temperature of the mosfets. All options from [Sensor](/components/sensor).
-- **cell_0_voltage** .. **cell_14_voltage** (*Optional*): Individual cell voltages (in V) from the `bat N` console command. Cell indices 0–14 correspond to the 15 cells of a Pylontech battery. All options from [Sensor](/components/sensor).
-- **cell_0_temperature** .. **cell_14_temperature** (*Optional*): Individual cell temperatures (in °C) from the `bat N` console command. All options from [Sensor](/components/sensor).
+- **cells** (*Optional*): A list of individual cell sensors from the `bat N` console command. Each entry has:
+  - **cell** (**Required**, int): Cell index (0–14).
+  - **voltage** (*Optional*): Cell voltage in V. All options from [Sensor](/components/sensor).
+  - **temperature** (*Optional*): Cell temperature in °C. All options from [Sensor](/components/sensor).
 
 :::note
 When any cell sensor is configured, the component automatically sends `bat N` commands after the `pwr` command to retrieve cell-level data. This increases the UART traffic per update cycle. It is recommended to set `rx_buffer_size: 2048` on the UART bus when using cell sensors.
@@ -118,14 +120,17 @@ sensor:
     battery: 1
     voltage:
       name: "Battery1 Voltage"
-    cell_0_voltage:
-      name: "Battery1 Cell 1 Voltage"
-    cell_0_temperature:
-      name: "Battery1 Cell 1 Temperature"
-    cell_14_voltage:
-      name: "Battery1 Cell 15 Voltage"
-    cell_14_temperature:
-      name: "Battery1 Cell 15 Temperature"
+    cells:
+      - cell: 0
+        voltage:
+          name: "Battery1 Cell 1 Voltage"
+        temperature:
+          name: "Battery1 Cell 1 Temperature"
+      - cell: 14
+        voltage:
+          name: "Battery1 Cell 15 Voltage"
+        temperature:
+          name: "Battery1 Cell 15 Temperature"
 ```
 
 ## Text Sensor

--- a/src/content/docs/components/pylontech.mdx
+++ b/src/content/docs/components/pylontech.mdx
@@ -99,6 +99,34 @@ sensor:
 - **voltage_low** (*Optional*): Voltage of the lowest cell. All options from [Sensor](/components/sensor).
 - **voltage_high** (*Optional*): Voltage of the highest cell. All options from [Sensor](/components/sensor).
 - **mos_temperature** (*Optional*): Temperature of the mosfets. All options from [Sensor](/components/sensor).
+- **cell_0_voltage** .. **cell_14_voltage** (*Optional*): Individual cell voltages (in V) from the `bat N` console command. Cell indices 0–14 correspond to the 15 cells of a Pylontech battery. All options from [Sensor](/components/sensor).
+- **cell_0_temperature** .. **cell_14_temperature** (*Optional*): Individual cell temperatures (in °C) from the `bat N` console command. All options from [Sensor](/components/sensor).
+
+:::note
+When any cell sensor is configured, the component automatically sends `bat N` commands after the `pwr` command to retrieve cell-level data. This increases the UART traffic per update cycle. It is recommended to set `rx_buffer_size: 2048` on the UART bus when using cell sensors.
+:::
+
+### Cell Sensor Example
+
+```yaml
+pylontech:
+  - id: pylontech0
+
+sensor:
+  - platform: pylontech
+    pylontech_id: pylontech0
+    battery: 1
+    voltage:
+      name: "Battery1 Voltage"
+    cell_0_voltage:
+      name: "Battery1 Cell 1 Voltage"
+    cell_0_temperature:
+      name: "Battery1 Cell 1 Temperature"
+    cell_14_voltage:
+      name: "Battery1 Cell 15 Voltage"
+    cell_14_temperature:
+      name: "Battery1 Cell 15 Temperature"
+```
 
 ## Text Sensor
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description
  Add documentation for the new Pylontech cell voltage and temperature sensors                                                                                                 
  (`cell_N_voltage`, `cell_N_temperature`) that read individual cell data via                                                                                                  
  the `bat N` console command. Includes configuration reference, example YAML,                                                                                                 
  and a note about recommended `rx_buffer_size`.  

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- [esphome/esphome#<esphome PR number goes here>](https://github.com/esphome/esphome/pull/14576)

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
