### PR TITLE
[ags10] Change tvoc from Optional to Required

### DIFF
--- a/src/content/docs/components/sensor/ags10.mdx
+++ b/src/content/docs/components/sensor/ags10.mdx
@@ -35,7 +35,7 @@ sensor:
 
 ## Configuration variables
 
-- **tvoc** (*Optional*): The information for the total Volatile Organic Compounds sensor.
+- **tvoc** (**Required**): The information for the total Volatile Organic Compounds sensor.
   All options from [Sensor](/components/sensor).
 
 - **address** (*Optional*, int): Manually specify the I²C address of


### PR DESCRIPTION
## Description

Change `tvoc` from Optional to Required in the AGS10 docs to match the code change in the matching esphome PR.

The `to_code` function accesses `config[CONF_TVOC]` unconditionally, so omitting it caused a `KeyError`. An AGS10 sensor without TVOC has no purpose, so it's now Required.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#15474

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.