### PR TITLE
Add microFLAC audio decoding to 2026.4.0 release notes

### DIFF
--- a/src/content/docs/changelog/2026.4.0.mdx
+++ b/src/content/docs/changelog/2026.4.0.mdx
@@ -349,6 +349,7 @@ This release adds support for several new sensors and hardware platforms:
 - **TM1637 buffer manipulation** - `set_buffer` method for raw segment writes and custom glyphs ([#13686](https://github.com/esphome/esphome/pull/13686))
 - **HUB75 scan wiring** - New `SCAN_1_8_32PX_FULL` wiring option ([#15130](https://github.com/esphome/esphome/pull/15130))
 - **`*/N` cron syntax** - Time-based automations now support `*/5` style step expressions ([#15434](https://github.com/esphome/esphome/pull/15434))
+- **microFLAC audio decoding** by [@kahrendt](https://github.com/kahrendt) - New FLAC decoder is **9% faster** on ESP32-S3 with CRC validation re-enabled, plus true streaming support that eliminates unnecessary memory copies ([#15372](https://github.com/esphome/esphome/pull/15372))
 
 ## Mitsubishi CN105 Climate Component
 


### PR DESCRIPTION
## Description

Add the microFLAC FLAC decoder (#15372) by @kahrendt to the Other Notable Features section of the 2026.4.0 release notes. This was reported as a noticeable improvement by beta testers but was missed because it was tagged `code-quality` rather than `new-feature`.

9% faster FLAC decoding on ESP32-S3 with CRC validation re-enabled, plus true streaming support.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#15372

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.