### PR TITLE
midea: document use_fahrenheit option

### DIFF
--- a/src/content/docs/components/climate/midea.mdx
+++ b/src/content/docs/components/climate/midea.mdx
@@ -34,6 +34,7 @@ climate:
     num_attempts: 3             # Optional
     autoconf: true              # Autoconfigure most options.
     beeper: true                # Beep on commands.
+    use_fahrenheit: true        # Optional. For models that display in Fahrenheit.
     visual:                     # Optional. Example of visual settings override.
       min_temperature: 17 °C    # min: 17
       max_temperature: 30 °C    # max: 30
@@ -78,6 +79,7 @@ climate:
   Defaults to `True`.
 
 - **beeper** (*Optional*, boolean): Beeper feedback on command. Defaults to `False`.
+- **use_fahrenheit** (*Optional*, boolean): For models that display in Fahrenheit (e.g. US-based models). When set to `true`, configures the climate entity for Fahrenheit display in Home Assistant by automatically setting min/max temperature (60-86 °F), 1 °F step size, and translating between the AC's internal Celsius setpoints and precise Celsius values that display as clean integer Fahrenheit in HA. Defaults to `false`.
 - **supported_modes** (*Optional*, list): List of supported modes. Possible values are: `HEAT_COOL`, `COOL`, `HEAT`, `DRY`, `FAN_ONLY`.
 - **custom_fan_modes** (*Optional*, list): List of supported custom fan modes. Possible values are: `SILENT`, `TURBO`.
 - **supported_presets** (*Optional*, list): List of supported presets. Possible values are: `ECO`, `BOOST`, `SLEEP`.


### PR DESCRIPTION
## Summary
- Documents the new `use_fahrenheit` configuration option for the midea climate component
- Adds example YAML and configuration variable description

## Related
- esphome/esphome#14700