### PR TITLE
[changelog] Clarify audio/media player changes

### DIFF
--- a/src/content/docs/changelog/2026.3.0.mdx
+++ b/src/content/docs/changelog/2026.3.0.mdx
@@ -333,7 +333,7 @@ The media player has been redesigned around a modular **source-based architectur
 
 **Key Features:**
 
-- **Pluggable media sources** - Audio sources are separate components that plug into the media player. This release includes the [audio_file](/components/audio_file) source for embedded firmware files, with HTTP streams and Sendspin sources planned for future releases
+- **Pluggable media sources** - Audio sources are separate components that plug into the media player. This release includes the [audio_file](/components/media_source/audio_file) media source for embedded firmware files, with HTTP streams and Sendspin sources planned for future releases
 - **Dual pipeline support** - Separate media and announcement pipelines with independent speakers, formats, and sources, allowing announcements to play alongside music
 - **Full playlist management** - Enqueue, next/previous track navigation, repeat (off/one/all), and shuffle with Fisher-Yates algorithm
 - **Volume persistence** - Volume and mute state are saved across reboots with configurable min/max/increment
@@ -343,10 +343,8 @@ The [audio_file](/components/audio_file) component lets you embed audio files (l
 
 ## Audio Playback Improvements
 
-These improvements apply to both the new `speaker_source` and existing `speaker` media players:
-
-- **Ogg Opus codec support** - The new microOpus library enables decoding Opus audio streams, completing the codec lineup alongside FLAC and MP3 ([#13967](https://github.com/esphome/esphome/pull/13967))
-- **Smarter codec builds** - The `codec_support_enabled` option now defaults to `needed`, building only the codecs your configuration actually requires instead of all three (users streaming arbitrary URLs should set `codec_support_enabled: all`)
+- **Ogg Opus codec support** - The new microOpus library enables decoding Ogg Opus files, completing the codec lineup alongside FLAC and MP3 ([#13967](https://github.com/esphome/esphome/pull/13967))
+- **Smarter codec builds** - Only the codecs your configuration actually requires are built. The `speaker_source` media player does this automatically, while the `speaker` media player's `codec_support_enabled` option now defaults to `needed` (users streaming arbitrary URLs should set `codec_support_enabled: all`)
 - **Speaker media player on/off** - The speaker media player now supports explicit on/off power control ([#9295](https://github.com/esphome/esphome/pull/9295))
 
 ## Other Notable Features

--- a/src/content/docs/changelog/2026.3.0.mdx
+++ b/src/content/docs/changelog/2026.3.0.mdx
@@ -333,15 +333,21 @@ The media player has been redesigned around a modular **source-based architectur
 
 **Key Features:**
 
-- **Pluggable media sources** - Audio can come from embedded [audio_file](/components/audio_file) files, HTTP streams, or future sources like Sendspin, each as a separate component
+- **Pluggable media sources** - Audio sources are separate components that plug into the media player. This release includes the [audio_file](/components/audio_file) source for embedded firmware files, with HTTP streams and Sendspin sources planned for future releases
 - **Dual pipeline support** - Separate media and announcement pipelines with independent speakers, formats, and sources, allowing announcements to play alongside music
 - **Full playlist management** - Enqueue, next/previous track navigation, repeat (off/one/all), and shuffle with Fisher-Yates algorithm
 - **Volume persistence** - Volume and mute state are saved across reboots with configurable min/max/increment
-- **Ogg Opus codec support** - The new microOpus library enables decoding Opus audio streams, completing the codec lineup alongside FLAC and MP3 ([#13967](https://github.com/esphome/esphome/pull/13967))
-- **Smarter codec builds** - The `codec_support_enabled` option now defaults to `needed`, building only the codecs your configuration actually requires instead of all three (users streaming arbitrary URLs should set `codec_support_enabled: all`)
 - **Expanded media player commands** - New `next`, `previous`, `repeat_all`, `shuffle`, `unshuffle`, `group_join`, and `clear_playlist` actions ([#12258](https://github.com/esphome/esphome/pull/12258))
 
 The [audio_file](/components/audio_file) component lets you embed audio files (local or from URLs) directly into firmware for instant playback without network access. Files are decoded directly from flash, saving two buffer copies compared to the previous approach.
+
+## Audio Playback Improvements
+
+These improvements apply to both the new `speaker_source` and existing `speaker` media players:
+
+- **Ogg Opus codec support** - The new microOpus library enables decoding Opus audio streams, completing the codec lineup alongside FLAC and MP3 ([#13967](https://github.com/esphome/esphome/pull/13967))
+- **Smarter codec builds** - The `codec_support_enabled` option now defaults to `needed`, building only the codecs your configuration actually requires instead of all three (users streaming arbitrary URLs should set `codec_support_enabled: all`)
+- **Speaker media player on/off** - The speaker media player now supports explicit on/off power control ([#9295](https://github.com/esphome/esphome/pull/9295))
 
 ## Other Notable Features
 
@@ -350,7 +356,6 @@ The [audio_file](/components/audio_file) component lets you embed audio files (l
 - **Safe mode explicit boot success** - New `safe_mode.mark_boot_ok` action lets you explicitly notify safe mode that a boot is successful, solving the issue for deep sleep devices that boot and sleep within the safe mode timeout window ([#14306](https://github.com/esphome/esphome/pull/14306))
 - **CC1101 runtime configuration** - New actions to change frequency, modulation type, symbol rate, filter bandwidth, and other CC1101 radio settings on the fly ([#14141](https://github.com/esphome/esphome/pull/14141))
 - **ESP32 BLE authentication** - Configurable `min_key_size`, `max_key_size`, and `auth_req_mode` for BLE security ([#7138](https://github.com/esphome/esphome/pull/7138))
-- **Speaker media player on/off** - Media players now support explicit on/off power control ([#9295](https://github.com/esphome/esphome/pull/9295))
 - **Integration sensor set action** - New `set` method to publish and save a specific value to an integration sensor ([#13316](https://github.com/esphome/esphome/pull/13316))
 - **LPS22DF pressure sensor** - Support for the DF variant of the LPS22 pressure sensor family ([#14397](https://github.com/esphome/esphome/pull/14397))
 - **OpenThread TX power** - Configurable transmit power for OpenThread radios ([#14200](https://github.com/esphome/esphome/pull/14200))


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Updates the changelog to separate out general audio improvements from features of the speaker source media player. Previously, they were interleaved, so it wasn't clear what applied to where. 

**Related issue (if applicable):** not applicable

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** not applicable

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
