### PR TITLE
[mcp23016] Add interrupt_pin documentation

### DIFF
--- a/src/content/docs/components/mcp230xx.mdx
+++ b/src/content/docs/components/mcp230xx.mdx
@@ -91,6 +91,7 @@ has 16 GPIOs and can be configured the same way than the other variants.
 mcp23016:
   - id: 'mcp23016_hub'
     address: 0x20
+    interrupt_pin: GPIOXX
 
 # Individual outputs
 switch:
@@ -122,6 +123,11 @@ binary_sensor:
 - **id** (**Required**, [ID](/guides/configuration-types#id)): The id to use for this MCP23016 component.
 - **address** (*Optional*, int): The I²C address of the driver.
   Defaults to `0x20`.
+- **interrupt_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The pin connected to the
+  INT output of the MCP23016. When configured, the component becomes interrupt-driven instead of
+  polling — it only reads the chip when a pin actually changes state, significantly reducing I²C bus traffic
+  and CPU usage. The INT pin is active-low and open-drain, so an external or internal pull-up resistor is
+  required. Must be an internal GPIO pin (not another expander pin).
 
 ### Pin configuration variables
 


### PR DESCRIPTION
## Description

Document the new `interrupt_pin` configuration option for the MCP23016 GPIO expander.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#15616

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.