### PR TITLE
[openthread] Document light_sleep option for Sleepy End Devices

### DIFF
--- a/src/content/docs/components/openthread.mdx
+++ b/src/content/docs/components/openthread.mdx
@@ -69,6 +69,11 @@ openthread:
 > [!NOTE]
 > esphome.ota does not work when poll_period > 0, instead use http_request.ota, timeout and watchdog_timeout need to be tested to find the correct values.  Values greater than 100sec may be required.
 
+- **light_sleep** (*Optional*, bool): Enables ESP32 light sleep between Thread poll periods for battery-powered Sleepy End Devices (SEDs). Requires ``poll_period`` to be set and ``device_type: MTD``. Defaults to ``false``.
+
+> [!NOTE]
+> On ESP32-C5, ESP32-C6, and ESP32-H2 variants, enabling ``light_sleep`` automatically disables the USB Serial JTAG peripheral at startup (``CONFIG_USJ_ENABLE_USB_SERIAL_JTAG=n``). These chips have a USB JTAG block that holds the BBPLL clock, preventing light sleep entry when a USB cable is connected (IDF-6395). Disabling the peripheral means the USB serial port will no longer be available — use hardware UART for logging instead (``logger: hardware_uart: UART0``).
+
 - **output_power** (*Optional*, integer): The amount of TX power for the Thread 802.15.4 radio in dBm.
   Range depends on the chip variant: ESP32-C5/C6 from ``-15dBm`` to ``20dBm``, ESP32-H2 from ``-24dBm`` to ``20dBm``.
   Defaults to the platform default (typically ``0dBm``). Ensure the configured value complies with local regulatory limits.
@@ -96,7 +101,17 @@ See [https://openthread.io/guides/thread-primer/node-roles-and-types](https://op
 
 ## Sleepy End Device (SED)
 
-The Poll Period makes the device behave as a SED.  Follow on work is needed utilizing Power Management and/or Light Sleep capability in esp-idf.
+Setting ``poll_period`` on an MTD device makes it behave as a Sleepy End Device (SED). The parent router enqueues messages and waits for the child to send a data poll request at each interval, allowing the radio to be inactive between polls.
+
+Enabling ``light_sleep: true`` in addition to ``poll_period`` allows the ESP32 to enter light sleep between poll periods, reducing power consumption further. The ESP32 power management (``esp_pm``) tickless idle and IEEE 802.15.4 sleep support are configured automatically.
+
+```yaml
+openthread:
+  device_type: MTD
+  poll_period: 30s
+  light_sleep: true
+```
+
 If the device is always awake, the API timeout is 60 seconds, so a ping request will force interaction with the parent when the poll period is greater than 60 seconds.
 
 ## OpenThread ESP-IDF Logging


### PR DESCRIPTION
Adds documentation for the new light_sleep config option introduced in the openthread-light-sleep branch, including the USB Serial JTAG caveat on ESP32-C5/C6/H2 and an updated SED section with example config.

<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** addresses https://github.com/orgs/esphome/discussions/3602#discussioncomment-16458179 

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** https://github.com/esphome/esphome/pull/15722

- esphome/esphome#15722

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
