### PR TITLE
[lvgl] Add notes about rotation impact on touchscreen config

### DIFF
--- a/src/content/docs/changelog/2026.4.0.mdx
+++ b/src/content/docs/changelog/2026.4.0.mdx
@@ -29,7 +29,7 @@ ESPHome 2026.4.0 delivers major performance and reliability improvements across 
 ## Upgrade Checklist
 
 {/* UPGRADE_CHECKLIST_START */}
-- If you use LVGL with `rotation` configured on the display component, move the `rotation` setting to the `lvgl:` block instead
+- If you use LVGL with `rotation` configured on the display component, move the `rotation` setting to the `lvgl:` block, and remove touchscreen `transform:`.
 - If you use the `i2s_audio` media player, migrate to the `speaker` media player component (the `i2s_audio` media player has been removed)
 - If you use `use_legacy` in your `i2s_audio` config, remove it (the legacy I2S driver has been removed)
 - If you have battery-powered ESP32/S2/S3/C5 devices, add `cpu_frequency: 160MHZ` to your config (the default is now 240MHz)
@@ -316,7 +316,10 @@ Led by [@clydebarrow](https://github.com/clydebarrow) with 27 PRs, ESPHome's LVG
 
 **Key changes:**
 
-- **Native rotation with hardware acceleration** - Rotation is now handled directly by LVGL instead of the display driver, with runtime rotation changes via `lvgl.display.set_rotation` and automatic use of hardware rotation when available. On ESP32-P4, rotation uses the PPA (Pixel Processing Accelerator) for zero-CPU-cost transforms ([#14955](https://github.com/esphome/esphome/pull/14955), [#15453](https://github.com/esphome/esphome/pull/15453)). Users will need to move their `rotation` config from the display component to the `lvgl:` block.
+- **Native rotation with hardware acceleration** - Rotation is now handled directly by [LVGL](/components/lvgl) instead of the display driver, with runtime rotation changes via `lvgl.display.set_rotation` and automatic use of hardware rotation when available.
+  On ESP32-P4, rotation uses the PPA (Pixel Processing Accelerator) for zero-CPU-cost transforms ([#14955](https://github.com/esphome/esphome/pull/14955), [#15453](https://github.com/esphome/esphome/pull/15453)).
+- **Automatic touchscreen rotation** - Touch input is automatically rotated to match display orientation, eliminating the need for manual coordinate transforms in most cases.
+  Users will need to move their `rotation` config from the display component to the `lvgl:` block, and remove or adjust the `transform:` block in the touchscreen component.
 - **Built-in dark theme** - A single `dark_mode: true` under `theme:` enables LVGL's native dark default theme, replacing the tedious process of manually replicating dark theme properties ([#15389](https://github.com/esphome/esphome/pull/15389))
 - **All LVGL 9 events** - Complete mapping of LVGL 9 events to ESPHome automation triggers ([#15362](https://github.com/esphome/esphome/pull/15362))
 - **Drop shadow support** - New `bitmap_mask_src` style property and A8 image format for drop shadow effects ([#15334](https://github.com/esphome/esphome/pull/15334))
@@ -412,7 +415,8 @@ Also thank you to [@bdraco](https://github.com/bdraco), [@thomwiggers](https://g
 
 ### Component Changes
 
-- **LVGL rotation**: The `rotation` option must now be configured under `lvgl:` instead of the display component. LVGL now handles rotation directly, with support for runtime rotation changes via `lvgl.display.set_rotation`. Users must move their `rotation` setting from the display config to the `lvgl:` block. [#14955](https://github.com/esphome/esphome/pull/14955)
+- **LVGL rotation**: The `rotation` option must now be configured under `lvgl:` instead of the display component. LVGL now handles rotation for the display and touchscreen directly, with support for runtime rotation changes via `lvgl.display.set_rotation`.
+  Users must move their `rotation` setting from the display config to the `lvgl:` block. [#14955](https://github.com/esphome/esphome/pull/14955) and remove or adjust the `transform:` block in their touchscreen config if they have one.
 
 - **I2S Audio**: The legacy I2S driver (`use_legacy` option) has been removed. The new I2S driver is always used. The `i2s_audio` media player sub-component has been removed entirely; users should migrate to the [speaker media player](/components/media_player/speaker) component. [#14932](https://github.com/esphome/esphome/pull/14932)
 

--- a/src/content/docs/components/lvgl/index.mdx
+++ b/src/content/docs/components/lvgl/index.mdx
@@ -231,12 +231,12 @@ lvgl:
 
 The `rotation` option allows you to rotate the display content by a specified angle. Valid values are `0`, `90`, `180` and `270`. Defaults to `0`.
 Using this in the LVGL configuration will automatically adjust both the display and touch input (if a touchscreen is configured) to the specified rotation.
-When using this the display configuration should not include a rotation option (it will be ignored if it does), and the touchscreen configuration should not
+When using this the display configuration should not include a rotation option and the touchscreen configuration should not
 transform the touchscreen unless required (for example if the touchscreen axes don't match the display.)
 
 If the display driver can rotate the display content in hardware, (for example, most `mipi_spi` display models can do this)
 LVGL will automatically use this to improve performance. If not, the rotation will be performed in software by LVGL,
-which will reduce performance.
+which will reduce performance. On ESP32P4 the software rotation is hardware accelerated using the PPA peripheral.
 
 Touchscreen coordinates will be automatically rotated when using LVGL rotation.
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
