### PR TITLE
Update bmp581 documentation to include BMP585

### DIFF
--- a/src/content/docs/components/sensor/bmp581.mdx
+++ b/src/content/docs/components/sensor/bmp581.mdx
@@ -7,7 +7,7 @@ import { Image } from 'astro:assets';
 import Figure from '@components/Figure.astro';
 
 The `bmp581` sensor platform allows you to use your BMP581
-([datasheet](https://www.bosch-sensortec.com/media/boschsensortec/downloads/datasheets/bst-bmp581-ds004.pdf), [SparkFun](https://www.sparkfun.com/products/20170) or [Adafruit](https://www.adafruit.com/product/6407)) temperature and pressure sensors with ESPHome. Either an [I²C](/components/i2c) bus or an [SPI](/components/spi) bus are required to be set up in your configuration for this sensor to work.
+([datasheet](https://www.bosch-sensortec.com/media/boschsensortec/downloads/datasheets/bst-bmp581-ds004.pdf), [SparkFun](https://www.sparkfun.com/products/20170) or [Adafruit](https://www.adafruit.com/product/6407)) and BMP585 ([datasheet](https://www.bosch-sensortec.com/media/boschsensortec/downloads/datasheets/bst-bmp585-ds003.pdf)) temperature and pressure sensors with ESPHome. Either an [I²C](/components/i2c) bus or an [SPI](/components/spi) bus are required to be set up in your configuration for this sensor to work.
 
 <Figure
   src="/images/bmp581.jpg"


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#15277

## Checklist

- [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
