### PR TITLE
Add interrupt_pin documentation for MCP23xxx and PI4IOE5V6408

### DIFF
--- a/src/content/docs/components/mcp230xx.mdx
+++ b/src/content/docs/components/mcp230xx.mdx
@@ -61,6 +61,10 @@ binary_sensor:
 - **open_drain_interrupt** (*Optional*, boolean): Configure the interrupt pin to open-drain mode.
   Useful when the MCP23008's power supply is greater than 3.3 volts. Note that this pin
   will require a pull-up resistor (to 3.3 volts) when this mode is enabled.
+- **interrupt_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The pin connected to the
+  INT output of the MCP23008. When configured, the component becomes interrupt-driven instead of
+  polling — it only reads the chip when a pin actually changes state, significantly reducing I²C bus traffic
+  and CPU usage. Must be an internal GPIO pin (not another expander pin).
 
 ### Pin configuration variables
 
@@ -183,6 +187,10 @@ binary_sensor:
 - **open_drain_interrupt** (*Optional*, boolean): Configure interrupt pins to open-drain mode.
   Useful when the MCP23017's power supply is greater than 3.3 volts. Note that these pins
   will require pull-up resistors (to 3.3 volts) when this mode is enabled.
+- **interrupt_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The pin connected to the
+  INTA or INTB output of the MCP23017. When configured, the component becomes interrupt-driven instead of
+  polling — it only reads the chip when a pin actually changes state, significantly reducing I²C bus traffic
+  and CPU usage. Must be an internal GPIO pin (not another expander pin).
 
 ### Pin configuration variables
 

--- a/src/content/docs/components/mcp23Sxx.mdx
+++ b/src/content/docs/components/mcp23Sxx.mdx
@@ -64,6 +64,10 @@ binary_sensor:
 - **open_drain_interrupt** (*Optional*, boolean): Configure interrupt pins to open-drain mode.
   Useful when the MCP23S08's power supply is greater than 3.3 volts. Note that these pins
   will require pull-up resistors (to 3.3 volts) when this mode is enabled.
+- **interrupt_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The pin connected to the
+  INT output of the MCP23S08. When configured, the component becomes interrupt-driven instead of
+  polling — it only reads the chip when a pin actually changes state, significantly reducing SPI bus traffic
+  and CPU usage. Must be an internal GPIO pin (not another expander pin).
 
 ### Pin Configuration Variables
 
@@ -129,6 +133,10 @@ binary_sensor:
 - **open_drain_interrupt** (*Optional*, boolean): Configure interrupt pins to open-drain mode.
   Useful when the MCP23S17's power supply is greater than 3.3 volts. Note that these pins
   will require pull-up resistors (to 3.3 volts) when this mode is enabled.
+- **interrupt_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The pin connected to the
+  INTA or INTB output of the MCP23S17. When configured, the component becomes interrupt-driven instead of
+  polling — it only reads the chip when a pin actually changes state, significantly reducing SPI bus traffic
+  and CPU usage. Must be an internal GPIO pin (not another expander pin).
 
 ### Pin Configuration Variables
 

--- a/src/content/docs/components/pca9554.mdx
+++ b/src/content/docs/components/pca9554.mdx
@@ -77,7 +77,7 @@ switch:
   Defaults to `0x20`.
 
 - **pin_count** (*Optional*, int): The number of bits implemented in the expander. Defaults to 8. This should be set
-  to 16 when using a PCA9535 and 4 when using a PCA95367.
+  to 16 when using a PCA9535 and 4 when using a PCA9536.
 - **interrupt_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The pin connected to the
   INT output of the PCA9554/PCA9535. When configured, the component becomes interrupt-driven instead of
   polling — it only reads the chip when a pin actually changes state, significantly reducing I²C bus traffic

--- a/src/content/docs/components/pca9554.mdx
+++ b/src/content/docs/components/pca9554.mdx
@@ -78,6 +78,11 @@ switch:
 
 - **pin_count** (*Optional*, int): The number of bits implemented in the expander. Defaults to 8. This should be set
   to 16 when using a PCA9535 and 4 when using a PCA95367.
+- **interrupt_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The pin connected to the
+  INT output of the PCA9554/PCA9535. When configured, the component becomes interrupt-driven instead of
+  polling — it only reads the chip when a pin actually changes state, significantly reducing I²C bus traffic
+  and CPU usage. The INT pin is active-low and open-drain, so an external or internal pull-up resistor is
+  required. Must be an internal GPIO pin (not another expander pin).
 
 > [!NOTE]
 > A PCA9535 will not work (even on the lower 8 bits) unless the **pin_count** is set to 16.

--- a/src/content/docs/components/pcf8574.mdx
+++ b/src/content/docs/components/pcf8574.mdx
@@ -56,6 +56,11 @@ switch:
   Defaults to `0x21`.
 
 - **pcf8575** (*Optional*, boolean): Whether this is a 16-pin PCF8575. Defaults to `false`.
+- **interrupt_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The pin connected to the
+  INT output of the PCF8574/PCF8575. When configured, the component becomes interrupt-driven instead of
+  polling — it only reads the chip when a pin actually changes state, significantly reducing I²C bus traffic
+  and CPU usage. The INT pin is active-low and open-drain, so an external or internal pull-up resistor is
+  required. Must be an internal GPIO pin (not another expander pin).
 
 > [!NOTE]
 > If you use PCF8575, pin numbers are from 0 to 15, not 0 to 7 and 10 to 17 as datasheet states!

--- a/src/content/docs/components/pi4ioe5v6408.mdx
+++ b/src/content/docs/components/pi4ioe5v6408.mdx
@@ -46,6 +46,10 @@ binary_sensor:
 - **reset** (*Optional*, boolean): Whether to reset the device state during setup. When `true` (default),
   all pins are configured as inputs with high impedance during setup. When `false`, the component will
   read the current state from the device registers. Defaults to `true`.
+- **interrupt_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The pin connected to the
+  INT output of the PI4IOE5V6408. When configured, the component becomes interrupt-driven instead of
+  polling — it only reads the chip when a pin actually changes state, significantly reducing I²C bus traffic
+  and CPU usage. Must be an internal GPIO pin (not another expander pin).
 
 ## Pin configuration variables
 


### PR DESCRIPTION
## Description

Documents the new `interrupt_pin` configuration option for MCP23008, MCP23017, MCP23S08, MCP23S17, and PI4IOE5V6408 GPIO expander components. When configured, these components become interrupt-driven instead of polling, significantly reducing bus traffic and CPU usage.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#15445

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.