### PR TITLE
Improve midea component docs

### DIFF
--- a/src/content/docs/components/climate/midea.mdx
+++ b/src/content/docs/components/climate/midea.mdx
@@ -10,11 +10,11 @@ The `midea` component creates a Midea air conditioner climate device.
 > [!NOTE]
 > This protocol also used by some vendors:
 >
-> - [Electrolux](https://www.electrolux.com/en/)
+> - [Electrolux](https://www.electrolux.com/)
 > - [Qlima](https://www.qlima.com/)
 > - [Artel](https://www.artelgroup.com/)
 > - [Carrier](https://www.carrier.com/)
-> - [Comfee](https://www.feelcomfee.com/global/)
+> - [Comfee](https://www.feelcomfee.com/)
 > - [Inventor](https://www.inventorairconditioner.com/)
 > - [Senville](https://senville.com/)
 > - and maybe others


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description
This PR removes the regional part of the URLs in the Midea integration.
## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
