### PR TITLE
Update FAQ with additional device reset instructions

### DIFF
--- a/src/content/docs/guides/faq.mdx
+++ b/src/content/docs/guides/faq.mdx
@@ -182,6 +182,7 @@ If you're just seeing `Connecting....____....` on the screen and installation ("
 - Some devices may require you to keep `GPIO0` and `GND` connected at least until flashing has begun.
 - Some devices may require you to power-cycle them to restart programming mode after erasing flash; they won't
   auto-reset.
+- Some devices may require you to double-click the RST or reset button.  Connecting RST to GND, disconnecting, then reconnecting quickly and disconnecting may also work.
 
 - Last but not least, this could be a sign that your microcontroller is defective, damaged or otherwise cannot be
   programmed. :(


### PR DESCRIPTION
Clarify instructions for devices requiring reset during programming.  This just worked fro my WEMOS D1 MINI and my MINI D1 W32 WROOM-32.

<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
