### PR TITLE
Document transmit_intertechno action in remote_transmitter

### DIFF
--- a/src/content/docs/components/remote_transmitter.mdx
+++ b/src/content/docs/components/remote_transmitter.mdx
@@ -440,6 +440,30 @@ on_...:
 
   - All other options from [Remote Transmitter Actions](#remote_transmitter-transmit_action).
 
+<span id="remote_transmitter-transmit_intertechno"></span>
+
+### `remote_transmitter.transmit_intertechno` Action
+
+This [action](/automations/actions#all-actions) sends a Intertecho remote code to a transmitter.
+
+```yaml
+on_...:
+  - remote_transmitter.transmit_intertechno:
+      code: "F00F00000FF0"
+        repeat:
+          times: 5
+          wait_time: 0s
+```
+
+#### Configuration variables
+
+- **code** (**Required**, string, [templatable](/automations/templates)): The Intertechno code to send. It usually contains 12 symbols, where every symbol can be `0`, `1`, or `F`. More information about the code structure can be found in the [FHEM Wiki](https://wiki.fhem.de/wiki/Intertechno_Code_Berechnung) (in German).
+- All other options from [Remote Transmitter Actions](#remote_transmitter-transmit_action).
+
+**Important:**
+
+- Most receivers only respond if the code is repeated multiple times. It is recommend set `repeat` to (at least) 5 and `wait_time` to 0s.
+
 <span id="remote_transmitter-transmit_jvc"></span>
 
 ### `remote_transmitter.transmit_jvc` Action


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#15420

## Checklist

- [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
