### PR TITLE
LVGL cookbook less lambda more condition

### DIFF
--- a/src/content/docs/cookbook/lvgl.mdx
+++ b/src/content/docs/cookbook/lvgl.mdx
@@ -1414,18 +1414,17 @@ text_sensor:
             state:
               checked: !lambda return (x == "on");
               disabled: !lambda return ((x == "unavailable") or (x == "unknown"));
-        - lvgl.label.update:
-            id: lbl_lightbulb
-            text: !lambda |-
-              static char buf[10];
-              std::string icon;
-              if (x == "on") {
-                  icon = "\U000F0335";
-              } else {
-                  icon = "\U000F0336";
-              }
-              snprintf(buf, sizeof(buf), "%s", icon.c_str());
-              return buf;
+        - if:
+            condition:
+              lambda: return (x == "on");
+            then:
+              - lvgl.label.update:
+                  id: lbl_lightbulb
+                  text: "\U000F0335"
+            else:
+              - lvgl.label.update:
+                  id: lbl_lightbulb
+                  text: "\U000F0336"
 
 lvgl:
     ...


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

It's becoming simpler now...

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
