### PR TITLE
[modbus_controller] Document read lambda failure path

### DIFF
--- a/src/content/docs/components/modbus_controller.mdx
+++ b/src/content/docs/components/modbus_controller.mdx
@@ -98,7 +98,7 @@ On the bus side, you need 120 Ohm termination resistors at the ends of the bus c
 
   - **read_lambda** (**Required**, [lambda](/automations/templates#config-lambda)):
     Lambda that returns the value of this register. Return `{}` when the value is temporarily unavailable or the read should fail;
-    ESPHome will send ModBUS exception code `4` (`SERVICE_DEVICE_FAILURE`) to the client instead of a register payload.
+    ESPHome will send ModBUS exception code `4` (Slave/Server Device Failure) to the client instead of a register payload.
 
   - **write_lambda** (*Optional*, [lambda](/automations/templates#config-lambda)):
     Lambda that sets the value of this register. A variable `x` of the appropriate type (`uint16_t`, `int32_t`, etc, see above) is provided with the value,

--- a/src/content/docs/components/modbus_controller.mdx
+++ b/src/content/docs/components/modbus_controller.mdx
@@ -97,7 +97,8 @@ On the bus side, you need 120 Ohm termination resistors at the ends of the bus c
     Defaults to `U_WORD`.
 
   - **read_lambda** (**Required**, [lambda](/automations/templates#config-lambda)):
-    Lambda that returns the value of this register.
+    Lambda that returns the value of this register. Return `{}` when the value is temporarily unavailable or the read should fail;
+    ESPHome will send ModBUS exception code `4` (`SERVICE_DEVICE_FAILURE`) to the client instead of a register payload.
 
   - **write_lambda** (*Optional*, [lambda](/automations/templates#config-lambda)):
     Lambda that sets the value of this register. A variable `x` of the appropriate type (`uint16_t`, `int32_t`, etc, see above) is provided with the value,


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#14789

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

