### PR TITLE
[esp8266] Document crash handler

### DIFF
--- a/src/content/docs/components/esp8266.mdx
+++ b/src/content/docs/components/esp8266.mdx
@@ -150,7 +150,6 @@ When a crash occurs, the exception cause, fault PC, and up to 16 stack-scanned r
 preserved across the reboot and logged at the `ERROR` level. The ESPHome CLI automatically decodes
 the addresses to function names.
 
-```text
 [E][esp8266]: *** CRASH DETECTED ON PREVIOUS BOOT ***
 [E][esp8266]:   Reason: Exception - StoreProhibit (exccause=29)
 [E][esp8266]:   PC: 0x40212EC5

--- a/src/content/docs/components/esp8266.mdx
+++ b/src/content/docs/components/esp8266.mdx
@@ -140,6 +140,27 @@ These reset causes [are documented](https://www.espressif.com/sites/default/file
 
 After a software reset, the reset cause will not change.
 
+## Crash Handler
+
+ESPHome automatically captures crash data from the previous boot and logs it on startup. This works
+for all crash types: exceptions (null pointer dereference, illegal instruction), software watchdog
+resets, and hardware watchdog resets.
+
+When a crash occurs, the exception cause, fault PC, and up to 16 stack-scanned return addresses are
+preserved across the reboot and logged at the `ERROR` level. The ESPHome CLI automatically decodes
+the addresses to function names.
+
+```text
+[E][esp8266]: *** CRASH DETECTED ON PREVIOUS BOOT ***
+[E][esp8266]:   Reason: Exception - StoreProhibit (exccause=29)
+[E][esp8266]:   PC: 0x40212EC5
+[E][esp8266]:   BT0: 0x40212F5A
+[E][esp8266]:   BT1: 0x40203B10
+[E][esp8266]:   BT2: 0x40203270
+```
+
+No configuration is needed — the crash handler is always enabled.
+
 ## Electrical Characteristics
 
 | **Parameter**                                      | **Min.**  | **Typical** | **Max.**  | **Unit** |

--- a/src/content/docs/components/esp8266.mdx
+++ b/src/content/docs/components/esp8266.mdx
@@ -120,7 +120,7 @@ There are three boot modes:
 You can identify these on boot-up by looking at the UART output, the first number
 in the `boot mode:` line tells you what mode was selected
 
-```text
+```log
 ets Jan  8 2013,rst cause:4, boot mode:(3,6)
 ```
 

--- a/src/content/docs/components/esp8266.mdx
+++ b/src/content/docs/components/esp8266.mdx
@@ -120,7 +120,7 @@ There are three boot modes:
 You can identify these on boot-up by looking at the UART output, the first number
 in the `boot mode:` line tells you what mode was selected
 
-```log
+```text
 ets Jan  8 2013,rst cause:4, boot mode:(3,6)
 ```
 
@@ -150,6 +150,7 @@ When a crash occurs, the exception cause, fault PC, and up to 16 stack-scanned r
 preserved across the reboot and logged at the `ERROR` level. The ESPHome CLI automatically decodes
 the addresses to function names.
 
+```log
 [E][esp8266]: *** CRASH DETECTED ON PREVIOUS BOOT ***
 [E][esp8266]:   Reason: Exception - StoreProhibit (exccause=29)
 [E][esp8266]:   PC: 0x40212EC5


### PR DESCRIPTION
## Description

Document the new ESP8266 crash handler that captures and logs crash data from previous boots.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#15465

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.