### PR TITLE
Update caching headers in netlify.toml for improved performance

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -16,17 +16,55 @@
   environment = { SITE_URL = "https://esphome.io", API_DOCS_URL = "https://api-docs.esphome.io" }
 
 
-# Caching HTML - 1 week
+# Default caching for all pages (HTML and everything else)
+# Browser: 1 hour, Cloudflare CDN: 1 week, serve stale while revalidating
+# Using /* as a catch-all since /*.html only matches single-level paths
 [[headers]]
-  for = "/*.html"
+  for = "/*"
   [headers.values]
-    Cache-Control = "public, max-age=604800"
+    Cache-Control = "public, max-age=3600, stale-while-revalidate=86400"
+    Cloudflare-CDN-Cache-Control = "public, max-age=604800, stale-while-revalidate=86400"
 
-# Images, CSS, JS - 1 year, immutable. CSS and JS are fingerprinted
+# Fingerprinted assets (Astro build output in /_astro/) - 1 year, immutable
 [[headers]]
-  for = "/*.{png,jpg,jpeg,gif,webp,svg,css,js}"
+  for = "/_astro/*"
   [headers.values]
     Cache-Control = "public, max-age=31536000, immutable"
+    Cloudflare-CDN-Cache-Control = "public, max-age=31536000, immutable"
+
+# Static images - browser: 1 week, CDN: 1 month
+[[headers]]
+  for = "/images/*"
+  [headers.values]
+    Cache-Control = "public, max-age=604800"
+    Cloudflare-CDN-Cache-Control = "public, max-age=2592000, stale-while-revalidate=604800"
+
+# Project images
+[[headers]]
+  for = "/projects/*"
+  [headers.values]
+    Cache-Control = "public, max-age=604800"
+    Cloudflare-CDN-Cache-Control = "public, max-age=2592000, stale-while-revalidate=604800"
+
+# Favicons - browser: 1 week, CDN: 1 month
+[[headers]]
+  for = "/favicon*"
+  [headers.values]
+    Cache-Control = "public, max-age=604800"
+    Cloudflare-CDN-Cache-Control = "public, max-age=2592000"
+
+# Sitemap and robots.txt - browser: 1 hour, CDN: 1 day
+[[headers]]
+  for = "/sitemap*"
+  [headers.values]
+    Cache-Control = "public, max-age=3600"
+    Cloudflare-CDN-Cache-Control = "public, max-age=86400"
+
+[[headers]]
+  for = "/robots.txt"
+  [headers.values]
+    Cache-Control = "public, max-age=3600"
+    Cloudflare-CDN-Cache-Control = "public, max-age=86400"
 
 # Hugo taxonomy pages - redirect to homepage
 [[redirects]]


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Update caching headers

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
