### PR TITLE
Update dlms_meter.mdx

### DIFF
--- a/src/content/docs/components/sensor/dlms_meter.mdx
+++ b/src/content/docs/components/sensor/dlms_meter.mdx
@@ -7,11 +7,12 @@ import APIClass from '@components/APIClass.astro';
 import APIRef from '@components/APIRef.astro';
 import { Image } from 'astro:assets';
 
-The `dlms_meter` component connects to smart meters which use the encrypted **DLMS/COSEM** protocol over UART. These
+The `dlms_meter` component connects to smart meters which use the **DLMS/COSEM** protocol over UART. These
 smart meters are (for example) widely deployed in Austria.
 
-**An M-Bus to UART adapter is required.** You must also request the 32‑character hexadecimal decryption key from your
-energy provider / grid operator.
+**An M-Bus to UART or RS485 to UART adapter is required.**
+
+You may also need to request a 32‑character hexadecimal decryption key from your energy provider / grid operator.
 
 This component is passive; it does not transmit data to the meter. The meter periodically broadcasts frames (often
 about every 5 seconds). ESPHome listens, decrypts and updates the configured sensors as data arrives.
@@ -112,11 +113,14 @@ text_sensor:
 
 ### Configuration Variables
 
-- **decryption_key** (**Required**, string, 32 hex chars, case-insensitive, templatable): Key used to decrypt DLMS telegrams.
+- **decryption_key** (*Optional*, string, 32 hex chars, case-insensitive, templatable): Key used to decrypt DLMS telegrams.
   Obtain this from your provider / grid operator.
 - **provider** (*Optional*): Grid operator profile. Options:
   - `generic` (default) – works for most operators.
   - `netznoe` – Netz Noe / EVN specific mapping.
+- **transport** (*Optional*): Transport protocol. Options:
+  - `mbus` (default) – M-Bus over UART.
+  - `raw` – Raw DLMS frames over UART.
 
 ## Sensor
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#14750

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
