### PR TITLE
Add cloudflare cache purging after a deployment

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -15,6 +15,9 @@
 [context.production]
   environment = { SITE_URL = "https://esphome.io", API_DOCS_URL = "https://api-docs.esphome.io" }
 
+# Purge Cloudflare CDN cache after successful deploy.
+[[plugins]]
+  package = "./plugins/cloudflare-cache-purge"
 
 # Default caching for all pages (HTML and everything else)
 # Browser: 1 hour, Cloudflare CDN: 1 week, serve stale while revalidating

--- a/plugins/cloudflare-cache-purge/index.js
+++ b/plugins/cloudflare-cache-purge/index.js
@@ -35,33 +35,39 @@ export const onSuccess = async function ({ utils }) {
     return;
   }
 
-  const hostname = new URL(siteUrl).hostname;
+  try {
+    const hostname = new URL(siteUrl).hostname;
 
-  console.log(`Purging Cloudflare cache for hostname: ${hostname}`);
+    console.log(`Purging Cloudflare cache for hostname: ${hostname}`);
 
-  const response = await fetch(
-    `https://api.cloudflare.com/client/v4/zones/${zoneId}/purge_cache`,
-    {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${apiToken}`,
-        "Content-Type": "application/json",
+    const response = await fetch(
+      `https://api.cloudflare.com/client/v4/zones/${zoneId}/purge_cache`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${apiToken}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ hosts: [hostname] }),
       },
-      body: JSON.stringify({ hosts: [hostname] }),
-    },
-  );
+    );
 
-  const result = await response.json();
+    const result = await response.json();
 
-  if (!result.success) {
-    const errors = result.errors.map((e) => `${e.code}: ${e.message}`).join(", ");
-    utils.build.failPlugin(`Cloudflare cache purge failed: ${errors}`);
-    return;
+    if (!result.success) {
+      const errors = result.errors
+        .map((e) => `${e.code}: ${e.message}`)
+        .join(", ");
+      utils.build.failPlugin(`Cloudflare cache purge failed: ${errors}`);
+      return;
+    }
+
+    console.log(`Cloudflare cache purge successful for ${hostname}`);
+    utils.status.show({
+      title: "Cloudflare Cache Purge",
+      summary: `Purged CDN cache for ${hostname}`,
+    });
+  } catch (error) {
+    utils.build.failPlugin("Cloudflare cache purge failed", { error });
   }
-
-  console.log(`Cloudflare cache purge successful for ${hostname}`);
-  utils.status.show({
-    title: "Cloudflare Cache Purge",
-    summary: `Purged CDN cache for ${hostname}`,
-  });
 };

--- a/plugins/cloudflare-cache-purge/index.js
+++ b/plugins/cloudflare-cache-purge/index.js
@@ -1,0 +1,67 @@
+/**
+ * Netlify Build Plugin: Purge Cloudflare CDN cache after successful deploy.
+ *
+ * Requires the following environment variables to be set in Netlify:
+ *   CLOUDFLARE_API_TOKEN  – API token with "Cache Purge" permission for the zone
+ *   CLOUDFLARE_ZONE_ID    – Zone ID of the Cloudflare zone (e.g. esphome.io zone)
+ *
+ * The hostname to purge is derived from the SITE_URL env var that Netlify
+ * sets per deploy context (production / beta / next).
+ */
+
+export const onSuccess = async function ({ utils }) {
+  const context = process.env.CONTEXT;
+
+  if (context !== "production" && context !== "branch-deploy") {
+    console.log(`Skipping Cloudflare cache purge: context is "${context}"`);
+    return;
+  }
+
+  const apiToken = process.env.CLOUDFLARE_API_TOKEN;
+  const zoneId = process.env.CLOUDFLARE_ZONE_ID;
+  const siteUrl = process.env.SITE_URL || process.env.URL;
+
+  if (!apiToken || !zoneId) {
+    console.log(
+      "Skipping Cloudflare cache purge: CLOUDFLARE_API_TOKEN or CLOUDFLARE_ZONE_ID not set",
+    );
+    return;
+  }
+
+  if (!siteUrl) {
+    utils.build.failPlugin(
+      "Cannot determine hostname: neither SITE_URL nor URL is set",
+    );
+    return;
+  }
+
+  const hostname = new URL(siteUrl).hostname;
+
+  console.log(`Purging Cloudflare cache for hostname: ${hostname}`);
+
+  const response = await fetch(
+    `https://api.cloudflare.com/client/v4/zones/${zoneId}/purge_cache`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ hosts: [hostname] }),
+    },
+  );
+
+  const result = await response.json();
+
+  if (!result.success) {
+    const errors = result.errors.map((e) => `${e.code}: ${e.message}`).join(", ");
+    utils.build.failPlugin(`Cloudflare cache purge failed: ${errors}`);
+    return;
+  }
+
+  console.log(`Cloudflare cache purge successful for ${hostname}`);
+  utils.status.show({
+    title: "Cloudflare Cache Purge",
+    summary: `Purged CDN cache for ${hostname}`,
+  });
+};

--- a/plugins/cloudflare-cache-purge/manifest.yml
+++ b/plugins/cloudflare-cache-purge/manifest.yml
@@ -1,0 +1,1 @@
+name: cloudflare-cache-purge


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Adds a plugin to run on a successful netlify build to purge the cloudflare cache for the (sub)domain that was deployed.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
