### PR TITLE
[ir_rf_proxy] Document `receiver_frequency`

### DIFF
--- a/src/content/docs/components/ir_rf_proxy.mdx
+++ b/src/content/docs/components/ir_rf_proxy.mdx
@@ -32,6 +32,7 @@ infrared:
   - platform: ir_rf_proxy
     name: IR Proxy Receiver
     id: ir_proxy_rx
+    receiver_frequency: 38kHz
     remote_receiver_id: ir_rx
 ```
 
@@ -47,6 +48,11 @@ infrared:
   a non-zero value for RF hardware. Defaults to `0` (infrared). This value is used to distinguish between IR and RF
   hardware types and is passed to Home Assistant, allowing it to identify integrations this IR/RF proxy instance can
   potentially support.
+- **receiver_frequency** (*Optional*, frequency): The demodulation frequency of the IR receiver hardware (for example,
+  `38kHz` for a TSOP38238). This value has **no effect on hardware** — it is metadata reported to API clients (such as
+  Home Assistant) so they can determine which IR protocols are compatible with the receiver. Only valid with
+  `remote_receiver_id`; a validation error will occur if used with `remote_transmitter_id`. Omit if the demodulation
+  frequency is unknown or not relevant.
 
   All other configuration variables from [infrared](/components/infrared).
 
@@ -95,7 +101,9 @@ Reception is non-blocking, allowing other listeners to also process signals simu
 
 The IR/RF proxy can work with both infrared and RF hardware:
 
-- **Infrared**: Do not set `frequency` (or set `frequency: 0`, which is the default) and use standard IR LEDs/receivers
+- **Infrared**: Do not set `frequency` (or set `frequency: 0`, which is the default) and use standard IR LEDs/receivers.
+  For receivers, you can set `receiver_frequency` to declare the demodulation frequency of the hardware (for example,
+  `38kHz` for a TSOP38238).
 - **RF**: Set `frequency` to match your RF hardware (for example, `315 MHz` for 315 MHz or `433 MHz` for 433.92 MHz)
 
 You can create separate instances for different purposes:


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

SSIA

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#15156

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
