### PR TITLE
Flag relative links as errors in linter

### DIFF
--- a/lint.mjs
+++ b/lint.mjs
@@ -306,8 +306,10 @@ async function checkInternalLinks(fname, content, anchorCache) {
       continue;
     }
 
-    // Skip relative links without leading slash
+    // Flag relative links - all internal links should use absolute paths
     if (!linkUrl.startsWith('/')) {
+      addError(fname, lineno, col,
+        `Relative link '${linkUrl}' should use an absolute path (e.g., /components/...)`);
       continue;
     }
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

The linter's internal link checker silently skips relative links (e.g., `../config-id.md`). These links result in 404s on the live site since the Astro docs use absolute paths everywhere.

This changes the linter to flag relative links as errors instead of silently skipping them.

Found via esphome/esphome-docs#6276 where `[ID](../config-id.md)` passes CI but produces a 404.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- N/A

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.