### PR TITLE
Document blocking warning and fix runtime_stats wall time docs

### DIFF
--- a/src/content/docs/components/runtime_stats.mdx
+++ b/src/content/docs/components/runtime_stats.mdx
@@ -40,7 +40,8 @@ runtime_stats:
 > times are much closer to actual CPU time spent in the component.
 >
 > For example, the same bluetooth_proxy component may show `avg=1.8ms` on an ESP32-C3 but only `avg=0.4ms`
-> on a dual-core ESP32 — the component isn't slower, it's being preempted by system tasks on the single core.
+> on a dual-core ESP32. The C3 is slower, but not by as much as the numbers suggest — the difference is
+> inflated by system task preemption on the single core.
 >
 > Runtime statistics are still valuable for identifying blocking components on single-core chips, but keep
 > in mind that the absolute times will appear higher than the actual CPU time consumed.

--- a/src/content/docs/components/runtime_stats.mdx
+++ b/src/content/docs/components/runtime_stats.mdx
@@ -31,10 +31,6 @@ runtime_stats:
 
 ## Understanding the Output
 
-> [!NOTE]
-> Runtime statistics use `micros()` for time measurement, which provides microsecond resolution. Times are
-> displayed in milliseconds with three decimal places (e.g., `avg=0.006ms`).
-
 > [!IMPORTANT]
 > **Wall time, not CPU time:** Runtime statistics measure wall time (elapsed real time), not CPU time.
 > This means the measured time includes any FreeRTOS context switches that occur while a component is

--- a/src/content/docs/components/runtime_stats.mdx
+++ b/src/content/docs/components/runtime_stats.mdx
@@ -32,11 +32,22 @@ runtime_stats:
 ## Understanding the Output
 
 > [!NOTE]
-> Runtime statistics use `millis()` for time measurement, which provides millisecond resolution. This means:
+> Runtime statistics use `micros()` for time measurement, which provides microsecond resolution. Times are
+> displayed in milliseconds with three decimal places (e.g., `avg=0.006ms`).
+
+> [!IMPORTANT]
+> **Wall time, not CPU time:** Runtime statistics measure wall time (elapsed real time), not CPU time.
+> This means the measured time includes any FreeRTOS context switches that occur while a component is
+> executing. On **single-core chips** (ESP32-C3, C2, H2), Wi-Fi, BLE, and other system tasks share the
+> same core and can preempt the main loop, inflating the measured times. On **dual-core chips** (ESP32, S3),
+> system tasks mostly run on the protocol core (core 0) while the main loop runs on core 1, so measured
+> times are much closer to actual CPU time spent in the component.
 >
-> - Components that execute in less than 1ms will show as 0ms
-> - Very fast operations cannot be accurately measured
-> - The statistics are best suited for finding components that take multiple milliseconds
+> For example, the same bluetooth_proxy component may show `avg=1.8ms` on an ESP32-C3 but only `avg=0.4ms`
+> on a dual-core ESP32 — the component isn't slower, it's being preempted by system tasks on the single core.
+>
+> Runtime statistics are still valuable for identifying blocking components on single-core chips, but keep
+> in mind that the absolute times will appear higher than the actual CPU time consumed.
 
 The component logs two types of statistics:
 

--- a/src/content/docs/components/runtime_stats.mdx
+++ b/src/content/docs/components/runtime_stats.mdx
@@ -43,8 +43,9 @@ runtime_stats:
 > on a dual-core ESP32. The C3 is slower, but not by as much as the numbers suggest — the difference is
 > inflated by system task preemption on the single core.
 >
-> Runtime statistics are still valuable for identifying blocking components on single-core chips, but keep
-> in mind that the absolute times will appear higher than the actual CPU time consumed.
+> Runtime statistics are still valuable for identifying blocking components, but keep in mind that the
+> absolute times will appear higher than the actual CPU time consumed, especially on single-core
+> FreeRTOS-based systems.
 
 The component logs two types of statistics:
 

--- a/src/content/docs/guides/troubleshooting.mdx
+++ b/src/content/docs/guides/troubleshooting.mdx
@@ -224,6 +224,23 @@ documentation for detailed information and examples.
 > reduce verbosity, not increase it beyond the global level. For example, if the global level is `INFO`, setting a
 > component to `DEBUG` will have no effect.
 
+## "Took a long time for an operation" Warning
+
+```log
+[W][component:511]: Component sensor.my_sensor took a long time for an operation (85 ms), max is 30 ms
+```
+
+A component blocked the main loop for longer than the threshold (default 50ms). While it was blocking, no other components could run. Severe cases can trigger watchdog resets or Wi-Fi disconnections.
+
+If you see this, please comment on [GitHub issue #9517](https://github.com/esphome/esphome/issues/9517) with the log output and the relevant component configuration so the component can be fixed.
+
+To gather more detail, enable [Runtime Stats](/components/runtime_stats/) and look at the `max` column:
+
+```yaml
+runtime_stats:
+  log_interval: 60s
+```
+
 ## Performance Troubleshooting
 
 If your device is experiencing performance issues such as:
@@ -234,8 +251,9 @@ If your device is experiencing performance issues such as:
 - Components not updating as expected
 
 The [Runtime Stats](/components/runtime_stats/) component can help identify which components are consuming the most
-processing time or blocking the event loop. See the runtime_stats documentation for detailed usage instructions
-and examples.
+processing time or blocking the event loop. See the [Runtime Stats documentation](/components/runtime_stats/) for
+detailed usage instructions and examples, including important notes about how wall time measurement differs between
+single-core and dual-core chips.
 
 ## See Also
 

--- a/src/content/docs/guides/troubleshooting.mdx
+++ b/src/content/docs/guides/troubleshooting.mdx
@@ -227,7 +227,7 @@ documentation for detailed information and examples.
 ## "Took a long time for an operation" Warning
 
 ```log
-[W][component:511]: Component sensor.my_sensor took a long time for an operation (85 ms), max is 30 ms
+[W][component:511]: Component sensor.my_sensor took a long time for an operation (85 ms), max is 50 ms
 ```
 
 A component blocked the main loop for longer than the threshold (default 50ms). While it was blocking, no other components could run. Severe cases can trigger watchdog resets or Wi-Fi disconnections.

--- a/src/content/docs/guides/troubleshooting.mdx
+++ b/src/content/docs/guides/troubleshooting.mdx
@@ -227,10 +227,10 @@ documentation for detailed information and examples.
 ## "Took a long time for an operation" Warning
 
 ```log
-[W][component:511]: Component sensor.my_sensor took a long time for an operation (85 ms), max is 50 ms
+[W][component:511]: Component sensor.my_sensor took a long time for an operation (85 ms), max is 30 ms
 ```
 
-A component blocked the main loop for longer than the threshold (default 50ms). While it was blocking, no other components could run. Severe cases can trigger watchdog resets or Wi-Fi disconnections.
+A component blocked the main loop for longer than the expected maximum. While it was blocking, no other components could run. Severe cases can trigger watchdog resets or Wi-Fi disconnections.
 
 This measurement is wall time, not CPU time. On single-core chips (ESP32-C3, C2, H2), the warning can be triggered or inflated by FreeRTOS system tasks preempting the main loop. See the [Runtime Stats wall time documentation](/components/runtime_stats/#understanding-the-output) for more detail.
 

--- a/src/content/docs/guides/troubleshooting.mdx
+++ b/src/content/docs/guides/troubleshooting.mdx
@@ -232,6 +232,8 @@ documentation for detailed information and examples.
 
 A component blocked the main loop for longer than the threshold (default 50ms). While it was blocking, no other components could run. Severe cases can trigger watchdog resets or Wi-Fi disconnections.
 
+This measurement is wall time, not CPU time. On single-core chips (ESP32-C3, C2, H2), the warning can be triggered or inflated by FreeRTOS system tasks preempting the main loop. See the [Runtime Stats wall time documentation](/components/runtime_stats/#understanding-the-output) for more detail.
+
 If you see this, please comment on [GitHub issue #9517](https://github.com/esphome/esphome/issues/9517) with the log output and the relevant component configuration so the component can be fixed.
 
 To gather more detail, enable [Runtime Stats](/components/runtime_stats/) and look at the `max` column:


### PR DESCRIPTION
## Description

- **runtime_stats**: Add wall time vs CPU time explanation — on single-core chips (C3, C2, H2) measured times include FreeRTOS context switches, inflating values compared to dual-core chips (ESP32, S3)
- **troubleshooting**: Add section for the "took a long time for an operation" warning, directing users to report and use runtime_stats to investigate
- **troubleshooting**: Link runtime_stats reference to the wall time documentation

**Related issue (if applicable):** Related to esphome "took a long time for an operation" tracking issue 9517

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.