### PR TITLE
add docs for added climate.pid. set_deadband_control_parameters_multipliers action and K[P,I,D]_DEADBAND_MULTIPLIER sensors in pid climate.

### DIFF
--- a/src/content/docs/components/climate/pid.mdx
+++ b/src/content/docs/components/climate/pid.mdx
@@ -382,6 +382,36 @@ Configuration variables:
 - **kd** (*Optional*, float, [templatable](/automations/templates)): The factor for the derivative term of the PID controller.
   Defaults to `0`.
 
+This action updates the active runtime PID controller. The new values are used on the
+next PID computation cycle.
+
+## `climate.pid.set_deadband_control_parameters_multipliers` Action
+
+This action sets runtime multipliers for the deadband PID terms. This can be used to tune
+how strongly the P/I/D terms are applied while the controller is in deadband.
+
+```yaml
+on_...:
+  - climate.pid.set_deadband_control_parameters_multipliers:
+      id: pid_climate
+      kp_multiplier: 0.0
+      ki_multiplier: 0.0
+      kd_multiplier: 0.0
+```
+
+Configuration variables:
+
+- **id** (**Required**, [ID](/guides/configuration-types#id)): ID of the PID Climate to update.
+- **kp_multiplier** (**Required**, float, [templatable](/automations/templates)): Deadband multiplier for the proportional term.
+- **ki_multiplier** (*Optional*, float, [templatable](/automations/templates)): Deadband multiplier for the integral term.
+  Defaults to `0`.
+
+- **kd_multiplier** (*Optional*, float, [templatable](/automations/templates)): Deadband multiplier for the derivative term.
+  Defaults to `0`.
+
+This action updates the active runtime PID controller. The new values are used on the
+next PID computation cycle.
+
 ## `climate.pid.reset_integral_term` Action
 
 This action resets the integral term of the PID controller to 0. This might be necessary under certain
@@ -423,6 +453,9 @@ Configuration variables:
   - `KP` - The current factor for the proportional term of the PID controller.
   - `KI` - The current factor for the integral term of the PID controller.
   - `KD` - The current factor for the differential term of the PID controller.
+  - `KP_DEADBAND_MULTIPLIER` - The current deadband multiplier for the proportional term.
+  - `KI_DEADBAND_MULTIPLIER` - The current deadband multiplier for the integral term.
+  - `KD_DEADBAND_MULTIPLIER` - The current deadband multiplier for the differential term.
 
 - All other options from [Sensor](/components/sensor).
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

Update docs for esphome PR14730.

Add action climate.pid.set_deadband_control_parameters_multipliers

Add sensors K{P,I,D]_DEADBAND_MULTIPLIER


**Related issue (if applicable): NA

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#14730

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
