### PR TITLE
Fix hero image size

### DIFF
--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -151,7 +151,7 @@ dialog::backdrop {
   padding-block: 0.5em;
 }
 
-.sidebar-content ul li > a {
+.sidebar-content ul li>a {
   padding-block: 0.5em;
 }
 
@@ -256,8 +256,8 @@ dialog::backdrop {
 }
 
 /* Ensure Image component wrapper centers its content */
-.sl-markdown-content > p > img,
-.sl-markdown-content > img {
+.sl-markdown-content>p>img,
+.sl-markdown-content>img {
   display: block;
   margin-left: auto;
   margin-right: auto;
@@ -266,4 +266,16 @@ dialog::backdrop {
 /* Transparent background pattern for badges */
 .transparent-background img {
   background: repeating-conic-gradient(#999 0% 25%, transparent 10% 50%) 50% / 10px 10px;
+}
+
+/* Better hero image */
+html[data-has-hero] .hero img {
+  width: auto;
+  max-width: 100%;
+}
+
+@media (min-width: 800px) {
+  html[data-has-hero] .hero {
+    grid-template-columns: 5fr 4fr;
+  }
 }

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -151,7 +151,7 @@ dialog::backdrop {
   padding-block: 0.5em;
 }
 
-.sidebar-content ul li > a {
+.sidebar-content ul li>a {
   padding-block: 0.5em;
 }
 

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -151,7 +151,7 @@ dialog::backdrop {
   padding-block: 0.5em;
 }
 
-.sidebar-content ul li>a {
+.sidebar-content ul li > a {
   padding-block: 0.5em;
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description
Improves the hero image proportions

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
