### PR TITLE
Add support for Siemens thermostats (IRA211 protocol)

### DIFF
--- a/src/content/docs/components/climate/climate_ir.mdx
+++ b/src/content/docs/components/climate/climate_ir.mdx
@@ -31,6 +31,7 @@ submit a feature request (see FAQ).
 | [Midea](#midea_ir) | `midea_ir`                         | yes |
 | [Mitsubishi](#mitsubishi) | `mitsubishi`                       | yes |
 | Noblex | `noblex`                           | yes |
+| [Siemens IRA211](#siemens_ira211) | `climate_ir_siemens_ira211`        | yes |
 | Electrolux, TCL, Fuego | `tcl112`                           | yes |
 | [Toshiba](#toshiba) | `toshiba`                          | yes |
 | [Whirlpool](#whirlpool) | `whirlpool`                        | yes |
@@ -235,6 +236,45 @@ climate:
     vertical_default: "down"
 ```
 
+<span id="siemens_ira211"></span>
+
+### `climate_ir_siemens_ira211`
+
+The Siemens IRA211 is an infrared remote for wall-mount Siemens thermostats using an NRZ-encoded IR protocol.
+
+The following thermostats are supported:
+
+- RDF600T
+- RDF660T
+- RDG160TU
+
+EOL thermostats supported:
+
+- RDF110.../IR
+- RDF210…/IR
+- RDF310.21
+- RDF410.21
+- RDE410
+- RDG1…T
+
+
+Functions and variables:
+
+- Temperature range: 5–35 °C in 0.5 °C steps
+- Modes: Heat/Cool (or Heat-only/Cool-only depending on hardware)
+- Presets: Comfort, Eco, Protection (OFF mode)
+- Fan speeds: Auto, Low, Medium, High
+
+No protocol-specific configuration variables are required beyond the base climate IR options.
+
+```yaml
+# Example configuration entry
+climate:
+  - platform: climate_ir_siemens_ira211
+    name: "Siemens IRA211"
+    sensor: room_temperature
+```
+
 <span id="toshiba"></span>
 
 ### `toshiba`
@@ -393,6 +433,7 @@ Additional configuration must be specified for this platform:
 - <APIRef text="hitachi_ac344.h" path="hitachi_ac344/hitachi_ac344.h" />
 - <APIRef text="midea_ir.h" path="midea_ir/midea_ir.h" />
 - <APIRef text="mitsubishi.h" path="mitsubishi/mitsubishi.h" />
+- <APIRef text="climate_ir_siemens_ira211.h" path="climate_ir_siemens_ira211/climate_ir_siemens_ira211.h" />
 - <APIRef text="tcl112.h" path="tcl112/tcl112.h" />
 - <APIRef text="toshiba.h" path="toshiba/toshiba.h" />
 - <APIRef text="whirlpool.h" path="whirlpool/whirlpool.h" />

--- a/src/content/docs/components/remote_receiver.mdx
+++ b/src/content/docs/components/remote_receiver.mdx
@@ -51,6 +51,7 @@ Multiple remote receivers can be configured as a list of dict definitions within
   - **gobox**: Decode and dump Go-Box infrared codes.
   - **keeloq**: Decode and dump KeeLoq RF codes.
   - **haier**: Decode and dump Haier infrared codes.
+  - **ira211**: Decode and dump Siemens IRA211 infrared codes.
   - **lg**: Decode and dump LG infrared codes.
   - **magiquest**: Decode and dump MagiQuest wand infrared codes.
   - **midea**: Decode and dump Midea infrared codes.
@@ -216,6 +217,10 @@ To enable signal demodulation, configure the signal carrier frequency and duty c
 
 - **on_haier** (*Optional*, [Automation](/automations)): An automation to perform when a
   Haier remote code has been decoded. A variable `x` of type <APIStruct text="remote_base::HaierData" path="remote_base::HaierData" />
+  is passed to the automation for use in lambdas.
+
+- **on_ira211** (*Optional*, [Automation](/automations)): An automation to perform when a
+  Siemens IRA211 remote code has been decoded. A variable `x` of type <APIStruct text="remote_base::IRA211Data" path="remote_base::IRA211Data" />
   is passed to the automation for use in lambdas.
 
 - **on_lg** (*Optional*, [Automation](/automations)): An automation to perform when a
@@ -470,6 +475,14 @@ Remote code selection (exactly one of these has to be included):
   - **code** (**Required**, 13-bytes list): The code to listen for, see
     [transmitter description](/components/remote_transmitter#remote_transmitter-transmit_haier) for more info. Usually you only need to copy
     this directly from the dumper output.
+
+- **ira211**: Trigger on a decoded Siemens IRA211 remote code with the given data.
+
+  - **command** (**Required**, string): The IRA211 command. One of `TEMP_UP`, `TEMP_DOWN`, `MODE`, `FAN`, `POWER`, `SYNC`.
+  - **temperature** (*Optional*, int): The target temperature (5–35). Defaults to `20`.
+  - **temp_tenths** (*Optional*, int): Tenths of a degree — `0` or `5`. Defaults to `0`.
+  - **mode** (*Optional*, string): The operating mode. One of `PROTECTION`, `TIMER`, `COMFORT`. Defaults to `COMFORT`.
+  - **fan_mode** (*Optional*, string): The fan speed. One of `AUTO`, `LOW`, `MEDIUM`, `HIGH`. Defaults to `AUTO`.
 
 - **lg**: Trigger on a decoded LG remote code with the given data.
 

--- a/src/content/docs/components/remote_transmitter.mdx
+++ b/src/content/docs/components/remote_transmitter.mdx
@@ -505,6 +505,31 @@ on_...:
 - All other options from [Remote Transmitter Actions](#remote_transmitter-transmit_action).
 - A repeat **wait_time** of 15ms as shown replicates the repetition of an HCS301.
 
+<span id="remote_transmitter-transmit_ira211"></span>
+
+### `remote_transmitter.transmit_ira211` Action
+
+This [action](/automations/actions#all-actions) sends a Siemens IRA211 infrared remote code to a remote transmitter.
+
+```yaml
+on_...:
+  - remote_transmitter.transmit_ira211:
+      command: SYNC
+      temperature: 22
+      temp_tenths: 5
+      mode: COMFORT
+      fan_mode: AUTO
+```
+
+#### Configuration variables
+
+- **command** (**Required**, string, [templatable](/automations/templates)): The IRA211 command to send. One of `TEMP_UP`, `TEMP_DOWN`, `MODE`, `FAN`, `POWER`, `SYNC`.
+- **temperature** (*Optional*, int, [templatable](/automations/templates)): The target temperature (5–35). Defaults to `20`.
+- **temp_tenths** (*Optional*, int, [templatable](/automations/templates)): Tenths of a degree — `0` or `5` (for 0.5 °C steps). Defaults to `0`.
+- **mode** (*Optional*, string, [templatable](/automations/templates)): The operating mode. One of `PROTECTION`, `TIMER`, `COMFORT`. Defaults to `COMFORT`.
+- **fan_mode** (*Optional*, string, [templatable](/automations/templates)): The fan speed. One of `AUTO`, `LOW`, `MEDIUM`, `HIGH`. Defaults to `AUTO`.
+- All other options from [Remote Transmitter Actions](#remote_transmitter-transmit_action).
+
 <span id="remote_transmitter-transmit_haier"></span>
 
 ### `remote_transmitter.transmit_haier` Action


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** ---

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#15154

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
