### PR TITLE
[ld2420] Add gate energy sensor documentation

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -16,17 +16,55 @@
   environment = { SITE_URL = "https://esphome.io", API_DOCS_URL = "https://api-docs.esphome.io" }
 
 
-# Caching HTML - 1 week
+# Default caching for all pages (HTML and everything else)
+# Browser: 1 hour, Cloudflare CDN: 1 week, serve stale while revalidating
+# Using /* as a catch-all since /*.html only matches single-level paths
 [[headers]]
-  for = "/*.html"
+  for = "/*"
   [headers.values]
-    Cache-Control = "public, max-age=604800"
+    Cache-Control = "public, max-age=3600, stale-while-revalidate=86400"
+    Cloudflare-CDN-Cache-Control = "public, max-age=604800, stale-while-revalidate=86400"
 
-# Images, CSS, JS - 1 year, immutable. CSS and JS are fingerprinted
+# Fingerprinted assets (Astro build output in /_astro/) - 1 year, immutable
 [[headers]]
-  for = "/*.{png,jpg,jpeg,gif,webp,svg,css,js}"
+  for = "/_astro/*"
   [headers.values]
     Cache-Control = "public, max-age=31536000, immutable"
+    Cloudflare-CDN-Cache-Control = "public, max-age=31536000, immutable"
+
+# Static images - browser: 1 week, CDN: 1 month
+[[headers]]
+  for = "/images/*"
+  [headers.values]
+    Cache-Control = "public, max-age=604800"
+    Cloudflare-CDN-Cache-Control = "public, max-age=2592000, stale-while-revalidate=604800"
+
+# Project images
+[[headers]]
+  for = "/projects/*"
+  [headers.values]
+    Cache-Control = "public, max-age=604800"
+    Cloudflare-CDN-Cache-Control = "public, max-age=2592000, stale-while-revalidate=604800"
+
+# Favicons - browser: 1 week, CDN: 1 month
+[[headers]]
+  for = "/favicon*"
+  [headers.values]
+    Cache-Control = "public, max-age=604800"
+    Cloudflare-CDN-Cache-Control = "public, max-age=2592000"
+
+# Sitemap and robots.txt - browser: 1 hour, CDN: 1 day
+[[headers]]
+  for = "/sitemap*"
+  [headers.values]
+    Cache-Control = "public, max-age=3600"
+    Cloudflare-CDN-Cache-Control = "public, max-age=86400"
+
+[[headers]]
+  for = "/robots.txt"
+  [headers.values]
+    Cache-Control = "public, max-age=3600"
+    Cloudflare-CDN-Cache-Control = "public, max-age=86400"
 
 # Hugo taxonomy pages - redirect to homepage
 [[redirects]]

--- a/src/content/docs/components/sensor/ld2420.mdx
+++ b/src/content/docs/components/sensor/ld2420.mdx
@@ -306,12 +306,20 @@ sensor:
   - platform: ld2420
     moving_distance:
       name : Moving Distance
+    gate_0:
+      gate_energy:
+        name: Gate 0 Energy
+    gate_1:
+      gate_energy:
+        name: Gate 1 Energy
 ```
 
 ### Configuration variables
 
 - **moving_distance** (*Optional*): Distance between the sensor and the detected moving target. May contain any options
   from [Sensor](/components/sensor).
+- **gate_x** (*Optional*, 0-15): Per-gate energy level sensors. Requires firmware v1.5.4 or greater and Normal operating mode. Each gate covers approximately 70 cm. Available gates are `gate_0` through `gate_15`.
+  - **gate_energy** (*Optional*): The energy level detected at this gate. Higher values indicate stronger reflections. May contain any options from [Sensor](/components/sensor).
 
 ## Binary Sensor
 


### PR DESCRIPTION
## Description

Add documentation for the new per-gate energy sensor feature on the LD2420 sensor platform.

The C++ infrastructure for per-gate energy reporting already existed but was never exposed through the Python schema. The matching esphome PR adds the `gate_0` through `gate_15` sensor configuration with `gate_energy` sub-sensors.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#PENDING

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.