### PR TITLE
Update ch422g docs

### DIFF
--- a/src/content/docs/components/ch422g.mdx
+++ b/src/content/docs/components/ch422g.mdx
@@ -48,8 +48,8 @@ Open drain mode is supported only on pins 8-11. Input is supported only on pins 
 
 ## See Also
 
-- [I²C Bus](/components/i2c)
+- [I²C Bus](/components/i2c/)
 - [GPIO Switch](/components/switch/gpio/)
 - [GPIO Binary Sensor](/components/binary_sensor/gpio/)
-- [CH422G datasheet](https://www.wch-ic.com/downloads/file/315.html?time=2024-07-29%2002:02:32&code=Fxex1sTRHysGLS6ALgh7PTOOZnAACY6KTQx05vzD)
+- [CH422G datasheet](https://www.wch-ic.com/download/file?id=315)
 - <APIRef text="ch422g.h" path="ch422g/ch422g.h" />


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description
This PR fixes the datasheet URL of the CH422G component.
## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
