### PR TITLE
Clarify on_click behavior with multiple entries

### DIFF
--- a/src/content/docs/components/binary_sensor/index.mdx
+++ b/src/content/docs/components/binary_sensor/index.mdx
@@ -373,6 +373,9 @@ Configuration variables:
 >       then:
 >         - switch.turn_on: relay_1
 > ```
+>
+> Entries are evaluated independently, so all matching automations will trigger.
+
 
 <span id="binary_sensor-on_double_click"></span>
 


### PR DESCRIPTION
I originally assumed that only the first matching entry would trigger.

## Checklist

- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.
