### PR TITLE
Updates to release note generation for astro

### DIFF
--- a/lint.mjs
+++ b/lint.mjs
@@ -29,6 +29,11 @@ const ignoreFolders = [
   '.astro/',
 ];
 
+// Files to ignore (skip all linting)
+const ignoreFiles = [
+  'script/release_notes_template.mdx',
+];
+
 // File types
 const fileTypes = [
   '.cfg', '.css', '.gif', '.h', '.html', '.ico', '.jpg', '.js', '.json',
@@ -451,6 +456,11 @@ async function main() {
   for (const [fname, gitMode] of gitFiles) {
     // Skip ignored folders
     if (ignoreFolders.some(folder => fname.startsWith(folder) || fname.includes(`/${folder}`))) {
+      continue;
+    }
+
+    // Skip ignored files
+    if (ignoreFiles.includes(fname)) {
       continue;
     }
 

--- a/script/generate_release_notes.py
+++ b/script/generate_release_notes.py
@@ -57,7 +57,7 @@ Step 3: Review AI Responses (CRITICAL!)
 
 Step 4: Assemble Changelog
   $ python script/generate_release_notes.py 2025.11.0 --assemble
-  This combines AI responses with auto-generated PR lists into content/changelog/2025.11.0.md
+  This combines AI responses with auto-generated PR lists into src/content/docs/changelog/2025.11.0.mdx
 
 Troubleshooting Common Issues:
 -----------------------------
@@ -629,7 +629,7 @@ class ReleaseNotesGenerator:
         print("=" * 80)
         print("\n⚠️  WARNING: AI-generated content MUST be reviewed for accuracy!")
         print("\nCarefully review and edit the assembled changelog:")
-        print(f"  content/changelog/{self.version}.md")
+        print(f"  src/content/docs/changelog/{self.version}.mdx")
         print("\nCheck for:")
         print("  ✓ Hallucinations or inaccurate technical claims")
         print(
@@ -694,7 +694,7 @@ class ReleaseNotesGenerator:
             return False
 
         # Load template
-        template_file = Path("script/release_notes_template.md")
+        template_file = Path("script/release_notes_template.mdx")
         if not template_file.exists():
             print(f"Error: Template not found: {template_file}")
             return False
@@ -702,19 +702,22 @@ class ReleaseNotesGenerator:
         template = template_file.read_text()
 
         # Check if destination file exists and has content to preserve
-        output_file = Path("content/changelog") / f"{self.version}.md"
+        output_file = Path("src/content/docs/changelog") / f"{self.version}.mdx"
         existing_imgtable = None
         existing_full_list = None
         if output_file.exists():
             existing_content = output_file.read_text()
 
-            # Extract existing imgtable content
+            # Extract existing ImgTable content
             imgtable_match = re.search(
-                r"{{< imgtable >}}(.*?){{< /imgtable >}}", existing_content, re.DOTALL
+                r"<ImgTable items=\{\[.*?\]\} />", existing_content, re.DOTALL
             )
-            if imgtable_match and imgtable_match.group(1).strip():
-                existing_imgtable = imgtable_match.group(0)
-                print("✓ Preserving existing imgtable")
+            if imgtable_match:
+                items_content = imgtable_match.group(0)
+                # Only preserve if it has actual entries (not just comments/empty)
+                if re.search(r'\[".+?"', items_content):
+                    existing_imgtable = items_content
+                    print("✓ Preserving existing ImgTable")
 
             # Extract existing "Full list of changes" section
             # This regex matches from "## Full list of changes" to end of file
@@ -812,7 +815,7 @@ class ReleaseNotesGenerator:
         # Replace imgtable if we have one preserved
         if existing_imgtable:
             template = re.sub(
-                r"<!-- MANUAL: Add featured components here -->\s*{{< imgtable >}}.*?{{< /imgtable >}}",
+                r"<ImgTable items=\{\[.*?\]\} />",
                 existing_imgtable,
                 template,
                 flags=re.DOTALL,
@@ -843,9 +846,9 @@ class ReleaseNotesGenerator:
         return True
 
     def _replace_marker_content(self, template: str, marker: str, content: str) -> str:
-        """Replace content between <!-- MARKER_START --> and <!-- MARKER_END -->"""
-        pattern = f"<!-- {marker}_START -->.*?<!-- {marker}_END -->"
-        replacement = f"<!-- {marker}_START -->\n{content}\n<!-- {marker}_END -->"
+        """Replace content between {/* MARKER_START */} and {/* MARKER_END */}"""
+        pattern = re.escape("{/* ") + marker + re.escape("_START */}") + ".*?" + re.escape("{/* ") + marker + re.escape("_END */}")
+        replacement = "{/* " + marker + "_START */}\n" + content + "\n{/* " + marker + "_END */}"
 
         result, count = re.subn(pattern, replacement, template, flags=re.DOTALL)
 

--- a/script/release_notes_template.mdx
+++ b/script/release_notes_template.mdx
@@ -2,22 +2,20 @@
 description: "Changelog for ESPHome {VERSION}."
 title: "ESPHome {VERSION} - {DATE}"
 pagefind: false
-slug: "{VERSION}"
+slug: "changelog/{VERSION}"
 ---
 
-<!-- NOTE: When creating a new changelog, save this as a .mdx file -->
+import ImgTable from "@components/ImgTable.astro";
 
-import ImgTable from '@components/ImgTable.astro';
-
-<!-- MANUAL: Add featured components here -->
+{/* MANUAL: Add featured components here */}
 <ImgTable items={[
   // ["Component Name", "/components/path/", "image.png"],
 ]} />
 
 ## Release Overview
 
-<!-- RELEASE_OVERVIEW_START -->
-<!--
+{/* RELEASE_OVERVIEW_START */}
+{/*
   Generate 1-2 paragraphs providing a high-level summary of this release.
   Focus on the most significant changes and improvements.
 
@@ -26,21 +24,21 @@ import ImgTable from '@components/ImgTable.astro';
   - Highlight major themes (e.g., security, performance, new features)
   - Be specific about what users can expect
   - Keep it concise but informative
--->
-<!-- RELEASE_OVERVIEW_END -->
+*/}
+{/* RELEASE_OVERVIEW_END */}
 
 ## Upgrade Checklist
 
-<!-- UPGRADE_CHECKLIST_START -->
-<!--
+{/* UPGRADE_CHECKLIST_START */}
+{/*
   AI-generated checklist of actionable items for users upgrading to this version.
   Generated from breaking changes and undocumented API changes.
   Each item starts with "If you..." and gives a concise action.
--->
-<!-- UPGRADE_CHECKLIST_END -->
+*/}
+{/* UPGRADE_CHECKLIST_END */}
 
-<!-- FEATURE_HIGHLIGHTS_START -->
-<!--
+{/* FEATURE_HIGHLIGHTS_START */}
+{/*
   FEATURE HIGHLIGHT SECTIONS
 
   Detailed deep-dive sections for major features, appearing after Key Highlights
@@ -57,13 +55,13 @@ import ImgTable from '@components/ImgTable.astro';
   - Use [Component Name](/components/path/) for component links
   - Professional but enthusiastic tone
   - Order by importance (most impactful first)
--->
-<!-- FEATURE_HIGHLIGHTS_END -->
+*/}
+{/* FEATURE_HIGHLIGHTS_END */}
 
 ## Breaking Changes
 
-<!-- BREAKING_CHANGES_USERS_START -->
-<!--
+{/* BREAKING_CHANGES_USERS_START */}
+{/*
   USER-FACING BREAKING CHANGES
 
   For breaking changes that affect ESPHome users (YAML configuration changes,
@@ -78,13 +76,13 @@ import ImgTable from '@components/ImgTable.astro';
   - Start with the most impactful changes
   - Be clear and specific about what action users need to take
   - Use code blocks for YAML examples
--->
-<!-- BREAKING_CHANGES_USERS_END -->
+*/}
+{/* BREAKING_CHANGES_USERS_END */}
 
 ### Undocumented API Changes
 
-<!-- UNDOCUMENTED_API_CHANGES_START -->
-<!--
+{/* UNDOCUMENTED_API_CHANGES_START */}
+{/*
   UNDOCUMENTED API CHANGES
 
   For C++ API changes that don't affect YAML configurations but may affect
@@ -97,13 +95,13 @@ import ImgTable from '@components/ImgTable.astro';
   - Include before/after code examples where helpful
   - Link to relevant PRs
   - Explain who is affected (lambda users, external component developers)
--->
-<!-- UNDOCUMENTED_API_CHANGES_END -->
+*/}
+{/* UNDOCUMENTED_API_CHANGES_END */}
 
 ### Breaking Changes for Developers
 
-<!-- BREAKING_CHANGES_DEVELOPERS_START -->
-<!--
+{/* BREAKING_CHANGES_DEVELOPERS_START */}
+{/*
   DEVELOPER-FACING BREAKING CHANGES
 
   For breaking changes that affect external component developers, C++ API users,
@@ -118,46 +116,46 @@ import ImgTable from '@components/ImgTable.astro';
   - Use C++ code blocks for examples
   - Be technical and precise
   - Focus on what external component developers need to change
--->
-<!-- BREAKING_CHANGES_DEVELOPERS_END -->
+*/}
+{/* BREAKING_CHANGES_DEVELOPERS_END */}
 
-<!-- markdownlint-disable MD013 -->
+{/* markdownlint-disable MD013 */}
 
 ## Full list of changes
 
 ### New Features
 
-<!-- AUTO_GENERATED_NEW_FEATURES_START -->
-<!-- This section is automatically generated from PR labels -->
-<!-- AUTO_GENERATED_NEW_FEATURES_END -->
+{/* AUTO_GENERATED_NEW_FEATURES_START */}
+{/* This section is automatically generated from PR labels */}
+{/* AUTO_GENERATED_NEW_FEATURES_END */}
 
 ### New Components
 
-<!-- AUTO_GENERATED_NEW_COMPONENTS_START -->
-<!-- This section is automatically generated from PR labels -->
-<!-- AUTO_GENERATED_NEW_COMPONENTS_END -->
+{/* AUTO_GENERATED_NEW_COMPONENTS_START */}
+{/* This section is automatically generated from PR labels */}
+{/* AUTO_GENERATED_NEW_COMPONENTS_END */}
 
 ### Breaking Changes
 
-<!-- AUTO_GENERATED_BREAKING_CHANGES_LIST_START -->
-<!-- This section is automatically generated from PR labels -->
-<!-- AUTO_GENERATED_BREAKING_CHANGES_LIST_END -->
+{/* AUTO_GENERATED_BREAKING_CHANGES_LIST_START */}
+{/* This section is automatically generated from PR labels */}
+{/* AUTO_GENERATED_BREAKING_CHANGES_LIST_END */}
 
 ### Undocumented API Changes
 
-<!-- AUTO_GENERATED_UNDOCUMENTED_API_CHANGES_LIST_START -->
-<!-- This section is automatically generated from PR labels -->
-<!-- AUTO_GENERATED_UNDOCUMENTED_API_CHANGES_LIST_END -->
+{/* AUTO_GENERATED_UNDOCUMENTED_API_CHANGES_LIST_START */}
+{/* This section is automatically generated from PR labels */}
+{/* AUTO_GENERATED_UNDOCUMENTED_API_CHANGES_LIST_END */}
 
 ### All changes
 
 <details>
 <summary></summary>
 
-<!-- AUTO_GENERATED_ALL_CHANGES_START -->
-<!-- This section is automatically generated from all merged PRs -->
-<!-- AUTO_GENERATED_ALL_CHANGES_END -->
+{/* AUTO_GENERATED_ALL_CHANGES_START */}
+{/* This section is automatically generated from all merged PRs */}
+{/* AUTO_GENERATED_ALL_CHANGES_END */}
 
 </details>
 
-<!-- markdownlint-enable MD013 -->
+{/* markdownlint-enable MD013 */}


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
