### PR TITLE
Remove doubled 'Overview' TOC sections from pages with manual section set

### DIFF
--- a/src/content/docs/components/camera/index.mdx
+++ b/src/content/docs/components/camera/index.mdx
@@ -14,8 +14,6 @@ standardized interface between camera hardware/software implementations and the 
 > This component cannot be used directly. It serves as the base platform that specific camera
 > implementations (like [Esp32 Camera](/components/esp32_camera/)) build upon.
 
-## Overview
-
 The camera component acts as a foundation for camera integrations, with [Esp32 Camera](/components/esp32_camera/) being the
 first implementation using this framework.
 

--- a/src/content/docs/components/dfplayer.mdx
+++ b/src/content/docs/components/dfplayer.mdx
@@ -20,8 +20,6 @@ allows you to play sound and music stored in an SD card or USB flash drive.
 
 For this component to work you need to have set up a [UART bus](/components/uart) in your configuration.
 
-## Overview
-
 The module can be powered by the 3.3V output of a NodeMCU. For communication you can connect only
 the `tx_pin` of the `uart` bus to the module's `RX` but if you need feedback of playback active
 you will also need to connect the `rx_pin` to the module's `TX`.

--- a/src/content/docs/components/display_menu/graphical_display_menu.mdx
+++ b/src/content/docs/components/display_menu/graphical_display_menu.mdx
@@ -15,8 +15,6 @@ ESPHome node, without the requirement of a network connection.
 
 <Image src="/images/graphical_display_menu.png" width={300} height={111} layout="constrained" alt="" />
 
-## Overview
-
 The component implements the [Display Menu](/components/display_menu#display_menu) component providing
 a hierarchical menu primarily intended to be controlled either by a rotary encoder
 with a button or a five-button joystick controller.

--- a/src/content/docs/components/display_menu/index.mdx
+++ b/src/content/docs/components/display_menu/index.mdx
@@ -15,8 +15,6 @@ and submenus with the ability to change the values and execute commands. The men
 be activated and deactivated on demand, allowing alternating between using the screen for
 the menu and other information.
 
-## Overview
-
 This document describes the configuration and automations common for the components implementing
 this component. At the moment the character based LCD displays are supported using
 the [lcd_menu](/components/display_menu/lcd_menu#lcd_menu) component and an instance of this is used in the configuration

--- a/src/content/docs/components/display_menu/lcd_menu.mdx
+++ b/src/content/docs/components/display_menu/lcd_menu.mdx
@@ -15,8 +15,6 @@ ESPHome node, without the requirement of a network connection.
 
 <Image src="/images/lcd_menu.png" width={300} height={102} layout="constrained" alt="" />
 
-## Overview
-
 The component implements the [Display Menu](/components/display_menu#display_menu) component providing
 a hierarchical menu primarily intended to be controlled either by a rotary encoder
 with a button or a five-button joystick controller.

--- a/src/content/docs/components/pipsolar.mdx
+++ b/src/content/docs/components/pipsolar.mdx
@@ -25,8 +25,6 @@ Once configured, you can use sensors, binary sensors, switches and outputs as de
   height={300}
 />
 
-## Overview
-
 You can connect a wide variety of PV Inverters as long as they provide a serial interface and talk the commands used (at least those you want to use).
 A documentation about the communication protocol mostly supported can be found [here](https://github.com/jblance/mpp-solar/tree/master/docs).
 

--- a/src/content/docs/components/sensor/kuntze.mdx
+++ b/src/content/docs/components/sensor/kuntze.mdx
@@ -20,8 +20,6 @@ Once configured you can use sensors as described below for your projects.
   height={300}
 />
 
-## Overview
-
 Kuntze devices have an RS485 (ModBUS RTU) communication port. Please see the
 Kuntze papers for the pinout of the RS485 connector on your unit. ModBUS line
 has to be terminated properly (with a `120Ω` resistor), and since this is likely

--- a/src/content/docs/guides/yaml.mdx
+++ b/src/content/docs/guides/yaml.mdx
@@ -5,8 +5,6 @@ title: "YAML Configuration in ESPHome"
 
 <span id="yaml-configuration"></span>
 
-## Overview
-
 ESPHome configuration files use YAML, a human-friendly data serialization standard. This page explains both standard
 YAML features and ESPHome-specific extensions.
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

The new site engine generates an "Overview" TOC section for the text block under the page title.
The previous engine didn't do that, and some pages included that as a separate heading.

This produced double "Overview" TOC entries:

<img width="142" height="134" alt="kép" src="https://github.com/user-attachments/assets/e5cb7cf0-1f70-43f3-bf10-0d6d6b5e5dd5" />

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
