### PR TITLE
DNM: Test component index ordering check workflow

### DIFF
--- a/.github/workflows/check-component-index.yml
+++ b/.github/workflows/check-component-index.yml
@@ -1,0 +1,140 @@
+name: Check Component Index Order
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+    paths:
+      - 'src/content/docs/components/index.mdx'
+
+permissions:
+  pull-requests: write
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+env:
+  BOT_NAME: "github-actions[bot]"
+  REVIEW_MARKER: "ImgTable blocks are not in alphabetical order"
+
+jobs:
+  check:
+    name: Component Index Ordering
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: '20'
+
+      - name: Check ordering
+        id: check
+        run: |
+          set +e
+          OUTPUT=$(node script/check_component_index.mjs --suggestions 2>&1)
+          EXIT_CODE=$?
+          set -e
+
+          if [ "$EXIT_CODE" -eq 0 ]; then
+            echo "sorted=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "sorted=false" >> "$GITHUB_OUTPUT"
+            # Write the JSON output to a file for the next step
+            echo "$OUTPUT" > /tmp/suggestions.json
+          fi
+
+      - name: Post or dismiss review
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          SORTED: ${{ steps.check.outputs.sorted }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        with:
+          script: |
+            const fs = require('fs');
+            const { owner, repo } = context.repo;
+            const pr_number = parseInt(process.env.PR_NUMBER);
+            const sorted = process.env.SORTED === 'true';
+
+            // Helper: find the most recent bot review for this check
+            async function findBotReview() {
+              const { data: reviews } = await github.rest.pulls.listReviews({
+                owner,
+                repo,
+                pull_number: pr_number
+              });
+              return reviews
+                .filter(r =>
+                  r.user.login === process.env.BOT_NAME &&
+                  r.state === 'CHANGES_REQUESTED' &&
+                  r.body && r.body.includes(process.env.REVIEW_MARKER)
+                )
+                .sort((a, b) => new Date(b.submitted_at) - new Date(a.submitted_at))[0];
+            }
+
+            if (sorted) {
+              console.log('All ImgTable blocks are correctly sorted.');
+              // Dismiss any previous review from this bot
+              const botReview = await findBotReview();
+              if (botReview) {
+                console.log('Dismissing previous review', botReview.id);
+                await github.rest.pulls.dismissReview({
+                  owner,
+                  repo,
+                  pull_number: pr_number,
+                  review_id: botReview.id,
+                  message: 'Component index ordering has been fixed — dismissing review.'
+                });
+              }
+              return;
+            }
+
+            // Read the suggestions JSON produced by the script
+            const data = JSON.parse(fs.readFileSync('/tmp/suggestions.json', 'utf-8'));
+            console.log(`Found ${data.suggestions.length} unsorted table(s).`);
+
+            // Build inline suggestion comments
+            const comments = data.suggestions.map(s => ({
+              path: data.file,
+              start_line: s.startLine,
+              line: s.endLine,
+              side: 'RIGHT',
+              body: [
+                `**${s.section}**: items are not in alphabetical order.`,
+                '',
+                '```suggestion',
+                s.body,
+                '```'
+              ].join('\n')
+            }));
+
+            // Create REQUEST_CHANGES review with inline suggestions
+            await github.rest.pulls.createReview({
+              owner,
+              repo,
+              pull_number: pr_number,
+              commit_id: process.env.HEAD_SHA,
+              event: 'REQUEST_CHANGES',
+              body: [
+                `### ${process.env.REVIEW_MARKER}`,
+                '',
+                `Found ${data.suggestions.length} ImgTable block(s) with incorrect ordering below **Network Protocols**.`,
+                'Each table has at most one Core item (the first name ending with " Core"), pinned first, followed by Template items (names starting with "Template "), then all remaining items sorted alphabetically.',
+                '',
+                'You can fix this automatically by running:',
+                '```',
+                'node script/check_component_index.mjs --fix',
+                '```',
+                '',
+                'See the inline suggestions below for the correct order in each section.'
+              ].join('\n'),
+              comments
+            });
+
+            console.log('Posted REQUEST_CHANGES review with inline suggestions.');

--- a/script/check_component_index.mjs
+++ b/script/check_component_index.mjs
@@ -1,0 +1,223 @@
+#!/usr/bin/env node
+/**
+ * Check (and optionally fix) alphabetical ordering of ImgTable blocks
+ * in the components index page.
+ *
+ * Only operates on tables below the "## Network Protocols" heading.
+ * Within each table the pinned order is:
+ *   1. "Core" item   — at most one, the first name ending with " Core"
+ *   2. "Template" items — names starting with "Template " (e.g. "Template Sensor")
+ * All remaining items must be sorted case-insensitively by display name.
+ *
+ * Usage:
+ *   node script/check_component_index.mjs                # check only (exit 1 if unsorted)
+ *   node script/check_component_index.mjs --fix          # rewrite the file in-place
+ *   node script/check_component_index.mjs --suggestions  # output JSON for CI review comments
+ */
+
+import { readFileSync, writeFileSync } from "fs";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const INDEX_REL = "src/content/docs/components/index.mdx";
+const INDEX_PATH = join(__dirname, "..", INDEX_REL);
+const SORT_AFTER_HEADING = "## Network Protocols";
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+/** Extract the display name from a raw item line, e.g. '  ["Foo", …],' → 'Foo' */
+function getName(line) {
+  const m = line.match(/\["([^"]+)"/);
+  return m ? m[1] : "";
+}
+
+/**
+ * Identify the single "Core" entry in a table, if any.
+ *
+ * Each table has at most one core item — the primary entry point for
+ * the section (e.g. "Sensor Core", "Display Core", "Switch Core").
+ * A core item's display name ends with " Core".
+ *
+ * Only the *first* matching item is treated as core. This avoids
+ * false positives like "Display Menu Core", which lives in the
+ * Display Components table but is not the section's core item
+ * (that role belongs to "Display Core").
+ *
+ * Product names that happen to contain "Core" as a substring
+ * (e.g. "iAQ-Core") are not matched because the regex requires
+ * a preceding whitespace character.
+ */
+function identifyCoreItem(lines) {
+  for (let i = 0; i < lines.length; i++) {
+    const name = getName(lines[i]);
+    if (/\sCore$/i.test(name)) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+/**
+ * Decide whether an item is a "Template" entry.
+ *
+ * A template item's display name starts with "Template " (e.g.
+ * "Template Sensor", "Template Switch"). These are pinned right
+ * after Core items in each table, before the alphabetically sorted
+ * remainder.
+ */
+function isTemplateItem(name) {
+  return /^Template\s/i.test(name);
+}
+
+/** Normalize an item line to consistent 2-space indent + trailing comma */
+function normalizeLine(line) {
+  const stripped = line.trim().replace(/,$/, "");
+  return `  ${stripped},`;
+}
+
+// ── main logic ───────────────────────────────────────────────────────────────
+
+function processFile(content) {
+  const headingIdx = content.indexOf(SORT_AFTER_HEADING);
+  if (headingIdx === -1) {
+    console.error(`Could not find "${SORT_AFTER_HEADING}" in ${INDEX_PATH}`);
+    process.exit(2);
+  }
+
+  const before = content.slice(0, headingIdx);
+  const after = content.slice(headingIdx);
+  // Line number where the "after" region starts (1-indexed)
+  const afterStartLine = before.split("\n").length;
+
+  const tableRe = /(<ImgTable items=\{\[\n)([\s\S]*?)(\]\} \/>)/g;
+
+  const results = []; // { section, startLine, endLine, original, fixed }
+  let tableIndex = 0;
+
+  const replaced = after.replace(
+    tableRe,
+    (match, prefix, itemsText, suffix, offset) => {
+      tableIndex++;
+
+      // Section heading for context
+      const textBefore = after.slice(0, offset);
+      const headingMatch = textBefore.match(/^(#{2,3}) (.+)$/gm);
+      const sectionName = headingMatch
+        ? headingMatch[headingMatch.length - 1].replace(/^#+\s*/, "")
+        : `table #${tableIndex}`;
+
+      // Parse item lines (skip blanks)
+      const allItemLines = itemsText.split("\n");
+      const lines = allItemLines.filter((l) => l.trim().length > 0);
+
+      if (lines.length <= 1) return match;
+
+      // Core item stays first (at most one), then Template items, then the rest sorted
+      const coreIdx = identifyCoreItem(lines);
+      const coreLines = coreIdx >= 0 ? [lines[coreIdx]] : [];
+      const templateLines = lines.filter(
+        (_, i) => i !== coreIdx && isTemplateItem(getName(lines[i])),
+      );
+      const restLines = lines.filter(
+        (_, i) => i !== coreIdx && !isTemplateItem(getName(lines[i])),
+      );
+
+      const sorted = [...restLines].sort((a, b) =>
+        getName(a).toLowerCase().localeCompare(getName(b).toLowerCase()),
+      );
+
+      const expectedOrder = [...coreLines, ...templateLines, ...sorted];
+      const isFullyOrdered = lines.every(
+        (line, i) => getName(line) === getName(expectedOrder[i]),
+      );
+
+      if (!isFullyOrdered) {
+        // Compute 1-indexed line numbers in the original file.
+        // offset is the position within `after`; the items text starts
+        // after the prefix (<ImgTable items={[\n).
+        const prefixLines = prefix.split("\n").length - 1; // lines consumed by prefix
+        const linesBeforeInAfter = after.slice(0, offset).split("\n").length - 1;
+        const startLine = afterStartLine + linesBeforeInAfter + prefixLines;
+        const endLine = startLine + allItemLines.filter((l) => l.trim().length > 0).length - 1;
+
+        const originalBlock = lines.map(normalizeLine).join("\n");
+        const fixedBlock = [...coreLines, ...templateLines, ...sorted]
+          .map(normalizeLine)
+          .join("\n");
+
+        results.push({
+          section: sectionName,
+          startLine,
+          endLine,
+          original: originalBlock,
+          fixed: fixedBlock,
+        });
+      }
+
+      // Build the fixed version (used by --fix)
+      const fixedResult = [...coreLines, ...templateLines, ...sorted]
+        .map(normalizeLine)
+        .join("\n");
+
+      return `${prefix}${fixedResult}\n${suffix}`;
+    },
+  );
+
+  return { before, after: replaced, results };
+}
+
+// ── entry point ──────────────────────────────────────────────────────────────
+
+const mode = process.argv.includes("--fix")
+  ? "fix"
+  : process.argv.includes("--suggestions")
+    ? "suggestions"
+    : "check";
+
+const content = readFileSync(INDEX_PATH, "utf-8");
+const { before, after, results } = processFile(content);
+
+if (results.length === 0) {
+  console.log("All ImgTable blocks are correctly sorted.");
+  process.exit(0);
+}
+
+switch (mode) {
+  case "fix":
+    writeFileSync(INDEX_PATH, before + after, "utf-8");
+    console.log(`Fixed ${results.length} ImgTable block(s) in ${INDEX_PATH}`);
+    process.exit(0);
+    break;
+
+  case "suggestions":
+    // Output JSON consumed by the GitHub Actions workflow.
+    // Each entry has the file path, line range, and the suggested replacement.
+    console.log(
+      JSON.stringify({
+        file: INDEX_REL,
+        suggestions: results.map((r) => ({
+          section: r.section,
+          startLine: r.startLine,
+          endLine: r.endLine,
+          body: r.fixed,
+        })),
+      }),
+    );
+    process.exit(1);
+    break;
+
+  default:
+    console.error(
+      "Component index ImgTable blocks are not sorted correctly:\n",
+    );
+    for (const r of results) {
+      console.error(`  ${r.section} (lines ${r.startLine}-${r.endLine})`);
+    }
+    console.error(
+      "\nRun `node script/check_component_index.mjs --fix` to fix automatically.",
+    );
+    process.exit(1);
+}

--- a/src/content/docs/components/index.mdx
+++ b/src/content/docs/components/index.mdx
@@ -100,26 +100,26 @@ ESPHome-specific components or components supporting ESPHome device provisioning
 
 <ImgTable items={[
   ["Network Core", "/components/network/", "server-network.svg", "dark-invert"],
-  ["Native API", "/components/api/", "server-network.svg", "dark-invert"],
-  ["MQTT", "/components/mqtt/", "mqtt.png"],
   ["ESP-NOW", "/components/espnow/", "esp-now.svg"],
   ["HTTP Request", "/components/http_request/", "connection.svg", "dark-invert"],
   ["mDNS", "/components/mdns/", "radio-tower.svg", "dark-invert"],
-  ["WireGuard", "/components/wireguard/", "wireguard_custom_logo.svg", "dark-invert"],
+  ["MQTT", "/components/mqtt/", "mqtt.png"],
+  ["Native API", "/components/api/", "server-network.svg", "dark-invert"],
+  ["Packet Transport", "/components/packet_transport/", "packet_transport.svg", "dark-invert"],
   ["StatsD", "/components/statsd/", "connection.svg", "dark-invert"],
   ["UDP", "/components/udp/", "udp.svg"],
-  ["Packet Transport", "/components/packet_transport/", "packet_transport.svg", "dark-invert"],
+  ["WireGuard", "/components/wireguard/", "wireguard_custom_logo.svg", "dark-invert"],
   ["Zigbee End Device", "/components/zigbee/", "zigbee.svg"],
 ]} />
 
 ## Bluetooth/BLE
 
 <ImgTable items={[
+  ["Bluetooth Proxy", "/components/bluetooth_proxy/", "bluetooth.svg", "dark-invert"],
   ["ESP32 BLE Beacon", "/components/esp32_ble_beacon/", "bluetooth.svg", "dark-invert"],
   ["ESP32 BLE Client", "/components/ble_client/", "bluetooth.svg", "dark-invert"],
-  ["ESP32 BLE Tracker", "/components/esp32_ble_tracker/", "bluetooth.svg", "dark-invert"],
   ["ESP32 BLE Server", "/components/esp32_ble_server/", "bluetooth.svg", "dark-invert"],
-  ["Bluetooth Proxy", "/components/bluetooth_proxy/", "bluetooth.svg", "dark-invert"],
+  ["ESP32 BLE Tracker", "/components/esp32_ble_tracker/", "bluetooth.svg", "dark-invert"],
   ["Improv via BLE", "/components/esp32_improv/", "improv.svg", "dark-invert"],
   ["Nordic UART Service (NUS)", "/components/ble_nus/", "bluetooth.svg", "dark-invert"],
 ]} />
@@ -128,13 +128,13 @@ ESPHome-specific components or components supporting ESPHome device provisioning
 
 <ImgTable items={[
   ["Debug", "/components/debug/", "bug-report.svg", "dark-invert"],
-  ["Logger", "/components/logger/", "file-document-box.svg", "dark-invert"],
-  ["Syslog", "/components/syslog/", "file-document-box.svg", "dark-invert"],
-  ["Prometheus", "/components/prometheus/", "prometheus.svg"],
-  ["StatsD", "/components/statsd/", "connection.svg", "dark-invert"],
-  ["Safe Mode", "/components/safe_mode/", "restart-alert.svg", "dark-invert"],
-  ["Web Server", "/components/web_server/", "http.svg"],
   ["ESP32 Camera Web Server", "/components/esp32_camera_web_server/", "camera.svg", "dark-invert"],
+  ["Logger", "/components/logger/", "file-document-box.svg", "dark-invert"],
+  ["Prometheus", "/components/prometheus/", "prometheus.svg"],
+  ["Safe Mode", "/components/safe_mode/", "restart-alert.svg", "dark-invert"],
+  ["StatsD", "/components/statsd/", "connection.svg", "dark-invert"],
+  ["Syslog", "/components/syslog/", "file-document-box.svg", "dark-invert"],
+  ["Web Server", "/components/web_server/", "http.svg"],
 ]} />
 
 ## Update Installation
@@ -165,8 +165,8 @@ Create update entities simplifying management of OTA updates.
   ["I²S Audio", "/components/i2s_audio/", "i2s_audio.svg"],
   ["OpenTherm", "/components/opentherm/", "opentherm.png"],
   ["SPI Bus", "/components/spi/", "spi.svg"],
-  ["UART", "/components/uart/", "uart.svg"],
   ["TinyUSB", "/components/tinyusb/", "usb.svg", "dark-invert"],
+  ["UART", "/components/uart/", "uart.svg"],
   ["USB CDC-ACM", "/components/usb_cdc_acm/", "usb.svg", "dark-invert"],
   ["USB Host", "/components/usb_host/", "usb.svg", "dark-invert"],
   ["USB UART", "/components/usb_uart/", "usb.svg", "dark-invert"],
@@ -231,8 +231,8 @@ Sensors are organized into categories; if a given sensor fits into more than one
 ### Air Quality
 
 <ImgTable items={[
-  ["Air Quality Index", "/components/sensor/aqi/", "aqi.svg"],
   ["AGS10", "/components/sensor/ags10/", "ags10.jpg", "Volatile Organic Compound Sensor"],
+  ["Air Quality Index", "/components/sensor/aqi/", "aqi.svg"],
   ["AirThings BLE", "/components/sensor/airthings_ble/", "airthings_logo.png", "Radon", "CO2", "Volatile organics"],
   ["CCS811", "/components/sensor/ccs811/", "ccs811.jpg", "CO2 & Volatile organics"],
   ["CM1106", "/components/sensor/cm1106/", "cm1106.png", "CO2"],
@@ -371,9 +371,9 @@ Sensors are organized into categories; if a given sensor fits into more than one
   ["b-parasite", "/components/sensor/b_parasite/", "b_parasite.jpg", "Moisture & Temperature & Humidity & Light"],
   ["BH1900NUX", "/components/sensor/bh1900nux/", "bh1900nux-evk-001.png", "Temperature"],
   ["BME280", "/components/sensor/bme280/", "bme280.jpg", "Temperature & Humidity & Pressure"],
-  ["BME68x via BSEC2", "/components/sensor/bme68x_bsec2/", "bme680.jpg", "Temperature & Humidity & Pressure & Gas"],
-  ["BME680 via BSEC", "/components/sensor/bme680_bsec/", "bme680.jpg", "Temperature & Humidity & Pressure & Gas"],
   ["BME680", "/components/sensor/bme680/", "bme680.jpg", "Temperature & Humidity & Pressure & Gas"],
+  ["BME680 via BSEC", "/components/sensor/bme680_bsec/", "bme680.jpg", "Temperature & Humidity & Pressure & Gas"],
+  ["BME68x via BSEC2", "/components/sensor/bme68x_bsec2/", "bme680.jpg", "Temperature & Humidity & Pressure & Gas"],
   ["BMP085", "/components/sensor/bmp085/", "bmp180.jpg", "Temperature & Pressure"],
   ["BMP280", "/components/sensor/bmp280/", "bmp280.jpg", "Temperature & Pressure"],
   ["BMP388 and BMP390", "/components/sensor/bmp3xx/", "bmp388.jpg", "Temperature & Pressure"],
@@ -423,8 +423,8 @@ Sensors are organized into categories; if a given sensor fits into more than one
   ["STS3X", "/components/sensor/sts3x/", "sts3x.jpg", "Temperature"],
   ["STTS22H", "/components/sensor/stts22h/", "stts22h.jpg", "Temperature"],
   ["TC74", "/components/sensor/tc74/", "tc74.jpg", "Temperature"],
-  ["TEE501", "/components/sensor/tee501/", "TEE501.png", "Temperature"],
   ["TE-M3200", "/components/sensor/tem3200/", "tem3200.jpg", "Temperature & Pressure"],
+  ["TEE501", "/components/sensor/tee501/", "TEE501.png", "Temperature"],
   ["TMP102", "/components/sensor/tmp102/", "tmp102.jpg", "Temperature"],
   ["TMP1075", "/components/sensor/tmp1075/", "tmp1075.jpg", "Temperature"],
   ["TMP117", "/components/sensor/tmp117/", "tmp117.jpg", "Temperature"],
@@ -504,8 +504,8 @@ Sensors are organized into categories; if a given sensor fits into more than one
   ["Resol VBus", "/components/vbus/", "resol_deltasol_bs_plus.jpg"],
   ["Rotary Encoder", "/components/sensor/rotary_encoder/", "rotary_encoder.jpg"],
   ["SMT100", "/components/sensor/smt100/", "smt100.jpg", "Moisture & Temperature"],
-  ["SY6970", "/components/sensor/sy6970/", "sy6970.jpg", "Battery charge IC"],
   ["Sound Level", "/components/sensor/sound_level/", "waveform.svg", "dark-invert"],
+  ["SY6970", "/components/sensor/sy6970/", "sy6970.jpg", "Battery charge IC"],
   ["Tuya Sensor", "/components/sensor/tuya/", "tuya.png"],
   ["TX20", "/components/sensor/tx20/", "tx20.jpg", "Wind speed & Wind direction"],
   ["uFire EC sensor", "/components/sensor/ufire_ec/", "ufire_ec.png", "EC & Temperature"],
@@ -522,11 +522,11 @@ Sensors are organized into categories; if a given sensor fits into more than one
   ["LD2412", "/components/sensor/ld2412/", "ld2412.jpg", "Motion & Presence"],
   ["LD2420", "/components/sensor/ld2420/", "ld2420.jpg", "Motion & Presence"],
   ["LD2450", "/components/sensor/ld2450/", "ld2450.png", "Motion & Presence"],
-  ["RD-03D", "/components/sensor/rd03d/", "rd03d.webp", "Motion & Presence"],
   ["MPU6050", "/components/sensor/mpu6050/", "mpu6050.jpg", "Accelerometer & Gyroscope"],
   ["MPU6886", "/components/sensor/mpu6886/", "mpu6886.jpg", "Accelerometer & Gyroscope"],
   ["MSA301", "/components/sensor/msa3xx/", "msa301.jpg", "Accelerometer"],
   ["MSA311", "/components/sensor/msa3xx/", "msa311.jpg", "Accelerometer"],
+  ["RD-03D", "/components/sensor/rd03d/", "rd03d.webp", "Motion & Presence"],
   ["RuuviTag", "/components/sensor/ruuvitag/", "ruuvitag.jpg", "Temperature & Humidity & Accelerometer"],
   ["Seeed Studio MR24HPC1 mmWave", "/components/seeed_mr24hpc1/", "seeed-mr24hpc1.jpg", "Motion & Presence"],
 ]} />
@@ -563,9 +563,9 @@ Binary Sensors are organized into categories; if a given sensor fits into more t
   ["Template Binary Sensor", "/components/binary_sensor/template/", "description.svg", "dark-invert"],
   ["GPIO", "/components/binary_sensor/gpio/", "gpio.svg"],
   ["Home Assistant", "/components/binary_sensor/homeassistant/", "home-assistant.svg", "dark-invert"],
+  ["Host SDL2", "/components/binary_sensor/sdl/", "sdl.png"],
   ["Status", "/components/binary_sensor/status/", "server-network.svg", "dark-invert"],
   ["Switch", "/components/binary_sensor/switch/", "electric-switch.svg", "dark-invert"],
-  ["Host SDL2", "/components/binary_sensor/sdl/", "sdl.png"],
 ]} />
 
 ### Capacitive Touch
@@ -605,9 +605,9 @@ Often known as "tag" or "card" readers within the community.
   ["Touchscreen Core", "/components/touchscreen/", "touch.svg", "dark-invert"],
   ["FT5X06", "/components/touchscreen/ft5x06/", "indicator.jpg"],
   ["GT911", "/components/touchscreen/gt911/", "esp32_s3_box_3.png"],
+  ["LVGL widget", "/components/binary_sensor/lvgl/", "lvgl_c_bns.png"],
   ["Nextion Binary Sensor", "/components/binary_sensor/nextion/", "nextion.jpg"],
   ["TT21100", "/components/touchscreen/tt21100/", "esp32-s3-korvo-2-lcd.png"],
-  ["LVGL widget", "/components/binary_sensor/lvgl/", "lvgl_c_bns.png"],
 ]} />
 
 ### Presence Detection
@@ -719,16 +719,16 @@ Often known as "tag" or "card" readers within the community.
 
 <ImgTable items={[
   ["Display Core", "/components/display/", "folder-open.svg", "dark-invert"],
+  ["Animation", "/components/animation/", "image-multiple-outline.svg", "dark-invert"],
+  ["Display Menu Core", "/components/display_menu/", "folder-open.svg", "dark-invert"],
   ["Font Renderer", "/components/font/", "format-font.svg", "dark-invert"],
   ["Graph", "/components/graph/", "chart-line.svg", "dark-invert"],
-  ["QR Code", "/components/qr_code/", "qr-code.svg", "dark-invert"],
-  ["Image", "/components/image/", "image-outline.svg", "dark-invert"],
-  ["Animation", "/components/animation/", "image-multiple-outline.svg", "dark-invert"],
-  ["Online Image", "/components/online_image/", "image-sync-outline.svg", "dark-invert"],
-  ["Display Menu Core", "/components/display_menu/", "folder-open.svg", "dark-invert"],
   ["Graphical Display Menu", "/components/display_menu/graphical_display_menu/", "graphical_display_menu.png"],
+  ["Image", "/components/image/", "image-outline.svg", "dark-invert"],
   ["LCD Menu", "/components/display_menu/lcd_menu/", "lcd_menu.png"],
   ["LVGL Graphics", "/components/lvgl/", "lvgl.png"],
+  ["Online Image", "/components/online_image/", "image-sync-outline.svg", "dark-invert"],
+  ["QR Code", "/components/qr_code/", "qr-code.svg", "dark-invert"],
 ]} />
 
 <span id="display-hw"></span>
@@ -737,22 +737,22 @@ Often known as "tag" or "card" readers within the community.
 
 <ImgTable items={[
   ["Addressable Light", "/components/display/addressable_light/", "addressable_light.jpg"],
-  ["MIPI DSI Displays", "/components/display/mipi_dsi/", "tab5.jpg"],
-  ["MIPI RGB Displays", "/components/display/mipi_rgb/", "t4-s3.jpg"],
-  ["MIPI SPI Displays", "/components/display/mipi_spi/", "t4-s3.jpg"],
   ["ePaper SPI Displays", "/components/display/epaper_spi/", "waveshare_epaper.jpg"],
-  ["ILI9xxx", "/components/display/ili9xxx/", "ili9341.jpg"],
+  ["Host SDL2 display", "/components/display/sdl/", "sdl.png"],
+  ["HUB75 LED Matrix", "/components/display/hub75/", "hub75.svg"],
   ["ILI9341", "/components/display/ili9xxx/", "ili9341.svg"],
   ["ILI9342", "/components/display/ili9xxx/", "ili9342.svg"],
   ["ILI9481", "/components/display/ili9xxx/", "ili9481.svg"],
   ["ILI9486", "/components/display/ili9xxx/", "ili9341.jpg"],
   ["ILI9488", "/components/display/ili9xxx/", "ili9488.svg"],
-  ["WSPICOLCD", "/components/display/ili9xxx/", "ili9488.svg"],
-  ["HUB75 LED Matrix", "/components/display/hub75/", "hub75.svg"],
+  ["ILI9xxx", "/components/display/ili9xxx/", "ili9341.jpg"],
   ["Inkplate", "/components/display/inkplate/", "inkplate6.jpg"],
   ["LCD Display", "/components/display/lcd_display/", "lcd.jpg"],
-  ["MAX7219 Dot Matrix", "/components/display/max7219digit/", "max7219digit.jpg"],
   ["MAX7219", "/components/display/max7219/", "max7219.jpg"],
+  ["MAX7219 Dot Matrix", "/components/display/max7219digit/", "max7219digit.jpg"],
+  ["MIPI DSI Displays", "/components/display/mipi_dsi/", "tab5.jpg"],
+  ["MIPI RGB Displays", "/components/display/mipi_rgb/", "t4-s3.jpg"],
+  ["MIPI SPI Displays", "/components/display/mipi_spi/", "t4-s3.jpg"],
   ["Nextion", "/components/display/nextion/", "nextion.jpg"],
   ["PCD8544 (Nokia 5110/ 3310)", "/components/display/pcd8544/", "pcd8544.jpg"],
   ["PVVX MiThermometer", "/components/display/pvvx_mithermometer/", "xiaomi_lywsd03mmc.jpg"],
@@ -775,7 +775,7 @@ Often known as "tag" or "card" readers within the community.
   ["TM1638", "/components/display/tm1638/", "tm1638.jpg"],
   ["TM1651 Battery Display", "/components/tm1651/", "tm1651_battery_display.jpg"],
   ["Waveshare E-Paper", "/components/display/waveshare_epaper/", "waveshare_epaper.jpg"],
-  ["Host SDL2 display", "/components/display/sdl/", "sdl.png"],
+  ["WSPICOLCD", "/components/display/ili9xxx/", "ili9488.svg"],
 ]} />
 
 ## Electromechanical
@@ -976,6 +976,7 @@ Used for creating infrared (IR) remote control transmitters and/or receivers.
   ["Generic Output Switch", "/components/switch/output/", "upload.svg", "dark-invert"],
   ["GPIO Switch", "/components/switch/gpio/", "gpio.svg"],
   ["H-bridge Switch", "/components/switch/hbridge/", "hbridge-relay.jpg"],
+  ["Home Assistant", "/components/switch/homeassistant/", "home-assistant.svg", "dark-invert"],
   ["LVGL Widget", "/components/switch/lvgl/", "lvgl_c_swi.png"],
   ["Modbus Switch", "/components/switch/modbus_controller/", "modbus.png"],
   ["Nextion Switch", "/components/switch/nextion/", "nextion.jpg"],
@@ -984,7 +985,6 @@ Used for creating infrared (IR) remote control transmitters and/or receivers.
   ["Shutdown Switch", "/components/switch/shutdown/", "power_settings.svg", "dark-invert"],
   ["Tuya Switch", "/components/switch/tuya/", "tuya.png"],
   ["UART Switch", "/components/switch/uart/", "uart.svg"],
-  ["Home Assistant", "/components/switch/homeassistant/", "home-assistant.svg", "dark-invert"],
 ]} />
 
 ## Text Components
@@ -1026,8 +1026,8 @@ Used for creating infrared (IR) remote control transmitters and/or receivers.
   ["GPS Time", "/components/time/gps/", "crosshairs-gps.svg", "dark-invert"],
   ["Home Assistant Time", "/components/time/homeassistant/", "home-assistant.svg", "dark-invert"],
   ["PCF85063 RTC", "/components/time/pcf85063/", "clock-outline.svg", "dark-invert"],
-  ["RX8130 RTC", "/components/time/rx8130/", "clock-outline.svg", "dark-invert"],
   ["PCF8563 RTC", "/components/time/pcf8563/", "clock-outline.svg", "dark-invert"],
+  ["RX8130 RTC", "/components/time/rx8130/", "clock-outline.svg", "dark-invert"],
   ["SNTP", "/components/time/sntp/", "clock-outline.svg", "dark-invert"],
   ["Zigbee Time", "/components/time/zigbee/", "zigbee.svg"],
 ]} />
@@ -1037,9 +1037,9 @@ Used for creating infrared (IR) remote control transmitters and/or receivers.
 <ImgTable items={[
   ["Touchscreen Core", "/components/touchscreen/", "folder-open.svg", "dark-invert"],
   ["AXS15231", "/components/touchscreen/axs15231/", "axs15231.svg"],
+  ["CHSC6X", "/components/touchscreen/chsc6x/", "chsc6x.png"],
   ["CST226", "/components/touchscreen/cst226/", "t4-s3.jpg"],
   ["CST816", "/components/touchscreen/cst816/", "cst816.jpg"],
-  ["CHSC6X", "/components/touchscreen/chsc6x/", "chsc6x.png"],
   ["EKTF2232", "/components/touchscreen/ektf2232/", "ektf2232.svg", "Inkplate 6 Plus"],
   ["FT63X6", "/components/touchscreen/ft63x6/", "wt32-sc01.png"],
   ["GT911", "/components/touchscreen/gt911/", "esp32_s3_box_3.png"],
@@ -1101,17 +1101,17 @@ ESPHome to cellular networks. **Does not encompass Wi-Fi.**
 ## Cookbook
 
 <ImgTable items={[
+  ["Arduino Port Extender", "/cookbook/arduino_port_extender/", "arduino_logo.svg"],
+  ["BME280 Environment extras", "/cookbook/bme280_environment/", "bme280.jpg"],
+  ["EHMTX a matrix status/text display", "/cookbook/ehmtx/", "ehmtx.jpg"],
+  ["ESP32 Water Leak Detector", "/cookbook/leak-detector-m5stickC/", "leak-detector-m5stickC_main_index.jpg"],
+  ["Garage Door Template Cover", "/cookbook/garage-door/", "garage-variant.svg", "dark-invert"],
   ["Lambda Magic: Tips and Tricks", "/cookbook/lambda_magic/", "head-lightbulb-outline.svg", "dark-invert"],
   ["LVGL Recipes", "/cookbook/lvgl/", "lvgl.png"],
-  ["Garage Door Template Cover", "/cookbook/garage-door/", "garage-variant.svg", "dark-invert"],
-  ["Time & Temperature on OLED Display", "/cookbook/display_time_temp_oled/", "display_time_temp_oled_2.jpg"],
-  ["ESP32 Water Leak Detector", "/cookbook/leak-detector-m5stickC/", "leak-detector-m5stickC_main_index.jpg"],
-  ["BME280 Environment extras", "/cookbook/bme280_environment/", "bme280.jpg"],
   ["Non-Invasive Power Meter", "/cookbook/power_meter/", "power_meter.jpg"],
-  ["Sonoff Fishpond Pump", "/cookbook/sonoff-fishpond-pump/", "cookbook-sonoff-fishpond-pump.jpg"],
-  ["Arduino Port Extender", "/cookbook/arduino_port_extender/", "arduino_logo.svg"],
-  ["EHMTX a matrix status/text display", "/cookbook/ehmtx/", "ehmtx.jpg"],
   ["Pulse Catcher", "/cookbook/pulse-catcher/", "pulses.png"],
+  ["Sonoff Fishpond Pump", "/cookbook/sonoff-fishpond-pump/", "cookbook-sonoff-fishpond-pump.jpg"],
+  ["Time & Temperature on OLED Display", "/cookbook/display_time_temp_oled/", "display_time_temp_oled_2.jpg"],
 ]} />
 
 ## Contributing

--- a/src/content/docs/components/index.mdx
+++ b/src/content/docs/components/index.mdx
@@ -100,6 +100,7 @@ ESPHome-specific components or components supporting ESPHome device provisioning
 
 <ImgTable items={[
   ["Network Core", "/components/network/", "server-network.svg", "dark-invert"],
+  ["WireGuard", "/components/wireguard/", "wireguard_custom_logo.svg", "dark-invert"],
   ["ESP-NOW", "/components/espnow/", "esp-now.svg"],
   ["HTTP Request", "/components/http_request/", "connection.svg", "dark-invert"],
   ["mDNS", "/components/mdns/", "radio-tower.svg", "dark-invert"],
@@ -108,7 +109,6 @@ ESPHome-specific components or components supporting ESPHome device provisioning
   ["Packet Transport", "/components/packet_transport/", "packet_transport.svg", "dark-invert"],
   ["StatsD", "/components/statsd/", "connection.svg", "dark-invert"],
   ["UDP", "/components/udp/", "udp.svg"],
-  ["WireGuard", "/components/wireguard/", "wireguard_custom_logo.svg", "dark-invert"],
   ["Zigbee End Device", "/components/zigbee/", "zigbee.svg"],
 ]} />
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

**Do not merge** — this PR intentionally moves WireGuard out of alphabetical order in the Network Protocols table to test the `check-component-index` workflow from #6304.

Expecting the workflow to post a `REQUEST_CHANGES` review with an inline suggestion showing the correct order.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- N/A

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.