### PR TITLE
Add RP2350 microcontroller to documentation index

### DIFF
--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -1,12 +1,12 @@
 ---
-description: "Smart Home Made Simple. ESPHome turns ESP32, ESP8266, and RP2040 microcontrollers into fully-featured smart home devices."
+description: "Smart Home Made Simple. ESPHome turns ESP32, ESP8266, RP2040, and RP2350 microcontrollers into fully-featured smart home devices."
 title: "ESPHome"
 head:
   - tag: title
     content: "ESPHome - Smart Home Made Simple"
 template: splash
 hero:
-  tagline: Turn your ESP32, ESP8266, BK72xx, RP2040, and other supported boards into powerful smart home devices with simple YAML configuration.
+  tagline: Turn your ESP32, ESP8266, BK72xx, RP2040, RP2350, and other supported boards into powerful smart home devices with simple YAML configuration.
   image:
     html: <img src="/images/hero.png" alt="ESPHome dashboard showing connected devices" loading="eager" decoding="async" />
   actions:
@@ -52,7 +52,7 @@ hero:
 ## Which microcontrollers does ESPHome support?
 
 - **Espressif ESP32 and ESP8266** - Wide support for ESP32 and ESP8266 microcontrollers, the heart of many IoT projects.
-- **RP2040** - Support for Raspberry Pi's RP2040 microcontroller.
+- **RP2040 and RP2350** - Support for Raspberry Pi's RP2040 and RP2350 microcontrollers.
 - **Others** - Nordic Semiconductor nRF52, Realtek RTL87xx, and Beken BK72xx chips are supported.
 - **Desktop** - Many ESPHome components can be run on a desktop computer using the *host* platform!
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Add RP2350 microcontroller to documentation index now that ESPHome 2026.3.0 have added first-class platform support for both RP2040 and RP2350:

* https://esphome.io/changelog/2026.3.0/#rp2040rp2350-first-class-platform-support

    "_RP2350 (Pico 2 W) is now verified on real hardware with WiFi, debug sensors, and OTA all working, and the platform gains the same reliability, tooling, and developer experience that ESP32 users expect._"

**Related issue (if applicable):** Not applicable.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- Not applicable.

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
