### PR TITLE
[esp32] Document adc_oneshot_in_iram advanced option

### DIFF
--- a/src/content/docs/components/esp32.mdx
+++ b/src/content/docs/components/esp32.mdx
@@ -585,6 +585,10 @@ The following options disable debug features that are rarely needed in productio
   These functions are used internally by ESP-IDF for analog peripherals (ADC, DAC, temperature sensor calibration). Moving
   them to flash saves IRAM. This is safe for ESPHome because no ESPHome IRAM interrupt service routines call ADC or other
   analog functions. Defaults to `true` (regi2c functions in flash to save IRAM).
+- **adc_oneshot_in_iram** (*Optional*, boolean): Place ADC oneshot control functions in IRAM. When flash cache is
+  disabled during background flash operations (NVS writes by WiFi, BLE, Zigbee, Thread, power management, etc.),
+  ADC reads will crash if these functions are in flash. The ADC component automatically enables this when used.
+  Defaults to `false` (automatically enabled by the ADC component).
 
 These defaults are chosen to reduce flash and IRAM usage for typical ESPHome devices. Adjust them only if you have specific
 debugging or performance requirements that justify changing them.
@@ -628,6 +632,7 @@ esp32:
       # Filesystem and peripheral options
       disable_fatfs: true  # Saves code size (auto-enabled by SD card components)
       disable_regi2c_in_iram: true  # Saves IRAM
+      adc_oneshot_in_iram: false  # Auto-enabled by ADC component
 
       # ESP32 (original) only options
       # sram1_as_iram: true  # +40 KB IRAM (requires bootloader from ESP-IDF >= 5.1)


### PR DESCRIPTION
## Description

Documents the new `adc_oneshot_in_iram` advanced configuration option for the ESP32 platform.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#15717

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.