### PR TITLE
Fix YAML code block headers to render as filename tabs

### DIFF
--- a/src/content/docs/components/packages.mdx
+++ b/src/content/docs/components/packages.mdx
@@ -35,7 +35,7 @@ Note how the piece of configuration describing `api` component in `device_base.y
 definitions from main configuration file.
 
 ```yaml
-# In config.yaml
+# config.yaml
 packages:   # as a list
   - !include common/wifi.yaml
   - !include common/device_base.yaml
@@ -50,14 +50,14 @@ api:
 ```
 
 ```yaml
-# In wifi.yaml
+# wifi.yaml
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
 ```
 
 ```yaml
-# In device_base.yaml
+# device_base.yaml
 esphome:
   name: ${node_name}
 
@@ -140,7 +140,7 @@ As an example, if the configuration needed to support three garage doors using t
 `time_based` cover platform, it could be constructed like this:
 
 ```yaml
-# In config.yaml
+# config.yaml
 packages:
   left_garage_door: !include
     file: garage-door.yaml
@@ -157,7 +157,7 @@ packages:
 ```
 
 ```yaml
-# In garage-door.yaml
+# garage-door.yaml
 switch:
   - name: ${door_name} Garage Door Switch
     platform: gpio
@@ -170,7 +170,7 @@ You can include a package based on a condition, or choose a package dynamically 
 `!include` into a substitution variable instead of under `packages`:
 
 ```yaml
-# In config.yaml
+# config.yaml
 substitutions:
   left_garage_door: !include
     file: garage-door.yaml
@@ -197,7 +197,7 @@ To make changes or add additional configuration to included configurations, `!ex
 For example, to set a specific update interval on a common uptime sensor that is shared between configurations:
 
 ```yaml
-# In common.yaml
+# common.yaml
 captive_portal:
 
 sensor:
@@ -218,7 +218,7 @@ sensor:
 LVGL-style configuration hierarchies are also supported:
 
 ```yaml
-# In interface.yaml
+# interface.yaml
 lvgl:
   pages:
     - id: main_page

--- a/src/content/docs/components/substitutions.mdx
+++ b/src/content/docs/components/substitutions.mdx
@@ -243,7 +243,7 @@ Additionally, you can use the YAML insertion operator `<<` syntax to create a si
 of nodes inherit:
 
 ```yaml
-# In common.yaml
+# common.yaml
 esphome:
   name: $devicename
   # ...
@@ -258,7 +258,7 @@ sensor:
 ```
 
 ```yaml
-# In nodemcu1.yaml
+# nodemcu1.yaml
 substitutions:
   devicename: nodemcu1
 

--- a/src/content/docs/guides/security_best_practices.mdx
+++ b/src/content/docs/guides/security_best_practices.mdx
@@ -258,7 +258,7 @@ If you have extreme security requirements, you can physically disable USB/serial
 Use `secrets.yaml` to avoid storing sensitive information in your configuration files, especially if you share your configs in a public Git repository:
 
 ```yaml
-# Example: device1.yaml
+# device1.yaml
 api:
   encryption:
     key: !secret device1_api_key


### PR DESCRIPTION
## Description

Change YAML code block comment headers from `# In filename.yaml` to `# filename.yaml` so the docs renderer displays them as nice filename tabs instead of plain comments.

<img width="408" height="301" alt="image" src="https://github.com/user-attachments/assets/703411b1-60eb-4641-a4c7-cc342a5e6c27" />

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- N/A

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.