### PR TITLE
2026.3.3

### DIFF
--- a/data/version.yaml
+++ b/data/version.yaml
@@ -1,2 +1,2 @@
-release: 2026.3.2
+release: 2026.3.3
 version: '2026.3'

--- a/src/content/docs/changelog/2026.3.0.mdx
+++ b/src/content/docs/changelog/2026.3.0.mdx
@@ -552,6 +552,17 @@ For detailed migration guides and API documentation, see the [ESPHome Developers
 
 </details>
 
+## Release 2026.3.3 - April 7
+
+<details>
+<summary></summary>
+
+- [nextion] Fix queue age check using inconsistent time sources [esphome#15317](https://github.com/esphome/esphome/pull/15317) by [@edwardtfn](https://github.com/edwardtfn)
+- [online_image] Clear LVGL dsc when image size changes. [esphome#15360](https://github.com/esphome/esphome/pull/15360) by [@clydebarrow](https://github.com/clydebarrow)
+- [esp32] Clean build when sdkconfig options change [esphome#15439](https://github.com/esphome/esphome/pull/15439) by [@clydebarrow](https://github.com/clydebarrow)
+
+</details>
+
 {/* markdownlint-disable MD013 */}
 
 ## Full list of changes

--- a/src/content/docs/guides/supporters.mdx
+++ b/src/content/docs/guides/supporters.mdx
@@ -440,6 +440,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [cretep (@cretep)](https://github.com/cretep)
 - [CrewMdk (@CrewMdk)](https://github.com/CrewMdk)
 - [Corey Rice (@crice009)](https://github.com/crice009)
+- [Boris Krivonog (@crnjan)](https://github.com/crnjan)
 - [crp500 (@crp500)](https://github.com/crp500)
 - [cryptelli (@cryptelli)](https://github.com/cryptelli)
 - [cryptk (@cryptk)](https://github.com/cryptk)
@@ -1645,6 +1646,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Omar Amin (@omaramin-2000)](https://github.com/omaramin-2000)
 - [Omar Ghader (@omarghader)](https://github.com/omarghader)
 - [Ömer Şiar Baysal (@omersiar)](https://github.com/omersiar)
+- [OmerZ7 (@OmerZ7)](https://github.com/OmerZ7)
 - [Oncleben31 (@oncleben31)](https://github.com/oncleben31)
 - [onde2rock (@onde2rock)](https://github.com/onde2rock)
 - [Onne (@onnlucky)](https://github.com/onnlucky)
@@ -2093,6 +2095,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [TBobsin (@TBobsin)](https://github.com/TBobsin)
 - [TD-er (@TD-er)](https://github.com/TD-er)
 - [Team Super Panda (@teamsuperpanda)](https://github.com/teamsuperpanda)
+- [David Bishop (@teancom)](https://github.com/teancom)
 - [Jake Kromer (@techwithjake)](https://github.com/techwithjake)
 - [teffcz (@teffcz)](https://github.com/teffcz)
 - [tehniemer (@tehniemer)](https://github.com/tehniemer)
@@ -2194,6 +2197,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Teemu Simola (@tpssim)](https://github.com/tpssim)
 - [Manu (@tr4nt0r)](https://github.com/tr4nt0r)
 - [tracestep (@tracestep)](https://github.com/tracestep)
+- [Steve Wavler (@trenchcoatjedi)](https://github.com/trenchcoatjedi)
 - [Trent Houliston (@TrentHouliston)](https://github.com/TrentHouliston)
 - [Trevor Schirmer (@TrevorSchirmer)](https://github.com/TrevorSchirmer)
 - [Trianglesis (@trianglesis)](https://github.com/trianglesis)
@@ -2370,4 +2374,4 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Christian Zufferey (@zuzu59)](https://github.com/zuzu59)
 - [Zynth-dev (@Zynth-dev)](https://github.com/Zynth-dev)
 
-*This page was last updated April 1, 2026.*
+*This page was last updated April 7, 2026.*


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- Update caching headers in netlify.toml for improved performance [docs#6376](https://github.com/esphome/esphome-docs/pull/6376)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
