### PR TITLE
[online_image] Add 8-bit indexed BMP to supported formats

### DIFF
--- a/src/content/docs/components/online_image.mdx
+++ b/src/content/docs/components/online_image.mdx
@@ -15,6 +15,7 @@ With this component you can define images that will be downloaded, decoded and d
 > - BMP images
 >
 >   - 1-bit / binary / black and white
+>   - 8-bit / indexed
 >   - 24-bit / RGB
 >
 > - JPEG images, currently only baseline images (no progressive support)


### PR DESCRIPTION
## Description

Add 8-bit indexed BMP to the list of supported BMP formats in the online_image documentation.

**Related issue (if applicable):**

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#10733

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.