### PR TITLE
Bring back components.json generation

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -9,6 +9,7 @@ import { imageBreakpoints } from "./src/lib/breakpoints.ts";
 import { remarkAlert } from "remark-github-blockquote-alert";
 import remarkMath from "remark-math";
 import rehypeKatex from "rehype-katex";
+import componentsJson from "./src/integrations/components-json.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -275,5 +276,6 @@ export default defineConfig({
       ],
     }),
     sitemap(),
+    componentsJson(),
   ],
 });

--- a/src/integrations/components-json.ts
+++ b/src/integrations/components-json.ts
@@ -1,6 +1,7 @@
 import type { AstroIntegration } from "astro";
 import fs from "fs";
 import path from "path";
+import { fileURLToPath } from "url";
 
 function getTitle(filePath: string): string | null {
   const content = fs.readFileSync(filePath, "utf-8");
@@ -14,7 +15,7 @@ function getSeoImage(filePath: string): string | null {
   return match ? match[1] : null;
 }
 
-const IMAGE_EXTENSIONS = [".png", ".jpg", ".svg"];
+const IMAGE_EXTENSIONS = [".png", ".jpg", ".svg", ".webp"];
 
 function findPublicImage(imagesDir: string, slug: string): string | null {
   for (const ext of IMAGE_EXTENSIONS) {
@@ -29,7 +30,7 @@ function findPublicImage(imagesDir: string, slug: string): string | null {
 /**
  * Parse the components index page to build a map from component URL path
  * to the image filename used in the ImgTable entries.
- * e.g. "/components/api/" -> "server-network.svg"
+ * e.g. "/components/api" -> "server-network.svg"
  */
 function buildIndexImageMap(indexPath: string): Record<string, string> {
   const map: Record<string, string> = {};
@@ -48,6 +49,8 @@ function buildIndexImageMap(indexPath: string): Record<string, string> {
 
 export default function componentsJson(): AstroIntegration {
   let siteURL = "https://esphome.io";
+  let rootDir = "";
+  let outDir = "";
 
   return {
     name: "components-json",
@@ -56,10 +59,10 @@ export default function componentsJson(): AstroIntegration {
         if (config.site) {
           siteURL = config.site.replace(/\/$/, "");
         }
+        rootDir = fileURLToPath(config.root);
+        outDir = fileURLToPath(config.outDir);
       },
-      "astro:build:done": async ({ dir, logger }) => {
-        const outDir = new URL(dir).pathname;
-        const rootDir = path.resolve(outDir, "..");
+      "astro:build:done": async ({ logger }) => {
         const imagesDir = path.join(rootDir, "public/images");
         const componentsDir = path.join(
           rootDir,
@@ -150,7 +153,7 @@ export default function componentsJson(): AstroIntegration {
               components[key] = {
                 title,
                 url: `${siteURL}/components/${entry.name}/${slug}/`,
-                path: `components/${slug}`,
+                path: `components/${entry.name}/${slug}`,
                 ...(image && {
                   image: `${siteURL}/images/${image}`,
                 }),

--- a/src/integrations/components-json.ts
+++ b/src/integrations/components-json.ts
@@ -153,7 +153,7 @@ export default function componentsJson(): AstroIntegration {
               components[key] = {
                 title,
                 url: `${siteURL}/components/${entry.name}/${slug}/`,
-                path: `components/${entry.name}/${slug}`,
+                path: `components/${slug}`,
                 ...(image && {
                   image: `${siteURL}/images/${image}`,
                 }),

--- a/src/integrations/components-json.ts
+++ b/src/integrations/components-json.ts
@@ -1,0 +1,170 @@
+import type { AstroIntegration } from "astro";
+import fs from "fs";
+import path from "path";
+
+function getTitle(filePath: string): string | null {
+  const content = fs.readFileSync(filePath, "utf-8");
+  const match = content.match(/^title:\s*["']?([^"'\n]+)["']?/m);
+  return match ? match[1] : null;
+}
+
+function getSeoImage(filePath: string): string | null {
+  const content = fs.readFileSync(filePath, "utf-8");
+  const match = content.match(/^seo:\s*\n\s*image:\s*["']?([^"'\n]+)["']?/m);
+  return match ? match[1] : null;
+}
+
+const IMAGE_EXTENSIONS = [".png", ".jpg", ".svg"];
+
+function findPublicImage(imagesDir: string, slug: string): string | null {
+  for (const ext of IMAGE_EXTENSIONS) {
+    const candidate = path.join(imagesDir, `${slug}${ext}`);
+    if (fs.existsSync(candidate)) {
+      return `${slug}${ext}`;
+    }
+  }
+  return null;
+}
+
+/**
+ * Parse the components index page to build a map from component URL path
+ * to the image filename used in the ImgTable entries.
+ * e.g. "/components/api/" -> "server-network.svg"
+ */
+function buildIndexImageMap(indexPath: string): Record<string, string> {
+  const map: Record<string, string> = {};
+  const content = fs.readFileSync(indexPath, "utf-8");
+  // Match entries like: ["Label", "/components/api/", "server-network.svg", ...]
+  const re = /\["[^"]*",\s*"(\/components\/[^"]+)",\s*"([^"]+)"/g;
+  let match;
+  while ((match = re.exec(content)) !== null) {
+    const url = match[1].replace(/\/$/, "");
+    if (!map[url]) {
+      map[url] = match[2];
+    }
+  }
+  return map;
+}
+
+export default function componentsJson(): AstroIntegration {
+  let siteURL = "https://esphome.io";
+
+  return {
+    name: "components-json",
+    hooks: {
+      "astro:config:done": ({ config }) => {
+        if (config.site) {
+          siteURL = config.site.replace(/\/$/, "");
+        }
+      },
+      "astro:build:done": async ({ dir, logger }) => {
+        const outDir = new URL(dir).pathname;
+        const rootDir = path.resolve(outDir, "..");
+        const imagesDir = path.join(rootDir, "public/images");
+        const componentsDir = path.join(
+          rootDir,
+          "src/content/docs/components",
+        );
+        const indexImageMap = buildIndexImageMap(
+          path.join(componentsDir, "index.mdx"),
+        );
+
+        const components: Record<
+          string,
+          { title: string; url: string; path: string; image?: string }
+        > = {};
+
+        const entries = fs.readdirSync(componentsDir, {
+          withFileTypes: true,
+        });
+
+        for (const entry of entries) {
+          if (entry.name === "images" || entry.name === "index.mdx") continue;
+
+          if (entry.isFile() && entry.name.endsWith(".mdx")) {
+            const filePath = path.join(componentsDir, entry.name);
+            const title = getTitle(filePath);
+            if (!title) continue;
+
+            const slug = entry.name.replace(".mdx", "");
+            const seoImage = getSeoImage(filePath);
+            const urlPath = `/components/${slug}`;
+            const image =
+              seoImage ||
+              findPublicImage(imagesDir, slug) ||
+              indexImageMap[urlPath];
+
+            components[slug] = {
+              title,
+              url: `${siteURL}/components/${slug}/`,
+              path: `components/${slug}`,
+              ...(image && {
+                image: `${siteURL}/images/${image}`,
+              }),
+            };
+          } else if (entry.isDirectory()) {
+            const dirPath = path.join(componentsDir, entry.name);
+            const indexPath = path.join(dirPath, "index.mdx");
+
+            if (fs.existsSync(indexPath)) {
+              const title = getTitle(indexPath);
+              if (title) {
+                const seoImage = getSeoImage(indexPath);
+                const urlPath = `/components/${entry.name}`;
+                const image =
+                  seoImage ||
+                  findPublicImage(imagesDir, entry.name) ||
+                  indexImageMap[urlPath];
+                components[entry.name] = {
+                  title,
+                  url: `${siteURL}/components/${entry.name}/`,
+                  path: `components/${entry.name}`,
+                  ...(image && {
+                    image: `${siteURL}/images/${image}`,
+                  }),
+                };
+              }
+            }
+
+            const subFiles = fs
+              .readdirSync(dirPath)
+              .filter((f) => f.endsWith(".mdx"));
+            for (const f of subFiles) {
+              if (f === "index.mdx") continue;
+
+              const subPath = path.join(dirPath, f);
+              const title = getTitle(subPath);
+              if (!title) continue;
+
+              const slug = f.replace(".mdx", "");
+              const key = `${entry.name}_${slug}`;
+              const seoImage = getSeoImage(subPath);
+              const urlPath = `/components/${entry.name}/${slug}`;
+              const image =
+                seoImage ||
+                findPublicImage(imagesDir, slug) ||
+                indexImageMap[urlPath] ||
+                indexImageMap[`/components/${slug}`] ||
+                findPublicImage(imagesDir, entry.name);
+
+              components[key] = {
+                title,
+                url: `${siteURL}/components/${entry.name}/${slug}/`,
+                path: `components/${slug}`,
+                ...(image && {
+                  image: `${siteURL}/images/${image}`,
+                }),
+              };
+            }
+          }
+        }
+
+        const outPath = path.join(outDir, "components.json");
+        fs.writeFileSync(outPath, JSON.stringify(components, null, 2));
+        logger.info(
+          `Generated components.json with ${Object.keys(components).length} components`,
+        );
+      },
+    },
+  };
+}


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

THis brings back a components.json generation script that was lost in the Astro/Starlight migration. This file is used by the ESPHome discord bot

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
