### PR TITLE
added time_based_valve

### DIFF
--- a/src/content/docs/components/index.mdx
+++ b/src/content/docs/components/index.mdx
@@ -1073,6 +1073,7 @@ Used for creating infrared (IR) remote control transmitters and/or receivers.
 <ImgTable items={[
   ["Valve Core", "/components/valve/", "folder-open.svg", "dark-invert"],
   ["Template Valve", "/components/valve/template/", "description.svg", "dark-invert"],
+  ["Time-Based Valve", "/components/valve/time_based/", "timer.svg", "dark-invert"],
 ]} />
 
 ## Water Heater Components

--- a/src/content/docs/components/valve/time_based.mdx
+++ b/src/content/docs/components/valve/time_based.mdx
@@ -1,0 +1,75 @@
+---
+description: "Instructions for setting up time-based valves in ESPHome."
+title: "Time Based Valve"
+---
+
+import APIRef from '@components/APIRef.astro';
+
+The `time_based` valve platform allows you to create valves with position control that do not
+have any position feedback. The state of the valve is always an assumed one - the current
+position is approximated with the time the valve has been moving.
+
+The valve learns its endstops over time by tracking the measured position during each operation.
+Full position range (0.0 to 1.0) becomes available after the valve has traveled its full
+duration in either direction. Until then the position is clamped (0.01 to 0.99) to ensure the endstops will be reached.
+
+## Example Configuration
+
+```yaml
+valve:
+  - platform: time_based
+    name: "Time-Based Valve"
+    duration: 10s
+    open_action:
+      - switch.turn_on: open_valve_switch
+    close_action:
+      - switch.turn_on: close_valve_switch
+    stop_action:
+      - switch.turn_off: open_valve_switch
+      - switch.turn_off: close_valve_switch
+```
+
+## Configuration variables
+
+- **open_action** (**Required**, [Action](/automations/actions#all-actions)): The action that should
+  be performed when the valve is commanded to open.
+
+- **close_action** (**Required**, [Action](/automations/actions#all-actions)): The action that should
+  be performed when the valve is commanded to close.
+
+- **stop_action** (**Required**, [Action](/automations/actions#all-actions)): The action that should
+  be performed when the valve is commanded to stop.
+
+- **duration** (**Required**, [Time](/guides/configuration-types#time)): The time it takes for the valve
+  to travel from fully closed to fully open (or vice versa).
+
+- **restore_mode** (*Optional*, enum): Control how the valve attempts to restore state on bootup.
+  Defaults to `NO_RESTORE`.
+
+  - `NO_RESTORE` - Do not save or restore state.
+  - `RESTORE` - Attempts to restore the state on startup. The valve position is clamped to 0.01-0.99
+    until endstops are learned.
+  - `ALWAYS_OPEN` - Fully open on start.
+  - `ALWAYS_CLOSED` - Fully close on start.
+
+- All other options from [Valve](/components/valve#config-valve).
+
+## Lambda Functions
+
+From [lambdas](/automations/templates#config-lambda), you can access the current state of the valve:
+
+- `is_endstop_reached()`: Returns `true` if the valve has traveled its full duration in either
+  direction and now knows its complete position range. Before this is true, every `position` value 0.0 > x > 1.0 is assumed.
+
+```yaml
+// Example: Check if endstops are learned
+if (id(my_valve).is_endstop_reached()) {
+  // Valve knows its complete position range (0.0 to 1.0)
+}
+```
+
+## See Also
+
+- [Valve Component](/components/valve/)
+- [Automation](/automations)
+- <APIRef text="time_based_valve.h" path="time_based/time_based_valve.h" />


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#15604

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [x] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
