### PR TITLE
[pca6416a] Add interrupt_pin documentation

### DIFF
--- a/src/content/docs/components/pca6416a.mdx
+++ b/src/content/docs/components/pca6416a.mdx
@@ -34,6 +34,7 @@ GPIO pin and can therefore be used with many of ESPHome's components such as the
 pca6416a:
   - id: 'pca6416a_device'
     address: 0x20
+    interrupt_pin: GPIOXX
 
 # Individual outputs
 switch:
@@ -75,6 +76,11 @@ switch:
 - **id** (**Required**, [ID](/guides/configuration-types#id)): The id to use for this `pca6416a` component.
 - **address** (*Optional*, int): The I²C address of the driver.
   Defaults to `0x20`.
+- **interrupt_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The pin connected to the
+  INT output of the PCA6416A/PCAL6416A. When configured, the component becomes interrupt-driven instead of
+  polling — it only reads the chip when a pin actually changes state, significantly reducing I²C bus traffic
+  and CPU usage. The INT pin is active-low and open-drain, so an external or internal pull-up resistor is
+  required. Must be an internal GPIO pin (not another expander pin).
 
 ## Pin configuration variables
 


### PR DESCRIPTION
## Description

Document the new `interrupt_pin` configuration option for the PCA6416A/PCAL6416A GPIO expander.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#15614

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.