### PR TITLE
[zephyr_ble_server] add doc

### DIFF
--- a/src/content/docs/components/index.mdx
+++ b/src/content/docs/components/index.mdx
@@ -124,6 +124,7 @@ ESPHome-specific components or components supporting ESPHome device provisioning
   ["Improv via BLE", "/components/esp32_improv/", "improv.svg", "dark-invert"],
   ["Nordic UART Service (NUS)", "/components/ble_nus/", "bluetooth.svg", "dark-invert"],
   ["RP2040 BLE", "/components/rp2040_ble/", "bluetooth.svg", "dark-invert"],
+  ["Zephyr BLE Server", "/components/zephyr_ble_server/", "bluetooth.svg", "dark-invert"],
 ]} />
 
 ## Management and Monitoring

--- a/src/content/docs/components/zephyr_ble_server.mdx
+++ b/src/content/docs/components/zephyr_ble_server.mdx
@@ -1,0 +1,93 @@
+---
+description: "Zephyr BLE Server"
+title: "Zephyr BLE Server"
+---
+
+The `zephyr_ble_server` component enables a Bluetooth Low Energy GATT server on devices running the
+Zephyr RTOS. It supports secure pairing flows, including the **Numeric Comparison** passkey
+confirmation model defined in the Bluetooth specification.
+
+```yaml
+# Example configuration entry
+zephyr_ble_server:
+  on_numeric_comparison_request:
+    then:
+      - logger.log:
+          format: "Compare this passkey with the one on your BLE device: %06d"
+          args: [passkey]
+      - ble_server.numeric_comparison_reply:
+          accept: true
+```
+
+## Configuration variables
+
+- **on_numeric_comparison_request** (*Optional*, [Automation](/automations)): An automation to
+  compare the passkeys shown on the two BLE devices. See [`on_numeric_comparison_request`](#on_numeric_comparison_request).
+
+## BLE Server Automation
+
+### `on_numeric_comparison_request`
+
+This automation is triggered when a numeric comparison is requested by the BLE device.
+
+```yaml
+zephyr_ble_server:
+  on_numeric_comparison_request:
+    then:
+      - logger.log:
+          format: "Compare this passkey with the one on your BLE device: %06d"
+          args: [passkey]
+      - ble_server.numeric_comparison_reply:
+          accept: true
+```
+
+## `ble_server.numeric_comparison_reply` Action
+
+This action triggers an authentication attempt after a numeric comparison.
+
+Example usage:
+
+```yaml
+on_...:
+  then:
+    - ble_server.numeric_comparison_reply:
+        accept: true
+```
+
+### Configuration variables
+
+- **accept** (**Required**, boolean, [templatable](/automations/templates)): Should be `true` if the
+  passkeys displayed on both BLE devices are matching.
+
+## Passkey examples
+
+Secure connection with numeric comparison accepted automatically:
+
+```yaml
+zephyr_ble_server:
+  on_numeric_comparison_request:
+    then:
+      - logger.log:
+          format: "Compare this passkey with the one on your BLE device: %06d"
+          args: [passkey]
+      - ble_server.numeric_comparison_reply:
+          accept: true
+```
+
+Secure connection with numeric comparison accepted via a lambda:
+
+```yaml
+zephyr_ble_server:
+  on_numeric_comparison_request:
+    then:
+      - logger.log:
+          format: "Compare this passkey with the one on your BLE device: %06d"
+          args: [passkey]
+      - ble_server.numeric_comparison_reply:
+          accept: !lambda "return true;"
+```
+
+## See Also
+
+- [BLE Client](/components/ble_client)
+- [Automations](/automations)


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- https://github.com/esphome/esphome/pull/14400

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [x] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
