### PR TITLE
[modbus_device_tcp] Documentation for new component modbus_device_tcp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Node.js
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: '20'
           cache: 'npm'
@@ -38,7 +38,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Set up Node.js
-      uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+      uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
       with:
         node-version: '20'
         cache: 'npm'

--- a/data/version.yaml
+++ b/data/version.yaml
@@ -1,2 +1,2 @@
-release: 2026.2.3
+release: 2026.2.4
 version: '2026.2'

--- a/package-lock.json
+++ b/package-lock.json
@@ -6595,9 +6595,9 @@
       }
     },
     "node_modules/sax": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.4.tgz",
-      "integrity": "sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.5.0.tgz",
+      "integrity": "sha512-21IYA3Q5cQf089Z6tgaUTr7lDAyzoTPx5HRtbhsME8Udispad8dC/+sziTNugOEx54ilvatQ9YCzl4KQLPcRHA==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
@@ -6880,9 +6880,9 @@
       }
     },
     "node_modules/svgo": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.0.tgz",
-      "integrity": "sha512-VvrHQ+9uniE+Mvx3+C9IEe/lWasXCU0nXMY2kZeLrHNICuRiC8uMPyM14UEaMOFA5mhyQqEkB02VoQ16n3DLaw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.1.tgz",
+      "integrity": "sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==",
       "license": "MIT",
       "dependencies": {
         "commander": "^11.1.0",
@@ -6891,7 +6891,7 @@
         "css-what": "^6.1.0",
         "csso": "^5.0.5",
         "picocolors": "^1.1.1",
-        "sax": "^1.4.1"
+        "sax": "^1.5.0"
       },
       "bin": {
         "svgo": "bin/svgo.js"

--- a/src/content/docs/changelog/2026.2.0.mdx
+++ b/src/content/docs/changelog/2026.2.0.mdx
@@ -328,6 +328,15 @@ For detailed migration guides and API documentation, see the [ESPHome Developers
 
 </details>
 
+## Release 2026.2.4 - March 3
+
+<details>
+<summary></summary>
+
+- [wifi] Revert cyw43_wifi_link_status change for RP2040 [esphome#14424](https://github.com/esphome/esphome/pull/14424) by [@bdraco](https://github.com/bdraco)
+
+</details>
+
 ## Full list of changes
 
 The lists below are grouped by tag and may contain duplicates across sections.

--- a/src/content/docs/components/display/ssd1306.mdx
+++ b/src/content/docs/components/display/ssd1306.mdx
@@ -130,6 +130,12 @@ display:
       it.print(0, 0, id(font), "Hello World!");
 ```
 
+> [!TIP]
+> Display content might become corrupted for many reasons, including electrical or RF interference. Some people reported
+> mixing of multiple devices with a different [SPI mode](/components/spi#spi-modes) on a single bus as a contributing
+> factor. While the chip's datasheet suggests that the SSD1306 uses `MODE3`, other (non-ESPHome) drivers successfully
+> use `MODE0` for accessing the display. Using `spi_mode: MODE0` might therefore help reduce glitching.
+
 ### Configuration variables
 
 - **model** (**Required**): The model of the display. Options are:

--- a/src/content/docs/components/index.mdx
+++ b/src/content/docs/components/index.mdx
@@ -1089,6 +1089,7 @@ ESPHome to cellular networks. **Does not encompass Wi-Fi.**
   ["HLK-FM22x Face Recognition", "/components/hlk_fm22x/", "fingerprint.svg", "dark-invert"],
   ["Key Collector", "/components/key_collector/", "matrix_keypad.jpg"],
   ["Modbus Controller", "/components/modbus_controller/", "modbus.png"],
+  ["Modbus Device TCP", "/components/modbus_device_tcp/", "modbus.png"],
   ["Sprinkler", "/components/sprinkler/", "sprinkler-variant.svg", "dark-invert"],
   ["Status LED", "/components/status_led/", "led-on.svg", "dark-invert"],
   ["Sun", "/components/sun/", "weather-sunny.svg", "dark-invert"],

--- a/src/content/docs/components/index.mdx
+++ b/src/content/docs/components/index.mdx
@@ -381,7 +381,7 @@ Sensors are organized into categories; if a given sensor fits into more than one
   ["Dallas DS18B20", "/components/sensor/dallas_temp/", "dallas.jpg", "Temperature"],
   ["DHT", "/components/sensor/dht/", "dht.jpg", "Temperature & Humidity"],
   ["DHT12", "/components/sensor/dht12/", "dht12.jpg", "Temperature & Humidity"],
-  ["DPS310", "/components/sensor/dps310/", "dps310.jpg", "Temperature & Pressure"],
+  ["DPS310/DPS368", "/components/sensor/dps310/", "dps310.jpg", "Temperature & Pressure"],
   ["EMC2101", "/components/emc2101/", "emc2101.jpg", "Temperature"],
   ["ENS160", "/components/sensor/ens160/", "ens160.jpg", "CO2 & Air Quality"],
   ["ENS210", "/components/sensor/ens210/", "ens210.jpg", "Temperature & Humidity"],

--- a/src/content/docs/components/modbus_device_tcp.mdx
+++ b/src/content/docs/components/modbus_device_tcp.mdx
@@ -1,0 +1,155 @@
+---
+title: "Modbus Device TCP"
+description: "ESP32 as a Modbus TCP device using Espressif esp-modbus on ESP-IDF."
+---
+
+This component turns an **ESP32** into a **Modbus TCP device** (responder) using [Espressif esp-modbus](https://github.com/espressif/esp-modbus) on the **ESP-IDF** framework. It exposes coils, discrete inputs, input registers, and holding registers that you fill from sensors, GPIO, or lambdas.
+
+**Tested on:** Ubuntu 24 with ESPHome 2026.1.5
+
+## Requirements
+
+- **ESP32** (tested with NodeMCU-32S)
+- **ESP-IDF** framework: set `framework: type: esp-idf` in your YAML
+- **WiFi** (TCP needs network; the component starts the device after WiFi is connected)
+
+## Configuration
+
+```yaml
+# Example configuration entry
+esp32:
+  board: nodemcu-32s
+  framework:
+    type: esp-idf
+
+modbus_device_tcp:
+  id: modbus_server
+  port: 1502        # optional; default 1502
+  unit_id: 1         # optional; default 1 (0–247)
+  num_objects: 5     # optional; default 5; range 1–128
+```
+
+## Configuration variables
+
+- **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID used for code generation.
+- **port** (*Optional*, int): TCP port the device listens on. Defaults to `1502`.
+- **unit_id** (*Optional*, int): Modbus unit address (0–247). Defaults to `1`.
+- **num_objects** (*Optional*, int): Size of each map (coils, discrete inputs, input registers, holding registers). Each map has `num_objects` elements (indices 0..num_objects-1). Defaults to `5`. Range 1–128.
+
+You can set `port` and `unit_id` in your YAML; those values are used at runtime. The component injects esp-modbus, include paths, and the pre-build script—no need to add `platformio_options` or build flags in your app YAML.
+
+## Usage
+
+From **interval**, **automation**, or **lambda**, call the component by `id` to push values into the Modbus maps:
+
+| Method | Description |
+|--------|-------------|
+| `id(modbus_server).set_coil(index, value)` | Set coil at `index` (0..num_objects-1). `value`: `true`/`false`. |
+| `id(modbus_server).set_discrete_input(index, value)` | Set discrete input at `index`. Read-only for the controller. |
+| `id(modbus_server).set_input_register(index, value)` | Set input register at `index` (16-bit). Read-only for the controller. |
+| `id(modbus_server).set_holding_register(index, value)` | Set holding register at `index` (16-bit). Read/write for the controller. |
+
+Example: drive coils from a GPIO and fill holding/input registers from sensors:
+
+```yaml
+modbus_device_tcp:
+  id: modbus_server
+  num_objects: 8
+
+interval:
+  - interval: 1s
+    then:
+      - lambda: |-
+          id(modbus_server).set_coil(0, id(some_binary_sensor).state);
+          id(modbus_server).set_holding_register(0, (uint16_t)id(some_sensor).state);
+          id(modbus_server).set_input_register(0, (uint16_t)id(uptime_sensor).state);
+```
+
+## Full example
+
+Complete configuration with a GPIO binary sensor, internal/WiFi/uptime sensors, and a 1s interval filling all four Modbus maps:
+
+```yaml
+esphome:
+  name: mbsl1
+
+esp32:
+  board: nodemcu-32s
+  framework:
+    type: esp-idf
+
+modbus_device_tcp:
+  id: modbus_server
+  port: 503
+  unit_id: 1
+  num_objects: 5
+
+binary_sensor:
+  - platform: gpio
+    pin:
+      number: GPIO4
+      inverted: true
+      mode:
+        input: true
+        pullup: true
+    id: coil1_source
+    name: "Coil 1 from GPIO"
+
+sensor:
+  - platform: internal_temperature
+    id: esp_temp
+    name: "ESP internal temp"
+    update_interval: 10s
+    accuracy_decimals: 1
+  - platform: wifi_signal
+    id: wifi_rssi
+    name: "WiFi RSSI"
+    update_interval: 10s
+  - platform: uptime
+    id: uptime_sec
+    name: "Uptime"
+    update_interval: 1s
+
+interval:
+  - interval: 1s
+    then:
+      - lambda: |-
+          id(modbus_server).set_coil(0, true);
+          id(modbus_server).set_coil(1, id(coil1_source).state);
+          id(modbus_server).set_holding_register(0, (uint16_t)id(esp_temp).state);
+          id(modbus_server).set_holding_register(1, (uint16_t)(rand() % 101));
+          float rssi = id(wifi_rssi).state;
+          float pct = (rssi + 100.0f) * 100.0f / 70.0f;
+          if (pct < 0.0f) pct = 0.0f;
+          if (pct > 100.0f) pct = 100.0f;
+          id(modbus_server).set_holding_register(2, (uint16_t)pct);
+          id(modbus_server).set_input_register(0, (uint16_t)id(uptime_sec).state);
+          id(modbus_server).set_input_register(1, 88);
+          id(modbus_server).set_discrete_input(0, true);
+          id(modbus_server).set_discrete_input(1, false);
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+
+logger:
+  level: DEBUG
+```
+
+Use a `secrets.yaml` with `wifi_ssid` and `wifi_password` in the same directory.
+
+## Optional: request/response logging
+
+The component uses a pre-build script that can patch esp-modbus to log each Modbus request and response (function code, address, count, length) at INFO level. By default this is **off**. To enable it, edit the component source (e.g. in your external component or custom component):
+
+- **File:** `components/modbus_device_tcp/filter_esp_modbus.py`
+- **Variable:** `ENABLE_MODBUS_REQUEST_RESPONSE_LOGGING = True`
+
+Then run a normal compile. Set back to `False` and recompile to turn logging off again.
+
+## See Also
+
+- [Modbus](/components/modbus/) (RTU client/server)
+- [Modbus Controller](/components/modbus_controller/)
+- [External Components](/components/external_components/)
+- [Espressif esp-modbus](https://github.com/espressif/esp-modbus)

--- a/src/content/docs/components/sensor/dps310.mdx
+++ b/src/content/docs/components/sensor/dps310.mdx
@@ -1,6 +1,6 @@
 ---
-description: "Instructions for setting up DPS310 atmospheric pressure sensors"
-title: "DPS310 Atmospheric Pressure Sensor"
+description: "Instructions for setting up DPS310/DPS368 atmospheric pressure sensors"
+title: "DPS310/DPS368 Atmospheric Pressure Sensor"
 ---
 
 import { Image } from 'astro:assets';
@@ -9,8 +9,15 @@ import dps310FullImg from './images/dps310-full.jpg';
 import APIRef from '@components/APIRef.astro';
 
 The `dps310` sensor platform allows you to use both the temperature and pressure sensors on
-your DPS310 atmospheric pressure sensor ([Adafruit](https://www.adafruit.com/product/4494))
-with ESPHome. The [I²C](/components/i2c) component is required to be set up in your configuration.
+your DPS310 or DPS368 atmospheric pressure sensor
+([Adafruit](https://www.adafruit.com/product/4494)) with ESPHome.
+The [I²C](/components/i2c) component is required to be set up in your configuration.
+
+> [!NOTE]
+> The Infineon DPS368 is a drop-in replacement for the discontinued DPS310 and is fully
+> supported by this component. The two sensors share identical register maps, I²C addresses, and
+> calibration procedures - no configuration changes are needed. If you are designing a new project,
+> Infineon recommends the DPS368.
 
 <Figure
   src={dps310FullImg}

--- a/src/content/docs/guides/diy.mdx
+++ b/src/content/docs/guides/diy.mdx
@@ -103,6 +103,7 @@ unless it's truly exceptional, etc.
 - [Adaptive Lighting for white/warm lights](https://github.com/mdvorak/esphome-adaptive-lighting) by [@mdvorak](https://github.com/mdvorak)
 - [Connecting the PAJ7620 gesture sensor](https://github.com/apaex/PAJ7620-ESPHome) by [@apaex](https://github.com/apaex)
 - [Dew Point Sensor using Magnus formula](https://github.com/iret33/esphome-dew-point) by [@iret33](https://github.com/iret33)
+- [ESPHome Bluetooth Keyboard for Windows](https://github.com/markusg1234/ESPHome-espidf_ble_keyboard) by [@markusg1234](https://github.com/markusg1234)
 
 ## Sample Configurations
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
