### PR TITLE
[remote_base] support for brennenstuhl rf codes

### DIFF
--- a/src/content/docs/components/remote_receiver.mdx
+++ b/src/content/docs/components/remote_receiver.mdx
@@ -38,6 +38,7 @@ Multiple remote receivers can be configured as a list of dict definitions within
 
   - **aeha**: Decode and dump AEHA infrared codes.
   - **beo4**: Decode and dump B&O Beo4 infrared codes.
+  - **brennenstuhl**: Decode and dump brennenstuhl RF codes.
   - **byronsx**: Decode and dump Byron SX doorbell RF codes.
   - **canalsat**: Decode and dump CanalSat infrared codes.
   - **canalsatld**: Decode and dump CanalSatLD infrared codes.
@@ -162,6 +163,10 @@ To enable signal demodulation, configure the signal carrier frequency and duty c
 
 - **on_beo4** (*Optional*, [Automation](/automations)): An automation to perform when a
   B&O Beo4 infrared remote code has been decoded. A variable `x` of type <APIStruct text="remote_base::Beo4Data" path="remote_base::Beo4Data" />
+  is passed to the automation for use in lambdas.
+
+- **on_brennenstuhl** (*Optional*, [Automation](/automations)): An automation to perform when a
+  brennenstuhl RF code has been decoded. A variable `x` of type <APIStruct text="remote_base::BrennenstuhlData" path="remote_base::BrennenstuhlData" />
   is passed to the automation for use in lambdas.
 
 - **on_byronsx** (*Optional*, [Automation](/automations)): An automation to perform when a
@@ -390,6 +395,10 @@ Remote code selection (exactly one of these has to be included):
   - **source** (**Required**, int): The 8-bit source to trigger on, e.g. 0x00=video, 0x01=audio,..., see dumper output for more info.
   - **command** (**Required**, int): The 8-bit command to listen for, e.g. 0x00=number0, 0x0C=standby,..., see dumper output for more info.
 
+- **brennenstuhl**: Trigger on a decoded brennenstuhl RF code with the given data.
+
+  - **code** (**Required**, int): The 24-bit code to trigger on, see dumper output for more info.
+  
 - **byronsx**: Trigger on a decoded Byron SX Doorbell RF remote code with the given data.
 
   - **address** (**Required**, int): The 8-bit ID code to trigger on, see dumper output for more info.

--- a/src/content/docs/components/remote_transmitter.mdx
+++ b/src/content/docs/components/remote_transmitter.mdx
@@ -237,9 +237,8 @@ on_...:
 > The brennenstuhl devices use rolling codes, i.e. each button of the remote generates 4 different codes in
 > a pseudo random manner. The yaml snippet from above handles the codes of the button **A-ON** that are stored
 > in the vector `id(a_on)[]`. The vector is looped with `id(idx)` to provide the transmit function with codes
-> that differ from the previous ones. See [Setting up RF Devices](/guides/setting_up_rmt_devices#remote-setting-up-rf)
-> and [Setting up RF Devices](/guides/setting_up_rmt_devices#remote-setting-up-rf) for details and a complete
-> YAML example
+> that differ from the previous ones. See [Setting up RF Devices](/guides/setting_up_rmt_devices#remote-setting-up-rolling-codes)
+> for details and a complete YAML example.
 
 <span id="remote_transmitter-transmit_byronsx"></span>
 

--- a/src/content/docs/components/remote_transmitter.mdx
+++ b/src/content/docs/components/remote_transmitter.mdx
@@ -226,11 +226,7 @@ This [action](/automations/actions#all-actions) sends a brennenstuhl protocol co
 ```yaml
 on_...:
   - remote_transmitter.transmit_brennenstuhl:
-      code: !lambda |-
-        code=id(a_on)[id(idx)];
-        id(idx) = (id(idx) + 1) & 3;
-      
-```
+      code: 0xBD2E2C
 
 #### Configuration variables
 

--- a/src/content/docs/components/remote_transmitter.mdx
+++ b/src/content/docs/components/remote_transmitter.mdx
@@ -217,6 +217,34 @@ on_...:
 - **command** (**Required**, int, [templatable](/automations/templates)): The command to send, e.g. 0x01=num1, 0x0d=mute,..., see dumper output for more info.
 - All other options from [Remote Transmitter Actions](#remote_transmitter-transmit_action).
 
+<span id="remote_transmitter-transmit_brennenstuhl"></span>
+
+### `remote_transmitter.transmit_brennenstuhl` Action
+
+This [action](/automations/actions#all-actions) sends a brennenstuhl protocol code to a remote transmitter.
+
+```yaml
+on_...:
+  - remote_transmitter.transmit_brennenstuhl:
+      code: !lambda |-
+        code=id(a_on)[id(idx)];
+        id(idx) = (id(idx) + 1) & 3;
+      
+```
+
+#### Configuration variables
+
+- **code** (**Required**, int, [templatable](/automations/templates)): The 24-bit rolling code from a vector.
+- All other options from [Remote Transmitter Actions](#remote_transmitter-transmit_action).
+
+> [!NOTE]
+> The brennenstuhl devices use rolling codes, i.e. each button of the remote generates 4 different codes in
+> a pseudo random manner. The yaml snippet from above handles the codes of the button **A-ON** that are stored
+> in the vector `id(a_on)[]`. The vector is looped with `id(idx)` to provide the transmit function with codes
+> that differ from the previous ones. See [Setting up RF Devices](/guides/setting_up_rmt_devices#remote-setting-up-rf)
+> and [Setting up RF Devices](/guides/setting_up_rmt_devices#remote-setting-up-rf) for details and a complete
+> YAML example
+
 <span id="remote_transmitter-transmit_byronsx"></span>
 
 ### `remote_transmitter.transmit_byronsx` Action

--- a/src/content/docs/components/remote_transmitter.mdx
+++ b/src/content/docs/components/remote_transmitter.mdx
@@ -231,15 +231,13 @@ on_...:
 
 #### Configuration variables
 
-- **code** (**Required**, int, [templatable](/automations/templates)): The 24-bit rolling code from a vector.
+- **code** (**Required**, int, [templatable](/automations/templates)): The 24-bit code to send.
 - All other options from [Remote Transmitter Actions](#remote_transmitter-transmit_action).
 
 > [!NOTE]
 > The brennenstuhl devices use rolling codes, i.e. each button of the remote generates 4 different codes in
-> a pseudo random manner. The yaml snippet from above handles the codes of the button **A-ON** that are stored
-> in the vector `id(a_on)[]`. The vector is looped with `id(idx)` to provide the transmit function with codes
-> that differ from the previous ones. See [Setting up RF Devices](/guides/setting_up_rmt_devices#remote-setting-up-rf)
-> and [Rolling codes](/guides/setting_up_rmt_devices#rolling-codes) for details and a complete YAML example.
+> a pseudo random manner. See [Rolling Codes](/guides/setting_up_rmt_devices#remote-setting-up-rolling-codes)
+> for details and a complete YAML example.
 
 <span id="remote_transmitter-transmit_byronsx"></span>
 

--- a/src/content/docs/components/remote_transmitter.mdx
+++ b/src/content/docs/components/remote_transmitter.mdx
@@ -227,6 +227,7 @@ This [action](/automations/actions#all-actions) sends a brennenstuhl protocol co
 on_...:
   - remote_transmitter.transmit_brennenstuhl:
       code: 0xBD2E2C
+```
 
 #### Configuration variables
 
@@ -237,8 +238,8 @@ on_...:
 > The brennenstuhl devices use rolling codes, i.e. each button of the remote generates 4 different codes in
 > a pseudo random manner. The yaml snippet from above handles the codes of the button **A-ON** that are stored
 > in the vector `id(a_on)[]`. The vector is looped with `id(idx)` to provide the transmit function with codes
-> that differ from the previous ones. See [Setting up RF Devices](/guides/setting_up_rmt_devices#remote-setting-up-rolling-codes)
-> for details and a complete YAML example.
+> that differ from the previous ones. See [Setting up RF Devices](/guides/setting_up_rmt_devices#remote-setting-up-rf)
+> and [Rolling codes](/guides/setting_up_rmt_devices#rolling-codes) for details and a complete YAML example.
 
 <span id="remote_transmitter-transmit_byronsx"></span>
 

--- a/src/content/docs/guides/setting_up_rmt_devices.mdx
+++ b/src/content/docs/guides/setting_up_rmt_devices.mdx
@@ -191,7 +191,7 @@ logic: the current code must differ from the previous one. In such a case, the n
 can be recorded by pressing each button several times and stored in a vector. The
 brennenstuhl remote for example uses four rolling codes for each button. The YAML below
 shows the transmitter for the three buttons **A_ON**, **A_OFF** and **B_ON**. Additional
-buttons are simply added in the same way :
+buttons are simply added in the same way:
 
 ```yaml
 
@@ -237,24 +237,7 @@ script:
             }
             idx = (idx + 1) & 3;
             return code;
-
-# buttons for the GUI
-button:
-- platform: template
-  name: "A ON"
-  on_press:
-    - lambda: id(bs_transmitter)->execute(10);
-- platform: template
-  name: "A OFF"
-  on_press:
-    - lambda: id(bs_transmitter)->execute(11);
-- platform: template
-  name: "B ON"
-  on_press:
-    - lambda: id(bs_transmitter)->execute(20);
-
 ```
-
 
 ## See Also
 

--- a/src/content/docs/guides/setting_up_rmt_devices.mdx
+++ b/src/content/docs/guides/setting_up_rmt_devices.mdx
@@ -201,10 +201,10 @@ globals:
   type: std::vector<uint32_t>
   initial_value: '{ 0xbfcf6c, 0xbe821c, 0xb1d75c, 0xb593ac }'
 - id: a_off
-  type: std::vector<int>
+  type: std::vector<uint32_t>
   initial_value: '{ 0xbd2e2c, 0xb4ed8c, 0xb2b6bc, 0xb3017c }'
 - id: b_on
-  type: std::vector<int>
+  type: std::vector<uint32_t>
   initial_value: '{ 0xbb3535, 0xb87af5, 0xbca0e5, 0xba5c05 }'
 
 script:

--- a/src/content/docs/guides/setting_up_rmt_devices.mdx
+++ b/src/content/docs/guides/setting_up_rmt_devices.mdx
@@ -198,7 +198,7 @@ buttons are simply added in the same way :
 globals:
   # the code vectors of three buttons A_ON, A_OFF and B_ON
 - id: a_on
-  type: std::vector<int>
+  type: std::vector<uint32_t>
   initial_value: '{ 0xbfcf6c, 0xbe821c, 0xb1d75c, 0xb593ac }'
 - id: a_off
   type: std::vector<int>

--- a/src/content/docs/guides/setting_up_rmt_devices.mdx
+++ b/src/content/docs/guides/setting_up_rmt_devices.mdx
@@ -183,7 +183,7 @@ in the frontend. Click on it and you should see the remote signal being transmit
 
 ## Rolling Codes
 
-<span id="remote-setting-up-infrared"></span>
+<span id="remote-setting-up-rolling-codes"></span>
 
 Some devices are using rolling codes, i.e. instead of **one unique** code, the buttons
 generate **n different** codes in a random manner. Good-natured receivers have a simple

--- a/src/content/docs/guides/setting_up_rmt_devices.mdx
+++ b/src/content/docs/guides/setting_up_rmt_devices.mdx
@@ -189,7 +189,7 @@ Some devices are using rolling codes, i.e. instead of **one unique** code, the b
 generate **n different** codes in a random manner. Good-natured receivers have a simple
 logic: the current code must differ from the previous one. In such a case, the n codes
 can be recorded by pressing each button several times and stored in a vector. The
-brennenstuhl remote for example uses four rolling codes for each button.The YAML below
+brennenstuhl remote for example uses four rolling codes for each button. The YAML below
 shows the transmitter for the three buttons **A_ON**, **A_OFF** and **B_ON**. Additional
 buttons are simply added in the same way :
 

--- a/src/content/docs/guides/setting_up_rmt_devices.mdx
+++ b/src/content/docs/guides/setting_up_rmt_devices.mdx
@@ -181,6 +181,81 @@ in the frontend. Click on it and you should see the remote signal being transmit
 > repetition logs are consistent between the remote controller and the transmitter node.
 > You can adjust the `repeat:` settings accordingly.
 
+## Rolling Codes
+
+<span id="remote-setting-up-infrared"></span>
+
+Some devices are using rolling codes, i.e. instead of **one unique** code, the buttons
+generate **n different** codes in a random manner. Good-natured receivers have a simple
+logic: the current code must differ from the previous one. In such a case, the n codes
+can be recorded by pressing each button several times and stored in a vector. The
+brennenstuhl remote for example uses four rolling codes for each button.The YAML below
+shows the transmitter for the three buttons **A_ON**, **A_OFF** and **B_ON**. Additional
+buttons are simply added in the same way :
+
+```yaml
+
+globals:
+  # the code vectors of three buttons A_ON, A_OFF and B_ON
+- id: a_on
+  type: std::vector<int>
+  initial_value: '{ 0xbfcf6c, 0xbe821c, 0xb1d75c, 0xb593ac }'
+- id: a_off
+  type: std::vector<int>
+  initial_value: '{ 0xbd2e2c, 0xb4ed8c, 0xb2b6bc, 0xb3017c }'
+- id: b_on
+  type: std::vector<int>
+  initial_value: '{ 0xbb3535, 0xb87af5, 0xbca0e5, 0xba5c05 }'
+
+script:
+    # - select vector with bs_button
+    # - lookup code from vector with idx
+    # - call remote_transmitter
+    # - update idx
+  - id: bs_transmitter
+    mode: single
+    parameters: 
+      bs_button: int
+    then:
+      - remote_transmitter.transmit_brennenstuhl:
+          code: !lambda |-
+            uint32_t code = 0;
+            static int32_t idx = 0; // rolling index
+            switch(bs_button) {
+              case 10: { // A_ON
+                code=id(a_on)[idx];
+                break;
+              }
+              case 11: { // A_OFF
+                code=id(a_off)[idx];
+                break;
+              }
+              case 20: {  // B_ON
+                code=id(b_on)[idx];
+                break;
+              }
+            }
+            idx = (idx + 1) & 3;
+            return code;
+
+# buttons for the GUI
+button:
+- platform: template
+  name: "A ON"
+  on_press:
+    - lambda: id(bs_transmitter)->execute(10);
+- platform: template
+  name: "A OFF"
+  on_press:
+    - lambda: id(bs_transmitter)->execute(11);
+- platform: template
+  name: "B ON"
+  on_press:
+    - lambda: id(bs_transmitter)->execute(20);
+
+```
+
+
 ## See Also
 
 - [Remote Receiver](/components/remote_receiver/)


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description
- add documentation for brennenstuhl protocol of RF decoder. 
- add **rolling code** chapter to setting_up_rmt_devices.mdx

**Note**: this PR replaces PR #5420 , which was still based on "hugo" format. There were to much changes and an merge was not possible, once everything was changed to astro/starlight

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#9407

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
