### PR TITLE
[opentherm] Update documentation for t_set, t_set_ch2 and communicati…

### DIFF
--- a/src/content/docs/components/opentherm.mdx
+++ b/src/content/docs/components/opentherm.mdx
@@ -60,6 +60,11 @@ opentherm:
   from disabling interrupts while we are talking to the boiler. Enable if you experience a lot of random intermittent
   invalid response errors (very likely to happen while using Dallas temperature sensors).
 
+- **communication_delay** (*Optional*, [Time](/guides/configuration-types#config-time), default `100ms`): The delay
+  between OpenTherm conversations. The OpenTherm specification requires the master to wait at least 100ms between
+  conversations. Additionally, the master must communicate at least every 1s; otherwise, the boiler will time out.
+  It is strongly recommended to keep this value at 100ms.
+
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID used for code generation. Required if you have
   multiple busses.
 
@@ -162,7 +167,7 @@ There are three ways to set a numerical value:
 ```
 
 For the output and number variants, there are four more properties you can configure beyond those included in the
-output and number components by default:
+[output](/components/output/) and [number](/components/number/) components by default:
 
 - `min_value` (float): The minimum value. For a number this is the minimum value you are allowed to input. For an
   output this is the number that will be sent to the boiler when the output is at 0%.
@@ -335,6 +340,8 @@ available:
 - `max_t_set_lb`  : Lower bound for adjustment of max CH setpoint (°C)
 - `t_dhw_set`  : Domestic hot water temperature setpoint (°C)
 - `max_t_set`  : Maximum allowable CH water setpoint (°C)
+- `t_set`  : Control setpoint: temperature setpoint for the boiler's supply water (°C)
+- `t_set_ch2`  : Control setpoint 2: temperature setpoint for the boiler's supply water on the second heating circuit (°C)
 - `opentherm_version_device`  : Version of OpenTherm implemented by device
 - `device_type`  : Device product type
 - `device_version`  : Device product version


### PR DESCRIPTION
## Description

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
