### PR TITLE
Remove Python 3.14 warning from installation guide

### DIFF
--- a/src/content/docs/guides/installing_esphome.mdx
+++ b/src/content/docs/guides/installing_esphome.mdx
@@ -6,13 +6,9 @@ title: "Installing ESPHome Manually"
 import { Image } from 'astro:assets';
 import pythonWinInstallerImg from './images/python-win-installer.png';
 
-> [!WARNING]
-> **Python 3.14 is not yet supported.** Please use Python 3.11, 3.12, or 3.13.
-> Python 3.14 introduced breaking changes that ESPHome's dependencies have not yet adapted to.
-
 ## Windows
 
-Download Python from [the official site](https://www.python.org/downloads/). Use Python 3.11, 3.12, or 3.13.
+Download Python from [the official site](https://www.python.org/downloads/).
 
 <Image src={pythonWinInstallerImg} layout="constrained" alt={"Python installer window with arrows pointing to \"Add Python to PATH\" and \"Install Now\""} />
 


### PR DESCRIPTION
## Summary
- Remove the Python 3.14 unsupported warnings from the installation guide
- Python 3.14 is now supported on all platforms including Windows

**Related PR:** esphome/esphome#15666