### PR TITLE
[number] Add sensor platform

### DIFF
--- a/src/content/docs/components/index.mdx
+++ b/src/content/docs/components/index.mdx
@@ -224,10 +224,10 @@ Sensors are organized into categories; if a given sensor fits into more than one
 
 <ImgTable items={[
   ["Sensor Core", "/components/sensor/", "folder-open.svg", "dark-invert"],
-  ["Number Sensor", "/components/sensor/number/", "description.svg", "dark-invert"],
   ["Template Sensor", "/components/sensor/template/", "description.svg", "dark-invert"],
   ["Home Assistant", "/components/sensor/homeassistant/", "home-assistant.svg", "dark-invert"],
   ["MQTT Subscribe", "/components/sensor/mqtt_subscribe/", "mqtt.png"],
+  ["Number Sensor", "/components/sensor/number/", "description.svg", "dark-invert"],
   ["Uptime Sensor", "/components/sensor/uptime/", "timer.svg", "dark-invert"],
   ["WiFi Signal Strength", "/components/sensor/wifi_signal/", "network-wifi.svg", "dark-invert"],
 ]} />

--- a/src/content/docs/components/index.mdx
+++ b/src/content/docs/components/index.mdx
@@ -224,6 +224,7 @@ Sensors are organized into categories; if a given sensor fits into more than one
 
 <ImgTable items={[
   ["Sensor Core", "/components/sensor/", "folder-open.svg", "dark-invert"],
+  ["Number Sensor", "/components/sensor/number/", "description.svg", "dark-invert"],
   ["Template Sensor", "/components/sensor/template/", "description.svg", "dark-invert"],
   ["Home Assistant", "/components/sensor/homeassistant/", "home-assistant.svg", "dark-invert"],
   ["MQTT Subscribe", "/components/sensor/mqtt_subscribe/", "mqtt.png"],

--- a/src/content/docs/components/number/index.mdx
+++ b/src/content/docs/components/number/index.mdx
@@ -330,5 +330,6 @@ advanced stuff (see the full API Reference for more info).
 
 ## See Also
 
+- [Number Sensor](/components/sensor/number/)
 - <APIClass text="Number" path="number::Number" />
 - <APIClass text="NumberCall" path="number::NumberCall" />

--- a/src/content/docs/components/sensor/number.mdx
+++ b/src/content/docs/components/sensor/number.mdx
@@ -1,0 +1,39 @@
+---
+description: "Instructions for setting up number sensors with ESPHome."
+title: "Number Sensor"
+---
+import APIRef from '@components/APIRef.astro';
+
+
+<span id="number-sensor"></span>
+
+The Number Sensor platform allows you to view the state of any number component as a
+read-only sensor.
+
+```yaml
+# Example configuration entry
+sensor:
+  - platform: number
+    name: "Volume level"
+    source_id: my_number
+
+number:
+  - platform: template
+    id: my_number
+    name: "Volume"
+    optimistic: true
+    min_value: 0
+    max_value: 100
+    step: 1
+```
+
+## Configuration variables
+
+- **source_id** (**Required**, [ID](/guides/configuration-types#id)): The source number to observe.
+- All other options from [Sensor](/components/sensor#config-sensor).
+
+## See Also
+
+- [Sensor Component](/components/sensor/)
+- [Number Component](/components/number/)
+- <APIRef text="number_sensor.h" path="number/sensor/number_sensor.h" />


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#15125

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
