### PR TITLE
Document docker secrets option

### DIFF
--- a/src/content/docs/guides/getting_started_command_line.mdx
+++ b/src/content/docs/guides/getting_started_command_line.mdx
@@ -74,6 +74,11 @@ better:
 - `dev` is the bleeding edge release; built daily based on the latest changes
   in the `dev` branch.
 
+> [!TIP]
+> The dashboard credentials can also be passed using docker secrets. See
+> [Secrets Management](/guides/security_best_practices#secrets-management) for
+> more information.
+
 ## Connecting the ESP Device
 
 Follow the instructions in [Physical Device Connection](/guides/physical_device_connection/) to connect to your

--- a/src/content/docs/guides/security_best_practices.mdx
+++ b/src/content/docs/guides/security_best_practices.mdx
@@ -333,7 +333,7 @@ services:
       - PASSWORD_FILE=/run/secrets/my_password
 ```
 
-If credentials are passed using multiples methods, they are applied with the following order of priority:
+If credentials are passed using multiple methods, they are applied with the following order of priority:
 1. `--username`/`--password` flags passed directly to the `esphome` executable
 2. `USERNAME`/`PASSWORD` environment variables
 3. `USERNAME_FILE`/`PASSWORD_FILE` environment variables

--- a/src/content/docs/guides/security_best_practices.mdx
+++ b/src/content/docs/guides/security_best_practices.mdx
@@ -291,6 +291,54 @@ wifi_password: "your-wifi-password"
 
 **Important:** Even when using `secrets.yaml`, **each device must have unique API encryption keys, OTA passwords, and web server credentials**. Never reuse these across devices. Only WiFi credentials can be shared.
 
+### Dashboard Credentials with Docker Secrets
+
+To avoid placing your dashboard credentials in plaintext in a docker compose file, the [Docker Secrets Engine](https://docs.docker.com/compose/how-tos/use-secrets) is supported through the `USERNAME_FILE` and `PASSWORD_FILE` environment variables.
+
+To use secrets files, create a location for your secrets to live alongside your docker compose file. An example file structure might look like:
+```
+esphome
+├── compose.yaml
+├── config
+└── docker_secrets  <--- Name this whatever you want
+    ├── username.txt
+    └── password.txt
+```
+
+**Be sure to exclude the secrets from version control and to set appropriate file permissions** - `600` or similar.
+
+Then, to use the secrets in your docker compose file:
+```yaml
+# Tell docker about your secrets files
+secrets:
+  my_username:
+    file: ./docker_secrets/username.txt
+  my_password:
+    file: ./docker_secrets/password.txt
+
+services:
+  esphome:
+    container_name: esphome
+    image: ghcr.io/esphome/esphome
+
+    # Other configuration...
+
+    # Provide your secrets to the esphome container
+    secrets:
+      - my_username
+      - my_password
+    # Tell the dashboard where to find the secrets
+    environment:
+      - USERNAME_FILE=/run/secrets/my_username
+      - PASSWORD_FILE=/run/secrets/my_password
+```
+
+If credentials are passed using multiples methods, they are applied with the following order of priority:
+1. `--username`/`--password` flags passed directly to the `esphome` executable
+2. `USERNAME`/`PASSWORD` environment variables
+3. `USERNAME_FILE`/`PASSWORD_FILE` environment variables
+4. No credentials
+
 ### Version Control
 
 <details>
@@ -298,9 +346,10 @@ wifi_password: "your-wifi-password"
 
 **Add to `.gitignore`:**
 
-```txt
+```gitignore
 secrets.yaml
 *.backup
+docker_secrets/  # If applicable
 ```
 
 **Verify secrets.yaml is not tracked:**


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#15452

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
