### PR TITLE
Improve ch423 component docs

### DIFF
--- a/src/content/docs/components/ch423.mdx
+++ b/src/content/docs/components/ch423.mdx
@@ -7,7 +7,7 @@ import APIClass from '@components/APIClass.astro';
 import APIRef from '@components/APIRef.astro';
 
 The CH423 component allows you to use the **CH423** I/O expander in ESPHome.
-It uses an [I²C Bus](/components/i2c) for communication. The I²C address is not configurable as the CH423 has a separate address for each internal register.
+It uses an [I²C Bus](/components/i2c/) for communication. The I²C address is not configurable as the CH423 has a separate address for each internal register.
 
 Once configured, you can use any of the 24 available GPIO pins in many places a GPIO pin is required.
 Within ESPHome they can be used in place of internal GPIO pins in many of ESPHome's components such as the GPIO Binary Sensor or GPIO Switch. They are not usable for PWM or other situations requiring an internal GPIO pin.
@@ -60,9 +60,9 @@ These restrictions are enforced at configuration validation time.
 
 ## See Also
 
-- [I²C Bus](/components/i2c)
+- [I²C Bus](/components/i2c/)
 - [GPIO Switch](/components/switch/gpio/)
 - [GPIO Binary Sensor](/components/binary_sensor/gpio/)
-- [CH423 datasheet](https://www.wch-ic.com/downloads/CH423DS1_PDF.html)
+- [CH423 datasheet](https://www.wch-ic.com/download/file?id=104)
 - <APIClass text="CH423Component" path="ch423::CH423Component" />
 - <APIRef text="ch423.h" path="ch423/ch423.h" />


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description
This PR fixes the datasheet URL of the ch423
## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
