### PR TITLE
[rp2040] Document enable_full_printf option

### DIFF
--- a/src/content/docs/components/rp2040.mdx
+++ b/src/content/docs/components/rp2040.mdx
@@ -41,6 +41,7 @@ rp2040:
 - **watchdog_timeout** (*Optional*, string): The timeout to apply to the RP2040 watchdog (in seconds or milliseconds).
   When the device hangs for that period of time, it will reboot. Defaults to `8388ms` (maximum). Set to `0s` to
   disable the watchdog entirely.
+- **enable_full_printf** (*Optional*, boolean): Enable full `FILE*`-based printf support. By default, ESPHome wraps `printf()`, `vprintf()`, and `fprintf()` with lightweight stubs that use `vsnprintf()` + `fwrite()`, saving ~9.2 KB of flash. ESPHome logging uses `snprintf`/`vsnprintf`, not libc printf, so these functions are typically unused unless an external component calls them. Set to `true` only if an external component needs full `FILE*`-based printf. Defaults to `false`.
 
 ## See Also
 


### PR DESCRIPTION
## Description

Document the new `enable_full_printf` configuration option for RP2040, which allows users to disable the printf stub wrapping if they need full FILE*-based printf support from an external component.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#14622

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.