### PR TITLE
[toshiba] Add compatible Midea and Furrion models to documentation

### DIFF
--- a/src/content/docs/components/climate/climate_ir.mdx
+++ b/src/content/docs/components/climate/climate_ir.mdx
@@ -193,7 +193,7 @@ climate:
 
 > [!NOTE]
 > - See [Transmit Midea](/components/remote_transmitter#remote_transmitter-transmit_midea) to send custom commands, including Follow Me mode.
-> - See [Toshiba](#toshiba) below if you are looking for compatibility with Midea model MAP14HS1TBL or similar.
+> - See [Toshiba](#toshiba) below if you are looking for compatibility with Midea model MAP14HS1TBL, Midea U-shaped window units, and Furrion Chill Cube or similar.
 
 <span id="mitsubishi"></span>
 
@@ -264,8 +264,9 @@ climate:
 >   temperature, mode, and fan speed) followed by a secondary packet (containing fan speed confirmation and
 >   mode-specific data). Single-packet commands are used for power-off and swing toggle operations.
 >
-> - This climate IR component is also known to work with Midea model MAP14HS1TBL and may work with other similar
->   models, as well. (Midea acquired Toshiba's product line and re-branded it.)
+> - This climate IR component is also known to work with Midea model MAP14HS1TBL, the newer Midea U-shaped window
+>   units (MAW08U1QWT, MAW08V1QWT), and the Furrion Chill Cube RV AC/heat pump (FACR18HEPA-PS-AM). It may work
+>   with other similar models, as well. (Midea acquired Toshiba's product line and re-branded it.)
 
 ```yaml
 # Example configuration entry for RAS-2819T

--- a/src/content/docs/components/climate/climate_ir.mdx
+++ b/src/content/docs/components/climate/climate_ir.mdx
@@ -264,9 +264,10 @@ climate:
 >   temperature, mode, and fan speed) followed by a secondary packet (containing fan speed confirmation and
 >   mode-specific data). Single-packet commands are used for power-off and swing toggle operations.
 >
-> - This climate IR component is also known to work with Midea model MAP14HS1TBL, the newer Midea U-shaped window
->   units (MAW08U1QWT, MAW08V1QWT), and the Furrion Chill Cube RV AC/heat pump (FACR18HEPA-PS-AM). It may work
->   with other similar models, as well. (Midea acquired Toshiba's product line and re-branded it.)
+> - This climate IR component is also known to work with Midea model MAP14HS1TBL, the newer (US model) Midea
+>   U-shaped window units (MAW08U1QWT, MAW08V1QWT), and the Furrion Chill Cube RV AC/heat pump
+>   (FACR18HEPA-PS-AM) when configured with `model: RAC-PT1411HWRU-F`. It may work with other similar models,
+>   as well. (Midea acquired Toshiba's product line and re-branded it.)
 
 ```yaml
 # Example configuration entry for RAS-2819T


### PR DESCRIPTION
## Description

Adds tested compatible models to the Toshiba IR climate
documentation:

- Midea MAW08U1QWT (U-shaped window unit, 8000 BTU)
- Midea MAW08V1QWT (U-shaped window unit, 8000 BTU)
- Furrion FACR18HEPA-PS-AM (Chill Cube RV AC/heat pump)

All three models tested and confirmed working with the
RAC-PT1411HWRU-F model configuration, including Comfort
Sense functionality.

**Related issue (if applicable):** N/A
**Pull request in esphome with YAML changes (if applicable):** N/A


## Checklist
- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.
- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.