### PR TITLE
[uart] Return `flush` result, expose timeout via config

### DIFF
--- a/src/content/docs/components/uart.mdx
+++ b/src/content/docs/components/uart.mdx
@@ -70,6 +70,7 @@ uart:
   The default is calculated at compilation time to be approximately ten milliseconds (about 8 bytes at 9600 baud, 114 bytes at 115200 baud).
   
 - **rx_timeout** (*Optional*, int): ESP32 only. This value specifies a number of bytes used to determine the duration of the timeout. The duration of the timeout is based on the amount of time it would take to receive this number of bytes. In other words, for a given value and baud rate, doubling the baud rate will halve the duration of the timeout. After the timeout has elapsed, the data becomes available for processing. Defaults to `2`.
+- **flush_timeout** (*Optional*, [Time](/guides/configuration-types#time)): ESP32 only. The maximum time to wait for the TX FIFO to drain when `flush()` is called. If the TX FIFO does not drain within this time, `flush()` returns a `TIMEOUT` result. When not set, `flush()` waits indefinitely.
 - **data_bits** (*Optional*, int): The number of data bits used on the UART bus. Options: 5 to 8. Defaults to 8.
 - **parity** (*Optional*): The parity used on the UART bus. Options: `NONE`, `EVEN`, `ODD`. Defaults to `NONE`.
 - **stop_bits** (*Optional*, int): The number of stop bits to send. Options: 1, 2. Defaults to 1.
@@ -285,6 +286,8 @@ Below are the methods to read current settings and modify them dynamically:
     id(my_uart).set_rx_full_threshold_ms(uint8_t time);
     // RX timeout
     id(my_uart).set_rx_timeout(size_t rx_timeout);
+    // Flush timeout (ESP32 only; 0 = wait indefinitely)
+    id(my_uart).set_flush_timeout(uint32_t flush_timeout_ms);
     // Stop bits
     id(my_uart).set_stop_bits(uint8_t stop_bits);
     // Data bits


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#14608

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
