### PR TITLE
Fix OTA component index sorting

### DIFF
--- a/src/content/docs/components/index.mdx
+++ b/src/content/docs/components/index.mdx
@@ -146,8 +146,8 @@ Install updates over-the-air (OTA).
 <ImgTable items={[
   ["OTA Core", "/components/ota/", "system-update.svg", "dark-invert"],
   ["OTA Updates", "/components/ota/esphome/", "system-update.svg", "dark-invert"],
-  ["OTA Updates via HTTP Request", "/components/ota/http_request/", "system-update.svg", "dark-invert"],
   ["OTA Updates for nRF52", "/components/ota/zephyr_mcumgr/", "system-update.svg", "dark-invert"],
+  ["OTA Updates via HTTP Request", "/components/ota/http_request/", "system-update.svg", "dark-invert"],
 ]} />
 
 ## Update Management


### PR DESCRIPTION
## Description:

Fix alphabetical sorting of OTA entries in the component index. "OTA Updates for nRF52" should come before "OTA Updates via HTTP Request".

This was causing the `check_component_index` CI check to fail on unrelated PRs.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- N/A

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.