### PR TITLE
Add interrupt_pin documentation for PCF8574 and PCA9554

### DIFF
--- a/src/content/docs/components/pca9554.mdx
+++ b/src/content/docs/components/pca9554.mdx
@@ -77,7 +77,7 @@ switch:
   Defaults to `0x20`.
 
 - **pin_count** (*Optional*, int): The number of bits implemented in the expander. Defaults to 8. This should be set
-  to 16 when using a PCA9535 and 4 when using a PCA95367.
+  to 16 when using a PCA9535 and 4 when using a PCA9536.
 - **interrupt_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The pin connected to the
   INT output of the PCA9554/PCA9535. When configured, the component becomes interrupt-driven instead of
   polling — it only reads the chip when a pin actually changes state, significantly reducing I²C bus traffic

--- a/src/content/docs/components/pca9554.mdx
+++ b/src/content/docs/components/pca9554.mdx
@@ -78,6 +78,11 @@ switch:
 
 - **pin_count** (*Optional*, int): The number of bits implemented in the expander. Defaults to 8. This should be set
   to 16 when using a PCA9535 and 4 when using a PCA95367.
+- **interrupt_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The pin connected to the
+  INT output of the PCA9554/PCA9535. When configured, the component becomes interrupt-driven instead of
+  polling — it only reads the chip when a pin actually changes state, significantly reducing I²C bus traffic
+  and CPU usage. The INT pin is active-low and open-drain, so an external or internal pull-up resistor is
+  required. Must be an internal GPIO pin (not another expander pin).
 
 > [!NOTE]
 > A PCA9535 will not work (even on the lower 8 bits) unless the **pin_count** is set to 16.

--- a/src/content/docs/components/pcf8574.mdx
+++ b/src/content/docs/components/pcf8574.mdx
@@ -56,6 +56,11 @@ switch:
   Defaults to `0x21`.
 
 - **pcf8575** (*Optional*, boolean): Whether this is a 16-pin PCF8575. Defaults to `false`.
+- **interrupt_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The pin connected to the
+  INT output of the PCF8574/PCF8575. When configured, the component becomes interrupt-driven instead of
+  polling — it only reads the chip when a pin actually changes state, significantly reducing I²C bus traffic
+  and CPU usage. The INT pin is active-low and open-drain, so an external or internal pull-up resistor is
+  required. Must be an internal GPIO pin (not another expander pin).
 
 > [!NOTE]
 > If you use PCF8575, pin numbers are from 0 to 15, not 0 to 7 and 10 to 17 as datasheet states!


### PR DESCRIPTION
## Description

Documents the new `interrupt_pin` configuration option for PCF8574 and PCA9554 GPIO expander components. When configured, these components become interrupt-driven instead of polling, significantly reducing I2C bus traffic and CPU usage.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#15444

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.