### PR TITLE
[thermostat] Remove templatable from preset fan_mode, swing_mode, default_preset

### DIFF
--- a/src/content/docs/components/climate/thermostat.mdx
+++ b/src/content/docs/components/climate/thermostat.mdx
@@ -364,7 +364,7 @@ experience and automation.
     - `dry`
     - `fan_only`
     - `auto`
-  - **fan_mode** (*Optional*, climate fan mode, [templatable](/automations/templates)): The fan mode the thermostat should switch to when this preset
+  - **fan_mode** (*Optional*, climate fan mode): The fan mode the thermostat should switch to when this preset
     is activated. If not specified, the thermostat's fan mode will remain unchanged when the preset is activated.
     One of:
 
@@ -378,7 +378,7 @@ experience and automation.
     - `focus`
     - `diffuse`
     - `quiet`
-  - **swing_mode** (*Optional*, climate swing mode, [templatable](/automations/templates)): The fan swing mode the thermostat should switch to when this
+  - **swing_mode** (*Optional*, climate swing mode): The fan swing mode the thermostat should switch to when this
     preset is activated. If not specified, the thermostat's fan swing mode will remain unchanged when the preset
     is activated. One of:
 
@@ -429,7 +429,7 @@ climate:
 
 These configuration items determine default values the thermostat controller should use when it starts.
 
-- **default_preset** (*Optional*, string, [templatable](/automations/templates)): The name of the preset to use by default. Must match a preset
+- **default_preset** (*Optional*, string): The name of the preset to use by default. Must match a preset
   as per [preset](#thermostat-preset).
 
 - **on_boot_restore_from**: (*Optional*, on_boot_restore_from): Controls what the thermostat will do when


### PR DESCRIPTION
## Description

Remove `[templatable](/automations/templates)` annotation from `fan_mode`, `swing_mode`, and `default_preset` in the thermostat preset documentation.

These fields were documented as templatable but lambdas were never actually supported — they crashed at either validation or code generation. The matching esphome PR removes `cv.templatable()` from the schema.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#15481

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.