### PR TITLE
[sensor] Update lambda examples to use get_state()/get_raw_state()

### DIFF
--- a/src/content/docs/components/sensor/atm90e32.mdx
+++ b/src/content/docs/components/sensor/atm90e32.mdx
@@ -731,7 +731,7 @@ sensor:
   - platform: template
     name: ${friendly_name} Total Amps
     id: totalAmps
-    lambda: return id(ct1Amps).state + id(ct2Amps).state + id(ct3Amps).state + id(ct4Amps).state + id(ct5Amps).state + id(ct6Amps).state ;
+    lambda: return id(ct1Amps).get_state() + id(ct2Amps).get_state() + id(ct3Amps).get_state() + id(ct4Amps).get_state() + id(ct5Amps).get_state() + id(ct6Amps).get_state() ;
     accuracy_decimals: 2
     unit_of_measurement: A
     device_class: current
@@ -740,7 +740,7 @@ sensor:
   - platform: template
     name: ${friendly_name} Total Watts
     id: totalWatts
-    lambda: return id(ct1Watts).state + id(ct2Watts).state + id(ct3Watts).state + id(ct4Watts).state + id(ct5Watts).state + id(ct6Watts).state ;
+    lambda: return id(ct1Watts).get_state() + id(ct2Watts).get_state() + id(ct3Watts).get_state() + id(ct4Watts).get_state() + id(ct5Watts).get_state() + id(ct6Watts).get_state() ;
     accuracy_decimals: 1
     unit_of_measurement: W
     device_class: power
@@ -994,7 +994,7 @@ sensor:
   - platform: template
     name: ${disp_name} Total Amps Main
     id: totalAmpsMain
-    lambda: return id(ct1Amps).state + id(ct2Amps).state + id(ct3Amps).state + id(ct4Amps).state + id(ct5Amps).state + id(ct6Amps).state ;
+    lambda: return id(ct1Amps).get_state() + id(ct2Amps).get_state() + id(ct3Amps).get_state() + id(ct4Amps).get_state() + id(ct5Amps).get_state() + id(ct6Amps).get_state() ;
     accuracy_decimals: 2
     unit_of_measurement: A
     device_class: current
@@ -1003,7 +1003,7 @@ sensor:
   - platform: template
     name: ${disp_name} Total Amps Add-on
     id: totalAmpsAddOn
-    lambda: return id(ct7Amps).state + id(ct8Amps).state + id(ct9Amps).state + id(ct10Amps).state + id(ct11Amps).state + id(ct12Amps).state ;
+    lambda: return id(ct7Amps).get_state() + id(ct8Amps).get_state() + id(ct9Amps).get_state() + id(ct10Amps).get_state() + id(ct11Amps).get_state() + id(ct12Amps).get_state() ;
     accuracy_decimals: 2
     unit_of_measurement: A
     device_class: current
@@ -1012,7 +1012,7 @@ sensor:
   - platform: template
     name: ${disp_name} Total Amps
     id: totalAmps
-    lambda: return id(totalAmpsMain).state + id(totalAmpsAddOn).state ;
+    lambda: return id(totalAmpsMain).get_state() + id(totalAmpsAddOn).get_state() ;
     accuracy_decimals: 2
     unit_of_measurement: A
     device_class: current
@@ -1022,7 +1022,7 @@ sensor:
   - platform: template
     name: ${disp_name} Total Watts Main
     id: totalWattsMain
-    lambda: return id(ct1Watts).state + id(ct2Watts).state + id(ct3Watts).state + id(ct4Watts).state + id(ct5Watts).state + id(ct6Watts).state ;
+    lambda: return id(ct1Watts).get_state() + id(ct2Watts).get_state() + id(ct3Watts).get_state() + id(ct4Watts).get_state() + id(ct5Watts).get_state() + id(ct6Watts).get_state() ;
     accuracy_decimals: 1
     unit_of_measurement: W
     device_class: power
@@ -1031,7 +1031,7 @@ sensor:
   - platform: template
     name: ${disp_name} Total Watts Add-on
     id: totalWattsAddOn
-    lambda: return id(ct7Watts).state + id(ct8Watts).state + id(ct9Watts).state + id(ct10Watts).state + id(ct11Watts).state + id(ct12Watts).state ;
+    lambda: return id(ct7Watts).get_state() + id(ct8Watts).get_state() + id(ct9Watts).get_state() + id(ct10Watts).get_state() + id(ct11Watts).get_state() + id(ct12Watts).get_state() ;
     accuracy_decimals: 1
     unit_of_measurement: W
     device_class: power
@@ -1040,7 +1040,7 @@ sensor:
   - platform: template
     name: ${disp_name} Total Watts
     id: totalWatts
-    lambda: return id(totalWattsMain).state + id(totalWattsAddOn).state ;
+    lambda: return id(totalWattsMain).get_state() + id(totalWattsAddOn).get_state() ;
     accuracy_decimals: 1
     unit_of_measurement: W
     device_class: power

--- a/src/content/docs/components/sensor/bme680.mdx
+++ b/src/content/docs/components/sensor/bme680.mdx
@@ -128,32 +128,32 @@ sensor:
     icon: "mdi:gauge"
     # calculation: comp_gas = log(R_gas[ohm]) + 0.04 log(Ohm)/%rh * hum[%rh]
     lambda: |-
-      return log(id(gas_resistance).state) + 0.04 *  id(humidity).state;
+      return log(id(gas_resistance).get_state()) + 0.04 *  id(humidity).get_state();
     state_class: "measurement"
 text_sensor:
   - platform: template
     name: "BME680 IAQ Classification"
     icon: "mdi:checkbox-marked-circle-outline"
     lambda: |-
-      if (int(id(iaq).state) <= 50) {
+      if (int(id(iaq).get_state()) <= 50) {
         return {"Excellent"};
       }
-      else if (int(id(iaq).state) <= 100) {
+      else if (int(id(iaq).get_state()) <= 100) {
         return {"Good"};
       }
-      else if (int(id(iaq).state) <= 150) {
+      else if (int(id(iaq).get_state()) <= 150) {
         return {"Lightly polluted"};
       }
-      else if (int(id(iaq).state) <= 200) {
+      else if (int(id(iaq).get_state()) <= 200) {
         return {"Moderately polluted"};
       }
-      else if (int(id(iaq).state) <= 250) {
+      else if (int(id(iaq).get_state()) <= 250) {
         return {"Heavily polluted"};
       }
-      else if (int(id(iaq).state) <= 350) {
+      else if (int(id(iaq).get_state()) <= 350) {
         return {"Severely polluted"};
       }
-      else if (int(id(iaq).state) <= 500) {
+      else if (int(id(iaq).get_state()) <= 500) {
         return {"Extremely polluted"};
       }
       else {

--- a/src/content/docs/components/sensor/bme680_bsec.mdx
+++ b/src/content/docs/components/sensor/bme680_bsec.mdx
@@ -65,25 +65,25 @@ text_sensor:
     name: "BME680 IAQ Classification"
     icon: "mdi:checkbox-marked-circle-outline"
     lambda: |-
-      if ( int(id(iaq).state) <= 50) {
+      if ( int(id(iaq).get_state()) <= 50) {
         return {"Excellent"};
       }
-      else if (int(id(iaq).state) >= 51 && int(id(iaq).state) <= 100) {
+      else if (int(id(iaq).get_state()) >= 51 && int(id(iaq).get_state()) <= 100) {
         return {"Good"};
       }
-      else if (int(id(iaq).state) >= 101 && int(id(iaq).state) <= 150) {
+      else if (int(id(iaq).get_state()) >= 101 && int(id(iaq).get_state()) <= 150) {
         return {"Lightly polluted"};
       }
-      else if (int(id(iaq).state) >= 151 && int(id(iaq).state) <= 200) {
+      else if (int(id(iaq).get_state()) >= 151 && int(id(iaq).get_state()) <= 200) {
         return {"Moderately polluted"};
       }
-      else if (int(id(iaq).state) >= 201 && int(id(iaq).state) <= 250) {
+      else if (int(id(iaq).get_state()) >= 201 && int(id(iaq).get_state()) <= 250) {
         return {"Heavily polluted"};
       }
-      else if (int(id(iaq).state) >= 251 && int(id(iaq).state) <= 350) {
+      else if (int(id(iaq).get_state()) >= 251 && int(id(iaq).get_state()) <= 350) {
         return {"Severely polluted"};
       }
-      else if (int(id(iaq).state) >= 351) {
+      else if (int(id(iaq).get_state()) >= 351) {
         return {"Extremely polluted"};
       }
       else {

--- a/src/content/docs/components/sensor/bme68x_bsec2.mdx
+++ b/src/content/docs/components/sensor/bme68x_bsec2.mdx
@@ -199,19 +199,19 @@ text_sensor:
   - platform: template
     name: "BME68x IAQ Classification"
     lambda: |-
-      if (int(id(iaq).state) <= 50) {
+      if (int(id(iaq).get_state()) <= 50) {
         return {"Excellent"};
-      } else if (int(id(iaq).state) >= 51 && int(id(iaq).state) <= 100) {
+      } else if (int(id(iaq).get_state()) >= 51 && int(id(iaq).get_state()) <= 100) {
         return {"Good"};
-      } else if (int(id(iaq).state) >= 101 && int(id(iaq).state) <= 150) {
+      } else if (int(id(iaq).get_state()) >= 101 && int(id(iaq).get_state()) <= 150) {
         return {"Lightly polluted"};
-      } else if (int(id(iaq).state) >= 151 && int(id(iaq).state) <= 200) {
+      } else if (int(id(iaq).get_state()) >= 151 && int(id(iaq).get_state()) <= 200) {
         return {"Moderately polluted"};
-      } else if (int(id(iaq).state) >= 201 && int(id(iaq).state) <= 250) {
+      } else if (int(id(iaq).get_state()) >= 201 && int(id(iaq).get_state()) <= 250) {
         return {"Heavily polluted"};
-      } else if (int(id(iaq).state) >= 251 && int(id(iaq).state) <= 350) {
+      } else if (int(id(iaq).get_state()) >= 251 && int(id(iaq).get_state()) <= 350) {
         return {"Severely polluted"};
-      } else if (int(id(iaq).state) >= 351 && int(id(iaq).state) <= 500) {
+      } else if (int(id(iaq).get_state()) >= 351 && int(id(iaq).get_state()) <= 500) {
         return {"Extremely polluted"};
       } else {
         return {"Error"};

--- a/src/content/docs/components/sensor/cm1106.mdx
+++ b/src/content/docs/components/sensor/cm1106.mdx
@@ -90,7 +90,7 @@ binary_sensor:
   - platform: template
     id: co2_calibration
     lambda: |-
-      if (id(co2sensor).state < 400) {
+      if (id(co2sensor).get_state() < 400) {
         return true;
       } else {
         return false;

--- a/src/content/docs/components/sensor/ens160.mdx
+++ b/src/content/docs/components/sensor/ens160.mdx
@@ -99,7 +99,7 @@ text_sensor:
   - platform: template
     name: "ENS160 Air Quality Rating"
     lambda: |-
-      switch ( (int) (id(ens160_air_quality_index).state) ) {
+      switch ( (int) (id(ens160_air_quality_index).get_state()) ) {
         case 1: return {"Excellent"};
         case 2: return {"Good"};
         case 3: return {"Moderate"};

--- a/src/content/docs/components/sensor/ezo.mdx
+++ b/src/content/docs/components/sensor/ezo.mdx
@@ -112,7 +112,7 @@ with the information retrieved from the sensor. For more information on the comm
 - `set_tempcomp_value(float temp)`  : Send the given temperature (in Celcius) to the sensor (this is an alias of `set_t()` for backwards compatibility)
 
 ```cpp
-    id(ph_ezo).set_tempcomp_value(id(rtd_ezo).state);
+    id(ph_ezo).set_tempcomp_value(id(rtd_ezo).get_state());
 ```
 
 - `get_calibration()`  : Sensor retrieves calibration and triggers `on_calibration:` once done

--- a/src/content/docs/components/sensor/filter/delta.mdx
+++ b/src/content/docs/components/sensor/filter/delta.mdx
@@ -85,5 +85,5 @@ sensors:
     filters:
       - delta:
           max_value: 10
-          baseline: !lambda return id(baseline).state;
+          baseline: !lambda return id(baseline).get_state();
 ```

--- a/src/content/docs/components/sensor/filter/filter_out.mdx
+++ b/src/content/docs/components/sensor/filter/filter_out.mdx
@@ -20,5 +20,5 @@ A list of values may be supplied, and values are templatable:
 filters:
   - filter_out:
       - 85.0
-      - !lambda return id(some_sensor).state;
+      - !lambda return id(some_sensor).get_state();
 ```

--- a/src/content/docs/components/sensor/filter/offset.mdx
+++ b/src/content/docs/components/sensor/filter/offset.mdx
@@ -11,5 +11,5 @@ Adds a value to each sensor value. The value may be a constant or a lambda retur
 # Example configuration entry
 filters:
   - offset: 2.0
-  - offset: !lambda return id(some_sensor).state;
+  - offset: !lambda return id(some_sensor).get_state();
 ```

--- a/src/content/docs/components/sensor/filter/to_ntc_resistance.mdx
+++ b/src/content/docs/components/sensor/filter/to_ntc_resistance.mdx
@@ -26,7 +26,7 @@ Then enter these values in the calibration parameter:
   id: to_ntc_resistance_sensor1
   unit_of_measurement: "Ohm"
   lambda: |-
-    return id(some_sensor).state;
+    return id(some_sensor).get_state();
   update_interval: 1s
   filters:
     - to_ntc_resistance:
@@ -45,7 +45,7 @@ pairs of values which can also be specified directly as an alternative.
   id: to_ntc_resistance_sensor2
   unit_of_measurement: "Ohm"
   lambda: |-
-    return id(some_sensor).state;
+    return id(some_sensor).get_state();
   update_interval: 1s
   filters:
     - to_ntc_resistance:

--- a/src/content/docs/components/sensor/filter/to_ntc_temperature.mdx
+++ b/src/content/docs/components/sensor/filter/to_ntc_temperature.mdx
@@ -26,7 +26,7 @@ Then enter these values in the calibration parameter:
   id: to_ntc_temperature_sensor1
   unit_of_measurement: "°C"
   lambda: |-
-    return id(some_sensor).state;
+    return id(some_sensor).get_state();
   update_interval: 1s
   filters:
     - to_ntc_temperature:
@@ -45,7 +45,7 @@ pairs of values which can also be specified directly as an alternative.
   id: to_ntc_temperature_sensor2
   unit_of_measurement: "°C"
   lambda: |-
-    return id(some_sensor).state;
+    return id(some_sensor).get_state();
   update_interval: 1s
   filters:
     - to_ntc_temperature:

--- a/src/content/docs/components/sensor/gdk101.mdx
+++ b/src/content/docs/components/sensor/gdk101.mdx
@@ -148,7 +148,7 @@ text_sensor:
   - platform: template
     name: "GDK101 Status Description"
     lambda: |-
-      int status = int(id(gdk101_status).state);
+      int status = int(id(gdk101_status).get_state());
       if (status == 0) {
         return {"Powered On"};
       } else if (status == 1) {

--- a/src/content/docs/components/sensor/index.mdx
+++ b/src/content/docs/components/sensor/index.mdx
@@ -206,7 +206,7 @@ unit_of_measurement: "°F"
 ## Sensor Automation
 
 You can access the most recent state of the sensor in [lambdas](/automations/templates#config-lambda) using
-`id(sensor_id).state` and the most recent raw state using `id(sensor_id).raw_state`.
+`id(sensor_id).get_state()` and the most recent raw state using `id(sensor_id).get_raw_state()`.
 
 <span id="sensor-on_value"></span>
 
@@ -328,20 +328,20 @@ advanced stuff (see the full API Reference for more info).
     id(my_sensor).publish_state(42.0);
 ```
 
-- `.state`  : Retrieve the current value of the sensor that has passed through all sensor filters.
+- `.get_state()`  : Retrieve the current value of the sensor that has passed through all sensor filters.
   Is `NAN` if no value has gotten through all filters yet.
 
 ```cpp
     // For example, create a custom log message when a value is received:
-    ESP_LOGI("main", "Value of my sensor: %f", id(my_sensor).state);
+    ESP_LOGI("main", "Value of my sensor: %f", id(my_sensor).get_state());
 ```
 
-- `raw_state`  : Retrieve the current value of the sensor that has not passed through any filters.
+- `.get_raw_state()`  : Retrieve the current value of the sensor that has not passed through any filters.
   Is `NAN` if no value has been pushed by the sensor itself yet.
 
 ```cpp
     // For example, create a custom log message when a value is received:
-    ESP_LOGI("main", "Raw Value of my sensor: %f", id(my_sensor).raw_state);
+    ESP_LOGI("main", "Raw Value of my sensor: %f", id(my_sensor).get_raw_state());
 ```
 
 ## See Also

--- a/src/content/docs/components/sensor/scd30.mdx
+++ b/src/content/docs/components/sensor/scd30.mdx
@@ -78,7 +78,7 @@ button:
     on_press:
       then:
         - scd30.force_recalibration_with_reference:
-            value: !lambda 'return id(co2_cal).state;'
+            value: !lambda 'return id(co2_cal).get_state();'
 
 number:
   - platform: template

--- a/src/content/docs/components/sensor/ufire_ec.mdx
+++ b/src/content/docs/components/sensor/ufire_ec.mdx
@@ -63,7 +63,7 @@ on_...:
   - sensor.ufire_ec_board.calibrate_probe:
       id: ufire_ec_board
       solution: 0.146
-      temperature: !lambda "return id(temperature_liquit).state;"
+      temperature: !lambda "return id(temperature_liquit).get_state();"
 ```
 
 Configuration options:

--- a/src/content/docs/components/sensor/xiaomi_miscale.mdx
+++ b/src/content/docs/components/sensor/xiaomi_miscale.mdx
@@ -56,9 +56,9 @@ sensor:
       on_value:
         then:
           - lambda: |-
-              if (id(weight_miscale).state >= 69 && id(weight_miscale).state <= 74.49) {
+              if (id(weight_miscale).get_state() >= 69 && id(weight_miscale).get_state() <= 74.49) {
                 return id(weight_user1).publish_state(x);}
-              else if (id(weight_miscale).state >= 74.50 && id(weight_miscale).state <= 83) {
+              else if (id(weight_miscale).get_state() >= 74.50 && id(weight_miscale).get_state() <= 83) {
                 return id(weight_user2).publish_state(x);}
 
     impedance:
@@ -67,9 +67,9 @@ sensor:
       on_value:
         then:
           - lambda: |-
-              if (id(weight_miscale).state >= 69 && id(weight_miscale).state <= 74.49) {
+              if (id(weight_miscale).get_state() >= 69 && id(weight_miscale).get_state() <= 74.49) {
                 return id(impedance_user1).publish_state(x);}
-              else if (id(weight_miscale).state >= 74.50 && id(weight_miscale).state <= 83) {
+              else if (id(weight_miscale).get_state() >= 74.50 && id(weight_miscale).get_state() <= 83) {
                 return id(impedance_user2).publish_state(x);}
 
   - platform: template


### PR DESCRIPTION
## Description

Update all sensor lambda documentation examples to use the `get_state()` and `get_raw_state()` accessor methods instead of direct `.state`/`.raw_state` member access.

**Note:** `.state` is **not** deprecated — it remains a valid public member. The docs are updated to show `get_state()` in examples to avoid encouraging direct member access patterns, making future optimizations easier.

`.raw_state` is deprecated in ESPHome 2026.4.0 and will be removed in 2026.10.0. Use `get_raw_state()` instead.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#15094

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.