### PR TITLE
2026.4.0b3

### DIFF
--- a/data/version.yaml
+++ b/data/version.yaml
@@ -1,2 +1,2 @@
-release: 2026.4.0b2
+release: 2026.4.0b3
 version: '2026.4'

--- a/netlify.toml
+++ b/netlify.toml
@@ -15,6 +15,9 @@
 [context.production]
   environment = { SITE_URL = "https://esphome.io", API_DOCS_URL = "https://api-docs.esphome.io" }
 
+# Purge Cloudflare CDN cache after successful deploy.
+[[plugins]]
+  package = "./plugins/cloudflare-cache-purge"
 
 # Default caching for all pages (HTML and everything else)
 # Browser: 1 hour, Cloudflare CDN: 1 week, serve stale while revalidating

--- a/plugins/cloudflare-cache-purge/index.js
+++ b/plugins/cloudflare-cache-purge/index.js
@@ -1,0 +1,73 @@
+/**
+ * Netlify Build Plugin: Purge Cloudflare CDN cache after successful deploy.
+ *
+ * Requires the following environment variables to be set in Netlify:
+ *   CLOUDFLARE_API_TOKEN  – API token with "Cache Purge" permission for the zone
+ *   CLOUDFLARE_ZONE_ID    – Zone ID of the Cloudflare zone (e.g. esphome.io zone)
+ *
+ * The hostname to purge is derived from the SITE_URL env var that Netlify
+ * sets per deploy context (production / beta / next).
+ */
+
+export const onSuccess = async function ({ utils }) {
+  const context = process.env.CONTEXT;
+
+  if (context !== "production" && context !== "branch-deploy") {
+    console.log(`Skipping Cloudflare cache purge: context is "${context}"`);
+    return;
+  }
+
+  const apiToken = process.env.CLOUDFLARE_API_TOKEN;
+  const zoneId = process.env.CLOUDFLARE_ZONE_ID;
+  const siteUrl = process.env.SITE_URL || process.env.URL;
+
+  if (!apiToken || !zoneId) {
+    console.log(
+      "Skipping Cloudflare cache purge: CLOUDFLARE_API_TOKEN or CLOUDFLARE_ZONE_ID not set",
+    );
+    return;
+  }
+
+  if (!siteUrl) {
+    utils.build.failPlugin(
+      "Cannot determine hostname: neither SITE_URL nor URL is set",
+    );
+    return;
+  }
+
+  try {
+    const hostname = new URL(siteUrl).hostname;
+
+    console.log(`Purging Cloudflare cache for hostname: ${hostname}`);
+
+    const response = await fetch(
+      `https://api.cloudflare.com/client/v4/zones/${zoneId}/purge_cache`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${apiToken}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ hosts: [hostname] }),
+      },
+    );
+
+    const result = await response.json();
+
+    if (!result.success) {
+      const errors = result.errors
+        .map((e) => `${e.code}: ${e.message}`)
+        .join(", ");
+      utils.build.failPlugin(`Cloudflare cache purge failed: ${errors}`);
+      return;
+    }
+
+    console.log(`Cloudflare cache purge successful for ${hostname}`);
+    utils.status.show({
+      title: "Cloudflare Cache Purge",
+      summary: `Purged CDN cache for ${hostname}`,
+    });
+  } catch (error) {
+    utils.build.failPlugin("Cloudflare cache purge failed", { error });
+  }
+};

--- a/plugins/cloudflare-cache-purge/manifest.yml
+++ b/plugins/cloudflare-cache-purge/manifest.yml
@@ -1,0 +1,1 @@
+name: cloudflare-cache-purge

--- a/src/content/docs/changelog/2026.4.0.mdx
+++ b/src/content/docs/changelog/2026.4.0.mdx
@@ -23,7 +23,7 @@ import ImgTable from "@components/ImgTable.astro";
 ## Release Overview
 
 {/* RELEASE_OVERVIEW_START */}
-ESPHome 2026.4.0 delivers major performance and reliability improvements across all platforms. ESP32 devices default to maximum CPU frequency (33% faster API operations), unlock 40KB extra IRAM, signed OTA verification, and custom partition tables. ESP8266 gets a crash handler matching ESP32/RP2040, and a new client-side state logging architecture achieves up to 46x faster sensor publishing by moving log formatting off the device. Bluetooth Proxy advertisement forwarding (the constant hot path) dropped to just ~2% of main loop time on ESP32-C3. 31 PRs prepare the codebase for ESP-IDF 6.0, and CodSpeed benchmarking infrastructure now catches performance regressions before they ship. The substitution system has been redesigned for up to 18x faster config loading with dynamic `!include` paths, Ethernet expands with 5 new chip types across ESP32 and RP2040, and GPIO expanders gain interrupt-driven operation cutting idle I2C traffic by 99.7%. This release also adds LVGL v9.5.0, native Mitsubishi CN105 climate control, 4 new sensor components, and a `esphome bundle` CLI command to assist with remote compilation.
+ESPHome 2026.4.0 delivers major performance and reliability improvements across all platforms. ESP32 devices default to maximum CPU frequency (33% faster API operations), unlock 40KB extra IRAM, signed OTA verification, and custom partition tables. ESP8266 gets a crash handler matching ESP32/RP2040, and a new client-side state logging architecture achieves up to 46x faster sensor publishing by moving log formatting off the device. Bluetooth Proxy advertisement forwarding (the constant hot path) dropped to just ~1.8% of main loop time on ESP32-C3. 31 PRs prepare the codebase for ESP-IDF 6.0, and CodSpeed benchmarking infrastructure now catches performance regressions before they ship. The substitution system has been redesigned for up to 18x faster config loading with dynamic `!include` paths, Ethernet expands with 5 new chip types across ESP32 and RP2040, and GPIO expanders gain interrupt-driven operation cutting idle I2C traffic by 99.7%. This release also adds LVGL v9.5.0, native Mitsubishi CN105 climate control, 4 new sensor components, and a `esphome bundle` CLI command to assist with remote compilation.
 {/* RELEASE_OVERVIEW_END */}
 
 ## Upgrade Checklist
@@ -79,7 +79,11 @@ esp32:
 
 **Custom partition tables** ([#7682](https://github.com/esphome/esphome/pull/7682)): Components and YAML configs can now define custom data/app partitions that are appended to the flash layout. The partition table generation has been unified across Arduino and IDF, and NVS has been moved to the end of flash with increased size (20KB to 384KB on Arduino). See the [ESP32 documentation](/components/esp32#esp32-partitions) for details.
 
-**ESP-IDF 5.5.4 and Arduino 3.3.8** ([#15666](https://github.com/esphome/esphome/pull/15666)): Platform bumped to pioarduino 55.03.38 with ESP-IDF 5.5.4 and Arduino 3.3.8. PlatformIO is now run in a subprocess to isolate its virtualenv from ESPHome, preventing import errors after build.
+**ESP-IDF 5.5.4 and Arduino 3.3.8** ([#15666](https://github.com/esphome/esphome/pull/15666), [#15705](https://github.com/esphome/esphome/pull/15705)): Platform bumped to pioarduino 55.03.38-1 with ESP-IDF 5.5.4 and Arduino 3.3.8. PlatformIO is now run in a subprocess to isolate its virtualenv from ESPHome, preventing import errors after build.
+
+**ADC crash fix** ([#15717](https://github.com/esphome/esphome/pull/15717)): ADC oneshot control functions are now placed in IRAM for cache safety. Previously, ADC reads could crash when flash cache was disabled during background NVS writes by WiFi, BLE, Zigbee, Thread, or power management.
+
+**Web server OTA brick hazard fix** ([#15720](https://github.com/esphome/esphome/pull/15720)): Fixed a long-standing brick hazard in the captive portal and web server OTA flow where an interrupted upload followed by a retry could write concatenated firmware to flash, producing an invalid image that soft-bricked the device and required a serial flash to recover. The OTA backend now resets on each new upload.
 
 **mDNS crash fix** ([#15670](https://github.com/esphome/esphome/pull/15670)): Bumped espressif/mdns to 1.11.0, fixing heap corruption when processing sustained mDNS browse traffic that caused deterministic LoadProhibited crashes, and a null pointer exception in `mdns_parse_packet`.
 
@@ -215,7 +219,7 @@ This release introduces comprehensive C++ benchmarking infrastructure using [Cod
 - Scheduler interval and timeout operations
 - Plaintext and encrypted API frame writes
 
-**API layer optimizations** (the native API is the primary communication path between ESPHome devices and Home Assistant). The goal was to make Bluetooth Proxy lightweight enough that every ESP32-C3 can run it without worrying about performance impact, and this release delivers: combined with changes from 2026.3.0, the API and BLE proxy advertisement forwarding (the constant hot path) now consume only ~2% of main loop runtime on ESP32-C3, down from ~3.3% in 2026.3.0 and a fraction of what it was a year ago:
+**API layer optimizations** (the native API is the primary communication path between ESPHome devices and Home Assistant). The goal was to make Bluetooth Proxy lightweight enough that every ESP32-C3 can run it without worrying about performance impact, and this release delivers: combined with changes from 2026.3.0, the API and BLE proxy advertisement forwarding (the constant hot path) now consume only ~1.8% of main loop runtime on ESP32-C3, down from ~3.3% in 2026.3.0 and a fraction of what it was a year ago:
 
 - **Protobuf encoding**: 17-20% faster with register-optimized write path ([#15290](https://github.com/esphome/esphome/pull/15290))
 - **Precomputed tag bytes**: Varint and length-delimited field tags computed at compile time ([#15067](https://github.com/esphome/esphome/pull/15067))
@@ -236,6 +240,7 @@ This release introduces comprehensive C++ benchmarking infrastructure using [Cod
 - **Batch encoding**: Simplified encode_to_buffer to single resize call, inlined DeferredBatch::add_item ([#15355](https://github.com/esphome/esphome/pull/15355), [#15353](https://github.com/esphome/esphome/pull/15353))
 - **Enum auto-derivation**: Auto-derive max_value for enum fields in protobuf codegen ([#15469](https://github.com/esphome/esphome/pull/15469))
 - **Sub-message inlining**: New `(inline_encode)` proto option inlines small sub-messages directly into parent encoders, eliminating function pointer indirection. Applied to `BluetoothLERawAdvertisement` (encoded up to 12 times per BLE batch): **40-55% faster** BLE advertisement encoding ([#15599](https://github.com/esphome/esphome/pull/15599))
+- **`speed_optimized` hot paths**: New proto option emits `__attribute__((optimize("O2")))` on specific encode paths so they remain inlined even under firmware's default `-Os` flag. Applied to `SensorStateResponse`, `BluetoothLERawAdvertisementsResponse`, and `SubscribeLogsResponse`: BLE advertisement `calculate_size` is an additional **41% faster**, with similar gains for sensor state and log encoding ([#15691](https://github.com/esphome/esphome/pull/15691), [#15698](https://github.com/esphome/esphome/pull/15698))
 
 **Core framework optimizations:**
 

--- a/src/content/docs/changelog/2026.4.0.mdx
+++ b/src/content/docs/changelog/2026.4.0.mdx
@@ -606,6 +606,22 @@ For detailed migration guides and API documentation, see the [ESPHome Developers
 - [esp32] Bump platform to 55.03.38, Arduino to 3.3.8, ESP-IDF to 5.5.4 [esphome#15666](https://github.com/esphome/esphome/pull/15666) by [@swoboda1337](https://github.com/swoboda1337)
 - [packages] Fix false deprecation warning and wrong error paths in nested packages [esphome#15605](https://github.com/esphome/esphome/pull/15605) by [@bdraco](https://github.com/bdraco) (breaking-change)
 - [lvgl] Fix use of rotation on host SDL [esphome#15611](https://github.com/esphome/esphome/pull/15611) by [@clydebarrow](https://github.com/clydebarrow)
+- [packages] fix support `packages: !include mypackages.yaml` [esphome#15677](https://github.com/esphome/esphome/pull/15677) by [@jpeletier](https://github.com/jpeletier)
+- [core] Fix PlatformIO progress bar rendering in subprocess mode [esphome#15681](https://github.com/esphome/esphome/pull/15681) by [@swoboda1337](https://github.com/swoboda1337)
+- Bump aioesphomeapi from 44.13.3 to 44.14.0 [esphome#15695](https://github.com/esphome/esphome/pull/15695) by [@dependabot[bot]](https://github.com/apps/dependabot)
+- [api] Add speed_optimized proto option for hot encode paths [esphome#15691](https://github.com/esphome/esphome/pull/15691) by [@bdraco](https://github.com/bdraco)
+- Bump aioesphomeapi from 44.14.0 to 44.15.0 [esphome#15699](https://github.com/esphome/esphome/pull/15699) by [@dependabot[bot]](https://github.com/apps/dependabot)
+- [esp32] Fix some compiler warnings & bugs [esphome#15610](https://github.com/esphome/esphome/pull/15610) by [@diorcety](https://github.com/diorcety)
+- [micro_wake_word] Bugfix: Use es-nn v1.1.2 (last known working version) [esphome#15703](https://github.com/esphome/esphome/pull/15703) by [@kahrendt](https://github.com/kahrendt)
+- [esp32] Update the recommended platform to 55.03.38-1 [esphome#15705](https://github.com/esphome/esphome/pull/15705) by [@swoboda1337](https://github.com/swoboda1337)
+- [api] Add speed_optimized to SubscribeLogsResponse [esphome#15698](https://github.com/esphome/esphome/pull/15698) by [@bdraco](https://github.com/bdraco)
+- [adc] Place ADC oneshot control functions in IRAM for cache safety [esphome#15717](https://github.com/esphome/esphome/pull/15717) by [@bdraco](https://github.com/bdraco)
+- [web_server] Reset OTA backend on new upload to avoid brick after interrupted OTA [esphome#15720](https://github.com/esphome/esphome/pull/15720) by [@bdraco](https://github.com/bdraco)
+- [esphome] Skip missing extra flash images in upload_using_esptool [esphome#15723](https://github.com/esphome/esphome/pull/15723) by [@bdraco](https://github.com/bdraco)
+- [globals] Fix TemplatableFn deprecation warning for globals.set [esphome#15733](https://github.com/esphome/esphome/pull/15733) by [@bdraco](https://github.com/bdraco)
+- [i2s_audio] Add PDM mics support for ESP32-P4 [esphome#15333](https://github.com/esphome/esphome/pull/15333) by [@fintros](https://github.com/fintros)
+- [light] Avoid addressable transition stall at low gamma-corrected values [esphome#15726](https://github.com/esphome/esphome/pull/15726) by [@bdraco](https://github.com/bdraco)
+- [nextion] Fix command spacing pacer never throttling sends [esphome#15664](https://github.com/esphome/esphome/pull/15664) by [@edwardtfn](https://github.com/edwardtfn)
 
 ### All changes
 
@@ -1137,6 +1153,20 @@ For detailed migration guides and API documentation, see the [ESPHome Developers
 - [esp32] Bump platform to 55.03.38, Arduino to 3.3.8, ESP-IDF to 5.5.4 [esphome#15666](https://github.com/esphome/esphome/pull/15666) by [@swoboda1337](https://github.com/swoboda1337)
 - [packages] Fix false deprecation warning and wrong error paths in nested packages [esphome#15605](https://github.com/esphome/esphome/pull/15605) by [@bdraco](https://github.com/bdraco) (breaking-change)
 - [lvgl] Fix use of rotation on host SDL [esphome#15611](https://github.com/esphome/esphome/pull/15611) by [@clydebarrow](https://github.com/clydebarrow)
+- [packages] fix support `packages: !include mypackages.yaml` [esphome#15677](https://github.com/esphome/esphome/pull/15677) by [@jpeletier](https://github.com/jpeletier)
+- [core] Fix PlatformIO progress bar rendering in subprocess mode [esphome#15681](https://github.com/esphome/esphome/pull/15681) by [@swoboda1337](https://github.com/swoboda1337)
+- [api] Add speed_optimized proto option for hot encode paths [esphome#15691](https://github.com/esphome/esphome/pull/15691) by [@bdraco](https://github.com/bdraco)
+- [esp32] Fix some compiler warnings & bugs [esphome#15610](https://github.com/esphome/esphome/pull/15610) by [@diorcety](https://github.com/diorcety)
+- [micro_wake_word] Bugfix: Use es-nn v1.1.2 (last known working version) [esphome#15703](https://github.com/esphome/esphome/pull/15703) by [@kahrendt](https://github.com/kahrendt)
+- [esp32] Update the recommended platform to 55.03.38-1 [esphome#15705](https://github.com/esphome/esphome/pull/15705) by [@swoboda1337](https://github.com/swoboda1337)
+- [api] Add speed_optimized to SubscribeLogsResponse [esphome#15698](https://github.com/esphome/esphome/pull/15698) by [@bdraco](https://github.com/bdraco)
+- [adc] Place ADC oneshot control functions in IRAM for cache safety [esphome#15717](https://github.com/esphome/esphome/pull/15717) by [@bdraco](https://github.com/bdraco)
+- [web_server] Reset OTA backend on new upload to avoid brick after interrupted OTA [esphome#15720](https://github.com/esphome/esphome/pull/15720) by [@bdraco](https://github.com/bdraco)
+- [esphome] Skip missing extra flash images in upload_using_esptool [esphome#15723](https://github.com/esphome/esphome/pull/15723) by [@bdraco](https://github.com/bdraco)
+- [globals] Fix TemplatableFn deprecation warning for globals.set [esphome#15733](https://github.com/esphome/esphome/pull/15733) by [@bdraco](https://github.com/bdraco)
+- [i2s_audio] Add PDM mics support for ESP32-P4 [esphome#15333](https://github.com/esphome/esphome/pull/15333) by [@fintros](https://github.com/fintros)
+- [light] Avoid addressable transition stall at low gamma-corrected values [esphome#15726](https://github.com/esphome/esphome/pull/15726) by [@bdraco](https://github.com/bdraco)
+- [nextion] Fix command spacing pacer never throttling sends [esphome#15664](https://github.com/esphome/esphome/pull/15664) by [@edwardtfn](https://github.com/edwardtfn)
 
 </details>
 
@@ -1180,5 +1210,7 @@ For detailed migration guides and API documentation, see the [ESPHome Developers
 - Bump aioesphomeapi from 44.12.0 to 44.13.1 [esphome#15600](https://github.com/esphome/esphome/pull/15600) by [@dependabot[bot]](https://github.com/apps/dependabot)
 - Bump aioesphomeapi from 44.13.1 to 44.13.2 [esphome#15637](https://github.com/esphome/esphome/pull/15637) by [@dependabot[bot]](https://github.com/apps/dependabot)
 - Bump aioesphomeapi from 44.13.2 to 44.13.3 [esphome#15641](https://github.com/esphome/esphome/pull/15641) by [@dependabot[bot]](https://github.com/apps/dependabot)
+- Bump aioesphomeapi from 44.13.3 to 44.14.0 [esphome#15695](https://github.com/esphome/esphome/pull/15695) by [@dependabot[bot]](https://github.com/apps/dependabot)
+- Bump aioesphomeapi from 44.14.0 to 44.15.0 [esphome#15699](https://github.com/esphome/esphome/pull/15699) by [@dependabot[bot]](https://github.com/apps/dependabot)
 
 </details>

--- a/src/content/docs/components/esp32.mdx
+++ b/src/content/docs/components/esp32.mdx
@@ -585,6 +585,10 @@ The following options disable debug features that are rarely needed in productio
   These functions are used internally by ESP-IDF for analog peripherals (ADC, DAC, temperature sensor calibration). Moving
   them to flash saves IRAM. This is safe for ESPHome because no ESPHome IRAM interrupt service routines call ADC or other
   analog functions. Defaults to `true` (regi2c functions in flash to save IRAM).
+- **adc_oneshot_in_iram** (*Optional*, boolean): Place ADC oneshot control functions in IRAM. When flash cache is
+  disabled during background flash operations (NVS writes by WiFi, BLE, Zigbee, Thread, power management, etc.),
+  ADC reads will crash if these functions are in flash. The ADC component automatically enables this when used.
+  Defaults to `false` (automatically enabled by the ADC component).
 
 These defaults are chosen to reduce flash and IRAM usage for typical ESPHome devices. Adjust them only if you have specific
 debugging or performance requirements that justify changing them.
@@ -628,6 +632,7 @@ esp32:
       # Filesystem and peripheral options
       disable_fatfs: true  # Saves code size (auto-enabled by SD card components)
       disable_regi2c_in_iram: true  # Saves IRAM
+      adc_oneshot_in_iram: false  # Auto-enabled by ADC component
 
       # ESP32 (original) only options
       # sram1_as_iram: true  # +40 KB IRAM (requires bootloader from ESP-IDF >= 5.1)

--- a/src/content/docs/guides/supporters.mdx
+++ b/src/content/docs/guides/supporters.mdx
@@ -2374,4 +2374,4 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Christian Zufferey (@zuzu59)](https://github.com/zuzu59)
 - [Zynth-dev (@Zynth-dev)](https://github.com/Zynth-dev)
 
-*This page was last updated April 13, 2026.*
+*This page was last updated April 15, 2026.*


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- Add cloudflare cache purging after a deployment [docs#6456](https://github.com/esphome/esphome-docs/pull/6456)
- [esp32] Document adc_oneshot_in_iram advanced option [docs#6452](https://github.com/esphome/esphome-docs/pull/6452)
- Add 2026.4.0-beta3 items to release notes [docs#6458](https://github.com/esphome/esphome-docs/pull/6458)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
