### PR TITLE
Document clean-all and update-all CLI commands

### DIFF
--- a/src/content/docs/guides/cli.mdx
+++ b/src/content/docs/guides/cli.mdx
@@ -201,7 +201,7 @@ The `esphome clean <CONFIG>` command cleans all build files and can help with so
 
 ### `clean-all` Command
 
-The `esphome clean-all [CONFIG...]` command cleans all build files, PlatformIO platform and package
+The `esphome clean-all [<CONFIG>...]` command cleans all build files, PlatformIO platform and package
 files, and the PlatformIO core directory. Unlike `clean`, this command does not require a
 configuration file — if none is provided, it will clean the `.esphome` directory in the current
 working directory. Arguments can be YAML configuration files or directories containing them.
@@ -305,7 +305,7 @@ esphome logs my-device.yaml --device 192.168.1.100 --device 2001:db8::1
 
 ### `update-all` Command
 
-The `esphome update-all <CONFIG...>` command compiles and uploads firmware to all devices via OTA.
+The `esphome update-all <CONFIG>...` command compiles and uploads firmware to all devices via OTA.
 Arguments can be YAML configuration files or directories containing them. For each configuration
 found, it runs `esphome run <CONFIG> --no-logs --device OTA` and prints a summary of successes and
 failures at the end.

--- a/src/content/docs/guides/cli.mdx
+++ b/src/content/docs/guides/cli.mdx
@@ -204,7 +204,7 @@ The `esphome clean <CONFIG>` command cleans all build files and can help with so
 The `esphome clean-all [CONFIG...]` command cleans all build files, PlatformIO platform and package
 files, and the PlatformIO core directory. Unlike `clean`, this command does not require a
 configuration file — if none is provided, it will clean the `.esphome` directory in the current
-working directory.
+working directory. Arguments can be YAML configuration files or directories containing them.
 
 Storage files (`.json` files and the `storage` directory inside `.esphome`) are preserved so that
 the dashboard continues to function correctly.
@@ -302,6 +302,13 @@ esphome logs my-device.yaml --device 192.168.1.100 --device 2001:db8::1
 : If set, reset the device before starting the logs. May also be configured with the environment variable
 `ESPHOME_SERIAL_LOGGING_RESET=true`.
 
+
+### `update-all` Command
+
+The `esphome update-all <CONFIG...>` command compiles and uploads firmware to all devices via OTA.
+Arguments can be YAML configuration files or directories containing them. For each configuration
+found, it runs `esphome run <CONFIG> --no-logs --device OTA` and prints a summary of successes and
+failures at the end.
 
 ## Using Bash or ZSH auto-completion
 

--- a/src/content/docs/guides/cli.mdx
+++ b/src/content/docs/guides/cli.mdx
@@ -199,6 +199,16 @@ The `esphome version` command shows the current ESPHome version and exits.
 
 The `esphome clean <CONFIG>` command cleans all build files and can help with some build issues.
 
+### `clean-all` Command
+
+The `esphome clean-all [CONFIG...]` command cleans all build files, PlatformIO platform and package
+files, and the PlatformIO core directory. Unlike `clean`, this command does not require a
+configuration file — if none is provided, it will clean the `.esphome` directory in the current
+working directory.
+
+Storage files (`.json` files and the `storage` directory inside `.esphome`) are preserved so that
+the dashboard continues to function correctly.
+
 ### `dashboard` Command
 
 The `esphome dashboard <CONFIG>` command starts the ESPHome dashboard server for using ESPHome


### PR DESCRIPTION
## Description

Add documentation for the `clean-all` and `update-all` CLI commands to the CLI guide page. Both commands were undocumented.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- N/A

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.