### PR TITLE
[internal_temperature] Update description to include nRF52 support

### DIFF
--- a/src/content/docs/components/sensor/internal_temperature.mdx
+++ b/src/content/docs/components/sensor/internal_temperature.mdx
@@ -7,7 +7,7 @@ import { Image } from 'astro:assets';
 import internalTemperatureUiImg from './images/internal_temperature-ui.png';
 
 The `internal_temperature` sensor platform allows you to use the integrated
-temperature sensor of the ESP32, RP2040 and BK72XX chip.
+temperature sensor of the ESP32, RP2040, BK72XX chip and nRF52.
 
 > [!NOTE]
 > Some ESP32 variants return a large amount of invalid temperature


### PR DESCRIPTION
Add the nRF52 plataform to the internal_temperature.

<!-- markdownlint-disable -->

## Description
This updates the internal temperature documentation to reflect nRF52 support added in esphome/esphome#15297.

## Checklist
- [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.
- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.