### PR TITLE
[audio_http] Document new audio_http media source

### DIFF
--- a/src/content/docs/components/index.mdx
+++ b/src/content/docs/components/index.mdx
@@ -900,6 +900,7 @@ Used for creating infrared (IR) remote control transmitters and/or receivers.
 <ImgTable items={[
   ["Media Source Core", "/components/media_source/", "folder-open.svg", "dark-invert"],
   ["Audio File Media Source", "/components/media_source/audio_file/", "file-document-box.svg", "dark-invert"],
+  ["Audio HTTP Media Source", "/components/media_source/audio_http/", "http.svg", "dark-invert"],
 ]} />
 
 ## Media Player Components

--- a/src/content/docs/components/media_source/audio_http.mdx
+++ b/src/content/docs/components/media_source/audio_http.mdx
@@ -27,6 +27,7 @@ uses this media source.
 
 ## Configuration variables
 
+- **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID for this media source.
 - **buffer_size** (*Optional*, int): The size of the ring buffer in bytes used to transfer data
   between the HTTP reader and the audio decoder. Minimum is `5000`, maximum is `1000000`. Defaults
   to `50000`.

--- a/src/content/docs/components/media_source/audio_http.mdx
+++ b/src/content/docs/components/media_source/audio_http.mdx
@@ -32,6 +32,20 @@ media_source:
 To play a file, send a media URL like `https://example.com/audio/alert.mp3` to a media player that
 uses this media source.
 
+## HTTPS and TLS certificates
+
+HTTPS URLs are validated against ESP-IDF's bundled X.509 certificate store (the same
+Mozilla root CA list used by other ESPHome components). By default, ESPHome includes only
+the common-CA subset, which covers the vast majority of public servers; set
+`use_full_certificate_bundle: true` under the [`esp32`](/components/esp32/) component's
+advanced options for the full bundle. Servers using self-signed certificates or private
+CAs will fail to connect.
+
+To allow connections to such servers, add the [`http_request`](/components/http_request/)
+component with `verify_ssl: false`. This disables server certificate verification globally
+for all TLS connections in the build, including the ones made by `audio_http`. Use it
+only on trusted networks.
+
 <span id="config-audio_http_media_source"></span>
 
 ## Configuration variables

--- a/src/content/docs/components/media_source/audio_http.mdx
+++ b/src/content/docs/components/media_source/audio_http.mdx
@@ -12,6 +12,15 @@ Files are played using the `http://` or `https://` URI scheme.
 
 This component only works on ESP32 based chips.
 
+Decoding is provided by the [microDecoder library](https://github.com/esphome-libs/micro-decoder),
+which supports MP3, FLAC, Opus (Ogg-encapsulated), and WAV. To keep firmware size small, MP3,
+FLAC, and Opus decoders are compiled in only when another component in the configuration
+requests them; WAV is always available. A codec is enabled when any of the following is true:
+
+- An [`audio_file`](/components/media_source/audio_file/) media source is configured with a file of that format.
+- A [speaker media player](/components/media_player/speaker/) pipeline's `format` is set to that codec (or `codec_support_enabled: ALL` is used).
+- A [speaker_source media player](/components/media_player/speaker_source/) pipeline's `format` is set to that codec.
+
 ```yaml
 # Example configuration entry
 

--- a/src/content/docs/components/media_source/audio_http.mdx
+++ b/src/content/docs/components/media_source/audio_http.mdx
@@ -1,0 +1,41 @@
+---
+description: "Instructions for setting up the Audio HTTP media source in ESPHome."
+title: "Audio HTTP Media Source"
+---
+
+import APIRef from '@components/APIRef.astro';
+
+The `audio_http` media source platform plays audio streamed from HTTP and HTTPS URLs. Audio is fetched over the network and decoded
+on the device.
+
+Files are played using the `http://` or `https://` URI scheme.
+
+This component only works on ESP32 based chips.
+
+```yaml
+# Example configuration entry
+
+media_source:
+  - platform: audio_http
+    id: http_source
+```
+
+To play a file, send a media URL like `https://example.com/audio/alert.mp3` to a media player that
+uses this media source.
+
+<span id="config-audio_http_media_source"></span>
+
+## Configuration variables
+
+- **buffer_size** (*Optional*, int): The size of the ring buffer in bytes used to transfer data
+  between the HTTP reader and the audio decoder. Minimum is `5000`, maximum is `1000000`. Defaults
+  to `50000`.
+- **task_stack_in_psram** (*Optional*, boolean): If `true`, the FreeRTOS decode task stack is
+  allocated in PSRAM instead of internal RAM. Requires the [psram](/components/psram/) component. Defaults to `false`.
+- All other options from [Media Source](/components/media_source/).
+
+## See Also
+
+- [Media Source Components](/components/media_source/)
+- <APIRef text="audio_http_media_source.h" path="esphome/components/audio_http/audio_http_media_source.h" />
+- [microDecoder Library (GitHub)](https://github.com/esphome-libs/micro-decoder)


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Documents the new ``audio_http`` media source component.

**Related issue (if applicable):** not applicable

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#15741

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
