### PR TITLE
[usb_uart] Return flush result, expose timeout via config

### DIFF
--- a/src/content/docs/components/usb_uart.mdx
+++ b/src/content/docs/components/usb_uart.mdx
@@ -53,6 +53,7 @@ Setting both `vid` and `pid` to 0 will match any device.
 - **debug** (*Optional*, boolean): If set to true, the channel will log all data sent and received. Defaults to false.
 - **debug_prefix** (*Optional*, string): A string prepended to every debug log line for this channel.
   Useful when multiple channels have debugging enabled, to distinguish their output in the log. Defaults to "".
+- **flush_timeout** (*Optional*, [Time](/guides/configuration-types#time)): The maximum time to wait for the USB output queue to drain when `flush()` is called. If the queue does not drain within this time, `flush()` returns a `TIMEOUT` result. Defaults to `100ms`.
 
 ## Device types
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#14616

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
