### PR TITLE
Document --no-states flag for esphome logs command

### DIFF
--- a/src/content/docs/guides/cli.mdx
+++ b/src/content/docs/guides/cli.mdx
@@ -288,6 +288,11 @@ esphome logs my-device.yaml --device 192.168.1.100 --device 2001:db8::1
 : If set, reset the device before starting the logs. May also be configured with the environment variable
 `ESPHOME_SERIAL_LOGGING_RESET=true`.
 
+**`--no-states`**
+: Do not show entity state changes in log output. By default, when using the native API for logging,
+state changes are shown as `[S]` lines (e.g., `[S][sensor]: 'Temperature' >> 22.5 °C`). Use this flag
+to suppress them and only see firmware log messages.
+
 
 ## Using Bash or ZSH auto-completion
 


### PR DESCRIPTION
## Description

Document the new `--no-states` CLI flag for the `esphome logs` command. When using the native API for logging, state changes are now shown as `[S]` lines by default. The `--no-states` flag allows suppressing them.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#15160

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.