### PR TITLE
Documentation for new PTE font engine

### DIFF
--- a/src/content/docs/components/display/index.mdx
+++ b/src/content/docs/components/display/index.mdx
@@ -221,6 +221,23 @@ display:
       it.print(0, 10, id(my_font), "Hello World!");
 ```
 
+If the font is configured with `engine: pte`, choose the size at draw time with `pte_font(...)` instead of creating one font entry per size.
+
+```yaml
+font:
+  - id: ui_font
+    file: "fonts/Monocraft.ttf"
+    engine: pte
+
+display:
+  - platform: ...
+    lambda: |-
+      it.print(0, 0, pte_font(ui_font, 18), "Small text");
+      it.print(0, 24, pte_font(ui_font, 28), "Large text");
+```
+
+Passing `id(ui_font)` without `pte_font(...)` is still valid and uses the default PTE size of `20` pixels.
+
 By default, ESPHome will *align* the text at the top left. That means if you enter the coordinates
 `[0,10]` for your text, the top left of the text will be at `[0,10]`. If you want to draw some
 text at the right side of the display, it is however sometimes useful to choose a different **text alignment**.
@@ -556,6 +573,15 @@ on_...:
 >       - display.page.show_next: my_display
 >       - component.update: my_display
 > ```
+
+The same pattern works for PTE fonts too:
+
+```yaml
+display:
+  - platform: ...
+    lambda: |-
+      it.printf(0, 0, pte_font(ui_font, 20), "The sensor value is: %.1f", id(my_sensor).state);
+```
 
 <span id="display-is_displaying_page-condition"></span>
 

--- a/src/content/docs/components/display_menu/graphical_display_menu.mdx
+++ b/src/content/docs/components/display_menu/graphical_display_menu.mdx
@@ -42,7 +42,7 @@ Configuration variables:
 - **display** (*Optional*, [ID](/guides/configuration-types#id)): ID of the display to render to. See
   [Drawing Modes](#drawing_modes) for more details
 
-- **font** (**Required**, [Font](/components/font#display-fonts)): Specifies the font to use
+- **font** (**Required**, [Font](/components/font#display-fonts)): Specifies the font to use. This can be a plain font ID, a mapping with `font:` and `size:`, or the shorthand string `pte_font(font_id, size)`.
 - **foreground_color** (*Optional*, [Color](/components/display#config-color)): Specifies the foreground color to use.
   Defaults to COLOR_ON
 
@@ -56,6 +56,20 @@ Automations:
   For example E-Ink displays that are used with `display_interval: never`.
 
 Additional configuration is described in the [Display Menu](/components/display_menu#display_menu) component.
+
+For example, a menu backed by a PTE font can choose its render size directly in the menu configuration:
+
+```yaml
+font:
+  - id: ui_font
+    file: "fonts/Roboto-Regular.ttf"
+    engine: pte
+
+graphical_display_menu:
+  id: my_graphical_display_menu
+  display: my_display_component
+  font: pte_font(ui_font, 18)
+```
 
 <span id="drawing_modes"></span>
 

--- a/src/content/docs/components/font.mdx
+++ b/src/content/docs/components/font.mdx
@@ -10,7 +10,7 @@ import APIRef from '@components/APIRef.astro';
 
 <span id="display-fonts"></span>
 
-ESPHome's graphical rendering engine also has a powerful font drawer which integrates seamlessly into the system. You have the option to use **any** OpenType/TrueType (`.ttf`, `.otf`, `.woff`  ) font file at **any** size, as well as fixed-size [PCF](https://en.wikipedia.org/wiki/Portable_Compiled_Format) and [BDF](https://en.wikipedia.org/wiki/Glyph_Bitmap_Distribution_Format) bitmap fonts.
+ESPHome's graphical rendering engine also has a powerful font drawer which integrates seamlessly into the system. By default it generates bitmap fonts at build time from **any** OpenType/TrueType (`.ttf`, `.otf`, `.woff`  ) file, and it can also use fixed-size [PCF](https://en.wikipedia.org/wiki/Portable_Compiled_Format) and [BDF](https://en.wikipedia.org/wiki/Glyph_Bitmap_Distribution_Format) bitmap fonts. Scalable OpenType/TrueType fonts can also be configured with the `pte` engine when you want to pick the render size later at runtime.
 
 These fonts can be used in ESPHome's [own rendering engine](/components/display#display-engine) or in the [LVGL Graphics](/components/lvgl/) component.
 
@@ -94,8 +94,115 @@ font:
     id: web_font2
     size: 24
 
+  - file: "fonts/Monocraft.ttf"
+    id: ui_font
+    engine: pte
+    glyphs: "Helo, Wrd!0123456789"
+
 display:
   # ...
+```
+
+## Portable Type Engine
+
+The `pte` font engine keeps a font definition unsized and renders it later at the size you request. Use it when one scalable font needs to be reused across different sizes in display lambdas, LVGL widgets, graph legends, or graphical display menus.
+
+Example configuration:
+
+```yaml
+font:
+  - id: ui_font
+    file: "fonts/Roboto-Regular.ttf"
+    engine: pte
+    glyphsets:
+      - GF_Latin_Kernel
+```
+
+Current `pte` requirements and restrictions:
+
+- The source font must be scalable, such as TTF, OTF, or WOFF.
+- `size:` is not allowed on the font definition.
+- `bpp:` is not allowed.
+- `extras:` is not supported.
+- If you omit both `glyphs:` and `glyphsets:`, ESPHome falls back to its built-in default glyph string instead of `GF_Latin_Kernel`.
+
+For explicit glyph coverage, prefer declaring either `glyphs:` or `glyphsets:`. Characters listed in `glyphs:` must exist in the source font or validation fails. Characters that come only from `glyphsets:` generate warnings when missing unless `ignore_missing_glyphs: true` is set.
+
+### PTE In Display Lambdas
+
+Use `pte_font(font_id, size)` when you want a specific render size inside a display lambda. The helper returns a normal font reference, so the existing `print`, `printf`, `strftime`, and `get_text_bounds` call shapes stay the same.
+
+```yaml
+font:
+  - id: ui_font
+    file: "fonts/Monocraft.ttf"
+    engine: pte
+
+display:
+  - platform: sdl
+    lambda: |-
+      it.print(0, 0, pte_font(ui_font, 18), "Small text");
+      it.printf(0, 24, pte_font(ui_font, 24), "Temp: %.1f C", id(room_temp).state);
+      it.strftime(0, 56, pte_font(ui_font, 32), "%H:%M", id(home_time).now());
+```
+
+If you pass only the bare font reference, ESPHome uses the PTE default render size of `20` pixels.
+
+```yaml
+display:
+  - platform: sdl
+    lambda: |-
+      it.print(0, 0, id(ui_font), "Uses the default PTE size");
+```
+
+### PTE In LVGL
+
+For LVGL, keep the font definition unsized and set the size where the text is used with `text_size:`.
+
+```yaml
+font:
+  - id: ui_font
+    file: "fonts/NotoSans-Regular.ttf"
+    engine: pte
+
+lvgl:
+  widgets:
+    - label:
+        text: Hello
+        text_font: ui_font
+        text_size: 14
+```
+
+This also works in styles and themes. If `text_size:` is omitted, LVGL uses the PTE default render size of `20` pixels.
+
+### PTE In YAML Font References
+
+Graph legends and graphical display menus now accept sized font references. You can use any of these forms:
+
+- A plain font ID such as `ui_font`
+- A mapping with `font:` and `size:`
+- The shorthand string `pte_font(ui_font, 18)`
+
+Examples:
+
+```yaml
+graph:
+  - id: room_graph
+    duration: 1h
+    width: 128
+    height: 64
+    traces:
+      - sensor: room_temp
+    legend:
+      - name_font:
+          font: ui_font
+          size: 14
+        value_font: pte_font(ui_font, 12)
+
+graphical_display_menu:
+  id: main_menu
+  display: my_display
+  font: pte_font(ui_font, 18)
 ```
 
 ## Font metrics
@@ -185,12 +292,14 @@ it.horizontal_line(0, height, it.get_width());
 - **id** (**Required**, [ID](/guides/configuration-types#id)): The ID with which you will be able to reference the font later
   in your display code.
 
+- **engine** (*Optional*, string): Rendering engine to use. Can be `bitmap` or `pte`. Defaults to `bitmap`.
+
 - **size** (*Optional*, int): The desired size of the font. This will be the size (height) of the font in pixels
   when rendered. If you want to use the same font in different sizes, create two font objects.
-  Defaults to `20` for scalable fonts and the first available size for bitmap fonts. Requesting a size that is not available in a bitmap-only font will result in an error.
+  Defaults to `20` for scalable fonts and the first available size for bitmap fonts. Requesting a size that is not available in a bitmap-only font will result in an error. This option is only valid with the `bitmap` engine.
 
 - **bpp** (*Optional*, int): The bit depth of the rendered font from OpenType/TrueType, for anti-aliasing. Can be `1`, `2`, `4`, `8`. Defaults to `1`.
-  If set to 1 and the font has a bitmap version available at the requested size, that will be used. Otherwise the font will be rendered from the vector representation.
+  If set to 1 and the font has a bitmap version available at the requested size, that will be used. Otherwise the font will be rendered from the vector representation. This option is only valid with the `bitmap` engine.
 
 - **glyphsets** (*Optional*, list): A list of glyphsets you plan to use. Defaults to
   `GF_Latin_Kernel`, which contains the basic characters and necessary punctuation and symbols for
@@ -201,7 +310,7 @@ it.horizontal_line(0, height, it.get_width());
   See the [Google Fonts Glyphset documentation](https://github.com/googlefonts/glyphsets/blob/main/GLYPHSETS.md)
   for an extensive list of all possible sets, along with their names and the languages supported by
   each of those sets. Note that `GF_Latin_Kernel` may need to be included for glyphs for basic
-  characters such as numbers (0-9) and whitespace to be present.
+  characters such as numbers (0-9) and whitespace to be present. For the `pte` engine, omitting both `glyphs:` and `glyphsets:` uses ESPHome's built-in default glyph string instead.
 
 - **glyphs** (*Optional*, list): A list of characters you plan to use, in addition to the characters
   defined by the **glyphsets** option above. Adjust this list if you need some special characters or
@@ -215,7 +324,7 @@ it.horizontal_line(0, height, it.get_width());
   (specified via the **glyphs** option) will always be treated as an error and will not be influenced
   by this setting.
 
-- **extras** (*Optional*, enum): A list of font glyph configurations you'd like to include within this font, from other OpenType/TrueType files (eg. icons from other font, but at the same size as the main font):
+- **extras** (*Optional*, enum): A list of font glyph configurations you'd like to include within this font, from other OpenType/TrueType files (eg. icons from other font, but at the same size as the main font). This option is only valid with the `bitmap` engine:
 
   - **file** (**Required**, string): The path of the font file with the extra glyphs.
   - **glyphs** (**Required**, list): A list of glyphs you want to include. Can't repeat the same glyph codepoint if it was declared in the level above.

--- a/src/content/docs/components/graph.mdx
+++ b/src/content/docs/components/graph.mdx
@@ -78,8 +78,8 @@ Trace specific fields:
 
 The legend displays trace names, current values, units, and line style samples. Only one legend per graph is supported.
 
-- **name_font** (**Required**, [Font](/components/font#display-fonts)): Font used for trace names.
-- **value_font** (*Optional*, [Font](/components/font#display-fonts)): Font used for current values. If not specified, values are not displayed.
+- **name_font** (**Required**, [Font](/components/font#display-fonts)): Font used for trace names. This can be a plain font ID, a mapping with `font:` and `size:`, or the shorthand string `pte_font(font_id, size)`.
+- **value_font** (*Optional*, [Font](/components/font#display-fonts)): Font used for current values. If not specified, values are not displayed. This can be a plain font ID, a mapping with `font:` and `size:`, or the shorthand string `pte_font(font_id, size)`.
 - **width** (*Optional*, int): Legend width in pixels. If not specified, width is automatically calculated.
 - **height** (*Optional*, int): Legend height in pixels. If not specified, height is automatically calculated.
 - **border** (*Optional*, boolean): Draw a border around the legend. Defaults to `true`.

--- a/src/content/docs/components/lvgl/index.mdx
+++ b/src/content/docs/components/lvgl/index.mdx
@@ -269,6 +269,24 @@ You can use [fonts configured normally](/components/font#display-fonts), the gly
 > [!TIP]
 > For best results, set `bpp: 4` to get the glyphs rendered with proper anti-aliasing.
 
+Fonts configured with `engine: pte` stay unsized at definition time. For those fonts, set `text_font:` to the font ID and set `text_size:` on the widget, style, or theme entry where the text is rendered.
+
+```yaml
+font:
+  - id: ui_font
+    file: "fonts/NotoSans-Regular.ttf"
+    engine: pte
+
+lvgl:
+  widgets:
+    - label:
+        text: Hello
+        text_font: ui_font
+        text_size: 14
+```
+
+If `text_size:` is omitted, LVGL uses the PTE default size of `20` pixels.
+
 Check out [MDI icons in text](/cookbook/lvgl#lvgl-cookbook-icontext), [Toggle state icon button](/cookbook/lvgl#lvgl-cookbook-iconstat) and [Battery status icon](/cookbook/lvgl#lvgl-cookbook-iconbatt) in the Cookbook for examples which demonstrate how to use icons and text with TrueType/OpenType fonts.
 
 #### Library fonts

--- a/src/content/docs/guides/installing_esphome.mdx
+++ b/src/content/docs/guides/installing_esphome.mdx
@@ -6,13 +6,35 @@ title: "Installing ESPHome Manually"
 import { Image } from 'astro:assets';
 import pythonWinInstallerImg from './images/python-win-installer.png';
 
-> [!WARNING]
-> **Python 3.14 is not yet supported.** Please use Python 3.11, 3.12, or 3.13.
-> Python 3.14 introduced breaking changes that ESPHome's dependencies have not yet adapted to.
+## Cross-platform using uv
+
+[uv](https://docs.astral.sh/uv/) is a fast Python package and project manager.
+
+It offers a simple way to install and run ESPHome on Windows, macOS, and Linux.
+
+If you don't have Python installed, uv offers an easy way to [install and manage Python versions](https://docs.astral.sh/uv/guides/install-python/).
+
+Using uv, you can install esphome as a [tool](https://docs.astral.sh/uv/guides/tools/) with the following command:
+
+```shell
+uv tool install esphome --with wheel,pip
+```
+
+Now *esphome* will be available on your `PATH`:
+
+```shell
+esphome version
+```
+
+Upgrade to the latest version using `uv tool upgrade esphome`.
 
 ## Windows
 
 Download Python from [the official site](https://www.python.org/downloads/). Use Python 3.11, 3.12, or 3.13.
+
+> [!WARNING]
+> **Python 3.14 is not yet supported on Windows.** Please use Python 3.11, 3.12, or 3.13.
+> Python 3.14 introduced breaking changes that some of ESPHome's Windows dependencies have not yet adapted to.
 
 <Image src={pythonWinInstallerImg} layout="constrained" alt={"Python installer window with arrows pointing to \"Add Python to PATH\" and \"Install Now\""} />
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#15643

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
