### PR TITLE
Change h-/vsync_pin to optional

### DIFF
--- a/src/content/docs/components/display/mipi_rgb.mdx
+++ b/src/content/docs/components/display/mipi_rgb.mdx
@@ -106,8 +106,8 @@ display:
 
 - **de_pin** (**Required**, [Pin Schema](/guides/configuration-types#pin-schema)): The DE pin.
 - **pclk_pin** (**Required**, [Pin Schema](/guides/configuration-types#pin-schema)): The PCLK pin.
-- **hsync_pin** (**Required**, [Pin Schema](/guides/configuration-types#pin-schema)): The Horizontal sync pin.
-- **vsync_pin** (**Required**, [Pin Schema](/guides/configuration-types#pin-schema)): The Vertical sync pin.
+- **hsync_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The Horizontal sync pin.
+- **vsync_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The Vertical sync pin.
 - **reset_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The RESET pin.
 - **hsync_pulse_width** (*Optional*, int): The horizontal sync pulse width.
 - **hsync_front_porch** (*Optional*, int): The horizontal front porch length.


### PR DESCRIPTION
Updated h-/vsync_pin to be optional.

<!-- markdownlint-disable -->

## Description

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes:**

- esphome/esphome#14870

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
