### PR TITLE
2026.4.0b2

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -172,6 +172,7 @@ export default defineConfig({
       components: {
         Footer: "./src/components/Footer.astro",
         Head: "./src/components/Head.astro",
+        SiteTitle: "./src/components/SiteTitle.astro",
       },
       customCss: ["./src/styles/custom.css", "katex/dist/katex.min.css"],
       sidebar: [

--- a/data/version.yaml
+++ b/data/version.yaml
@@ -1,2 +1,2 @@
-release: 2026.4.0b1
+release: 2026.4.0b2
 version: '2026.4'

--- a/script/generate_release_notes.py
+++ b/script/generate_release_notes.py
@@ -73,6 +73,7 @@ For further help, see the ESPHome documentation or contact maintainers.
 from __future__ import annotations
 
 import argparse
+from collections import Counter
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
@@ -89,6 +90,10 @@ LABEL_BREAKING_CHANGE = "breaking-change"
 LABEL_NEW_FEATURE = "new-feature"
 LABEL_NEW_COMPONENT = "new-component"
 LABEL_UNDOCUMENTED_API_CHANGE = "undocumented-api-change"
+LABEL_CODE_QUALITY = "code-quality"
+
+# Bot accounts to exclude from contributor acknowledgments
+BOT_AUTHORS = {"app/dependabot", "app/copilot-swe-agent", "esphomebot"}
 
 
 @dataclass
@@ -571,10 +576,11 @@ class ReleaseNotesGenerator:
         undocumented_api_changes = [
             pr for pr in prs if LABEL_UNDOCUMENTED_API_CHANGE in pr.labels
         ]
+        code_quality = [pr for pr in prs if LABEL_CODE_QUALITY in pr.labels]
 
         # Generate Combined Overview + Feature Highlights Prompt
         overview_and_highlights_prompt = self._generate_overview_and_highlights_prompt(
-            prs, new_features, new_components, breaking_changes
+            prs, new_features, new_components, breaking_changes, code_quality
         )
         overview_highlights_file = self.prompts_dir / "overview_and_highlights.txt"
         overview_highlights_file.write_text(overview_and_highlights_prompt)
@@ -587,6 +593,12 @@ class ReleaseNotesGenerator:
         breaking_file = self.prompts_dir / "breaking_changes.txt"
         breaking_file.write_text(breaking_prompt)
 
+        # Generate Contributors Prompt
+        self._generate_contributor_stats_file(prs)
+        contributors_prompt = self._generate_contributors_prompt(prs)
+        contributors_file = self.prompts_dir / "contributors.txt"
+        contributors_file.write_text(contributors_prompt)
+
         # Print instructions
         print("\n" + "=" * 80)
         print("STEP 1: Process prompts through Claude Code CLI")
@@ -595,6 +607,7 @@ class ReleaseNotesGenerator:
         print("  claude")
         print(f"  > Please read {overview_highlights_file} and follow the instructions")
         print(f"  > Please read {breaking_file} and follow the instructions")
+        print(f"  > Please read {contributors_file} and follow the instructions")
 
         print("\nPrompt 1: Overview + Feature Highlights (COMBINED)")
         print(f"  Prompt: {overview_highlights_file}")
@@ -610,6 +623,10 @@ class ReleaseNotesGenerator:
         print(f"           {self.responses_dir / 'upgrade_checklist.md'}")
         if undocumented_api_changes:
             print(f"           {self.responses_dir / 'undocumented_api_changes.md'}")
+
+        print("\nPrompt 3: Contributor Acknowledgments")
+        print(f"  Prompt: {contributors_file}")
+        print(f"  Output: {self.responses_dir / 'contributors.md'}")
 
         print("\nNote: Each prompt will generate multiple output files automatically.")
 
@@ -646,6 +663,7 @@ class ReleaseNotesGenerator:
         new_features: list[PullRequest],
         new_components: list[PullRequest],
         breaking_changes: list[PullRequest],
+        code_quality: list[PullRequest],
     ) -> str:
         """Generate combined prompt for release overview and feature highlights"""
         template = self.jinja_env.get_template("overview_and_highlights.txt")
@@ -659,6 +677,7 @@ class ReleaseNotesGenerator:
             new_features=new_features,
             new_components=new_components,
             breaking_changes=breaking_changes,
+            code_quality=code_quality,
         )
 
     def _generate_breaking_changes_and_checklist_prompt(
@@ -681,6 +700,108 @@ class ReleaseNotesGenerator:
             undocumented_api_changes=undocumented_api_prs,
             all_prs=all_prs,
         )
+
+    def _get_contributor_stats(
+        self, prs: list[PullRequest]
+    ) -> list[tuple[str, int, list[str]]]:
+        """Get contributor stats sorted by PR count.
+
+        Returns list of (author, pr_count, pr_titles) excluding bots,
+        sorted by PR count descending.
+        """
+        author_counts: Counter[str] = Counter()
+        author_titles: dict[str, list[str]] = {}
+        for pr in prs:
+            if pr.author in BOT_AUTHORS:
+                continue
+            author_counts[pr.author] += 1
+            author_titles.setdefault(pr.author, []).append(pr.title)
+
+        return [
+            (author, count, author_titles[author])
+            for author, count in author_counts.most_common()
+        ]
+
+    def _generate_contributor_stats_file(self, prs: list[PullRequest]) -> None:
+        """Generate contributor statistics file for AI prompt input."""
+        stats = self._get_contributor_stats(prs)
+        human_count = len(stats)
+
+        lines = [
+            f"# Contributor Statistics for ESPHome {self.version}",
+            f"# Total PRs: {len([pr for pr in prs if pr.author not in BOT_AUTHORS])}",
+            f"# Unique contributors: {human_count}",
+            "",
+        ]
+
+        for author, count, titles in stats:
+            lines.append(f"## @{author} ({count} PRs)")
+            lines.extend(f"  - {title}" for title in titles)
+            lines.append("")
+
+        stats_file = self.version_dir / "contributor_stats.txt"
+        stats_file.write_text("\n".join(lines))
+        print(f"✓ Saved contributor stats to {stats_file}")
+
+    def _generate_contributors_prompt(self, prs: list[PullRequest]) -> str:
+        """Generate prompt for contributor acknowledgments."""
+        template = self.jinja_env.get_template("contributors.txt")
+
+        stats = self._get_contributor_stats(prs)
+        human_count = len(stats)
+        total_prs = len([pr for pr in prs if pr.author not in BOT_AUTHORS])
+
+        return template.render(
+            version=str(self.version),
+            contributors_file=self.responses_dir / "contributors.md",
+            prs_cache_dir=self.prs_cache_dir,
+            stats_file=self.version_dir / "contributor_stats.txt",
+            total_prs=total_prs,
+            human_count=human_count,
+            stats=stats,
+        )
+
+    def _generate_fallback_contributors(self, prs: list[PullRequest]) -> str:
+        """Generate a basic contributor section without AI descriptions."""
+        stats = self._get_contributor_stats(prs)
+        human_count = len(stats)
+        total_prs = len([pr for pr in prs if pr.author not in BOT_AUTHORS])
+
+        if human_count < 10:
+            contributors_phrase = f"from {human_count} contributors. "
+        else:
+            rounded_contributors = ((human_count - 1) // 10) * 10
+            contributors_phrase = f"from over {rounded_contributors} contributors. "
+
+        lines = [
+            f"This release includes {total_prs} pull requests "
+            f"{contributors_phrase}"
+            f"A huge thank you to everyone who made {self.version} possible:",
+            "",
+        ]
+
+        # Contributors with 2+ PRs get a bullet point
+        highlighted = [(a, c, t) for a, c, t in stats if c >= 2]
+        single_pr = [(a, c, t) for a, c, t in stats if c == 1]
+
+        for author, count, _titles in highlighted:
+            lines.append(
+                f"- [@{author}](https://github.com/{author}) - {count} PRs"
+            )
+
+        if single_pr:
+            lines.append("")
+            names = [
+                f"[@{author}](https://github.com/{author})"
+                for author, _, _ in single_pr
+            ]
+            lines.append(
+                f"Also thank you to {', '.join(names)} for their contributions, "
+                f"and to everyone who reported issues, tested pre-releases, "
+                f"and helped in the community."
+            )
+
+        return "\n".join(lines)
 
     def assemble_changelog(self) -> bool:
         """Assemble final changelog from template and AI responses"""
@@ -758,6 +879,11 @@ class ReleaseNotesGenerator:
         if undocumented_api_file.exists():
             undocumented_api = undocumented_api_file.read_text().strip()
 
+        contributors_file = self.responses_dir / "contributors.md"
+        contributors = ""
+        if contributors_file.exists():
+            contributors = contributors_file.read_text().strip()
+
         # Load the PR numbers for this version from a manifest file
         manifest_file = self.version_dir / "pr_numbers.txt"
         if not manifest_file.exists():
@@ -804,6 +930,17 @@ class ReleaseNotesGenerator:
         if breaking_devs:
             template = self._replace_marker_content(
                 template, "BREAKING_CHANGES_DEVELOPERS", breaking_devs
+            )
+
+        # Contributors section: use AI response if available, otherwise fallback
+        if contributors:
+            template = self._replace_marker_content(
+                template, "CONTRIBUTORS", contributors
+            )
+        else:
+            fallback_contributors = self._generate_fallback_contributors(prs)
+            template = self._replace_marker_content(
+                template, "CONTRIBUTORS", fallback_contributors
             )
 
         # Generate auto sections

--- a/script/prompt_templates/contributors.txt
+++ b/script/prompt_templates/contributors.txt
@@ -1,0 +1,65 @@
+SAVE YOUR RESPONSE TO:
+  {{ contributors_file }}
+
+NOTE: The output file and directories may not exist yet - that's fine, create them.
+
+════════════════════════════════════════════════════════════════════════════════
+
+TASK: Write the "Thank You, Contributors" section for ESPHome {{ version }}.
+
+════════════════════════════════════════════════════════════════════════════════
+
+CONTEXT:
+This section acknowledges the people who contributed code to this release.
+It appears in the changelog between the feature highlights and breaking changes.
+
+CONTRIBUTOR DATA:
+Read the contributor statistics file for PR counts and titles:
+  {{ stats_file }}
+
+Total PRs (excluding bots): {{ total_prs }}
+Unique human contributors: {{ human_count }}
+
+For detailed context on what each contributor worked on, you can read individual
+PR JSON files from: {{ prs_cache_dir }}/
+
+════════════════════════════════════════════════════════════════════════════════
+
+FORMAT:
+
+1. Opening line:
+   "This release includes N pull requests from over M contributors. A huge
+    thank you to everyone who made {VERSION} possible:"
+
+   Round M down to the nearest 10 (e.g., 54 contributors → "over 50").
+
+2. Highlighted contributors (2+ PRs), listed in descending PR count order:
+   - [@username](https://github.com/username) - N PRs including [short description of their main contributions]
+
+   For each highlighted contributor:
+   - Read their PR titles from the stats file
+   - Summarize their work in a concise phrase (not a full sentence)
+   - Focus on the most notable contributions, not an exhaustive list
+   - Mention new components, major features, or thematic work
+   - Example: "101 PRs including a correctness sweep across 100+ components and ESP32-C5 dual-band WiFi"
+   - Example: "20 PRs building the new media player architecture and Ogg Opus codec support"
+   - Example: "the new dew point sensor component"
+
+3. Notable single-PR contributors (optional):
+   If a single-PR contributor added a significant new component or feature,
+   you may promote them to the highlighted list with a brief description.
+   Example: "the new SEN6x sensor component"
+
+4. Remaining single-PR contributors in an "Also thank you to" paragraph:
+   List ALL remaining contributors as [@username](https://github.com/username),
+   separated by commas, ending with:
+   "for their contributions, and to everyone who reported issues, tested
+    pre-releases, and helped in the community."
+
+IMPORTANT:
+- Do NOT include bot accounts (dependabot, esphomebot, copilot-swe-agent)
+- Do NOT include bdraco in the highlighted list; instead include bdraco
+  in the "Also thank you to" paragraph with the single-PR contributors
+- DO verify PR counts match the stats file exactly
+- DO use GitHub profile links for every @mention
+- Keep descriptions factual - derive them from actual PR titles, don't embellish

--- a/script/prompt_templates/overview_and_highlights.txt
+++ b/script/prompt_templates/overview_and_highlights.txt
@@ -71,21 +71,28 @@ These are detailed deep-dive sections that appear AFTER the release overview and
 WHAT TO WRITE ABOUT:
 Select the 3-10 MOST IMPORTANT features/changes from the PRs and ORDER BY PRIORITY:
 
-**Priority Order (most important first):**
-1. **New Major Features** - Groundbreaking user-facing functionality (new protocols, major capabilities)
-2. **New Hardware/Platform Support** - New chips, new sensors, new component types
-3. **Architectural Improvements** - Framework changes, major refactorings with significant impact
-4. **Performance/Memory Optimizations** - Only if substantial (multiple KB savings, major speedups)
-5. **Security Enhancements** - Critical security improvements
-6. **Notable Bug Fixes** - Important fixes for crashes, data corruption, or major functionality issues
+**Priority Order (MOST USERS AFFECTED first, niche features last):**
+1. **Platform-Wide Changes** - Changes that affect ALL users of a platform (default setting changes, crash handlers, new diagnostics). ~40% of ESPHome users are on ESP8266, so ESP8266 changes are high-impact.
+2. **Performance/Memory Optimizations** - These affect every device. Separate performance (speed, CPU) from memory (RAM, flash, heap) into distinct sections. Include benchmarking infrastructure if it drove visible improvements.
+3. **Architectural Improvements** - Framework changes affecting many components (e.g., moving allocations from heap to BSS, substitution engine rewrites)
+4. **IDF/SDK Compatibility** - Preparation for future framework versions (e.g., ESP-IDF 6.0 compatibility) if substantial (10+ PRs)
+5. **Connectivity/Networking** - Ethernet, WiFi, BLE proxy improvements
+6. **Security Enhancements** - OTA signing, authentication improvements
+7. **Developer Infrastructure** - CI improvements, new tooling (CodSpeed, analyze-memory) if they drove user-visible improvements
+8. **New Hardware/Platform Support** - New sensors, chips, component types (group together)
+9. **New Major Features** - Niche but significant new capabilities (new climate components, new protocols)
+10. **Other Notable Features** - Catch-all for smaller features that didn't get their own section
+11. **Codebase Correctness** - Large-scale fix sweeps if substantial
 
 **What qualifies as "Major":**
+- Affects a large percentage of users (platform defaults, crash handlers, logging changes)
 - Enables entirely new use cases (Z-Wave support, USB host)
 - Adds support for popular/widely-used hardware
 - Framework changes affecting many components
-- Performance gains of 5KB+ or 50%+ improvements
+- Performance gains visible in benchmarks or real-world measurements
+- Memory savings across many component instances
 - Fixes that prevent crashes, data loss, or major malfunctions
-- Fixes for widely-used components affecting many users
+- Large coordinated efforts (10+ PRs for IDF 6.0 compat, 20+ PRs for correctness sweep)
 
 STYLE EXAMPLES from ESPHome 2025.10.0:
 
@@ -143,13 +150,24 @@ INSTRUCTIONS:
    - Framework PRs = internal improvements affecting existing components
    - Don't mischaracterize platform features (read the PR description!)
 
-3. **Identify 3-10 major themes** - group related PRs:
-   - All memory optimizations together (if substantial)
-   - All new sensor/hardware components together
-   - Major new features separately (if truly groundbreaking)
-   - Notable bug fixes in their own section (especially crashes, data corruption, major malfunctions)
+3. **Identify 5-15 major themes** - group related PRs:
+   - Performance optimizations in their own section (API, scheduler, loop elimination, etc.)
+   - Memory optimizations in a SEPARATE section from performance (RAM savings, heap→BSS, field packing)
+   - IDF/SDK compatibility prep in its own section if 10+ PRs
+   - All new sensor/hardware components together in one section
+   - Niche but significant new components (e.g., climate, media player) get their own section
+   - An "Other Notable Features" catch-all for smaller features not covered elsewhere
+   - Codebase correctness sweeps in their own section if substantial
+   - Credit the lead contributor with @username link when one person drove a section
 
-4. **Write detailed sections**:
+4. **Credit contributors in their sections** (IMPORTANT):
+   - When one person led a major effort, credit them in the opening: "Led by [@username](https://github.com/username), ..."
+   - For new components, credit the author: "Built by [@author](https://github.com/author) across N PRs, ..."
+   - For new sensors/hardware, add "by [@author](https://github.com/author)" after the component name
+   - For large coordinated efforts (IDF compat, correctness sweeps), credit the lead contributor
+   - Do NOT credit bdraco in feature sections
+
+5. **Write detailed sections**:
    - ## Heading for each major feature
    - Opening paragraph: what it is and why it matters
    - **Key Features/Benefits** bulleted list with bold labels
@@ -158,14 +176,17 @@ INSTRUCTIONS:
    - Use `code formatting` for config keys
    - Use **bold** for emphasis
 
-5. **What makes good sections**:
+6. **What makes good sections**:
    ✓ Explains WHY the feature matters, not just what it does
-   ✓ Includes specific numbers (RAM savings, performance gains)
+   ✓ Includes specific numbers (RAM savings, performance gains, benchmark results)
    ✓ Groups related PRs into one cohesive narrative
-   ✓ Provides actionable guidance (migration steps, recommendations)
+   ✓ Credits the lead contributor with [@username](https://github.com/username) when one person drove the work
+   ✓ Credits authors of new components (e.g., "by [@author](https://github.com/author)")
+   ✓ Links back to previous release notes when continuing multi-release efforts
+   ✓ Links to relevant documentation pages for detailed config (don't duplicate docs)
    ✓ Professional but enthusiastic tone
 
-6. **What to avoid**:
+7. **What to avoid**:
    ✗ Don't write about every PR - focus on major themes
    ✗ Don't just list features - explain benefits and context
    ✗ Don't discuss breaking changes themselves (they go in their own section)
@@ -173,6 +194,11 @@ INSTRUCTIONS:
    ✗ Skip minor bug fixes and small improvements
    ✗ Don't include sections about "Deprecation Removals" or "Migration Considerations"
    ✗ Don't claim breaking changes are "backward compatible" - be honest about compatibility
+   ✗ Don't use em dashes (—) or double dashes (--) to separate clauses; use commas or semicolons
+   ✗ Don't use "The problem:" / "The fix:" as bold headers - write flowing prose instead
+   ✗ Don't include config examples for dangerous options (e.g., options that can brick devices) - link to docs instead
+   ✗ Don't include config examples for niche features - link to docs instead
+   ✗ Don't put non-sensor items in the "New Sensors" section - use "Other Notable Features" instead
 
    **CRITICAL - Handling Breaking Change PRs:**
 
@@ -191,11 +217,12 @@ INSTRUCTIONS:
    - Save migration details for the Breaking Changes section
 
 OUTPUT FORMAT FOR HIGHLIGHTS:
-- 3-10 complete ## sections ordered by PRIORITY (see Priority Order above)
-- Order: New Major Features → New Hardware → Architectural Changes → Optimizations
+- 5-15 complete ## sections ordered by PRIORITY (see Priority Order above)
+- Order: Platform-wide changes → Performance → Memory → Architecture → IDF compat → Networking → Security → Infrastructure → New Hardware → New Features → Other Notable → Correctness
 - Do NOT include "Feature Highlights" heading - just write the ## sections
 - Do NOT include introductory text
 - Do NOT include "Deprecation Removals" or "Migration Considerations" sections
+- The release overview should match the section ordering (broadest impact first)
 
 ────────────────────────────────────────────────────────────────────────────────
 📁 PR DATA FILES - CRITICAL: You MUST read ALL of these files using the Read tool
@@ -225,6 +252,19 @@ NEW FEATURE PR FILES ({{ new_features|length }} total) - READ ALL {{ new_feature
 {% for pr in new_features %}
   {{ prs_cache_dir }}/{{ pr.number }}.json
 {% endfor %}
+
+{% if code_quality %}
+CODE QUALITY PR FILES ({{ code_quality|length }} total) - SCAN ALL TITLES, READ NOTABLE ONES:
+
+⚠️  These PRs contain performance optimizations, memory savings, architecture changes,
+    IDF compatibility work, and other improvements that may deserve their own sections.
+    Scan ALL titles below. Read the full JSON for any that look like they contain
+    benchmark results, significant memory savings, or architectural changes.
+
+{% for pr in code_quality %}
+  {{ prs_cache_dir }}/{{ pr.number }}.json — {{ pr.title }}
+{% endfor %}
+{% endif %}
 
 {% if breaking_changes %}
 BREAKING CHANGE PR FILES ({{ breaking_changes|length }} total) - READ ALL {{ breaking_changes|length }} FILES:

--- a/script/release_notes_template.mdx
+++ b/script/release_notes_template.mdx
@@ -58,6 +58,31 @@ import ImgTable from "@components/ImgTable.astro";
 */}
 {/* FEATURE_HIGHLIGHTS_END */}
 
+## Thank You, Contributors
+
+{/* CONTRIBUTORS_START */}
+{/*
+  CONTRIBUTOR ACKNOWLEDGMENTS
+
+  This section thanks contributors who made this release possible.
+  It is populated in two parts:
+
+  1. Auto-generated contributor statistics (PR counts per author) are
+     provided as input data alongside the PR cache files.
+  2. AI-generated descriptions summarize each highlighted contributor's
+     focus areas based on their PR titles.
+
+  Guidelines:
+  - Start with a summary line: "This release includes N pull requests from
+    over M contributors."
+  - List contributors with 2+ PRs in descending order, each with a short
+    description of their work derived from PR titles
+  - End with an "Also thank you to" paragraph listing all remaining
+    single-PR contributors by @username with GitHub profile links
+  - Exclude bot accounts (dependabot, esphomebot, copilot-swe-agent)
+*/}
+{/* CONTRIBUTORS_END */}
+
 ## Breaking Changes
 
 {/* BREAKING_CHANGES_USERS_START */}

--- a/src/components/SiteTitle.astro
+++ b/src/components/SiteTitle.astro
@@ -1,0 +1,70 @@
+---
+import Default from '@astrojs/starlight/components/SiteTitle.astro';
+import fs from 'node:fs';
+import path from 'node:path';
+
+// Cache the result so the filesystem scan only runs once per build,
+// not once per page render.
+const cache = globalThis as typeof globalThis & { __esphomeVersion?: { display: string; slug: string } };
+if (!cache.__esphomeVersion) {
+  // Find the latest version at build time.
+  // Shows the latest patch version (e.g., 2026.3.3) but links to the base
+  // changelog page (2026.3.0), matching how Home Assistant does it.
+  let display = '';
+  let slug = '';
+  const changelogDir = path.join(process.cwd(), 'src/content/docs/changelog');
+  try {
+    let bestFile = 0;
+    let bestFilename = '';
+    for (const f of fs.readdirSync(changelogDir)) {
+      const m = f.match(/^(\d{4})\.(\d+)\.(\d+)\.mdx$/);
+      if (!m) continue;
+      const v = parseInt(m[1]) * 10000 + parseInt(m[2]) * 100 + parseInt(m[3]);
+      if (v > bestFile) { bestFile = v; bestFilename = f; slug = `${m[1]}.${m[2]}.${m[3]}`; }
+    }
+    if (bestFilename) {
+      const content = fs.readFileSync(path.join(changelogDir, bestFilename), 'utf-8');
+      let bestPatch = 0;
+      for (const match of content.matchAll(/^## Release (\d{4}\.\d+\.\d+)/gm)) {
+        const p = parseInt(match[1].split('.')[2]);
+        if (p > bestPatch) { bestPatch = p; display = match[1]; }
+      }
+      if (!display) display = slug;
+    }
+  } catch (e: unknown) {
+    if (e && typeof e === 'object' && 'code' in e && (e as {code: string}).code !== 'ENOENT') throw e;
+  }
+  cache.__esphomeVersion = { display, slug };
+}
+
+const { display: displayVersion, slug: changelogSlug } = cache.__esphomeVersion;
+---
+
+<Default {...Astro.props}><slot /></Default>
+{displayVersion && (
+  <a href={`/changelog/${changelogSlug}/`} class="version-badge" title={`ESPHome ${displayVersion}`} translate="no">
+    {displayVersion}
+  </a>
+)}
+
+<style>
+  .version-badge {
+    align-self: center;
+    margin-left: 5px;
+    padding: 0 4px;
+    font-size: 10px;
+    font-weight: 500;
+    line-height: 15px;
+    height: 15px;
+    letter-spacing: 0.4px;
+    color: var(--sl-color-text-accent);
+    background-color: var(--sl-color-accent-low);
+    border-radius: 4px;
+    text-decoration: none;
+    white-space: nowrap;
+  }
+  .version-badge:hover {
+    background-color: var(--sl-color-accent);
+    color: var(--sl-color-black);
+  }
+</style>

--- a/src/content/docs/changelog/2026.4.0.mdx
+++ b/src/content/docs/changelog/2026.4.0.mdx
@@ -573,6 +573,28 @@ For detailed migration guides and API documentation, see the [ESPHome Developers
 - [esp8266] Add crash handler for post-mortem diagnostics [esphome#15465](https://github.com/esphome/esphome/pull/15465) by [@bdraco](https://github.com/bdraco) (new-feature) (breaking-change)
 - [lvgl] Implement rotation directly [esphome#14955](https://github.com/esphome/esphome/pull/14955) by [@clydebarrow](https://github.com/clydebarrow) (new-feature) (breaking-change)
 
+### Beta Changes
+
+- [api] Fix ListEntitiesRequest not read due to LWIP rcvevent tracking [esphome#15589](https://github.com/esphome/esphome/pull/15589) by [@bdraco](https://github.com/bdraco)
+- Bump aioesphomeapi from 44.12.0 to 44.13.1 [esphome#15600](https://github.com/esphome/esphome/pull/15600) by [@dependabot[bot]](https://github.com/apps/dependabot)
+- [gdk101] Increase reset retries for slow-booting sensor MCU [esphome#15584](https://github.com/esphome/esphome/pull/15584) by [@bdraco](https://github.com/bdraco)
+- [sx127x][cc1101] Disable loop when packet mode is inactive [esphome#15606](https://github.com/esphome/esphome/pull/15606) by [@swoboda1337](https://github.com/swoboda1337)
+- [hbridge] Move light pin switching to loop [esphome#15615](https://github.com/esphome/esphome/pull/15615) by [@jesserockz](https://github.com/jesserockz)
+- [tca9555] Add interrupt pin support [esphome#15613](https://github.com/esphome/esphome/pull/15613) by [@bdraco](https://github.com/bdraco) (new-feature)
+- [pca6416a] Add interrupt pin support [esphome#15614](https://github.com/esphome/esphome/pull/15614) by [@bdraco](https://github.com/bdraco) (new-feature)
+- [mcp23016] Add interrupt pin support [esphome#15616](https://github.com/esphome/esphome/pull/15616) by [@bdraco](https://github.com/bdraco) (new-feature)
+- [api] Add (inline_encode) proto option for sub-message inlining [esphome#15599](https://github.com/esphome/esphome/pull/15599) by [@bdraco](https://github.com/bdraco)
+- [micro_wake_word] Pin esp-nn version [esphome#15628](https://github.com/esphome/esphome/pull/15628) by [@kahrendt](https://github.com/kahrendt)
+- [sx127x][cc1101][sx126x] Use GPIO interrupt to wake loop [esphome#15627](https://github.com/esphome/esphome/pull/15627) by [@swoboda1337](https://github.com/swoboda1337)
+- [rp2040] Fix W5500 Ethernet pbuf corruption by mirroring LWIPMutex semantics [esphome#15624](https://github.com/esphome/esphome/pull/15624) by [@bdraco](https://github.com/bdraco)
+- Bump aioesphomeapi from 44.13.1 to 44.13.2 [esphome#15637](https://github.com/esphome/esphome/pull/15637) by [@dependabot[bot]](https://github.com/apps/dependabot)
+- Bump aioesphomeapi from 44.13.2 to 44.13.3 [esphome#15641](https://github.com/esphome/esphome/pull/15641) by [@dependabot[bot]](https://github.com/apps/dependabot)
+- [mdns] Bump espressif/mdns to 1.11.0 [esphome#15670](https://github.com/esphome/esphome/pull/15670) by [@swoboda1337](https://github.com/swoboda1337)
+- [canbus] Fix canbus.send can_id compile error [esphome#15668](https://github.com/esphome/esphome/pull/15668) by [@swoboda1337](https://github.com/swoboda1337)
+- [esp32] Bump platform to 55.03.38, Arduino to 3.3.8, ESP-IDF to 5.5.4 [esphome#15666](https://github.com/esphome/esphome/pull/15666) by [@swoboda1337](https://github.com/swoboda1337)
+- [packages] Fix false deprecation warning and wrong error paths in nested packages [esphome#15605](https://github.com/esphome/esphome/pull/15605) by [@bdraco](https://github.com/bdraco) (breaking-change)
+- [lvgl] Fix use of rotation on host SDL [esphome#15611](https://github.com/esphome/esphome/pull/15611) by [@clydebarrow](https://github.com/clydebarrow)
+
 ### All changes
 
 <details>
@@ -1087,6 +1109,22 @@ For detailed migration guides and API documentation, see the [ESPHome Developers
 - [climate] Store custom mode vectors on Climate entity to eliminate heap allocation [esphome#15206](https://github.com/esphome/esphome/pull/15206) by [@bdraco](https://github.com/bdraco)
 - [fan] Store preset mode vector on Fan entity to eliminate heap allocation [esphome#15209](https://github.com/esphome/esphome/pull/15209) by [@bdraco](https://github.com/bdraco)
 - [rpi_dpi_rgb][qspi_dbi] Add deprecation warnings [esphome#15583](https://github.com/esphome/esphome/pull/15583) by [@clydebarrow](https://github.com/clydebarrow)
+- [api] Fix ListEntitiesRequest not read due to LWIP rcvevent tracking [esphome#15589](https://github.com/esphome/esphome/pull/15589) by [@bdraco](https://github.com/bdraco)
+- [gdk101] Increase reset retries for slow-booting sensor MCU [esphome#15584](https://github.com/esphome/esphome/pull/15584) by [@bdraco](https://github.com/bdraco)
+- [sx127x][cc1101] Disable loop when packet mode is inactive [esphome#15606](https://github.com/esphome/esphome/pull/15606) by [@swoboda1337](https://github.com/swoboda1337)
+- [hbridge] Move light pin switching to loop [esphome#15615](https://github.com/esphome/esphome/pull/15615) by [@jesserockz](https://github.com/jesserockz)
+- [tca9555] Add interrupt pin support [esphome#15613](https://github.com/esphome/esphome/pull/15613) by [@bdraco](https://github.com/bdraco) (new-feature)
+- [pca6416a] Add interrupt pin support [esphome#15614](https://github.com/esphome/esphome/pull/15614) by [@bdraco](https://github.com/bdraco) (new-feature)
+- [mcp23016] Add interrupt pin support [esphome#15616](https://github.com/esphome/esphome/pull/15616) by [@bdraco](https://github.com/bdraco) (new-feature)
+- [api] Add (inline_encode) proto option for sub-message inlining [esphome#15599](https://github.com/esphome/esphome/pull/15599) by [@bdraco](https://github.com/bdraco)
+- [micro_wake_word] Pin esp-nn version [esphome#15628](https://github.com/esphome/esphome/pull/15628) by [@kahrendt](https://github.com/kahrendt)
+- [sx127x][cc1101][sx126x] Use GPIO interrupt to wake loop [esphome#15627](https://github.com/esphome/esphome/pull/15627) by [@swoboda1337](https://github.com/swoboda1337)
+- [rp2040] Fix W5500 Ethernet pbuf corruption by mirroring LWIPMutex semantics [esphome#15624](https://github.com/esphome/esphome/pull/15624) by [@bdraco](https://github.com/bdraco)
+- [mdns] Bump espressif/mdns to 1.11.0 [esphome#15670](https://github.com/esphome/esphome/pull/15670) by [@swoboda1337](https://github.com/swoboda1337)
+- [canbus] Fix canbus.send can_id compile error [esphome#15668](https://github.com/esphome/esphome/pull/15668) by [@swoboda1337](https://github.com/swoboda1337)
+- [esp32] Bump platform to 55.03.38, Arduino to 3.3.8, ESP-IDF to 5.5.4 [esphome#15666](https://github.com/esphome/esphome/pull/15666) by [@swoboda1337](https://github.com/swoboda1337)
+- [packages] Fix false deprecation warning and wrong error paths in nested packages [esphome#15605](https://github.com/esphome/esphome/pull/15605) by [@bdraco](https://github.com/bdraco) (breaking-change)
+- [lvgl] Fix use of rotation on host SDL [esphome#15611](https://github.com/esphome/esphome/pull/15611) by [@clydebarrow](https://github.com/clydebarrow)
 
 </details>
 
@@ -1127,5 +1165,8 @@ For detailed migration guides and API documentation, see the [ESPHome Developers
 - Bump cryptography from 46.0.6 to 46.0.7 [esphome#15550](https://github.com/esphome/esphome/pull/15550) by [@dependabot[bot]](https://github.com/apps/dependabot)
 - Bump esphome-dashboard from 20260210.0 to 20260408.1 [esphome#15552](https://github.com/esphome/esphome/pull/15552) by [@dependabot[bot]](https://github.com/apps/dependabot)
 - Bump CodSpeedHQ/action from 4.13.0 to 4.13.1 [esphome#15577](https://github.com/esphome/esphome/pull/15577) by [@dependabot[bot]](https://github.com/apps/dependabot)
+- Bump aioesphomeapi from 44.12.0 to 44.13.1 [esphome#15600](https://github.com/esphome/esphome/pull/15600) by [@dependabot[bot]](https://github.com/apps/dependabot)
+- Bump aioesphomeapi from 44.13.1 to 44.13.2 [esphome#15637](https://github.com/esphome/esphome/pull/15637) by [@dependabot[bot]](https://github.com/apps/dependabot)
+- Bump aioesphomeapi from 44.13.2 to 44.13.3 [esphome#15641](https://github.com/esphome/esphome/pull/15641) by [@dependabot[bot]](https://github.com/apps/dependabot)
 
 </details>

--- a/src/content/docs/changelog/2026.4.0.mdx
+++ b/src/content/docs/changelog/2026.4.0.mdx
@@ -29,7 +29,7 @@ ESPHome 2026.4.0 delivers major performance and reliability improvements across 
 ## Upgrade Checklist
 
 {/* UPGRADE_CHECKLIST_START */}
-- If you use LVGL with `rotation` configured on the display component, move the `rotation` setting to the `lvgl:` block instead
+- If you use LVGL with `rotation` configured on the display component, move the `rotation` setting to the `lvgl:` block, and remove touchscreen `transform:`.
 - If you use the `i2s_audio` media player, migrate to the `speaker` media player component (the `i2s_audio` media player has been removed)
 - If you use `use_legacy` in your `i2s_audio` config, remove it (the legacy I2S driver has been removed)
 - If you have battery-powered ESP32/S2/S3/C5 devices, add `cpu_frequency: 160MHZ` to your config (the default is now 240MHz)
@@ -316,7 +316,10 @@ Led by [@clydebarrow](https://github.com/clydebarrow) with 27 PRs, ESPHome's LVG
 
 **Key changes:**
 
-- **Native rotation with hardware acceleration** - Rotation is now handled directly by LVGL instead of the display driver, with runtime rotation changes via `lvgl.display.set_rotation` and automatic use of hardware rotation when available. On ESP32-P4, rotation uses the PPA (Pixel Processing Accelerator) for zero-CPU-cost transforms ([#14955](https://github.com/esphome/esphome/pull/14955), [#15453](https://github.com/esphome/esphome/pull/15453)). Users will need to move their `rotation` config from the display component to the `lvgl:` block.
+- **Native rotation with hardware acceleration** - Rotation is now handled directly by [LVGL](/components/lvgl) instead of the display driver, with runtime rotation changes via `lvgl.display.set_rotation` and automatic use of hardware rotation when available.
+  On ESP32-P4, rotation uses the PPA (Pixel Processing Accelerator) for zero-CPU-cost transforms ([#14955](https://github.com/esphome/esphome/pull/14955), [#15453](https://github.com/esphome/esphome/pull/15453)).
+- **Automatic touchscreen rotation** - Touch input is automatically rotated to match display orientation, eliminating the need for manual coordinate transforms in most cases.
+  Users will need to move their `rotation` config from the display component to the `lvgl:` block, and remove or adjust the `transform:` block in the touchscreen component.
 - **Built-in dark theme** - A single `dark_mode: true` under `theme:` enables LVGL's native dark default theme, replacing the tedious process of manually replicating dark theme properties ([#15389](https://github.com/esphome/esphome/pull/15389))
 - **All LVGL 9 events** - Complete mapping of LVGL 9 events to ESPHome automation triggers ([#15362](https://github.com/esphome/esphome/pull/15362))
 - **Drop shadow support** - New `bitmap_mask_src` style property and A8 image format for drop shadow effects ([#15334](https://github.com/esphome/esphome/pull/15334))
@@ -412,7 +415,8 @@ Also thank you to [@bdraco](https://github.com/bdraco), [@thomwiggers](https://g
 
 ### Component Changes
 
-- **LVGL rotation**: The `rotation` option must now be configured under `lvgl:` instead of the display component. LVGL now handles rotation directly, with support for runtime rotation changes via `lvgl.display.set_rotation`. Users must move their `rotation` setting from the display config to the `lvgl:` block. [#14955](https://github.com/esphome/esphome/pull/14955)
+- **LVGL rotation**: The `rotation` option must now be configured under `lvgl:` instead of the display component. LVGL now handles rotation for the display and touchscreen directly, with support for runtime rotation changes via `lvgl.display.set_rotation`.
+  Users must move their `rotation` setting from the display config to the `lvgl:` block. [#14955](https://github.com/esphome/esphome/pull/14955) and remove or adjust the `transform:` block in their touchscreen config if they have one.
 
 - **I2S Audio**: The legacy I2S driver (`use_legacy` option) has been removed. The new I2S driver is always used. The `i2s_audio` media player sub-component has been removed entirely; users should migrate to the [speaker media player](/components/media_player/speaker) component. [#14932](https://github.com/esphome/esphome/pull/14932)
 

--- a/src/content/docs/changelog/2026.4.0.mdx
+++ b/src/content/docs/changelog/2026.4.0.mdx
@@ -349,6 +349,7 @@ This release adds support for several new sensors and hardware platforms:
 - **TM1637 buffer manipulation** - `set_buffer` method for raw segment writes and custom glyphs ([#13686](https://github.com/esphome/esphome/pull/13686))
 - **HUB75 scan wiring** - New `SCAN_1_8_32PX_FULL` wiring option ([#15130](https://github.com/esphome/esphome/pull/15130))
 - **`*/N` cron syntax** - Time-based automations now support `*/5` style step expressions ([#15434](https://github.com/esphome/esphome/pull/15434))
+- **microFLAC audio decoding** by [@kahrendt](https://github.com/kahrendt) - New FLAC decoder is **9% faster** on ESP32-S3 with CRC validation re-enabled, plus true streaming support that eliminates unnecessary memory copies ([#15372](https://github.com/esphome/esphome/pull/15372))
 
 ## Mitsubishi CN105 Climate Component
 

--- a/src/content/docs/changelog/2026.4.0.mdx
+++ b/src/content/docs/changelog/2026.4.0.mdx
@@ -23,59 +23,141 @@ import ImgTable from "@components/ImgTable.astro";
 ## Release Overview
 
 {/* RELEASE_OVERVIEW_START */}
-ESPHome 2026.4.0 introduces native Mitsubishi A/C control via the CN105 connector, upgrades LVGL to v9.5.0 with runtime rotation and dark mode support, and massively expands Ethernet with 5 new chip types across ESP32 and RP2040 platforms. Performance improvements include interrupt-driven GPIO expanders with 99.7% I2C reduction, ESP32 CPU defaults raised to 240MHz for 34% faster operations, and an 18x faster substitution engine with support for variables in `!include` paths. This release also adds OTA signature verification, config bundles for remote compilation, custom ESP32 partition tables, and 4 new sensor components.
+ESPHome 2026.4.0 delivers major performance and reliability improvements across all platforms. ESP32 devices default to maximum CPU frequency (33% faster API operations), unlock 40KB extra IRAM, signed OTA verification, and custom partition tables. ESP8266 gets a crash handler matching ESP32/RP2040, and a new client-side state logging architecture achieves up to 46x faster sensor publishing by moving log formatting off the device. Bluetooth Proxy and API overhead dropped to just 2.3% of main loop time on ESP32-C3. 31 PRs prepare the codebase for ESP-IDF 6.0, and CodSpeed benchmarking infrastructure now catches performance regressions before they ship. The substitution system has been redesigned for up to 18x faster config loading with dynamic `!include` paths, Ethernet expands with 5 new chip types across ESP32 and RP2040, and GPIO expanders gain interrupt-driven operation cutting idle I2C traffic by 99.7%. This release also adds LVGL v9.5.0, native Mitsubishi CN105 climate control, 4 new sensor components, and a `esphome bundle` CLI command to assist with remote compilation.
 {/* RELEASE_OVERVIEW_END */}
 
 ## Upgrade Checklist
 
 {/* UPGRADE_CHECKLIST_START */}
-- If you use `rotation` in a display config with LVGL, move the `rotation` option from the display component to the `lvgl:` block
+- If you use LVGL with `rotation` configured on the display component, move the `rotation` setting to the `lvgl:` block instead
 - If you use the `i2s_audio` media player, migrate to the `speaker` media player component (the `i2s_audio` media player has been removed)
-- If you use `use_legacy: true` in `i2s_audio`, remove it (the legacy I2S driver has been removed)
-- If you have battery-powered or thermally constrained ESP32/S2/S3/C5 devices, consider adding `cpu_frequency: 160MHZ` (the default has been raised to 240MHz)
-- If you use `sen5x` with `voc_baseline`, remove it (the option was dead code and has been removed; use `store_baseline: true` instead)
+- If you use `use_legacy` in your `i2s_audio` config, remove it (the legacy I2S driver has been removed)
+- If you have battery-powered ESP32/S2/S3/C5 devices, add `cpu_frequency: 160MHZ` to your config (the default is now 240MHz)
+- If you have two YAML keys that resolve to the same substituted name, note that the later key now takes precedence ("last writer wins")
+- If you use `sen5x` with `voc_baseline`, remove it (it was dead code that never worked; use `store_baseline: true` instead)
 - If you use `rp2040_pio_led_strip` with `chipset: CUSTOM`, use explicit `bit0_high`/`bit0_low`/`bit1_high`/`bit1_low` timing parameters instead
+- If you use Nextion `get_wave_chan_id()` in lambdas, switch to `get_wave_channel_id()` (the old method is deprecated, removal in 2026.10.0)
 - If you use `sensor.raw_state` in lambdas, migrate to using filtered state or `on_raw_value` triggers (`.raw_state` is deprecated)
-- If you use Nextion `get_wave_chan_id()` in lambdas, switch to `get_wave_channel_id()` (the old name is deprecated)
 - If you maintain external components that call `TEMPLATABLE_VALUE` macro-generated setters with raw C++ constants, route values through `cg.templatable()` in Python codegen
+- If you maintain external components using `ButtonPressTrigger`, `SensorStateTrigger`, or similar trigger classes, migrate to `build_callback_automation()`
 - If you maintain external components using `FlushResult`, rename to `UARTFlushResult` with `UART_FLUSH_RESULT_` prefix
 {/* UPGRADE_CHECKLIST_END */}
 
 {/* FEATURE_HIGHLIGHTS_START */}
-## Mitsubishi CN105 Climate Component
+## ESP32 Performance and Security Improvements
 
-The new [mitsubishi_cn105](/components/climate/mitsubishi_cn105) component brings native climate control for Mitsubishi A/C units equipped with the CN105 connector. This has been one of the most requested integrations, enabling direct UART communication with a wide range of Mitsubishi heat pumps and air conditioners without relying on external libraries or custom components.
+Several ESP32 platform changes improve performance, security, and flexibility.
 
-**Key Features:**
+**Default CPU Frequency Raised to Maximum** ([#15143](https://github.com/esphome/esphome/pull/15143)):
 
-- **Full climate control** - Power, mode, target temperature, and fan speed can be controlled directly from Home Assistant
-- **Non-blocking protocol driver** - The parser implements the same CN105 protocol used by the popular SwiCago HeatPump project, ensuring compatibility with the same [range of devices](https://github.com/SwiCago/HeatPump/issues/13)
-- **Smart temperature polling** - The `current_temperature_min_interval` option rate-limits room temperature reads to prevent rapid oscillations near measurement boundaries while keeping a fast `update_interval` for responsive control
-- **Broad platform support** - Works on ESP32, ESP32 IDF, ESP8266, and RP2040/RP2350
+ESP32, ESP32-S2, ESP32-S3, and ESP32-C5 now default to **240MHz** instead of 160MHz. This restores the performance level that Arduino users had before May 2025 and delivers ~34% faster CPU-bound operations:
+
+- **API encryption handshake**: 90ms to 64ms (29% faster)
+- **Protobuf encoding** (BLE proxy): 34% faster
+- **Noise encryption**: 33-34% faster across all payload sizes
+
+Users on battery power or with thermal constraints can override with `cpu_frequency: 160MHZ`. This is a breaking change as it increases power consumption on affected variants.
+
+**ESP32 crash handler improvements**: The existing crash handler now captures backtraces from **both cores** on dual-core ESP32 variants ([#15559](https://github.com/esphome/esphome/pull/15559)) and preserves crash data across OTA rollback reboots ([#15578](https://github.com/esphome/esphome/pull/15578)).
+
+**40KB extra IRAM on original ESP32** ([#14874](https://github.com/esphome/esphome/pull/14874)): A new option reclaims 40KB of previously reserved SRAM1 as IRAM, expanding the flash cache window and reducing cache misses for WiFi, BLE, and API operations, at no cost to heap. ESPHome will automatically detect your bootloader version at boot and suggest enabling this option only when it is safe to do so. **Do not enable this option without the bootloader check confirming it is safe**; enabling it with a pre-v5.1 bootloader will brick the device (requiring USB reflash to recover). See the [ESP32 documentation](/components/esp32#esp32-advanced_configuration) for details.
+
+**Signed OTA verification** ([#15357](https://github.com/esphome/esphome/pull/15357)): New `signed_ota_verification` option enables firmware signature verification during OTA updates without requiring hardware Secure Boot (eFuse burning). Two workflows are supported:
+
+- **Private key mode** (`signing_key`) - Firmware is automatically signed during build. Simplest setup.
+- **Public key mode** (`verification_key`) - Only the public key is embedded; binaries are signed externally (e.g., in CI/CD with the private key in a secure vault).
 
 ```yaml
-climate:
-  - platform: mitsubishi_cn105
-    name: "Air Condition"
-    uart_id: ac_uart
-    update_interval: 1s
-    current_temperature_min_interval: 60s
+esp32:
+  framework:
+    type: esp-idf
+    advanced:
+      signed_ota_verification:
+        signing_key: secure_boot_signing_key.pem
+        signing_scheme: rsa3072
 ```
 
-## LVGL v9 Upgrade
+**Custom partition tables** ([#7682](https://github.com/esphome/esphome/pull/7682)): Components and YAML configs can now define custom data/app partitions that are appended to the flash layout. The partition table generation has been unified across Arduino and IDF, and NVS has been moved to the end of flash with increased size (20KB to 384KB on Arduino). See the [ESP32 documentation](/components/esp32#esp32-partitions) for details.
 
-ESPHome's LVGL integration has been upgraded from v8 to **LVGL v9.5.0** ([#12312](https://github.com/esphome/esphome/pull/12312)), a major library migration that brings significant improvements to the graphics framework. Existing configs should compile and run, though some properties are deprecated.
+## ESP8266 Crash Handler, Without a Serial Cable
 
-**Key Changes:**
+Completing the platform coverage started in [2026.3.0](/changelog/2026.3.0#crash-handlers-without-a-serial-cable) (which added crash handlers for ESP32 and RP2040), ESP8266 devices now have the same post-mortem crash diagnostics ([#15465](https://github.com/esphome/esphome/pull/15465)). When a device crashes, the exception details and up to 16 stack-scanned backtrace addresses are saved to RTC memory and reported over the API on the next boot. **No USB cable required**; crash data appears in `esphome logs` (which automatically decodes addresses to source locations via `addr2line`) and the Home Assistant log viewer, entirely over WiFi.
 
-- **Runtime rotation** - Rotation is now an LVGL-level config option with dynamic runtime changes via `lvgl.display.set_rotation`. This is a breaking change that requires moving `rotation` from the display configuration to the `lvgl:` block ([#14955](https://github.com/esphome/esphome/pull/14955))
-- **Dark mode support** - A simple `dark_mode: true` option under `theme:` enables LVGL's built-in dark theme with a single line of YAML ([#15389](https://github.com/esphome/esphome/pull/15389))
-- **All LVGL 9 events** - Complete mapping of LVGL 9 events to ESPHome automation triggers ([#15362](https://github.com/esphome/esphome/pull/15362))
-- **Drop shadow and bitmap masking** - New `bitmap_mask_src` style property and A8 image format for drop shadow effects ([#15334](https://github.com/esphome/esphome/pull/15334))
+```
+[E][esp8266]: *** CRASH DETECTED ON PREVIOUS BOOT ***
+[E][esp8266]:   Reason: Exception - StoreProhibit (exccause=29)
+[E][esp8266]:   PC: 0x40212EC5
+[E][esp8266]:   EXCVADDR: 0x00000000
+[E][esp8266]:   BT0: 0x40212F5A
+[E][esp8266]:   BT1: 0x40203B10
+```
+
+The `PC` is the program counter where the crash occurred, `EXCVADDR` is the memory address that caused the fault, and `BT0`/`BT1`/etc. are the stack backtrace showing the call chain leading to the crash. When using `esphome logs`, these addresses are automatically decoded to source file and line numbers via `addr2line`, so you see the actual function names instead of raw hex.
+
+No configuration needed; it's automatically enabled for all ESP8266 devices. Resource cost is minimal: 0 bytes RAM, 119 bytes IRAM, ~1KB flash.
+
+## Client-Side State Logging
+
+State change logging has been fundamentally redesigned to eliminate the single biggest CPU bottleneck on every ESPHome device ([#15155](https://github.com/esphome/esphome/pull/15155)).
+
+Every entity state change (`'CO2' >> 420 ppm`, `'Light' - Setting ON`) previously ran `vsnprintf` on the device to format a log string and sent it over UART, even when nobody was watching the serial console (which is 99.9% of devices). CodSpeed benchmarks revealed this was consuming **95%+ of sensor publish time**.
+
+State change logs are now reconstructed on the client instead of the device. When `esphome logs` or the dashboard connects, it subscribes to compact protobuf state messages and formats them locally. The protobuf messages are a fraction of the size of formatted strings, and formatting happens on your computer instead of the microcontroller. This achieves up to **46x faster** in the publish path, with flash savings of **1.4KB** (ESP32-C3) to **2.2KB** (ESP8266). State changes still appear in logs as `[S]` lines in bright cyan:
+
+```
+[18:03:14.677][S][sensor]: 'CO2' >> 420 ppm
+[18:03:14.677][S][sensor]: 'Temperature' >> 35.63 °C
+[18:03:51.747][S][light]: 'Light' >> ON
+```
+
+A new `--no-states` flag ([#15160](https://github.com/esphome/esphome/pull/15160)) lets users suppress state change lines entirely for the first time, useful for debugging when the log is flooded with sensor readings. Users who need the old device-side state logging can opt back in by setting `logger: level: VERBOSE`.
+
+## Preliminary ESP-IDF 6.0 Compatibility
+
+This release includes **31 pull requests** preparing ESPHome for ESP-IDF 6.0, which brings GCC 15, picolibc, and significant API changes from Espressif. Led by [@swoboda1337](https://github.com/swoboda1337), this effort touches cryptography, drivers, and toolchain compatibility across the entire codebase. While ESP-IDF 6.0 is not yet the default framework version, these changes ensure ESPHome is ready when it ships. All related PRs are tagged with the [`idf-6`](https://github.com/esphome/esphome/pulls?q=label%3Aidf-6+is%3Amerged) label.
+
+**PSA Crypto API migration:**
+
+IDF 6.0 deprecates the legacy mbedTLS crypto APIs. All ESPHome cryptographic operations have been migrated to the new PSA Crypto API:
+
+- SHA-256 hashing ([#14809](https://github.com/esphome/esphome/pull/14809))
+- HMAC-SHA256 ([#14814](https://github.com/esphome/esphome/pull/14814))
+- BLE tracker PSA Crypto ([#14811](https://github.com/esphome/esphome/pull/14811))
+- BTHome/Xiaomi BLE CCM decryption ([#14816](https://github.com/esphome/esphome/pull/14816))
+- DLMS meter GCM decryption ([#14817](https://github.com/esphome/esphome/pull/14817))
+
+**Driver and API compatibility fixes across 20+ components:**
+
+- WiFi, ADC, LEDC, RMT (LED strips, remote transmitter/receiver), MIPI DSI, PSRAM, I2S audio, I2C, deep sleep, MQTT, USB host, OpenTherm timer, ethernet, debug, and camera components all updated for IDF 6.0 API changes
+
+**Toolchain compatibility:**
+
+- PicoLibC `std::isnan` conflict resolved ([#14768](https://github.com/esphome/esphome/pull/14768))
+- `vfprintf` printf stub fixed for picolibc ([#15172](https://github.com/esphome/esphome/pull/15172))
+- Implicit `int`-to-`gpio_num_t` conversions fixed for GCC 15 ([#14830](https://github.com/esphome/esphome/pull/14830))
+- Legacy I2S driver removed in preparation for IDF 6.0 where it no longer exists ([#14932](https://github.com/esphome/esphome/pull/14932))
+
+## Substitution System Overhaul
+
+Led by [@jpeletier](https://github.com/jpeletier), the YAML configuration system receives two major improvements that make complex, multi-file configurations far more powerful and faster to load.
+
+**Substitutions in `!include` paths** ([#12213](https://github.com/esphome/esphome/pull/12213)): You can now use substitution variables and Jinja expressions directly in `!include` filenames, enabling dynamic file selection:
+
+```yaml
+substitutions:
+  eth_model: LAN8720
+
+packages:
+  - !include network/${eth_model}/config.yaml
+```
+
+This works with command-line substitutions too, allowing the same YAML to target different hardware configurations without duplicating files.
+
+**18x faster config loading** ([#14918](https://github.com/esphome/esphome/pull/14918)): The substitution engine has been redesigned to perform all variable substitutions in a single linear pass instead of the previous multi-pass approach. This achieves up to **18x faster config load times** for large projects with many packages and includes. The rewrite also fixes several edge cases where cross-file variable references (`${A * B}` mixing local and root variables) were unreliable. Note that `merge_config` argument order for duplicate substituted keys has changed to "last writer wins."
 
 ## Ethernet Expansion
 
-This release dramatically expands Ethernet support across platforms, adding **5 new chip types** and bringing SPI Ethernet to the RP2040 platform for the first time.
+Building on RP2040/RP2350's [first-class platform support in 2026.3.0](/changelog/2026.3.0#rp2040rp2350-first-class-platform-support), this release dramatically expands Ethernet support across platforms, adding **5 new chip types** and bringing SPI Ethernet to the RP2040 platform for the first time. RP2040 boards like the WIZnet EVB-Pico series can now be used as wired IoT controllers without WiFi.
 
 **New RP2040 Ethernet Support:**
 
@@ -86,11 +168,14 @@ This release dramatically expands Ethernet support across platforms, adding **5 
 **Cross-Platform Additions:**
 
 - **ENC28J60** ([#14945](https://github.com/esphome/esphome/pull/14945)) - Microchip's widely-available 10BASE-T controller now supported on both ESP32 (IDF) and RP2040
-- **SPI interface selection** ([#10285](https://github.com/esphome/esphome/pull/10285)) - New `interface` config variable lets users select `spi2` or `spi3` host, resolving conflicts with display components on boards like the M5Stack CoreS3
 
-## GPIO Expander Interrupt-Driven Mode
+**ESP32 Improvements:**
 
-A new optional `interrupt_pin` configuration for GPIO expanders eliminates constant I2C/SPI polling, achieving **99.7% reduction in I2C traffic** during idle periods ([#15444](https://github.com/esphome/esphome/pull/15444), [#15445](https://github.com/esphome/esphome/pull/15445)).
+- **SPI interface selection** ([#10285](https://github.com/esphome/esphome/pull/10285)) - New `interface` config variable lets ESP32 users select `spi2` or `spi3` host, resolving conflicts with display components on boards like the M5Stack CoreS3
+
+## GPIO Expander Interrupt Support
+
+The [PCF8574](/components/pcf8574), [PCA9554](/components/pca9554), [MCP23008/MCP23017/MCP23S08/MCP23S17](/components/mcp230xx), and [PI4IOE5V6408](/components/pi4ioe5v6408) GPIO expander components now support an optional `interrupt_pin` that eliminates I2C/SPI polling entirely ([#15444](https://github.com/esphome/esphome/pull/15444), [#15445](https://github.com/esphome/esphome/pull/15445)).
 
 **Supported Expanders:**
 
@@ -106,197 +191,292 @@ A new optional `interrupt_pin` configuration for GPIO expanders eliminates const
 | Loop iterations per gate cycle | 7477 | 16 | **468x fewer** |
 | Binary sensor read time | ~0.6ms (I2C) | ~0.002ms (cache) | **300x faster** |
 
-Configuration is simple and fully backward compatible:
+When configured, binary sensors return from cache (no bus reads) between interrupts, and the main loop is completely disabled until a pin change occurs. The MCP23x17 automatically enables the MIRROR bit so a single interrupt wire catches changes on all 16 pins.
 
 ```yaml
 pcf8574:
   id: my_pcf8574
-  interrupt_pin: GPIO16  # Connect to INT pin on PCF8574
+  interrupt_pin: GPIO16
 ```
 
-## ESP32 Performance Improvements
+## Performance Benchmarking with CodSpeed
 
-Two changes significantly improve ESP32 performance out of the box.
+This release introduces comprehensive C++ benchmarking infrastructure using [CodSpeed](https://codspeed.io/esphome/esphome), enabling continuous performance tracking and regression prevention. While initially added to protect the gains from 2026.3.0, the benchmarks quickly revealed remaining bottlenecks and drove a wave of targeted optimizations throughout this release cycle.
 
-**Default CPU Frequency Raised to Maximum** ([#15143](https://github.com/esphome/esphome/pull/15143)):
+**Benchmarks added:**
 
-ESP32, ESP32-S2, ESP32-S3, and ESP32-C5 now default to **240MHz** instead of 160MHz. This restores the performance level that Arduino users had before May 2025 and delivers ~34% faster CPU-bound operations:
+- Protobuf encoding/decoding (API messages, BLE advertisements, ListEntities)
+- Noise encryption handshakes and payload encryption
+- Sensor, binary sensor, light, cover, climate, fan, number, select, switch, text_sensor, and button publish/call paths
+- Scheduler interval and timeout operations
+- Plaintext and encrypted API frame writes
 
-- **API encryption handshake**: 90ms to 64ms (29% faster)
-- **Protobuf encoding** (BLE proxy): 34% faster
-- **Noise encryption**: 33-34% faster across all payload sizes
+**API layer optimizations** (the native API is the primary communication path between ESPHome devices and Home Assistant). The goal was to make Bluetooth Proxy lightweight enough that every ESP32-C3 can run it without worrying about performance impact, and this release delivers: combined with changes from 2026.3.0, the API and BLE proxy now consume only ~2.3% of main loop runtime on ESP32-C3, down from ~3.3% in 2026.3.0 and a fraction of what it was a year ago:
 
-Users on battery power or with thermal constraints can override with `cpu_frequency: 160MHZ`. This is a breaking change as it increases power consumption on affected variants.
+- **Protobuf encoding**: 17-20% faster with register-optimized write path ([#15290](https://github.com/esphome/esphome/pull/15290))
+- **Precomputed tag bytes**: Varint and length-delimited field tags computed at compile time ([#15067](https://github.com/esphome/esphome/pull/15067))
+- **Frame write hot path**: Peeled first write iteration, inlined socket writes, zero-gap batch encoding. Single sensor state writes **72% faster**, batch writes **21% faster**, stack frame reduced from 352 to 48 bytes (-86%) ([#15063](https://github.com/esphome/esphome/pull/15063))
+- **Varint encoding optimized**: Plaintext varint encoding and write_protobuf_packet devirtualized ([#14758](https://github.com/esphome/esphome/pull/14758))
+- **Command dispatch devirtualized**: Eliminates virtual call overhead on every incoming API message ([#15044](https://github.com/esphome/esphome/pull/15044))
+- **Protobuf decode non-virtual**: ProtoDecodableMessage::decode() devirtualized ([#15076](https://github.com/esphome/esphome/pull/15076))
+- **Constant-size varint codegen**: `max_value` proto option eliminates variable-length encoding for bounded fields ([#15424](https://github.com/esphome/esphome/pull/15424))
+- **Entity name/object_id optimized**: `max_data_length` proto option for known-bounded string fields ([#15426](https://github.com/esphome/esphome/pull/15426))
+- **Fixed32 decode**: Uses memcpy on little-endian platforms instead of byte-shifting ([#15292](https://github.com/esphome/esphome/pull/15292))
+- **Raw tag+value writes**: Forced fixed32 key fields emit raw bytes ([#15051](https://github.com/esphome/esphome/pull/15051))
+- **Float zero checks**: Integer comparison instead of floating-point ([#15490](https://github.com/esphome/esphome/pull/15490))
+- **Code size reduction**: Buffer and nodelay optimizations ([#14797](https://github.com/esphome/esphome/pull/14797))
+- **Overflow buffer extracted**: Frame helper buffer management simplified ([#14871](https://github.com/esphome/esphome/pull/14871))
+- **Noise encryption speedup**: Continuing from the [ChaCha20-Poly1305 optimization in 2026.3.0](/changelog/2026.3.0) (which achieved 8-32% faster encryption), this release enables `HAVE_WEAK_SYMBOLS` and `HAVE_INLINE_ASM` for libsodium, replacing a volatile byte-by-byte `sodium_memzero()` fallback with word-sized `memset()`. Small messages (the common case for sensor updates and service calls) see the biggest gains: **24% faster on ESP32, 11% on ESP8266, 10% on RP2040** ([#15038](https://github.com/esphome/esphome/pull/15038))
+- **Noise handshake**: Split state_action_ to reduce stack pressure ([#15464](https://github.com/esphome/esphome/pull/15464))
+- **PSK update**: Avoided heap allocation in timeout lambda ([#14921](https://github.com/esphome/esphome/pull/14921))
+- **Batch encoding**: Simplified encode_to_buffer to single resize call, inlined DeferredBatch::add_item ([#15355](https://github.com/esphome/esphome/pull/15355), [#15353](https://github.com/esphome/esphome/pull/15353))
+- **Enum auto-derivation**: Auto-derive max_value for enum fields in protobuf codegen ([#15469](https://github.com/esphome/esphome/pull/15469))
 
-**SRAM1 as IRAM Option** ([#14874](https://github.com/esphome/esphome/pull/14874)):
+**Core framework optimizations:**
 
-A new `sram1_as_iram: true` option for the original ESP32 reclaims **40KB of SRAM1** as additional IRAM at no cost to heap. This expands the flash cache window, reducing cache misses for WiFi, BLE, and API operations. ESPHome includes bootloader detection to prevent enabling this on old bootloaders (which would brick the device).
+- **Scheduler**: Integer math for interval offset calculation, reschedules fired intervals directly into the heap, early-exit cancel path, and inlined fast-path checks ([#14755](https://github.com/esphome/esphome/pull/14755), [#15516](https://github.com/esphome/esphome/pull/15516), [#14902](https://github.com/esphome/esphome/pull/14902), [#14905](https://github.com/esphome/esphome/pull/14905))
+- **Main loop inlined**: `Application::loop()` and `calculate_looping_components_` inlined to eliminate stack frames ([#15041](https://github.com/esphome/esphome/pull/15041), [#14944](https://github.com/esphome/esphome/pull/14944))
+- **std::bind eliminated**: Replaced across 20+ components with lambdas to fit within small-buffer optimization ([#14961](https://github.com/esphome/esphome/pull/14961) and related PRs)
+- **Automation call chain collapsed**: The `Trigger::trigger()` → `Automation::trigger()` → `ActionList::play()` forwarding chain is force-inlined, collapsing 3 stack frames into 1. Combined with ControllerRegistry dispatch inlining and `call_loop_` removal, a button→lambda automation went from **16 stack frames to 10**, significantly reducing stack overflow risk on devices with deep automation chains ([#15042](https://github.com/esphome/esphome/pull/15042), [#15173](https://github.com/esphome/esphome/pull/15173), [#14931](https://github.com/esphome/esphome/pull/14931))
+- **IfAction compile-time optimization**: `HasElse` parameter eliminates the else-branch check at compile time when no else block is configured ([#15134](https://github.com/esphome/esphome/pull/15134))
+- **Logger**: Reduced per-message overhead by inlining hot path helpers ([#14851](https://github.com/esphome/esphome/pull/14851))
+- **errno caching**: Avoids duplicate `__errno()` calls across API, async_tcp, captive_portal, and web_server_idf ([#14751](https://github.com/esphome/esphome/pull/14751))
+- **Loop elimination**: Many components were running their `loop()` every single main loop iteration just to check a condition or timestamp. These have been converted to event-driven patterns that only run when needed:
+  - `web_server`: Loop completely disabled when no SSE clients are connected; most devices have zero browser clients 99%+ of the time ([#15428](https://github.com/esphome/esphome/pull/15428))
+  - `total_daily_energy`: Replaced loop() with a single timeout that fires at midnight ([#15432](https://github.com/esphome/esphome/pull/15432))
+  - `CronTrigger`: Replaced loop() with `set_interval` ([#15433](https://github.com/esphome/esphome/pull/15433))
+  - `preferences`: Loop compiled out entirely when `flash_write_interval` is non-zero ([#14943](https://github.com/esphome/esphome/pull/14943))
+  - GPIO expanders (PCF8574, PCA9554, MCP23xxx, PI4IOE5V6408): Loop disabled when all pins are outputs ([#15455](https://github.com/esphome/esphome/pull/15455), [#15460](https://github.com/esphome/esphome/pull/15460))
+- **Bluetooth Proxy**: BLE event handler dispatch devirtualized, eliminating virtual call overhead on every BLE advertisement and GATT event ([#15310](https://github.com/esphome/esphome/pull/15310)). BLE `is_active`/`is_running` inlined and STL bloat removed ([#14875](https://github.com/esphome/esphome/pull/14875)). Advertisement flushing replaced `loop()` (which ran ~7,400 times/60s just to check a timestamp) with `set_interval(100ms)` so the flush logic only runs when needed (~600 times/60s), eliminating ~6,800 wasted iterations per minute ([#15347](https://github.com/esphome/esphome/pull/15347))
+- **Devirtualization**: Preferences backend, PollingComponent::set_update_interval ([#14825](https://github.com/esphome/esphome/pull/14825), [#14938](https://github.com/esphome/esphome/pull/14938))
+- **Light**: Reciprocal multiply in normalize_color, pass LightTraits to avoid redundant virtual calls ([#15401](https://github.com/esphome/esphome/pull/15401), [#15403](https://github.com/esphome/esphome/pull/15403))
 
-```yaml
-esp32:
-  framework:
-    type: esp-idf
-    advanced:
-      sram1_as_iram: true
-```
+CodSpeed runs on every pull request and push to `dev`, providing a continuous baseline that catches regressions before they ship. It was CodSpeed's benchmark visualization that revealed `vsnprintf` was consuming 95%+ of sensor publish time, leading to the [client-side state logging](#client-side-state-logging) change that achieved a **46x speedup** on the sensor publish path. Visit [codspeed.io/esphome/esphome](https://codspeed.io/esphome/esphome) to explore the benchmark results. Thank you to [CodSpeed](https://codspeed.io) for providing their service free to open source projects.
 
-## Substitutions and Config System Improvements
+## Memory Optimizations
 
-The substitution engine has been rewritten to perform **all variable substitutions in a single linear pass**, achieving up to **18x faster config load times** in large projects ([#14918](https://github.com/esphome/esphome/pull/14918)).
+Driven by the increased visibility from benchmarking and memory analysis tooling, this release includes significant RAM and flash savings across the framework.
 
-Additionally, **substitutions now work in `!include` file paths** ([#12213](https://github.com/esphome/esphome/pull/12213)), enabling dynamic file selection:
+**Component allocations moved from heap to BSS** ([#15079](https://github.com/esphome/esphome/pull/15079)): This is a major architectural change; all component instances (`new_Pvariable`) are now allocated via placement new into statically-sized BSS storage instead of individual heap allocations. Previously, every component, sensor, automation, and filter was a separate `new` call, fragmenting the heap over time. Now these allocations are packed into a single contiguous BSS region, freeing heap space for WiFi, BLE, and network buffers that genuinely need dynamic allocation. This eliminates hundreds of small heap allocations per device and significantly reduces heap fragmentation on long-running devices.
 
-```yaml
-substitutions:
-  eth_model: LAN8720
+ESPHome's CI automatically runs a home-grown memory impact analysis on every pull request, showing contributors the exact flash and RAM impact of their changes before merging. Previously, component memory was invisible to this tooling because it was all allocated at runtime on the heap. Once the BSS change landed, every component's memory became a statically-visible symbol that the CI could measure and attribute. The [`analyze-memory`](/guides/cli#analyze-memory-command) tool was extended to attribute placement new storage symbols back to their owning components ([#15092](https://github.com/esphome/esphome/pull/15092)), making it easy to spot which components still had room for improvement. This visibility drove the wave of targeted optimizations below.
 
-packages:
-  - !include network/${eth_model}/config.yaml
-```
+**Core framework savings:**
 
-**Key Improvements:**
+- **Component base class**: Shrunk from 12 to 8 bytes per instance, saving ~200-400 bytes across typical configs ([#15103](https://github.com/esphome/esphome/pull/15103))
+- **CallbackManager**: Replaced `std::function` (16 bytes) with lightweight `Callback` (8 bytes) across all callback registrations. Small lambdas like `[this]` are now stored inline in the function pointer context with zero heap allocation, covering 96% of all callback registrations. Measured **+488 bytes free heap** on an ESP8266 config with MQTT + web_server + many entities ([#14853](https://github.com/esphome/esphome/pull/14853))
+- **Trigger trampolines eliminated across 23 components**: Previously, every `on_press`, `on_value`, `on_state`, etc. automation instantiated a separate Trigger object just to forward a callback, a 4+ byte heap-allocated object that existed solely to hold a pointer. A new `build_callback_automation()` pattern collapses the trigger into a pointer-sized forwarder struct stored inline in the callback manager, eliminating the separate allocation entirely. The initial PR ([#15174](https://github.com/esphome/esphome/pull/15174)) migrated the core entity types (button, sensor, binary_sensor, switch, text_sensor, number, event) saving 88-208 bytes RAM, then **22 follow-up PRs** migrated alarm_control_panel, lock, media_player, ld2450, rtttl, online_image, rotary_encoder, dfplayer, hlk_fm22x, pn532, pn7150/pn7160, sim800l, fingerprint_grow, ltr_als_ps, ltr501, nextion, ezo, haier, modbus_controller, rf_bridge, factory_reset, sml, and safe_mode
+- **TemplatableValue → TemplatableFn**: The function-pointer pattern was first proven on `LightControlAction`, shrinking each instance from 128 to 72 bytes (44% reduction, saving 616 bytes RAM on an ESP8266 light config with 11 actions) ([#15132](https://github.com/esphome/esphome/pull/15132)). This was then generalized codebase-wide: ~340 `TEMPLATABLE_VALUE` fields automatically dropped from 8 to 4 bytes each by storing function pointers instead of tagged unions ([#15545](https://github.com/esphome/esphome/pull/15545))
+- **ActionList**: Removed `actions_end_` pointer to save RAM per automation ([#15283](https://github.com/esphome/esphome/pull/15283))
 
-- **Single-pass evaluation** - Eliminates the old `JinjaStr` deferred-evaluation workaround; all variables are visible at evaluation time
-- **Cross-scope expressions** - `${A * B}` inside included files now reliably resolves when `A` is a local var and `B` is a root substitution
-- **Better error messages** - Circular dependency warnings include the actual cause and variable paths
+**Entity and component savings:**
 
-The substitution pass has a minor breaking change: when multiple YAML keys resolve to the same substituted name, the last-appearing key now takes precedence ("last writer wins").
+- **Binary sensor**: Removed redundant `optional<bool>` state, saving 8 bytes per instance ([#15095](https://github.com/esphome/esphome/pull/15095))
+- **Text sensor**: `raw_callback_` gated behind `USE_TEXT_SENSOR_FILTER`, saving 4 bytes per instance when unused ([#15097](https://github.com/esphome/esphome/pull/15097))
+- **Light**: Reordered LightState fields to eliminate padding ([#15112](https://github.com/esphome/esphome/pull/15112))
+- **GPIO binary sensor**: Packed fields and removed redundant `last_state_` ([#15113](https://github.com/esphome/esphome/pull/15113))
+- **GPIO switch**: Compiled out interlock fields when unused ([#15111](https://github.com/esphome/esphome/pull/15111))
+- **Climate/Fan**: Custom mode vectors stored on entity directly, eliminating heap allocation ([#15206](https://github.com/esphome/esphome/pull/15206), [#15209](https://github.com/esphome/esphome/pull/15209))
+- **WebServerBase**: Reduced by 4 bytes ([#15251](https://github.com/esphome/esphome/pull/15251))
+- **[Runtime stats](/components/runtime_stats)**: Stored inline on Component, eliminating `std::map` lookup ([#15345](https://github.com/esphome/esphome/pull/15345))
 
-## OTA Signature Verification
+**Heap allocation elimination:**
 
-A new `signed_ota_verification` option enables **firmware signature verification during OTA updates** without requiring hardware Secure Boot (eFuse burning) ([#15357](https://github.com/esphome/esphome/pull/15357)). This protects against tampered firmware from network-based attacks.
+- **Sensor filters**: `OrFilter`, `CalibrateLinearFilter`, `CalibratePolynomialFilter`, `ValueList`, `FilterOut`, `ThrottleWithPriority` migrated to `std::array` ([#15262](https://github.com/esphome/esphome/pull/15262), [#15263](https://github.com/esphome/esphome/pull/15263), [#15264](https://github.com/esphome/esphome/pull/15264), [#15265](https://github.com/esphome/esphome/pull/15265))
+- **Text sensor filters**: `SubstituteFilter` and `MapFilter` migrated to `std::array` ([#15266](https://github.com/esphome/esphome/pull/15266), [#15269](https://github.com/esphome/esphome/pull/15269))
+- **Automation conditions**: `And`, `Or`, `Xor` conditions migrated to `std::array` ([#15282](https://github.com/esphome/esphome/pull/15282))
+- **PID**: Replaced `std::deque` with `FixedRingBuffer` ([#14733](https://github.com/esphome/esphome/pull/14733))
+- **Sensor sliding window**: Replaced with `FixedRingBuffer` ([#14736](https://github.com/esphome/esphome/pull/14736))
 
-**Two Workflows:**
+**ESP8266 RAM savings:**
 
-- **Private key mode** (`signing_key`) - Firmware is automatically signed during build. Simplest setup
-- **Public key mode** (`verification_key`) - Only the public key is embedded; binaries are signed externally (e.g., in CI/CD with the private key in a secure vault)
+- **API dump strings**: Moved to PROGMEM ([#14982](https://github.com/esphome/esphome/pull/14982))
+- **Logger**: Log level lookup tables and task log buffer moved to PROGMEM/BSS ([#15003](https://github.com/esphome/esphome/pull/15003), [#15153](https://github.com/esphome/esphome/pull/15153))
 
-```yaml
-esp32:
-  framework:
-    type: esp-idf
-    advanced:
-      signed_ota_verification:
-        signing_key: secure_boot_signing_key.pem
-        signing_scheme: rsa3072
-```
+## Config Bundle for Remote Compilation
 
-## Config Bundles for Remote Compilation
-
-The new `esphome bundle` CLI command packages a YAML config and all its local dependencies into a self-contained archive for remote compilation ([#13791](https://github.com/esphome/esphome/pull/13791)). This is the foundation for remote build server support, enabling low-powered devices like Home Assistant Green to offload compilation.
+The new `esphome bundle` CLI command packages a YAML config and all its local dependencies (fonts, images, certificates, local external_components, secrets) into a self-contained `.esphomebundle.tar.gz` archive ([#13791](https://github.com/esphome/esphome/pull/13791)). This is the foundation for **remote compilation support**, enabling devices like the Home Assistant Green to offload compilation to a remote build server.
 
 **Key Features:**
 
-- **Automatic dependency discovery** - Finds fonts, images, certificates, C++ includes, web assets, local external_components, and secrets
-- **Filtered secrets** - Only secrets actually referenced by bundled files are included
-- **Reproducible archives** - Deterministic output with sorted entries for consistent builds
-- **Incremental builds** - Preserves build caches across re-extractions
+- **Automatic dependency discovery** - Finds all referenced files (YAML includes, fonts, images, animations, certificates, C++ includes, web assets)
+- **Secrets filtering** - Only includes secrets actually referenced by bundled YAML files
+- **Deterministic archives** - Sorted entries and zeroed timestamps for reproducibility
+- **Incremental builds** - Preserves PlatformIO build caches across re-extractions
 
 ```bash
-esphome bundle my_device.yaml           # Create bundle
+esphome bundle my_device.yaml              # Create bundle
 esphome bundle my_device.yaml --list-only  # Preview files
 esphome compile my_device.esphomebundle.tar.gz  # Compile from bundle
 ```
 
-## ESP32 Custom Partition Tables
+## LVGL v9 Upgrade
 
-ESP32 users can now define **custom data partitions** directly in YAML ([#7682](https://github.com/esphome/esphome/pull/7682)). Custom partitions are appended at the end of flash and steal space from the OTA app partitions, enabling use cases like storing calibration data, custom file systems, or additional NVS namespaces.
+Led by [@clydebarrow](https://github.com/clydebarrow) with 27 PRs, ESPHome's LVGL integration has been upgraded from v8 to **LVGL v9.5.0** ([#12312](https://github.com/esphome/esphome/pull/12312)). This is a major library migration that brings a new rendering pipeline, improved performance, and new widget capabilities. Existing configurations should compile and run, though some properties are deprecated.
 
-The partition table generation has also been unified across Arduino and IDF frameworks, and NVS has been moved to the end of flash with significantly increased size (Arduino: 20KB to 384KB, IDF: 436KB to 448KB). The partition layout changes are a breaking change but NVS data is preserved as long as the partition name remains `nvs`.
+**Key changes:**
+
+- **Native rotation with hardware acceleration** - Rotation is now handled directly by LVGL instead of the display driver, with runtime rotation changes via `lvgl.display.set_rotation` and automatic use of hardware rotation when available. On ESP32-P4, rotation uses the PPA (Pixel Processing Accelerator) for zero-CPU-cost transforms ([#14955](https://github.com/esphome/esphome/pull/14955), [#15453](https://github.com/esphome/esphome/pull/15453)). Users will need to move their `rotation` config from the display component to the `lvgl:` block.
+- **Built-in dark theme** - A single `dark_mode: true` under `theme:` enables LVGL's native dark default theme, replacing the tedious process of manually replicating dark theme properties ([#15389](https://github.com/esphome/esphome/pull/15389))
+- **All LVGL 9 events** - Complete mapping of LVGL 9 events to ESPHome automation triggers ([#15362](https://github.com/esphome/esphome/pull/15362))
+- **Drop shadow support** - New `bitmap_mask_src` style property and A8 image format for drop shadow effects ([#15334](https://github.com/esphome/esphome/pull/15334))
+
+## New Sensors and Hardware Support
+
+This release adds support for several new sensors and hardware platforms:
+
+- **[SPA06-003](/components/sensor/spa06)** by [@danielkent-net](https://github.com/danielkent-net) - Goermicro digital pressure and temperature sensor with both I2C and SPI interfaces, available from Adafruit and Seeed Grove ([#14521](https://github.com/esphome/esphome/pull/14521), [#14522](https://github.com/esphome/esphome/pull/14522), [#14523](https://github.com/esphome/esphome/pull/14523))
+- **[HDC2080](/components/sensor/hdc2080)** by [@G-Pereira](https://github.com/G-Pereira) - Texas Instruments temperature and humidity sensor ([#9331](https://github.com/esphome/esphome/pull/9331))
+- **[emonTx](/components/sensor/emontx)** by [@FredM67](https://github.com/FredM67) - OpenEnergyMonitor emonTx/emonPi energy monitoring via UART serial bridge, with JSON triggers and command actions ([#9027](https://github.com/esphome/esphome/pull/9027))
+- **BMP581 SPI support** by [@danielkent-net](https://github.com/danielkent-net) - The BMP581 pressure sensor now supports SPI in addition to I2C ([#13124](https://github.com/esphome/esphome/pull/13124))
+- **BMP585 support** by [@nytaros](https://github.com/nytaros) - Adds the newer BMP585 ASIC ID to the BMP581 component ([#15277](https://github.com/esphome/esphome/pull/15277))
+- **ESP32-C61 PSRAM** - Quad mode PSRAM support at 40MHz and 80MHz ([#14795](https://github.com/esphome/esphome/pull/14795))
+- **Internal temperature** for nRF52 Zephyr by [@Ardumine](https://github.com/Ardumine) ([#15297](https://github.com/esphome/esphome/pull/15297)) and LN882H by [@Bl00d-B0b](https://github.com/Bl00d-B0b) ([#15370](https://github.com/esphome/esphome/pull/15370))
+## Other Notable Features
+
+- **Number-to-sensor and text-to-text_sensor bridges** - New read-only sensor/text_sensor views of number/text components for use in automations and displays ([#15125](https://github.com/esphome/esphome/pull/15125), [#15090](https://github.com/esphome/esphome/pull/15090))
+- **ESP32 Hosted SPI transport** - SPI transport and 1-bit SDIO bus width support for the `esp32_hosted` WiFi offloading component ([#15551](https://github.com/esphome/esphome/pull/15551))
+- **Nextion custom protocol triggers** - `on_custom_switch`, `on_custom_sensor`, `on_custom_text_sensor`, `on_custom_binary_sensor` triggers for event-driven Nextion workflows without entities ([#13248](https://github.com/esphome/esphome/pull/13248))
+- **MQTT alarm panel JSON payloads** - Alarm control panel command topic now accepts JSON payloads with PIN codes, e.g. `{"state": "DISARM", "code": "1234"}` ([#14731](https://github.com/esphome/esphome/pull/14731))
+- **Media player enqueue action** - New `media_player.enqueue` action for queueing media URLs from automations ([#14775](https://github.com/esphome/esphome/pull/14775))
+- **MIPI RGB optional sync pins** - `hsync_pin`/`vsync_pin` now optional for displays like the BigTreeTech PandaTouch ([#14870](https://github.com/esphome/esphome/pull/14870))
+- **Brennenstuhl remote switches** - New 433MHz rolling code protocol for Brennenstuhl comfort-line switches ([#9407](https://github.com/esphome/esphome/pull/9407))
+- **DSMR thermal MBUS id** - New `thermal_mbus_id` option for Warmtelink heat meters ([#7519](https://github.com/esphome/esphome/pull/7519))
+- **VBus DeltaSol CS4** - Support for Citrin Solar 1.3 controller ([#12477](https://github.com/esphome/esphome/pull/12477))
+- **TM1637 buffer manipulation** - `set_buffer` method for raw segment writes and custom glyphs ([#13686](https://github.com/esphome/esphome/pull/13686))
+- **HUB75 scan wiring** - New `SCAN_1_8_32PX_FULL` wiring option ([#15130](https://github.com/esphome/esphome/pull/15130))
+- **`*/N` cron syntax** - Time-based automations now support `*/5` style step expressions ([#15434](https://github.com/esphome/esphome/pull/15434))
+
+## Mitsubishi CN105 Climate Component
+
+Built by [@crnjan](https://github.com/crnjan) across 5 PRs, the new [mitsubishi_cn105](/components/climate/mitsubishi_cn105) component brings native support for controlling Mitsubishi A/C units through the CN105 connector, one of the most requested climate integrations in ESPHome. The component implements the same CN105 protocol used by the popular SwiCago HeatPump project, ensuring compatibility with the same [range of devices](https://github.com/SwiCago/HeatPump/issues/13) ([#15315](https://github.com/esphome/esphome/pull/15315), [#15358](https://github.com/esphome/esphome/pull/15358), [#15437](https://github.com/esphome/esphome/pull/15437), [#15462](https://github.com/esphome/esphome/pull/15462), [#15483](https://github.com/esphome/esphome/pull/15483)).
+
+**Key Features:**
+
+- **Full climate control** - Power, mode, target temperature, and fan speed can be controlled directly from Home Assistant
+- **Non-blocking protocol driver** - Custom UART parser designed for performance and reliability
+- **Smart temperature polling** - The `current_temperature_min_interval` option rate-limits room temperature reads to prevent rapid oscillations near measurement boundaries while keeping a fast `update_interval` for responsive control
+- **Broad platform support** - Works on ESP32, ESP32 IDF, ESP8266, and RP2040/RP2350
 
 ```yaml
-esp32:
-  partitions:
-    - name: my_data
-      type: data
-      subtype: spiffs
-      size: 0x4000
+climate:
+  - platform: mitsubishi_cn105
+    name: "Air Condition"
+    uart_id: ac_uart
+    update_interval: 1s
+    current_temperature_min_interval: 60s
 ```
 
-## New Sensor and Hardware Support
-
-This release adds support for several new sensors and hardware components:
-
-- **[SPA06-003](/components/sensor/spa06)** ([#14521](https://github.com/esphome/esphome/pull/14521), [#14522](https://github.com/esphome/esphome/pull/14522), [#14523](https://github.com/esphome/esphome/pull/14523)) - Goermicro digital pressure and temperature sensor with both I2C and SPI support, available on Adafruit and Seeed Grove breakout boards
-- **[HDC2080](/components/sensor/hdc2080)** ([#9331](https://github.com/esphome/esphome/pull/9331)) - Texas Instruments temperature and humidity sensor
-- **[emonTx](/components/sensor/emontx)** ([#9027](https://github.com/esphome/esphome/pull/9027)) - OpenEnergyMonitor energy monitoring devices (emonTx, emonPi) via UART, with JSON data parsing, automation triggers, and command sending
-- **[BMP581 SPI](/components/sensor/bmp581)** ([#13124](https://github.com/esphome/esphome/pull/13124)) - SPI interface support for the BMP581 pressure sensor (previously I2C only)
-- **BMP585 support** ([#15277](https://github.com/esphome/esphome/pull/15277)) - Adds the BMP585 ASIC ID to the existing BMP581 driver
-- **ESP8266 crash handler** ([#15465](https://github.com/esphome/esphome/pull/15465)) - Post-mortem diagnostics matching existing ESP32 and RP2040 implementations, logging exception info and stack-scanned backtrace on reboot after a crash
-- **ESP32 Hosted SPI transport** ([#15551](https://github.com/esphome/esphome/pull/15551)) - SPI transport and 1-bit SDIO bus width support for the `esp32_hosted` WiFi offloading component
 {/* FEATURE_HIGHLIGHTS_END */}
+
+### Codebase Correctness Sweep
+
+Continuing the [correctness sweep started in 2026.3.0](/changelog/2026.3.0), [@swoboda1337](https://github.com/swoboda1337) contributed another **99 bug fix and validation PRs** in this release, addressing missing `state_class` and `device_class` on sensor schemas, incorrect config validation (wrong types, missing range checks, broken `ensure_list` usage), dead code removal, format specifier warnings, and codegen type mismatches across 100+ components. This sustained effort has significantly improved the reliability and correctness of the ESPHome codebase.
+
+## Thank You, Contributors
+
+{/* CONTRIBUTORS_START */}
+This release includes 507 pull requests from over 40 contributors. A huge thank you to everyone who made 2026.4.0 possible:
+
+- [@swoboda1337](https://github.com/swoboda1337) - 121 PRs including a correctness sweep across 100+ components, ESP-IDF 6.0 compatibility across dozens of components, and the ESP32 CPU frequency default change
+- [@clydebarrow](https://github.com/clydebarrow) - 27 PRs including the LVGL v9.5.0 migration, native rotation support, and display component improvements
+- [@edwardtfn](https://github.com/edwardtfn) - 14 PRs including Nextion custom protocol triggers, performance optimizations, and code quality improvements across the Nextion component
+- [@jpeletier](https://github.com/jpeletier) - 10 PRs including the substitution system redesign for 18x faster config loading and `!include` path substitution support
+- [@kbx81](https://github.com/kbx81) - 10 PRs including signed OTA verification without hardware secure boot, IR receiver frequency metadata, and sensor code cleanups
+- [@kahrendt](https://github.com/kahrendt) - 7 PRs including the media player enqueue action, microFLAC decoding, and audio pipeline improvements
+- [@danielkent-net](https://github.com/danielkent-net) - 5 PRs including the new SPA06-003 pressure/temperature sensor (I2C and SPI) and BMP581 SPI support
+- [@crnjan](https://github.com/crnjan) - 5 PRs building the new Mitsubishi CN105 climate component from scaffold to full read/write control
+- [@exciton](https://github.com/exciton) - 4 PRs including modbus helper refactoring and integration tests
+- [@jesserockz](https://github.com/jesserockz) - 4 PRs including CI improvements and unbounded percentage validators
+- [@diorcety](https://github.com/diorcety) - 4 PRs including git subpath support and compiler compatibility fixes
+- [@FredM67](https://github.com/FredM67) - 2 PRs including the new emonTx energy monitoring component
+- [@tomaszduda23](https://github.com/tomaszduda23) - 2 PRs including debug peripherals status and Zigbee logging improvements
+- [@P4uLT](https://github.com/P4uLT) - 2 PRs including PID FixedRingBuffer optimization
+- [@Kamilcuk](https://github.com/Kamilcuk) - 2 PRs including placement new allocation for Pvariables
+- [@luar123](https://github.com/luar123) - custom ESP32 partition tables and partition table refactoring
+- [@G-Pereira](https://github.com/G-Pereira) - the new HDC2080 temperature and humidity sensor
+
+Also thank you to [@bdraco](https://github.com/bdraco), [@thomwiggers](https://github.com/thomwiggers), [@aanban](https://github.com/aanban), [@rtyle](https://github.com/rtyle), [@Szewcson](https://github.com/Szewcson), [@Pernotto](https://github.com/Pernotto), [@mike1703](https://github.com/mike1703), [@tuct](https://github.com/tuct), [@CFlix](https://github.com/CFlix), [@heythisisnate](https://github.com/heythisisnate), [@warthog618](https://github.com/warthog618), [@FWeinb](https://github.com/FWeinb), [@droscy](https://github.com/droscy), [@intcreator](https://github.com/intcreator), [@szupi-ipuzs](https://github.com/szupi-ipuzs), [@fblaese](https://github.com/fblaese), [@glmnet](https://github.com/glmnet), [@nytaros](https://github.com/nytaros), [@Ardumine](https://github.com/Ardumine), [@rguca](https://github.com/rguca), [@Bl00d-B0b](https://github.com/Bl00d-B0b), [@RAR](https://github.com/RAR), [@Passific](https://github.com/Passific), and [@Tomer27cz](https://github.com/Tomer27cz) for their contributions, and to everyone who reported issues, tested pre-releases, and helped in the community.
+{/* CONTRIBUTORS_END */}
 
 ## Breaking Changes
 
 {/* BREAKING_CHANGES_USERS_START */}
 ### Platform Changes
 
-- **ESP32 Partition Table**: Partition layout has changed for both Arduino and IDF frameworks. NVS has been moved to the end of flash with increased size (Arduino: 20KB to 384KB, IDF: 436KB to 448KB), and a `phy_init` partition has been added to Arduino. Existing devices will receive the new partition table on the next OTA update. NVS data is preserved as long as the partition name remains `nvs`. [#7682](https://github.com/esphome/esphome/pull/7682)
+- **ESP32 CPU frequency**: Default CPU frequency changed to maximum supported per variant (ESP32/S2/S3/C5: 160MHz to 240MHz). This improves performance ~33% but increases power consumption. Battery-powered devices should add `cpu_frequency: 160MHZ` to their config. [#15143](https://github.com/esphome/esphome/pull/15143)
 
-- **ESP32 CPU Frequency**: Default CPU frequency is now set to the maximum supported for each variant (ESP32/S2/S3/C5: 240MHz, up from 160MHz). This increases power consumption (~30-50% on CPU-bound workloads). Battery-powered or thermally constrained devices should explicitly set `cpu_frequency: 160MHZ`. [#15143](https://github.com/esphome/esphome/pull/15143)
+- **ESP32 partition table**: Partition layout changed for both Arduino and IDF frameworks. NVS moved to end of flash with increased size (20KB to 384KB on Arduino). Existing devices will get the new partition table on next OTA update. NVS data is preserved since the library finds it by name, not position. [#7682](https://github.com/esphome/esphome/pull/7682)
 
-- **ESP8266 RTC Preferences**: The crash handler reserves 72 bytes of RTC memory, reducing RTC preferences capacity from 96 to 78 words. Overflow goes to flash automatically. Very unlikely to affect real configs. [#15465](https://github.com/esphome/esphome/pull/15465)
+- **ESP8266 RTC preferences**: RTC preferences capacity reduced from 96 to 78 words to accommodate the new crash handler. Overflow goes to flash. Very unlikely to affect real configs. [#15465](https://github.com/esphome/esphome/pull/15465)
 
 ### Component Changes
 
-- **LVGL Rotation**: The `rotation` option must be moved from the display configuration to the `lvgl:` block. LVGL now handles rotation directly, with support for runtime rotation changes via `lvgl.display.set_rotation`. [#14955](https://github.com/esphome/esphome/pull/14955)
+- **LVGL rotation**: The `rotation` option must now be configured under `lvgl:` instead of the display component. LVGL now handles rotation directly, with support for runtime rotation changes via `lvgl.display.set_rotation`. Users must move their `rotation` setting from the display config to the `lvgl:` block. [#14955](https://github.com/esphome/esphome/pull/14955)
 
-- **I2S Audio**: The legacy I2S driver (`use_legacy` option) has been removed. The `i2s_audio` media player sub-component has also been removed. Users should migrate to the [speaker media player](/components/media_player/speaker/) component. [#14932](https://github.com/esphome/esphome/pull/14932)
+- **I2S Audio**: The legacy I2S driver (`use_legacy` option) has been removed. The new I2S driver is always used. The `i2s_audio` media player sub-component has been removed entirely; users should migrate to the [speaker media player](/components/media_player/speaker) component. [#14932](https://github.com/esphome/esphome/pull/14932)
 
-- **Substitutions**: When multiple YAML keys resolve to the same substituted name, the last-appearing key now takes precedence ("last writer wins"), instead of the first. This only affects the edge case where multiple keys in the same dict resolve to the same substituted name. [#14918](https://github.com/esphome/esphome/pull/14918)
+- **Binary Sensor multi_click**: `on_multi_click` timing sequences are now limited to 255 entries (previously unlimited). No real config would approach this limit. [#15267](https://github.com/esphome/esphome/pull/15267)
 
-- **Binary Sensor MultiClick**: Timing sequences are now limited to 255 entries (previously unlimited). No real config would approach this limit. [#15267](https://github.com/esphome/esphome/pull/15267)
+- **Binary Sensor autorepeat**: Autorepeat timing lists are now limited to 254 entries (previously unlimited). No real config would approach this limit. [#15268](https://github.com/esphome/esphome/pull/15268)
 
-- **Binary Sensor Autorepeat**: Timing lists are now limited to 254 entries (previously unlimited). No real config would approach this limit. [#15268](https://github.com/esphome/esphome/pull/15268)
+### Configuration System Changes
+
+- **Substitutions**: When two YAML keys in the same dict resolve to the same substituted name, the later-appearing key's value now takes precedence ("last writer wins"). Previously, the existing resolved value took precedence on dict merges. This only affects the edge case of duplicate substituted keys. [#14918](https://github.com/esphome/esphome/pull/14918)
 {/* BREAKING_CHANGES_USERS_END */}
 
 ### Undocumented API Changes
 
 {/* UNDOCUMENTED_API_CHANGES_START */}
-Several internal C++ APIs have changed in this release. These are not covered by the formal breaking change policy, but may affect users who write lambdas or developers maintaining external components.
+Several internal C++ APIs have changed in this release. While these are not part of the public API, they may affect users who write lambdas or maintain external components.
 
-### Component Base Class Changes
+#### Component and Preferences Infrastructure
 
-- **Component**: Shrunk from 12 to 8 bytes per instance. `set_component_source(const LogString *)` has been removed and replaced with a protected `set_component_source_(uint8_t)` index. `warn_if_blocking_over_` changed from milliseconds (`uint16_t`) to centiseconds (`uint8_t`). [#15103](https://github.com/esphome/esphome/pull/15103)
+- **Component**: `set_component_source(const LogString *)` removed and replaced with protected `set_component_source_(uint8_t)`. The `warn_if_blocking_over_` field changed from `uint16_t` (milliseconds) to `uint8_t` (centiseconds). Component base class shrunk from 12 to 8 bytes. [#15103](https://github.com/esphome/esphome/pull/15103)
 
-- **Preferences**: `ESPPreferenceBackend` and `ESPPreferences` virtual base classes have been removed and replaced with concrete `final` classes per platform. The type aliases `ESPPreferenceBackend` and `ESPPreferences` remain as backward-compatible aliases. No caller changes required. [#14825](https://github.com/esphome/esphome/pull/14825)
+- **Preferences**: `ESPPreferenceBackend` and `ESPPreferences` abstract base classes removed. They are now type aliases to concrete platform-specific `final` classes. All existing code using `global_preferences` or `ESPPreferenceObject` continues to work unchanged. [#14825](https://github.com/esphome/esphome/pull/14825)
 
-### Trigger and Automation Changes
+#### Automation Trigger Changes
 
-- **Trigger trampolines**: Trigger objects for common entity automations (button, sensor, binary_sensor, switch, text_sensor, number, event) are no longer instantiated as separate objects. The `Automation::trigger_` back-pointer (protected field) has been removed. `build_automation()` and Trigger subclasses remain available for external components. [#15174](https://github.com/esphome/esphome/pull/15174)
+- **Trigger classes removed**: `ButtonPressTrigger`, `SensorStateTrigger`, `SensorRawStateTrigger`, `PressTrigger`, `ReleaseTrigger`, `StateTrigger`, `StateChangeTrigger`, `SwitchStateTrigger`, `SwitchTurnOnTrigger`, `SwitchTurnOffTrigger`, `TextSensorStateTrigger`, `TextSensorStateRawTrigger`, `NumberStateTrigger`, and `EventTrigger` are no longer instantiated. Lambdas using `trigger_id` to access these objects will break. Use `Script` for action control instead. The `Automation::trigger_` protected field was also removed. [#15174](https://github.com/esphome/esphome/pull/15174)
 
-- **TemplatableFn**: The `TEMPLATABLE_VALUE` macro now uses `TemplatableFn` (4 bytes) instead of `TemplatableValue` (8 bytes) for trivially copyable types. `TemplatableValue<T>` for non-string types no longer accepts stateful lambdas (lambdas with captures). `TemplatableValue` used directly is fully backward compatible. [#15545](https://github.com/esphome/esphome/pull/15545)
+#### TemplatableValue Changes
 
-### Component-Specific Changes
+- **TemplatableValue for non-string types**: No longer accepts stateful lambdas (lambdas with captures). No external usage was found. If you need a stateful callable, use `std::function<T(X...)>` directly. The `TEMPLATABLE_VALUE` macro now uses `TemplatableFn` (4 bytes) for trivially copyable types. [#15545](https://github.com/esphome/esphome/pull/15545)
 
-- **Nextion**: `get_wave_chan_id()` is deprecated in favor of `get_wave_channel_id()` (removal target: 2026.10.0). Getter methods are now `const`-qualified; `get_variable_name()` and `get_variable_name_to_send()` now return `const` references instead of copies. Waveform code is gated behind `USE_NEXTION_WAVEFORM` define. [#15204](https://github.com/esphome/esphome/pull/15204), [#15273](https://github.com/esphome/esphome/pull/15273)
+#### Component-Specific Changes
 
-- **ATM90E32**: `get_phase_angle_()` return type changed from `uint16_t` to `float` for correct precision. Unused `last_periodic_millis` member removed. [#15238](https://github.com/esphome/esphome/pull/15238)
+- **Nextion**: `get_wave_chan_id()` deprecated in favor of `get_wave_channel_id()` (removal in 2026.10.0). Getter methods now return by `const` reference instead of by value. `get_queue_type_string()` returns `const char *` instead of `std::string`. Waveform-related methods are now gated behind `USE_NEXTION_WAVEFORM` and may not be available if no waveform sensors are configured. [#15204](https://github.com/esphome/esphome/pull/15204), [#15273](https://github.com/esphome/esphome/pull/15273)
 
-- **AS5600**: Dead `angle`, `raw_angle`, and `position` sensor code removed (setters, members, and codegen that were never connected to the config schema). [#15254](https://github.com/esphome/esphome/pull/15254)
+- **ATM90E32**: `get_phase_angle_()` return type changed from `uint16_t` to `float` (fixes precision loss). `last_periodic_millis` member removed (was never used). [#15238](https://github.com/esphome/esphome/pull/15238)
 
-- **SEN5x**: Dead `voc_baseline` config option removed (was accepted in schema but never passed to C++). Use `store_baseline: true` for VOC baseline management. [#15391](https://github.com/esphome/esphome/pull/15391)
+- **AS5600**: Dead `angle_sensor_`, `raw_angle_sensor_`, `position_sensor_` members and their setters removed (were never wired to config schema). [#15254](https://github.com/esphome/esphome/pull/15254)
 
-- **Graph**: `legend` config no longer accepts a list (only the first element was ever used). Single-legend configs continue to work unchanged. [#15522](https://github.com/esphome/esphome/pull/15522)
+- **SEN5x**: `voc_baseline` config option removed (was never wired to C++). Use `store_baseline: true` instead. [#15391](https://github.com/esphome/esphome/pull/15391)
 
-- **Haier**: `control_method` config for HON protocol no longer accepts a list. Single-value configs continue to work unchanged. [#15523](https://github.com/esphome/esphome/pull/15523)
+- **Graph**: `legend` config no longer accepts a list (only the first element was ever used). Single-value configs continue to work. [#15522](https://github.com/esphome/esphome/pull/15522)
 
-- **RP2040 PIO LED Strip**: `CUSTOM` removed from the `CHIPSETS` enum (it crashed at codegen time). Use explicit `bit0_high`/`bit0_low`/`bit1_high`/`bit1_low` timing parameters for custom LED strips. [#15537](https://github.com/esphome/esphome/pull/15537)
+- **Haier**: `control_method` config no longer accepts a list. Single-value configs continue to work. [#15523](https://github.com/esphome/esphome/pull/15523)
+
+- **RP2040 PIO LED Strip**: `CUSTOM` removed from `chipset` enum (it crashed at compile time). Use explicit timing parameters (`bit0_high`, `bit0_low`, `bit1_high`, `bit1_low`) instead. [#15537](https://github.com/esphome/esphome/pull/15537)
 {/* UNDOCUMENTED_API_CHANGES_END */}
 
 ### Breaking Changes for Developers
 
 {/* BREAKING_CHANGES_DEVELOPERS_START */}
-- **CallbackManager**: `std::function` replaced with lightweight `Callback` type. Components registering callbacks must use compatible function signatures. [#14853](https://github.com/esphome/esphome/pull/14853)
+- **CallbackManager**: `std::function` replaced with lightweight `Callback` type. Existing code continues to work but external components should migrate callback registration methods from `std::function` parameters to templates for optimal performance (non-template methods fall back to a heap-allocation path). [#14853](https://github.com/esphome/esphome/pull/14853)
 - **PollingComponent**: `set_update_interval()` is now non-virtual. Subclasses overriding this method should use alternative patterns. [#14938](https://github.com/esphome/esphome/pull/14938)
 - **UART FlushResult**: `FlushResult` renamed to `UARTFlushResult` with `UART_FLUSH_RESULT_` prefix for enum values. [#15101](https://github.com/esphome/esphome/pull/15101)
-- **Sensor raw_state**: `.raw_state` is deprecated. `raw_callback_` is now gated behind `USE_SENSOR_FILTER`. [#15094](https://github.com/esphome/esphome/pull/15094)
+- **Sensor raw_state**: `.raw_state` is deprecated. `raw_callback_` is now gated behind `USE_SENSOR_FILTER`, saving RAM on every sensor instance when no filters are configured. [#15094](https://github.com/esphome/esphome/pull/15094)
 - **Trigger trampolines eliminated**: Trigger objects for common entity automations (button, sensor, binary_sensor, switch, text_sensor, number, event) are no longer instantiated. `build_automation()` and Trigger subclasses remain available. [#15174](https://github.com/esphome/esphome/pull/15174)
+- **TemplatableFn**: `TEMPLATABLE_VALUE` macro now uses 4-byte `TemplatableFn` for trivially copyable types. External components calling macro-generated setters with raw C++ constants instead of going through `cg.templatable()` will fail to compile. [#15545](https://github.com/esphome/esphome/pull/15545)
 - **Climate/Fan custom modes**: Custom mode/preset vectors are now stored on the entity instead of heap-allocated. Constructors for climate and fan traits have changed. [#15206](https://github.com/esphome/esphome/pull/15206), [#15209](https://github.com/esphome/esphome/pull/15209)
 - **Trigger migrations to callback automation**: `alarm_control_panel`, `lock`, and `media_player` triggers now use callback automation pattern. [#15198](https://github.com/esphome/esphome/pull/15198), [#15199](https://github.com/esphome/esphome/pull/15199), [#15200](https://github.com/esphome/esphome/pull/15200)
 - **BLE event dispatch**: BLE event handler dispatch is devirtualized. [#15310](https://github.com/esphome/esphome/pull/15310)
 - **wake_loop**: Moved from socket component into core. [#15446](https://github.com/esphome/esphome/pull/15446)
-- **TemplatableFn**: `TEMPLATABLE_VALUE` macro now uses 4-byte `TemplatableFn` for trivially copyable types. External components calling macro-generated setters with raw C++ constants instead of going through `cg.templatable()` will fail to compile. [#15545](https://github.com/esphome/esphome/pull/15545)
+- **Preferences devirtualized**: `ESPPreferenceBackend` and `ESPPreferences` are now type aliases to concrete platform-specific classes (no virtual base). [#14825](https://github.com/esphome/esphome/pull/14825)
+- **Component shrunk from 12 to 8 bytes**: `set_component_source(const LogString *)` removed and replaced with `set_component_source_(uint8_t)` (protected). [#15103](https://github.com/esphome/esphome/pull/15103)
+- **AS5600**: Dead `angle`, `raw_angle`, and `position` sensor code removed. [#15254](https://github.com/esphome/esphome/pull/15254)
 - **Modbus helpers**: Shared helper functions refactored across modbus components. [#15291](https://github.com/esphome/esphome/pull/15291), [#14172](https://github.com/esphome/esphome/pull/14172)
 
 For detailed migration guides and API documentation, see the [ESPHome Developers Documentation](https://developers.esphome.io/).

--- a/src/content/docs/changelog/2026.4.0.mdx
+++ b/src/content/docs/changelog/2026.4.0.mdx
@@ -23,7 +23,7 @@ import ImgTable from "@components/ImgTable.astro";
 ## Release Overview
 
 {/* RELEASE_OVERVIEW_START */}
-ESPHome 2026.4.0 delivers major performance and reliability improvements across all platforms. ESP32 devices default to maximum CPU frequency (33% faster API operations), unlock 40KB extra IRAM, signed OTA verification, and custom partition tables. ESP8266 gets a crash handler matching ESP32/RP2040, and a new client-side state logging architecture achieves up to 46x faster sensor publishing by moving log formatting off the device. Bluetooth Proxy and API overhead dropped to just 2.3% of main loop time on ESP32-C3. 31 PRs prepare the codebase for ESP-IDF 6.0, and CodSpeed benchmarking infrastructure now catches performance regressions before they ship. The substitution system has been redesigned for up to 18x faster config loading with dynamic `!include` paths, Ethernet expands with 5 new chip types across ESP32 and RP2040, and GPIO expanders gain interrupt-driven operation cutting idle I2C traffic by 99.7%. This release also adds LVGL v9.5.0, native Mitsubishi CN105 climate control, 4 new sensor components, and a `esphome bundle` CLI command to assist with remote compilation.
+ESPHome 2026.4.0 delivers major performance and reliability improvements across all platforms. ESP32 devices default to maximum CPU frequency (33% faster API operations), unlock 40KB extra IRAM, signed OTA verification, and custom partition tables. ESP8266 gets a crash handler matching ESP32/RP2040, and a new client-side state logging architecture achieves up to 46x faster sensor publishing by moving log formatting off the device. Bluetooth Proxy advertisement forwarding (the constant hot path) dropped to just ~2% of main loop time on ESP32-C3. 31 PRs prepare the codebase for ESP-IDF 6.0, and CodSpeed benchmarking infrastructure now catches performance regressions before they ship. The substitution system has been redesigned for up to 18x faster config loading with dynamic `!include` paths, Ethernet expands with 5 new chip types across ESP32 and RP2040, and GPIO expanders gain interrupt-driven operation cutting idle I2C traffic by 99.7%. This release also adds LVGL v9.5.0, native Mitsubishi CN105 climate control, 4 new sensor components, and a `esphome bundle` CLI command to assist with remote compilation.
 {/* RELEASE_OVERVIEW_END */}
 
 ## Upgrade Checklist
@@ -78,6 +78,10 @@ esp32:
 ```
 
 **Custom partition tables** ([#7682](https://github.com/esphome/esphome/pull/7682)): Components and YAML configs can now define custom data/app partitions that are appended to the flash layout. The partition table generation has been unified across Arduino and IDF, and NVS has been moved to the end of flash with increased size (20KB to 384KB on Arduino). See the [ESP32 documentation](/components/esp32#esp32-partitions) for details.
+
+**ESP-IDF 5.5.4 and Arduino 3.3.8** ([#15666](https://github.com/esphome/esphome/pull/15666)): Platform bumped to pioarduino 55.03.38 with ESP-IDF 5.5.4 and Arduino 3.3.8. PlatformIO is now run in a subprocess to isolate its virtualenv from ESPHome, preventing import errors after build.
+
+**mDNS crash fix** ([#15670](https://github.com/esphome/esphome/pull/15670)): Bumped espressif/mdns to 1.11.0, fixing heap corruption when processing sustained mDNS browse traffic that caused deterministic LoadProhibited crashes, and a null pointer exception in `mdns_parse_packet`.
 
 ## ESP8266 Crash Handler, Without a Serial Cable
 
@@ -175,12 +179,12 @@ Building on RP2040/RP2350's [first-class platform support in 2026.3.0](/changelo
 
 ## GPIO Expander Interrupt Support
 
-The [PCF8574](/components/pcf8574), [PCA9554](/components/pca9554), [MCP23008/MCP23017/MCP23S08/MCP23S17](/components/mcp230xx), and [PI4IOE5V6408](/components/pi4ioe5v6408) GPIO expander components now support an optional `interrupt_pin` that eliminates I2C/SPI polling entirely ([#15444](https://github.com/esphome/esphome/pull/15444), [#15445](https://github.com/esphome/esphome/pull/15445)).
+The [PCF8574](/components/pcf8574), [PCA9554](/components/pca9554), [MCP23008/MCP23017](/components/mcp230xx), [MCP23S08/MCP23S17](/components/mcp23Sxx), [PI4IOE5V6408](/components/pi4ioe5v6408), [MCP23016](/components/mcp230xx/#mcp23016-label), [PCA6416A](/components/pca6416a), and [TCA9555](/components/tca9555) GPIO expander components now support an optional `interrupt_pin` that eliminates I2C/SPI polling entirely ([#15444](https://github.com/esphome/esphome/pull/15444), [#15445](https://github.com/esphome/esphome/pull/15445), [#15616](https://github.com/esphome/esphome/pull/15616), [#15614](https://github.com/esphome/esphome/pull/15614), [#15613](https://github.com/esphome/esphome/pull/15613)).
 
 **Supported Expanders:**
 
-- **PCF8574 and PCA9554** - I2C GPIO expanders
-- **MCP23008, MCP23017, MCP23S08, MCP23S17** - I2C and SPI GPIO expander family
+- **PCF8574, PCA9554, PCA6416A, TCA9555** - I2C GPIO expanders
+- **MCP23008, MCP23017, MCP23S08, MCP23S17, MCP23016** - I2C and SPI GPIO expander family
 - **PI4IOE5V6408** - I2C GPIO expander
 
 **Measured Impact (ESP32-IDF, PCF8574 + 3 binary sensors):**
@@ -211,7 +215,7 @@ This release introduces comprehensive C++ benchmarking infrastructure using [Cod
 - Scheduler interval and timeout operations
 - Plaintext and encrypted API frame writes
 
-**API layer optimizations** (the native API is the primary communication path between ESPHome devices and Home Assistant). The goal was to make Bluetooth Proxy lightweight enough that every ESP32-C3 can run it without worrying about performance impact, and this release delivers: combined with changes from 2026.3.0, the API and BLE proxy now consume only ~2.3% of main loop runtime on ESP32-C3, down from ~3.3% in 2026.3.0 and a fraction of what it was a year ago:
+**API layer optimizations** (the native API is the primary communication path between ESPHome devices and Home Assistant). The goal was to make Bluetooth Proxy lightweight enough that every ESP32-C3 can run it without worrying about performance impact, and this release delivers: combined with changes from 2026.3.0, the API and BLE proxy advertisement forwarding (the constant hot path) now consume only ~2% of main loop runtime on ESP32-C3, down from ~3.3% in 2026.3.0 and a fraction of what it was a year ago:
 
 - **Protobuf encoding**: 17-20% faster with register-optimized write path ([#15290](https://github.com/esphome/esphome/pull/15290))
 - **Precomputed tag bytes**: Varint and length-delimited field tags computed at compile time ([#15067](https://github.com/esphome/esphome/pull/15067))
@@ -231,6 +235,7 @@ This release introduces comprehensive C++ benchmarking infrastructure using [Cod
 - **PSK update**: Avoided heap allocation in timeout lambda ([#14921](https://github.com/esphome/esphome/pull/14921))
 - **Batch encoding**: Simplified encode_to_buffer to single resize call, inlined DeferredBatch::add_item ([#15355](https://github.com/esphome/esphome/pull/15355), [#15353](https://github.com/esphome/esphome/pull/15353))
 - **Enum auto-derivation**: Auto-derive max_value for enum fields in protobuf codegen ([#15469](https://github.com/esphome/esphome/pull/15469))
+- **Sub-message inlining**: New `(inline_encode)` proto option inlines small sub-messages directly into parent encoders, eliminating function pointer indirection. Applied to `BluetoothLERawAdvertisement` (encoded up to 12 times per BLE batch): **40-55% faster** BLE advertisement encoding ([#15599](https://github.com/esphome/esphome/pull/15599))
 
 **Core framework optimizations:**
 
@@ -247,6 +252,8 @@ This release introduces comprehensive C++ benchmarking infrastructure using [Cod
   - `CronTrigger`: Replaced loop() with `set_interval` ([#15433](https://github.com/esphome/esphome/pull/15433))
   - `preferences`: Loop compiled out entirely when `flash_write_interval` is non-zero ([#14943](https://github.com/esphome/esphome/pull/14943))
   - GPIO expanders (PCF8574, PCA9554, MCP23xxx, PI4IOE5V6408): Loop disabled when all pins are outputs ([#15455](https://github.com/esphome/esphome/pull/15455), [#15460](https://github.com/esphome/esphome/pull/15460))
+  - `sx127x`, `cc1101`, `sx126x`: Use GPIO interrupt to wake the loop instead of polling, with loop disabled entirely when packet mode is inactive ([#15627](https://github.com/esphome/esphome/pull/15627), [#15606](https://github.com/esphome/esphome/pull/15606))
+  - `hbridge` light: Loop only runs when both cold and warm white channels are active and multiplexing is needed; disabled for single-channel or off states ([#15615](https://github.com/esphome/esphome/pull/15615))
 - **Bluetooth Proxy**: BLE event handler dispatch devirtualized, eliminating virtual call overhead on every BLE advertisement and GATT event ([#15310](https://github.com/esphome/esphome/pull/15310)). BLE `is_active`/`is_running` inlined and STL bloat removed ([#14875](https://github.com/esphome/esphome/pull/14875)). Advertisement flushing replaced `loop()` (which ran ~7,400 times/60s just to check a timestamp) with `set_interval(100ms)` so the flush logic only runs when needed (~600 times/60s), eliminating ~6,800 wasted iterations per minute ([#15347](https://github.com/esphome/esphome/pull/15347))
 - **Devirtualization**: Preferences backend, PollingComponent::set_update_interval ([#14825](https://github.com/esphome/esphome/pull/14825), [#14938](https://github.com/esphome/esphome/pull/14938))
 - **Light**: Reciprocal multiply in normalize_color, pass LightTraits to avoid redundant virtual calls ([#15401](https://github.com/esphome/esphome/pull/15401), [#15403](https://github.com/esphome/esphome/pull/15403))
@@ -264,7 +271,7 @@ ESPHome's CI automatically runs a home-grown memory impact analysis on every pul
 **Core framework savings:**
 
 - **Component base class**: Shrunk from 12 to 8 bytes per instance, saving ~200-400 bytes across typical configs ([#15103](https://github.com/esphome/esphome/pull/15103))
-- **CallbackManager**: Replaced `std::function` (16 bytes) with lightweight `Callback` (8 bytes) across all callback registrations. Small lambdas like `[this]` are now stored inline in the function pointer context with zero heap allocation, covering 96% of all callback registrations. Measured **+488 bytes free heap** on an ESP8266 config with MQTT + web_server + many entities ([#14853](https://github.com/esphome/esphome/pull/14853))
+- **CallbackManager**: Replaced `std::function` (16 bytes) with lightweight `Callback` (8 bytes) across all callback registrations. Small lambdas like `[this]` are now stored inline in the function pointer context with zero heap allocation, covering 96% of all callback registrations. Measured **+488 bytes free heap** on an ESP8266 config with MQTT + web_server + many entities ([#14853](https://github.com/esphome/esphome/pull/14853)). A follow-up replaced `std::vector` with a trivial-copy container, eliminating per-signature template instantiations of vector reallocation machinery and saving **996 bytes of flash** on ESP8266 plus **4 bytes of RAM per CallbackManager instance** ([#15272](https://github.com/esphome/esphome/pull/15272))
 - **Trigger trampolines eliminated across 23 components**: Previously, every `on_press`, `on_value`, `on_state`, etc. automation instantiated a separate Trigger object just to forward a callback, a 4+ byte heap-allocated object that existed solely to hold a pointer. A new `build_callback_automation()` pattern collapses the trigger into a pointer-sized forwarder struct stored inline in the callback manager, eliminating the separate allocation entirely. The initial PR ([#15174](https://github.com/esphome/esphome/pull/15174)) migrated the core entity types (button, sensor, binary_sensor, switch, text_sensor, number, event) saving 88-208 bytes RAM, then **22 follow-up PRs** migrated alarm_control_panel, lock, media_player, ld2450, rtttl, online_image, rotary_encoder, dfplayer, hlk_fm22x, pn532, pn7150/pn7160, sim800l, fingerprint_grow, ltr_als_ps, ltr501, nextion, ezo, haier, modbus_controller, rf_bridge, factory_reset, sml, and safe_mode
 - **TemplatableValue → TemplatableFn**: The function-pointer pattern was first proven on `LightControlAction`, shrinking each instance from 128 to 72 bytes (44% reduction, saving 616 bytes RAM on an ESP8266 light config with 11 actions) ([#15132](https://github.com/esphome/esphome/pull/15132)). This was then generalized codebase-wide: ~340 `TEMPLATABLE_VALUE` fields automatically dropped from 8 to 4 bytes each by storing function pointers instead of tagged unions ([#15545](https://github.com/esphome/esphome/pull/15545))
 - **ActionList**: Removed `actions_end_` pointer to save RAM per automation ([#15283](https://github.com/esphome/esphome/pull/15283))

--- a/src/content/docs/components/lvgl/index.mdx
+++ b/src/content/docs/components/lvgl/index.mdx
@@ -231,12 +231,12 @@ lvgl:
 
 The `rotation` option allows you to rotate the display content by a specified angle. Valid values are `0`, `90`, `180` and `270`. Defaults to `0`.
 Using this in the LVGL configuration will automatically adjust both the display and touch input (if a touchscreen is configured) to the specified rotation.
-When using this the display configuration should not include a rotation option (it will be ignored if it does), and the touchscreen configuration should not
+When using this the display configuration should not include a rotation option and the touchscreen configuration should not
 transform the touchscreen unless required (for example if the touchscreen axes don't match the display.)
 
 If the display driver can rotate the display content in hardware, (for example, most `mipi_spi` display models can do this)
 LVGL will automatically use this to improve performance. If not, the rotation will be performed in software by LVGL,
-which will reduce performance.
+which will reduce performance. On ESP32P4 the software rotation is hardware accelerated using the PPA peripheral.
 
 Touchscreen coordinates will be automatically rotated when using LVGL rotation.
 

--- a/src/content/docs/components/mcp230xx.mdx
+++ b/src/content/docs/components/mcp230xx.mdx
@@ -91,6 +91,7 @@ has 16 GPIOs and can be configured the same way than the other variants.
 mcp23016:
   - id: 'mcp23016_hub'
     address: 0x20
+    interrupt_pin: GPIOXX
 
 # Individual outputs
 switch:
@@ -122,6 +123,11 @@ binary_sensor:
 - **id** (**Required**, [ID](/guides/configuration-types#id)): The id to use for this MCP23016 component.
 - **address** (*Optional*, int): The I²C address of the driver.
   Defaults to `0x20`.
+- **interrupt_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The pin connected to the
+  INT output of the MCP23016. When configured, the component becomes interrupt-driven instead of
+  polling — it only reads the chip when a pin actually changes state, significantly reducing I²C bus traffic
+  and CPU usage. The INT pin is active-low and open-drain, so an external or internal pull-up resistor is
+  required. Must be an internal GPIO pin (not another expander pin).
 
 ### Pin configuration variables
 

--- a/src/content/docs/components/pca6416a.mdx
+++ b/src/content/docs/components/pca6416a.mdx
@@ -34,6 +34,7 @@ GPIO pin and can therefore be used with many of ESPHome's components such as the
 pca6416a:
   - id: 'pca6416a_device'
     address: 0x20
+    interrupt_pin: GPIOXX
 
 # Individual outputs
 switch:
@@ -75,6 +76,11 @@ switch:
 - **id** (**Required**, [ID](/guides/configuration-types#id)): The id to use for this `pca6416a` component.
 - **address** (*Optional*, int): The I²C address of the driver.
   Defaults to `0x20`.
+- **interrupt_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The pin connected to the
+  INT output of the PCA6416A/PCAL6416A. When configured, the component becomes interrupt-driven instead of
+  polling — it only reads the chip when a pin actually changes state, significantly reducing I²C bus traffic
+  and CPU usage. The INT pin is active-low and open-drain, so an external or internal pull-up resistor is
+  required. Must be an internal GPIO pin (not another expander pin).
 
 ## Pin configuration variables
 

--- a/src/content/docs/components/tca9555.mdx
+++ b/src/content/docs/components/tca9555.mdx
@@ -20,7 +20,8 @@ not work.
 ```yaml
 # Example configuration entry
 tca9555:
-  - id: 'TCA9555_hub'
+  - id: 'tca9555_hub'
+    interrupt_pin: GPIOXX
 
 # Individual outputs
 switch:
@@ -37,6 +38,11 @@ switch:
 - **id** (**Required**, [ID](/guides/configuration-types#id)): The id to use for this TCA9555 component.
 - **address** (*Optional*, int): The I²C address of the driver.
   Defaults to `0x21`.
+- **interrupt_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The pin connected to the
+  INT output of the TCA9555. When configured, the component becomes interrupt-driven instead of
+  polling — it only reads the chip when a pin actually changes state, significantly reducing I²C bus traffic
+  and CPU usage. The INT pin is active-low and open-drain, so an external or internal pull-up resistor is
+  required. Must be an internal GPIO pin (not another expander pin).
 
 ## Pin configuration variables
 

--- a/src/content/docs/guides/installing_esphome.mdx
+++ b/src/content/docs/guides/installing_esphome.mdx
@@ -30,11 +30,7 @@ Upgrade to the latest version using `uv tool upgrade esphome`.
 
 ## Windows
 
-Download Python from [the official site](https://www.python.org/downloads/). Use Python 3.11, 3.12, or 3.13.
-
-> [!WARNING]
-> **Python 3.14 is not yet supported on Windows.** Please use Python 3.11, 3.12, or 3.13.
-> Python 3.14 introduced breaking changes that some of ESPHome's Windows dependencies have not yet adapted to.
+Download Python from [the official site](https://www.python.org/downloads/).
 
 <Image src={pythonWinInstallerImg} layout="constrained" alt={"Python installer window with arrows pointing to \"Add Python to PATH\" and \"Install Now\""} />
 

--- a/src/content/docs/guides/installing_esphome.mdx
+++ b/src/content/docs/guides/installing_esphome.mdx
@@ -6,13 +6,35 @@ title: "Installing ESPHome Manually"
 import { Image } from 'astro:assets';
 import pythonWinInstallerImg from './images/python-win-installer.png';
 
-> [!WARNING]
-> **Python 3.14 is not yet supported.** Please use Python 3.11, 3.12, or 3.13.
-> Python 3.14 introduced breaking changes that ESPHome's dependencies have not yet adapted to.
+## Cross-platform using uv
+
+[uv](https://docs.astral.sh/uv/) is a fast Python package and project manager.
+
+It offers a simple way to install and run ESPHome on Windows, macOS, and Linux.
+
+If you don't have Python installed, uv offers an easy way to [install and manage Python versions](https://docs.astral.sh/uv/guides/install-python/).
+
+Using uv, you can install esphome as a [tool](https://docs.astral.sh/uv/guides/tools/) with the following command:
+
+```shell
+uv tool install esphome --with wheel,pip
+```
+
+Now *esphome* will be available on your `PATH`:
+
+```shell
+esphome version
+```
+
+Upgrade to the latest version using `uv tool upgrade esphome`.
 
 ## Windows
 
 Download Python from [the official site](https://www.python.org/downloads/). Use Python 3.11, 3.12, or 3.13.
+
+> [!WARNING]
+> **Python 3.14 is not yet supported on Windows.** Please use Python 3.11, 3.12, or 3.13.
+> Python 3.14 introduced breaking changes that some of ESPHome's Windows dependencies have not yet adapted to.
 
 <Image src={pythonWinInstallerImg} layout="constrained" alt={"Python installer window with arrows pointing to \"Add Python to PATH\" and \"Install Now\""} />
 

--- a/src/content/docs/guides/supporters.mdx
+++ b/src/content/docs/guides/supporters.mdx
@@ -2374,4 +2374,4 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Christian Zufferey (@zuzu59)](https://github.com/zuzu59)
 - [Zynth-dev (@Zynth-dev)](https://github.com/Zynth-dev)
 
-*This page was last updated April 9, 2026.*
+*This page was last updated April 13, 2026.*


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- Improve 2026.4.0 release notes [docs#6420](https://github.com/esphome/esphome-docs/pull/6420)
- Add version badge to navbar linking to latest changelog [docs#6421](https://github.com/esphome/esphome-docs/pull/6421)
- Add contributor acknowledgments and improve release notes prompts [docs#6260](https://github.com/esphome/esphome-docs/pull/6260)
- [lvgl] Add notes about rotation impact on touchscreen config [docs#6424](https://github.com/esphome/esphome-docs/pull/6424)
- Add microFLAC audio decoding to 2026.4.0 release notes [docs#6429](https://github.com/esphome/esphome-docs/pull/6429)
- [tca9555] Add interrupt_pin documentation [docs#6430](https://github.com/esphome/esphome-docs/pull/6430)
- [pca6416a] Add interrupt_pin documentation [docs#6431](https://github.com/esphome/esphome-docs/pull/6431)
- [mcp23016] Add interrupt_pin documentation [docs#6432](https://github.com/esphome/esphome-docs/pull/6432)
- uv [docs#6397](https://github.com/esphome/esphome-docs/pull/6397)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
