### PR TITLE
added WeAct-4.2in-bw to supported modules in epaper_spi

### DIFF
--- a/src/content/docs/components/display/epaper_spi.mdx
+++ b/src/content/docs/components/display/epaper_spi.mdx
@@ -49,6 +49,7 @@ the pins used to interface to the display to be specified.
 | WeAct-2.13in-3c     | WeAct        | 2.13" 3-color e-paper (250x122, SSD1683)           |
 | WeAct-2.9in-3c      | WeAct        | 2.9" 3-color e-paper (128x296, SSD1683)           |
 | WeAct-4.2in-3c      | WeAct        | 4.2" 3-color e-paper (400x300, SSD1683)           |
+| WeAct-4.2in-bw      | WeAct        | 4.2" black/white e-paper (400x300, SSD1683)       |
 
 ## Supported integrated display boards
 


### PR DESCRIPTION
## Description

Adds `WeAct-4.2in-bw` to the supported display panels table in the `epaper_spi` component documentation.

The WeAct 4.2" black/white e-paper (400×300, SSD1683) is a new model added to the `epaper_spi` component in the linked code PR.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#15520

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.