### PR TITLE
DNM: Add version badge to navbar linking to latest changelog

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -172,6 +172,7 @@ export default defineConfig({
       components: {
         Footer: "./src/components/Footer.astro",
         Head: "./src/components/Head.astro",
+        SiteTitle: "./src/components/SiteTitle.astro",
       },
       customCss: ["./src/styles/custom.css", "katex/dist/katex.min.css"],
       sidebar: [

--- a/src/components/SiteTitle.astro
+++ b/src/components/SiteTitle.astro
@@ -19,29 +19,21 @@ try {
 
 <Default {...Astro.props}><slot /></Default>
 {latestVersion && (
-  <a href={`/changelog/${latestVersion}/`} class="version-badge" translate="no">
+  <a href={`/changelog/${latestVersion}/`} class="version-badge" title={`ESPHome ${latestVersion}`} translate="no">
     {latestVersion}
   </a>
 )}
 
 <style>
   .version-badge {
-    display: inline-flex;
-    align-items: center;
-    padding: 0.1em 0.45em;
-    margin-left: 0.4em;
+    margin-left: 4px;
     font-size: 0.7rem;
-    font-weight: 500;
-    line-height: 1;
-    color: var(--sl-color-text-accent);
-    background-color: var(--sl-color-accent-low);
-    border-radius: 999px;
+    font-weight: 400;
+    color: var(--sl-color-gray-3);
     text-decoration: none;
     white-space: nowrap;
-    transition: background-color 0.2s;
   }
   .version-badge:hover {
-    background-color: var(--sl-color-accent);
-    color: var(--sl-color-black);
+    color: var(--sl-color-text-accent);
   }
 </style>

--- a/src/components/SiteTitle.astro
+++ b/src/components/SiteTitle.astro
@@ -42,7 +42,7 @@ try {
 <style>
   .version-badge {
     align-self: center;
-    margin-left: 20px;
+    margin-left: 5px;
     padding: 0.1em 0.4em;
     font-size: 0.7rem;
     font-weight: 500;

--- a/src/components/SiteTitle.astro
+++ b/src/components/SiteTitle.astro
@@ -3,24 +3,39 @@ import Default from '@astrojs/starlight/components/SiteTitle.astro';
 import fs from 'node:fs';
 import path from 'node:path';
 
-// Find the latest changelog version at build time
+// Find the latest version at build time.
+// Shows the latest patch version (e.g., 2026.3.3) but links to the base
+// changelog page (2026.3.0), matching how Home Assistant does it.
 const changelogDir = path.join(process.cwd(), 'src/content/docs/changelog');
-let latestVersion = '';
+let displayVersion = '';
+let changelogSlug = '';
 try {
-  let best = 0;
+  let bestFile = 0;
+  let bestFilename = '';
   for (const f of fs.readdirSync(changelogDir)) {
     const m = f.match(/^(\d{4})\.(\d+)\.(\d+)\.mdx$/);
     if (!m) continue;
     const v = parseInt(m[1]) * 10000 + parseInt(m[2]) * 100 + parseInt(m[3]);
-    if (v > best) { best = v; latestVersion = `${m[1]}.${m[2]}.${m[3]}`; }
+    if (v > bestFile) { bestFile = v; bestFilename = f; changelogSlug = `${m[1]}.${m[2]}.${m[3]}`; }
+  }
+  if (bestFilename) {
+    // Scan for patch release headers like "## Release 2026.3.1 - March 23"
+    const content = fs.readFileSync(path.join(changelogDir, bestFilename), 'utf-8');
+    let bestPatch = 0;
+    for (const match of content.matchAll(/^## Release (\d{4}\.\d+\.\d+)/gm)) {
+      const parts = match[1].split('.');
+      const p = parseInt(parts[2]);
+      if (p > bestPatch) { bestPatch = p; displayVersion = match[1]; }
+    }
+    if (!displayVersion) displayVersion = changelogSlug;
   }
 } catch { /* empty changelog dir is fine */ }
 ---
 
 <Default {...Astro.props}><slot /></Default>
-{latestVersion && (
-  <a href={`/changelog/${latestVersion}/`} class="version-badge" title={`ESPHome ${latestVersion}`} translate="no">
-    {latestVersion}
+{displayVersion && (
+  <a href={`/changelog/${changelogSlug}/`} class="version-badge" title={`ESPHome ${displayVersion}`} translate="no">
+    {displayVersion}
   </a>
 )}
 

--- a/src/components/SiteTitle.astro
+++ b/src/components/SiteTitle.astro
@@ -26,14 +26,21 @@ try {
 
 <style>
   .version-badge {
+    align-self: center;
     margin-left: 4px;
+    padding: 0.1em 0.4em;
     font-size: 0.7rem;
-    font-weight: 400;
-    color: var(--sl-color-gray-3);
+    font-weight: 500;
+    line-height: 1;
+    color: var(--sl-color-text-accent);
+    background-color: var(--sl-color-accent-low);
+    border-radius: 999px;
     text-decoration: none;
     white-space: nowrap;
+    transition: background-color 0.2s;
   }
   .version-badge:hover {
-    color: var(--sl-color-text-accent);
+    background-color: var(--sl-color-accent);
+    color: var(--sl-color-black);
   }
 </style>

--- a/src/components/SiteTitle.astro
+++ b/src/components/SiteTitle.astro
@@ -1,0 +1,47 @@
+---
+import Default from '@astrojs/starlight/components/SiteTitle.astro';
+import fs from 'node:fs';
+import path from 'node:path';
+
+// Find the latest changelog version at build time
+const changelogDir = path.join(process.cwd(), 'src/content/docs/changelog');
+let latestVersion = '';
+try {
+  let best = 0;
+  for (const f of fs.readdirSync(changelogDir)) {
+    const m = f.match(/^(\d{4})\.(\d+)\.(\d+)\.mdx$/);
+    if (!m) continue;
+    const v = parseInt(m[1]) * 10000 + parseInt(m[2]) * 100 + parseInt(m[3]);
+    if (v > best) { best = v; latestVersion = `${m[1]}.${m[2]}.${m[3]}`; }
+  }
+} catch { /* empty changelog dir is fine */ }
+---
+
+<Default {...Astro.props}><slot /></Default>
+{latestVersion && (
+  <a href={`/changelog/${latestVersion}/`} class="version-badge" translate="no">
+    {latestVersion}
+  </a>
+)}
+
+<style>
+  .version-badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.1em 0.45em;
+    margin-left: 0.4em;
+    font-size: 0.7rem;
+    font-weight: 500;
+    line-height: 1;
+    color: var(--sl-color-text-accent);
+    background-color: var(--sl-color-accent-low);
+    border-radius: 999px;
+    text-decoration: none;
+    white-space: nowrap;
+    transition: background-color 0.2s;
+  }
+  .version-badge:hover {
+    background-color: var(--sl-color-accent);
+    color: var(--sl-color-black);
+  }
+</style>

--- a/src/components/SiteTitle.astro
+++ b/src/components/SiteTitle.astro
@@ -42,7 +42,7 @@ try {
 <style>
   .version-badge {
     align-self: center;
-    margin-left: 4px;
+    margin-left: 20px;
     padding: 0.1em 0.4em;
     font-size: 0.7rem;
     font-weight: 500;

--- a/src/components/SiteTitle.astro
+++ b/src/components/SiteTitle.astro
@@ -43,16 +43,17 @@ try {
   .version-badge {
     align-self: center;
     margin-left: 5px;
-    padding: 0.1em 0.4em;
-    font-size: 0.7rem;
+    padding: 0 4px;
+    font-size: 10px;
     font-weight: 500;
-    line-height: 1;
+    line-height: 15px;
+    height: 15px;
+    letter-spacing: 0.4px;
     color: var(--sl-color-text-accent);
     background-color: var(--sl-color-accent-low);
-    border-radius: 999px;
+    border-radius: 4px;
     text-decoration: none;
     white-space: nowrap;
-    transition: background-color 0.2s;
   }
   .version-badge:hover {
     background-color: var(--sl-color-accent);


### PR DESCRIPTION
## Description

**Do not merge** - this is a preview PR against `current` to see how the version badge looks on the live site. The real PR is #6421 targeting `next`.

See #6421 for full description.

**Related issue (if applicable):** #6421

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- N/A

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.