### PR TITLE
Add version badge to navbar linking to latest changelog

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -172,6 +172,7 @@ export default defineConfig({
       components: {
         Footer: "./src/components/Footer.astro",
         Head: "./src/components/Head.astro",
+        SiteTitle: "./src/components/SiteTitle.astro",
       },
       customCss: ["./src/styles/custom.css", "katex/dist/katex.min.css"],
       sidebar: [

--- a/src/components/SiteTitle.astro
+++ b/src/components/SiteTitle.astro
@@ -1,0 +1,108 @@
+---
+import { logos } from 'virtual:starlight/user-images';
+import config from 'virtual:starlight/user-config';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const { siteTitle, siteTitleHref } = Astro.locals.starlightRoute;
+
+// Find the latest changelog version for the badge
+function getLatestVersion() {
+  const changelogDir = path.join(process.cwd(), 'src/content/docs/changelog');
+  try {
+    const files = fs.readdirSync(changelogDir).filter((f: string) => f.endsWith('.mdx'));
+    let latest = { slug: '', sortValue: 0 };
+    for (const f of files) {
+      const match = f.match(/^(\d{4})\.(\d+)\.(\d+)\.mdx$/);
+      if (match) {
+        const [, year, month, patch] = match;
+        const sortValue = parseInt(year) * 10000 + parseInt(month) * 100 + parseInt(patch);
+        if (sortValue > latest.sortValue) {
+          latest = { slug: `${year}.${month}.${patch}`, sortValue };
+        }
+      }
+    }
+    return latest.slug || null;
+  } catch {
+    return null;
+  }
+}
+
+const latestVersion = getLatestVersion();
+---
+
+<a href={siteTitleHref} class="site-title sl-flex">
+	{
+		config.logo && logos.dark && (
+			<>
+				<img
+					class:list={{ 'light:sl-hidden print:hidden': !('src' in config.logo) }}
+					alt={config.logo.alt}
+					src={logos.dark.src}
+					width={logos.dark.width}
+					height={logos.dark.height}
+				/>
+				{!('src' in config.logo) && (
+					<img
+						class="dark:sl-hidden print:block"
+						alt={config.logo.alt}
+						src={logos.light?.src}
+						width={logos.light?.width}
+						height={logos.light?.height}
+					/>
+				)}
+			</>
+		)
+	}
+	<span class:list={{ 'sr-only': config.logo?.replacesTitle }} translate="no">
+		{siteTitle}
+	</span>
+</a>
+{latestVersion && (
+	<a href={`/changelog/${latestVersion}/`} class="version-badge" translate="no">
+		{latestVersion}
+	</a>
+)}
+
+<style>
+	@layer starlight.core {
+		.site-title {
+			align-items: center;
+			gap: var(--sl-nav-gap);
+			font-size: var(--sl-text-h4);
+			font-weight: 600;
+			color: var(--sl-color-text-accent);
+			text-decoration: none;
+			white-space: nowrap;
+			min-width: 0;
+		}
+		span {
+			overflow: hidden;
+		}
+		img {
+			height: calc(var(--sl-nav-height) - 2 * var(--sl-nav-pad-y));
+			width: auto;
+			max-width: 100%;
+			object-fit: contain;
+			object-position: 0 50%;
+		}
+	}
+	.version-badge {
+		display: inline-flex;
+		align-items: center;
+		padding: 0.15em 0.5em;
+		font-size: 0.75rem;
+		font-weight: 600;
+		line-height: 1;
+		color: var(--sl-color-text-accent);
+		background-color: var(--sl-color-accent-low);
+		border-radius: 999px;
+		text-decoration: none;
+		white-space: nowrap;
+		transition: background-color 0.2s;
+	}
+	.version-badge:hover {
+		background-color: var(--sl-color-accent);
+		color: var(--sl-color-black);
+	}
+</style>

--- a/src/components/SiteTitle.astro
+++ b/src/components/SiteTitle.astro
@@ -19,29 +19,21 @@ try {
 
 <Default {...Astro.props}><slot /></Default>
 {latestVersion && (
-  <a href={`/changelog/${latestVersion}/`} class="version-badge" translate="no">
+  <a href={`/changelog/${latestVersion}/`} class="version-badge" title={`ESPHome ${latestVersion}`} translate="no">
     {latestVersion}
   </a>
 )}
 
 <style>
   .version-badge {
-    display: inline-flex;
-    align-items: center;
-    padding: 0.1em 0.45em;
-    margin-left: 0.4em;
+    margin-left: 4px;
     font-size: 0.7rem;
-    font-weight: 500;
-    line-height: 1;
-    color: var(--sl-color-text-accent);
-    background-color: var(--sl-color-accent-low);
-    border-radius: 999px;
+    font-weight: 400;
+    color: var(--sl-color-gray-3);
     text-decoration: none;
     white-space: nowrap;
-    transition: background-color 0.2s;
   }
   .version-badge:hover {
-    background-color: var(--sl-color-accent);
-    color: var(--sl-color-black);
+    color: var(--sl-color-text-accent);
   }
 </style>

--- a/src/components/SiteTitle.astro
+++ b/src/components/SiteTitle.astro
@@ -42,7 +42,7 @@ try {
 <style>
   .version-badge {
     align-self: center;
-    margin-left: 20px;
+    margin-left: 5px;
     padding: 0.1em 0.4em;
     font-size: 0.7rem;
     font-weight: 500;

--- a/src/components/SiteTitle.astro
+++ b/src/components/SiteTitle.astro
@@ -26,14 +26,21 @@ try {
 
 <style>
   .version-badge {
+    align-self: center;
     margin-left: 4px;
+    padding: 0.1em 0.4em;
     font-size: 0.7rem;
-    font-weight: 400;
-    color: var(--sl-color-gray-3);
+    font-weight: 500;
+    line-height: 1;
+    color: var(--sl-color-text-accent);
+    background-color: var(--sl-color-accent-low);
+    border-radius: 999px;
     text-decoration: none;
     white-space: nowrap;
+    transition: background-color 0.2s;
   }
   .version-badge:hover {
-    color: var(--sl-color-text-accent);
+    background-color: var(--sl-color-accent);
+    color: var(--sl-color-black);
   }
 </style>

--- a/src/components/SiteTitle.astro
+++ b/src/components/SiteTitle.astro
@@ -3,37 +3,59 @@ import Default from '@astrojs/starlight/components/SiteTitle.astro';
 import fs from 'node:fs';
 import path from 'node:path';
 
-// Find the latest changelog version at build time
+// Find the latest version at build time.
+// Shows the latest patch version (e.g., 2026.3.3) but links to the base
+// changelog page (2026.3.0), matching how Home Assistant does it.
 const changelogDir = path.join(process.cwd(), 'src/content/docs/changelog');
-let latestVersion = '';
+let displayVersion = '';
+let changelogSlug = '';
 try {
-  let best = 0;
+  let bestFile = 0;
+  let bestFilename = '';
   for (const f of fs.readdirSync(changelogDir)) {
     const m = f.match(/^(\d{4})\.(\d+)\.(\d+)\.mdx$/);
     if (!m) continue;
     const v = parseInt(m[1]) * 10000 + parseInt(m[2]) * 100 + parseInt(m[3]);
-    if (v > best) { best = v; latestVersion = `${m[1]}.${m[2]}.${m[3]}`; }
+    if (v > bestFile) { bestFile = v; bestFilename = f; changelogSlug = `${m[1]}.${m[2]}.${m[3]}`; }
+  }
+  if (bestFilename) {
+    // Scan for patch release headers like "## Release 2026.3.1 - March 23"
+    const content = fs.readFileSync(path.join(changelogDir, bestFilename), 'utf-8');
+    let bestPatch = 0;
+    for (const match of content.matchAll(/^## Release (\d{4}\.\d+\.\d+)/gm)) {
+      const parts = match[1].split('.');
+      const p = parseInt(parts[2]);
+      if (p > bestPatch) { bestPatch = p; displayVersion = match[1]; }
+    }
+    if (!displayVersion) displayVersion = changelogSlug;
   }
 } catch { /* empty changelog dir is fine */ }
 ---
 
 <Default {...Astro.props}><slot /></Default>
-{latestVersion && (
-  <a href={`/changelog/${latestVersion}/`} class="version-badge" title={`ESPHome ${latestVersion}`} translate="no">
-    {latestVersion}
+{displayVersion && (
+  <a href={`/changelog/${changelogSlug}/`} class="version-badge" title={`ESPHome ${displayVersion}`} translate="no">
+    {displayVersion}
   </a>
 )}
 
 <style>
   .version-badge {
+    align-self: center;
     margin-left: 4px;
+    padding: 0.1em 0.4em;
     font-size: 0.7rem;
-    font-weight: 400;
-    color: var(--sl-color-gray-3);
+    font-weight: 500;
+    line-height: 1;
+    color: var(--sl-color-text-accent);
+    background-color: var(--sl-color-accent-low);
+    border-radius: 999px;
     text-decoration: none;
     white-space: nowrap;
+    transition: background-color 0.2s;
   }
   .version-badge:hover {
-    color: var(--sl-color-text-accent);
+    background-color: var(--sl-color-accent);
+    color: var(--sl-color-black);
   }
 </style>

--- a/src/components/SiteTitle.astro
+++ b/src/components/SiteTitle.astro
@@ -1,108 +1,46 @@
 ---
-import { logos } from 'virtual:starlight/user-images';
-import config from 'virtual:starlight/user-config';
+import Default from '@astrojs/starlight/components/SiteTitle.astro';
 import fs from 'node:fs';
 import path from 'node:path';
 
-const { siteTitle, siteTitleHref } = Astro.locals.starlightRoute;
-
-// Find the latest changelog version for the badge
-function getLatestVersion() {
-  const changelogDir = path.join(process.cwd(), 'src/content/docs/changelog');
-  try {
-    const files = fs.readdirSync(changelogDir).filter((f: string) => f.endsWith('.mdx'));
-    let latest = { slug: '', sortValue: 0 };
-    for (const f of files) {
-      const match = f.match(/^(\d{4})\.(\d+)\.(\d+)\.mdx$/);
-      if (match) {
-        const [, year, month, patch] = match;
-        const sortValue = parseInt(year) * 10000 + parseInt(month) * 100 + parseInt(patch);
-        if (sortValue > latest.sortValue) {
-          latest = { slug: `${year}.${month}.${patch}`, sortValue };
-        }
-      }
-    }
-    return latest.slug || null;
-  } catch {
-    return null;
+// Find the latest changelog version at build time
+const changelogDir = path.join(process.cwd(), 'src/content/docs/changelog');
+let latestVersion = '';
+try {
+  let best = 0;
+  for (const f of fs.readdirSync(changelogDir)) {
+    const m = f.match(/^(\d{4})\.(\d+)\.(\d+)\.mdx$/);
+    if (!m) continue;
+    const v = parseInt(m[1]) * 10000 + parseInt(m[2]) * 100 + parseInt(m[3]);
+    if (v > best) { best = v; latestVersion = `${m[1]}.${m[2]}.${m[3]}`; }
   }
-}
-
-const latestVersion = getLatestVersion();
+} catch { /* empty changelog dir is fine */ }
 ---
 
-<a href={siteTitleHref} class="site-title sl-flex">
-	{
-		config.logo && logos.dark && (
-			<>
-				<img
-					class:list={{ 'light:sl-hidden print:hidden': !('src' in config.logo) }}
-					alt={config.logo.alt}
-					src={logos.dark.src}
-					width={logos.dark.width}
-					height={logos.dark.height}
-				/>
-				{!('src' in config.logo) && (
-					<img
-						class="dark:sl-hidden print:block"
-						alt={config.logo.alt}
-						src={logos.light?.src}
-						width={logos.light?.width}
-						height={logos.light?.height}
-					/>
-				)}
-			</>
-		)
-	}
-	<span class:list={{ 'sr-only': config.logo?.replacesTitle }} translate="no">
-		{siteTitle}
-	</span>
-</a>
+<Default {...Astro.props}><slot /></Default>
 {latestVersion && (
-	<a href={`/changelog/${latestVersion}/`} class="version-badge" translate="no">
-		{latestVersion}
-	</a>
+  <a href={`/changelog/${latestVersion}/`} class="version-badge" translate="no">
+    {latestVersion}
+  </a>
 )}
 
 <style>
-	@layer starlight.core {
-		.site-title {
-			align-items: center;
-			gap: var(--sl-nav-gap);
-			font-size: var(--sl-text-h4);
-			font-weight: 600;
-			color: var(--sl-color-text-accent);
-			text-decoration: none;
-			white-space: nowrap;
-			min-width: 0;
-		}
-		span {
-			overflow: hidden;
-		}
-		img {
-			height: calc(var(--sl-nav-height) - 2 * var(--sl-nav-pad-y));
-			width: auto;
-			max-width: 100%;
-			object-fit: contain;
-			object-position: 0 50%;
-		}
-	}
-	.version-badge {
-		display: inline-flex;
-		align-items: center;
-		padding: 0.15em 0.5em;
-		font-size: 0.75rem;
-		font-weight: 600;
-		line-height: 1;
-		color: var(--sl-color-text-accent);
-		background-color: var(--sl-color-accent-low);
-		border-radius: 999px;
-		text-decoration: none;
-		white-space: nowrap;
-		transition: background-color 0.2s;
-	}
-	.version-badge:hover {
-		background-color: var(--sl-color-accent);
-		color: var(--sl-color-black);
-	}
+  .version-badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.15em 0.5em;
+    font-size: 0.75rem;
+    font-weight: 600;
+    line-height: 1;
+    color: var(--sl-color-text-accent);
+    background-color: var(--sl-color-accent-low);
+    border-radius: 999px;
+    text-decoration: none;
+    white-space: nowrap;
+    transition: background-color 0.2s;
+  }
+  .version-badge:hover {
+    background-color: var(--sl-color-accent);
+    color: var(--sl-color-black);
+  }
 </style>

--- a/src/components/SiteTitle.astro
+++ b/src/components/SiteTitle.astro
@@ -26,21 +26,14 @@ try {
 
 <style>
   .version-badge {
-    align-self: center;
     margin-left: 4px;
-    padding: 0.1em 0.4em;
     font-size: 0.7rem;
-    font-weight: 500;
-    line-height: 1;
-    color: var(--sl-color-text-accent);
-    background-color: var(--sl-color-accent-low);
-    border-radius: 999px;
+    font-weight: 400;
+    color: var(--sl-color-gray-3);
     text-decoration: none;
     white-space: nowrap;
-    transition: background-color 0.2s;
   }
   .version-badge:hover {
-    background-color: var(--sl-color-accent);
-    color: var(--sl-color-black);
+    color: var(--sl-color-text-accent);
   }
 </style>

--- a/src/components/SiteTitle.astro
+++ b/src/components/SiteTitle.astro
@@ -42,7 +42,7 @@ try {
 <style>
   .version-badge {
     align-self: center;
-    margin-left: 4px;
+    margin-left: 20px;
     padding: 0.1em 0.4em;
     font-size: 0.7rem;
     font-weight: 500;

--- a/src/components/SiteTitle.astro
+++ b/src/components/SiteTitle.astro
@@ -28,9 +28,10 @@ try {
   .version-badge {
     display: inline-flex;
     align-items: center;
-    padding: 0.15em 0.5em;
-    font-size: 0.75rem;
-    font-weight: 600;
+    padding: 0.1em 0.45em;
+    margin-left: 0.4em;
+    font-size: 0.7rem;
+    font-weight: 500;
     line-height: 1;
     color: var(--sl-color-text-accent);
     background-color: var(--sl-color-accent-low);

--- a/src/components/SiteTitle.astro
+++ b/src/components/SiteTitle.astro
@@ -43,16 +43,17 @@ try {
   .version-badge {
     align-self: center;
     margin-left: 5px;
-    padding: 0.1em 0.4em;
-    font-size: 0.7rem;
+    padding: 0 4px;
+    font-size: 10px;
     font-weight: 500;
-    line-height: 1;
+    line-height: 15px;
+    height: 15px;
+    letter-spacing: 0.4px;
     color: var(--sl-color-text-accent);
     background-color: var(--sl-color-accent-low);
-    border-radius: 999px;
+    border-radius: 4px;
     text-decoration: none;
     white-space: nowrap;
-    transition: background-color 0.2s;
   }
   .version-badge:hover {
     background-color: var(--sl-color-accent);

--- a/src/components/SiteTitle.astro
+++ b/src/components/SiteTitle.astro
@@ -3,33 +3,41 @@ import Default from '@astrojs/starlight/components/SiteTitle.astro';
 import fs from 'node:fs';
 import path from 'node:path';
 
-// Find the latest version at build time.
-// Shows the latest patch version (e.g., 2026.3.3) but links to the base
-// changelog page (2026.3.0), matching how Home Assistant does it.
-const changelogDir = path.join(process.cwd(), 'src/content/docs/changelog');
-let displayVersion = '';
-let changelogSlug = '';
-try {
-  let bestFile = 0;
-  let bestFilename = '';
-  for (const f of fs.readdirSync(changelogDir)) {
-    const m = f.match(/^(\d{4})\.(\d+)\.(\d+)\.mdx$/);
-    if (!m) continue;
-    const v = parseInt(m[1]) * 10000 + parseInt(m[2]) * 100 + parseInt(m[3]);
-    if (v > bestFile) { bestFile = v; bestFilename = f; changelogSlug = `${m[1]}.${m[2]}.${m[3]}`; }
-  }
-  if (bestFilename) {
-    // Scan for patch release headers like "## Release 2026.3.1 - March 23"
-    const content = fs.readFileSync(path.join(changelogDir, bestFilename), 'utf-8');
-    let bestPatch = 0;
-    for (const match of content.matchAll(/^## Release (\d{4}\.\d+\.\d+)/gm)) {
-      const parts = match[1].split('.');
-      const p = parseInt(parts[2]);
-      if (p > bestPatch) { bestPatch = p; displayVersion = match[1]; }
+// Cache the result so the filesystem scan only runs once per build,
+// not once per page render.
+const cache = globalThis as typeof globalThis & { __esphomeVersion?: { display: string; slug: string } };
+if (!cache.__esphomeVersion) {
+  // Find the latest version at build time.
+  // Shows the latest patch version (e.g., 2026.3.3) but links to the base
+  // changelog page (2026.3.0), matching how Home Assistant does it.
+  let display = '';
+  let slug = '';
+  const changelogDir = path.join(process.cwd(), 'src/content/docs/changelog');
+  try {
+    let bestFile = 0;
+    let bestFilename = '';
+    for (const f of fs.readdirSync(changelogDir)) {
+      const m = f.match(/^(\d{4})\.(\d+)\.(\d+)\.mdx$/);
+      if (!m) continue;
+      const v = parseInt(m[1]) * 10000 + parseInt(m[2]) * 100 + parseInt(m[3]);
+      if (v > bestFile) { bestFile = v; bestFilename = f; slug = `${m[1]}.${m[2]}.${m[3]}`; }
     }
-    if (!displayVersion) displayVersion = changelogSlug;
+    if (bestFilename) {
+      const content = fs.readFileSync(path.join(changelogDir, bestFilename), 'utf-8');
+      let bestPatch = 0;
+      for (const match of content.matchAll(/^## Release (\d{4}\.\d+\.\d+)/gm)) {
+        const p = parseInt(match[1].split('.')[2]);
+        if (p > bestPatch) { bestPatch = p; display = match[1]; }
+      }
+      if (!display) display = slug;
+    }
+  } catch (e: unknown) {
+    if (e && typeof e === 'object' && 'code' in e && (e as {code: string}).code !== 'ENOENT') throw e;
   }
-} catch { /* empty changelog dir is fine */ }
+  cache.__esphomeVersion = { display, slug };
+}
+
+const { display: displayVersion, slug: changelogSlug } = cache.__esphomeVersion;
 ---
 
 <Default {...Astro.props}><slot /></Default>


### PR DESCRIPTION
## Description

The current ESPHome version number and changelog are buried in the sidebar under "Changelog" at the bottom right of [esphome.io](https://esphome.io/), making them hard to find. Users have no easy way to see what version is current or quickly access the release notes.

[Home Assistant](https://www.home-assistant.io/) solves this perfectly by displaying the version number right in the navbar header, linking directly to the changelog. This PR brings the same approach to [ESPHome](https://esphome.io/).

A version badge appears next to the ESPHome logo showing the latest patch version (e.g., `2026.3.3`), linking to the base changelog page (`/changelog/2026.3.0/`). The version is auto-detected at build time by scanning changelog files and their patch release headers.

**Deploy previews:**
- Against `current` (shows `2026.3.3`): https://deploy-preview-6422--esphome.netlify.app/
- Against `next` (shows `2026.4.0`): https://deploy-preview-6421--esphome.netlify.app/

**Changes:**
- **`src/components/SiteTitle.astro`**: Wraps Starlight's default SiteTitle and appends a version badge. Scans `## Release YYYY.M.P` headers to find the latest patch version.
- **`astro.config.mjs`**: Register the SiteTitle component override.

Uses Starlight's accent color variables for consistent light/dark theming.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- N/A

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.