### PR TITLE
add docs for 4gray image and waveshare eink config

### DIFF
--- a/src/content/docs/components/display/waveshare_epaper.mdx
+++ b/src/content/docs/components/display/waveshare_epaper.mdx
@@ -135,6 +135,7 @@ lambda: |-
   - `7.50inV2` - Can't use with an ESP8266 as it runs out of RAM
   - `7.50inV2alt` (alternative version to the above `7.50inV2`  )
   - `7.50inV2p` - Support for partial refresh and fast refresh (Only suitable for `7.50inV2` models manufactured after September 2023)
+  - `7.50inV2p4Gray` - Support for fast refresh and 4-gray rendering (Only suitable for `7.50inV2` models manufactured after September 2023)
   - `7.50in-hd-b` - Can't use with an ESP8266 as it runs out of RAM
   - `gdey029t94` - GooDisplay GDEY029t94, as used in the monochrome 2.9inch display from seeedstudio
   - `gdew029t5` - GooDisplay GDEW029T5, as used on the AdaFruit MagTag and Pimoroni Badger

--- a/src/content/docs/components/image.mdx
+++ b/src/content/docs/components/image.mdx
@@ -62,7 +62,7 @@ image:
 
   - `BINARY`  : Two colors, suitable for 1 color displays or 2 color image in color displays. Uses 1 bit
     per pixel, 8 pixels per byte. Only `chroma_key` transparency is available.
-
+  - `4GRAY`  : 2-bit, 4-gray grayscale. Uses 2 bits per pixel, 4 pixels per byte.
   - `GRAYSCALE`  : Full scale grey. Uses 8 bits per pixel, 1 pixel per byte.
   - `RGB565`  : Lossy RGB color stored. Uses 2 bytes per pixel, 3 with an alpha channel.
   - `RGB`  : Full RGB color stored. Uses 3 bytes per pixel, 4 with an alpha channel.
@@ -70,7 +70,7 @@ image:
 - **transparency** (*Optional*): If set the alpha channel of the input image will be taken into account. The possible values are `opaque` (default), `chroma_key` and `alpha_channel`. Binary images do not support `alpha_channel`. See discussion on transparency below.
 - **invert_alpha** (*Optional*, boolean): Applicable to binary and grayscale only, this will invert the colors, i.e. make black white and vice versa. Useful for e-ink displays. Defaults to `false`.
 
-- **dither** (*Optional*): Specifies which dither method used to process the image, only used in GRAYSCALE and BINARY type image. Defaults to `NONE`. You can read more about it on the [Pillow documentation](https://pillow.readthedocs.io/en/stable/reference/Image.html?highlight=Dither#PIL.Image.Image.convert) and on [Wikipedia](https://en.wikipedia.org/wiki/Dither).
+- **dither** (*Optional*): Specifies which dither method used to process the image, only used in GRAYSCALE, 4GRAY, and BINARY type image. Defaults to `NONE`. You can read more about it on the [Pillow documentation](https://pillow.readthedocs.io/en/stable/reference/Image.html?highlight=Dither#PIL.Image.Image.convert) and on [Wikipedia](https://en.wikipedia.org/wiki/Dither).
 
   - `NONE`  : Every pixel converts to its nearest color.
   - `FLOYDSTEINBERG`  : Uses Floyd-Steinberg dither to approximate the original image luminosity levels.

--- a/src/content/docs/components/online_image.mdx
+++ b/src/content/docs/components/online_image.mdx
@@ -56,7 +56,7 @@ online_image:
 
   - `BINARY`  : Two colors, suitable for 1 color displays or 2 color image in color displays. Uses 1 bit
     per pixel, 8 pixels per byte. Only `chroma_key` transparency is available.
-
+  - `4GRAY`  : 2-bit, 4-gray grayscale. Uses 2 bits per pixel, 4 pixels per byte.
   - `GRAYSCALE`  : Full scale grey. Uses 8 bits per pixel, 1 pixel per byte.
   - `RGB565`  : Lossy RGB color stored. Uses 2 bytes per pixel, 3 with an alpha channel
   - `RGB`  : Full RGB color stored. Uses 3 bytes per pixel, 4 with an alpha channel.


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

- Adds documentation about added `4GRAY` image type to `online_image` and `image` components.
- Add documentation about added `7.50inv2p4Gray` mode to Waveshare EPaper display

**Related issue (if applicable):** 
Feature request: [#3035 - Add support for 4 gray-scale in waveshare_epaper 7.50inV2alt](https://github.com/esphome/feature-requests/issues/3035)

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#15657

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
