### PR TITLE
[ags10] Document mode and value as templatable

### DIFF
--- a/src/content/docs/components/sensor/ags10.mdx
+++ b/src/content/docs/components/sensor/ags10.mdx
@@ -76,13 +76,13 @@ on_...:
 Configuration option:
 
 - **id** (**Required**, [ID](/guides/configuration-types#id)): The ID of the AGS10 sensor.
-- **mode** (**Required**, enum): One of supported modes:
+- **mode** (**Required**, enum, [templatable](/automations/templates)): One of supported modes:
 
   - `FACTORY_DEFAULT` - reset to the factory zero-point
   - `CURRENT_VALUE` - set zero-point calibration with current resistance
   - `CUSTOM_VALUE` - set zero-point calibration with resistance pointed with `value` option
 
-- **value** (*Optional*, int): nominated resistance value to set (unit: 0.1 kΩ).
+- **value** (*Optional*, int, [templatable](/automations/templates)): nominated resistance value to set (unit: 0.1 kΩ).
 
 <span id="sensor-ags10newi2caddressaction"></span>
 


### PR DESCRIPTION
## Description

Document that `mode` and `value` in the `ags10.set_zero_point` action are templatable (support lambda expressions).

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#15467

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.