### PR TITLE
Fix link in esp32_rmt_led_strip.mdx

### DIFF
--- a/src/content/docs/components/light/esp32_rmt_led_strip.mdx
+++ b/src/content/docs/components/light/esp32_rmt_led_strip.mdx
@@ -93,4 +93,4 @@ please consider adding support to the codebase and add it to the list above.
 
 - [Light Component](/components/light/)
 - [Power Supply Component](/components/power_supply/)
-- <APIRef text="esp32_rmt_led_strip.h" path="esp32_rmt_led_strip/esp32_rmt_led_strip.h" />
+- <APIRef text="esp32_rmt_led_strip.h" path="esp32_rmt_led_strip/led_strip.h" />


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Fixes link in docs to h file:
https://api-docs.esphome.io/dir_e0ebe1cc7cb01fee3e19370a14ecbe57

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.
