### PR TITLE
[esp32] Add signed app verification without hardware secure boot to `esp32`

### DIFF
--- a/src/content/docs/components/esp32.mdx
+++ b/src/content/docs/components/esp32.mdx
@@ -382,9 +382,9 @@ esp32:
   `boot_is_good_after` time (default 60s), the firmware is marked as valid. If the device crashes before that,
   it will roll back to the previous working firmware. Defaults to `true`.
 
-> [!NOTE]
-> OTA rollback requires the bootloader to be compiled with rollback support. Existing devices may need to be
-> reflashed via serial to update the bootloader - OTA updates do not update the bootloader.
+  > [!NOTE]
+  > OTA rollback requires the bootloader to be compiled with rollback support. Existing devices may need to be
+  > reflashed via serial to update the bootloader - OTA updates do not update the bootloader.
 
 - **signed_ota_verification** (*Optional*, mapping): Enable
   [Signed App Verification Without Hardware Secure Boot](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/security/secure-boot-v2.html#signed-app-verification-without-hardware-secure-boot).

--- a/src/content/docs/components/esp32.mdx
+++ b/src/content/docs/components/esp32.mdx
@@ -386,6 +386,56 @@ esp32:
 > OTA rollback requires the bootloader to be compiled with rollback support. Existing devices may need to be
 > reflashed via serial to update the bootloader - OTA updates do not update the bootloader.
 
+- **signed_ota_verification** (*Optional*, mapping): Enable
+  [Signed App Verification Without Hardware Secure Boot](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/security/secure-boot-v2.html#signed-app-verification-without-hardware-secure-boot).
+  When configured, OTA firmware updates are verified using a cryptographic signature. The public key is embedded in
+  the running firmware's signature block and used to verify the signature of any incoming OTA update. This protects
+  against tampered firmware from network-based attacks without requiring hardware Secure Boot (eFuse).
+  **ESP-IDF framework only.** Contains the following options:
+
+  - **signing_key** (*Optional*, filename): Path to a PEM-encoded private signing key. When provided, the firmware
+    is **automatically signed during build** using `espsecure`. This is the simplest workflow — the public key is
+    derived automatically and embedded in the signature block. **Mutually exclusive with `verification_key`.**
+  - **verification_key** (*Optional*, filename): Path to a PEM-encoded public verification key. When provided, the
+    public key is embedded for verification but the binary is **not signed during build**. You must sign the firmware
+    externally (typically by way of `espsecure.py sign-data --version 2 --keyfile private.pem firmware.bin`) before
+    flashing. This is useful for CI/CD pipelines where the private key is stored in a secure vault.
+    **Mutually exclusive with `signing_key`.**
+  - **signing_scheme** (*Optional*, string): The signing algorithm. One of `rsa3072` or `ecdsa256`. Defaults to
+    `rsa3072`. **Not all schemes are supported on all variants** — see the table below.
+
+    | Variant | `rsa3072` | `ecdsa256` |
+    |---------|-----------|------------|
+    | ESP32 (rev 3+) | yes | no |
+    | ESP32-S2 | yes | no |
+    | ESP32-S3 | yes | no |
+    | ESP32-C2 | no | yes |
+    | ESP32-C3 | yes | no |
+    | ESP32-C5 | yes | yes |
+    | ESP32-C6 | yes | yes |
+    | ESP32-C61 | no | yes |
+    | ESP32-H2 | yes | yes |
+    | ESP32-P4 | yes | yes |
+
+  > [!WARNING]
+  > **Keep your signing key safe!** If you lose the private signing key, you will **not be able to OTA update** any
+  > devices running firmware signed with that key. Without the signing key, you must reflash the device via serial.
+
+  > [!NOTE]
+  > The **first firmware** flashed to a device must also be signed. When using `signing_key`, this happens
+  > automatically. Flash the initial firmware via serial — serial flashing does not perform signature verification.
+  > All subsequent OTA updates will be verified against the public key in the running firmware.
+
+  To generate a signing key, use the `espsecure.py` tool from ESP-IDF:
+
+  ```bash
+  # Generate an RSA-3072 signing key
+  espsecure.py generate_signing_key --version 2 --scheme rsa3072 secure_boot_signing_key.pem
+
+  # Extract the public verification key (for the verification_key workflow)
+  espsecure.py extract_public_key --keyfile secure_boot_signing_key.pem secure_boot_verification_key.pem
+  ```
+
 **LWIP Optimization Options (ESP-IDF only):**
 
 The following options are available under the `advanced` section when using the ESP-IDF framework to optimize

--- a/src/content/docs/components/esp32.mdx
+++ b/src/content/docs/components/esp32.mdx
@@ -391,7 +391,7 @@ esp32:
   When configured, OTA firmware updates are verified using a cryptographic signature. The public key is embedded in
   the running firmware's signature block and used to verify the signature of any incoming OTA update. This protects
   against tampered firmware from network-based attacks without requiring hardware Secure Boot (eFuse).
-  **ESP-IDF framework only.** Contains the following options:
+  Contains the following options:
 
   - **signing_key** (*Optional*, filename): Path to a PEM-encoded private signing key. When provided, the firmware
     is **automatically signed during build** using `espsecure`. This is the simplest workflow — the public key is


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Documents signed app verification without hardware secure boot for `esp32`.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#15357

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
