### PR TITLE
[tuya_fan] Add documentation for preset modes configuration

### DIFF
--- a/src/content/docs/components/fan/tuya.mdx
+++ b/src/content/docs/components/fan/tuya.mdx
@@ -55,12 +55,17 @@ fan:
 - **speed_datapoint** (**Required**, int): The datapoint id number of the fan speed.
 - **switch_datapoint** (**Required**, int): The datapoint id number of the fan switch.
 - **oscillation_datapoint** (*Optional*, int): The datapoint id number of the oscillation
-  switch. Probably not supported on any Tuya controllers currently, but it's there if need be.
+  switch.
 
 - **direction_datapoint** (*Optional*, int): The datapoint id number of the direction
   switch. Supported by some ceiling fans.
 
 - **speed_count** (*Optional*, int): Set the number of supported discrete speed levels. Defaults to `3`.
+- **preset_modes_datapoint** (*Optional*, int): The datapoint id number of the fan preset mode. Some fans support preset modes
+  controlled by the MCU. You must provide a list of `preset_modes` if you set this variable.
+- **preset_modes** (*Optional*): A list of preset modes supported by this fan. The position in the list determines what value
+  is sent to the MCU (the first item sends 0, etc.). You must set the `preset_modes_datapoint` variable if you provide this
+  list.
 - All other options from [Fan](/components/fan#config-fan).
 
 > [!NOTE]


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Update the documentation for the Tuya Fan plaform to include the `preset_modes_datapoint` and `preset_modes` configuration variables.

Also removed the "Probably not supported on any Tuya controllers currently, but it's there if need be." line from the description of the `oscillation_datapoint` configuration variable. There are products on the market that use Tuya MCU and support oscillation.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#15450

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
