### PR TITLE
Add unit_of_measurement to climate and water_heater

### DIFF
--- a/src/content/docs/components/climate/index.mdx
+++ b/src/content/docs/components/climate/index.mdx
@@ -28,15 +28,16 @@ and can be put in different modes like `HEAT`, `COOL`, `HEAT_COOL` or `OFF`.
 
 ## Base Climate Configuration
 
-All climate platforms in ESPHome inherit from the climate configuration schema. In ESPHome, `°C` is assumed for all temperature values. Some platforms allow conversion or setting in `°F`, this is specified separately.
+All climate platforms in ESPHome inherit from the climate configuration schema. Use `unit_of_measurement` to configure the temperature unit used by this device. All temperature values in the configuration must either use that unit or omit the unit suffix. If no unit is specified anywhere, Celsius is assumed.
 
 ```yaml
 climate:
   - platform: ...
+    unit_of_measurement: °F
     visual:
-      min_temperature: 18
-      max_temperature: 25
-      temperature_step: 0.1
+      min_temperature: 60°F
+      max_temperature: 86°F
+      temperature_step: 1°F
       min_humidity: 30%
       max_humidity: 99%
   - platform: ...
@@ -58,15 +59,16 @@ Configuration variables:
 > you want the climate to use that name, you can set `name: None`.
 
 - **icon** (*Optional*, icon): Manually set the icon to use for the climate device in the frontend.
+- **unit_of_measurement** (*Optional*, string): The temperature unit for this device. One of `°C`, `°F`, or `K`. Defaults to `°C` if no unit is specified anywhere. Temperature values in `visual` may include an explicit unit suffix (e.g. `60°F`); if omitted, `unit_of_measurement` is assumed. All explicitly specified units must match. `unit_of_measurement` can also be set implicitly by including a unit suffix on any temperature field — if all suffixed values agree, that unit is used.
 - **visual** (*Optional*): Visual settings for the climate device - these do not
   affect operation and are solely for controlling how the climate device shows up in the
   frontend.
 
   - **min_temperature** (*Optional*, float): The minimum temperature the climate device can reach.
-    Used to set the range of the frontend gauge.
+    Used to set the range of the frontend gauge. May include an explicit unit suffix (e.g. `18`, `64.4°F`).
 
   - **max_temperature** (*Optional*, float): The maximum temperature the climate device can reach.
-    Used to set the range of the frontend gauge.
+    Used to set the range of the frontend gauge. May include an explicit unit suffix (e.g. `25`, `77°F`).
 
   - **temperature_step** (*Optional*, float): The granularity with which the target temperature
     can be controlled. Can be a single number, or split as below:

--- a/src/content/docs/components/water_heater/index.mdx
+++ b/src/content/docs/components/water_heater/index.mdx
@@ -17,11 +17,16 @@ The `water_heater` component is a generic representation of water heaters (boile
 
 ## Base Water Heater Configuration
 
-All water heater config schemas inherit from this schema - you can set these keys for water heaters.
+All water heater platforms in ESPHome inherit from the water heater configuration schema. Use `unit_of_measurement` to configure the temperature unit used by this device. All temperature values in the configuration must either use that unit or omit the unit suffix. If no unit is specified anywhere, Celsius is assumed.
 
 ```yaml
 water_heater:
   - platform: ...
+    unit_of_measurement: °F
+    visual:
+      min_temperature: 100°F
+      max_temperature: 145°F
+      temperature_step: 1°F
 ```
 
 Configuration variables:
@@ -34,13 +39,14 @@ Configuration variables:
 > to use that name, you can set `name: None`.
 
 - **icon** (*Optional*, icon): Manually set the icon to use for the water heater in the frontend.
+- **unit_of_measurement** (*Optional*, string): The temperature unit for this device. One of `°C`, `°F`, or `K`. Defaults to `°C` if no unit is specified anywhere. Temperature values in `visual` may include an explicit unit suffix (e.g. `140°F`); if omitted, `unit_of_measurement` is assumed. All explicitly specified units must match. `unit_of_measurement` can also be set implicitly by including a unit suffix on any temperature field — if all suffixed values agree, that unit is used.
 
 Advanced options:
 
 - **visual** (*Optional*): Configuration for the frontend representation.
-  - **min_temperature** (*Optional*, float): Override the minimum temperature shown in the frontend.
-  - **max_temperature** (*Optional*, float): Override the maximum temperature shown in the frontend.
-  - **target_temperature_step** (*Optional*, float): Override the temperature steps shown in the frontend.
+  - **min_temperature** (*Optional*, float): Override the minimum temperature shown in the frontend. May include an explicit unit suffix (e.g. `40`, `104°F`).
+  - **max_temperature** (*Optional*, float): Override the maximum temperature shown in the frontend. May include an explicit unit suffix (e.g. `60`, `140°F`).
+  - **target_temperature_step** (*Optional*, float): Override the temperature step shown in the frontend. May include an explicit unit suffix (e.g. `1`, `1°F`).
 
 - **supported_modes** (*Optional*, list): Static list of operation modes that will be exposed to the frontend (for example Home Assistant). When not specified, all modes supported by the platform are exposed.
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description


Exposes temperature unit for climate and water_heater, with corresponding changes in home-assistant/core, aioesphome, esphome, and esphome-docs, to enable native Fahrenheit measurements on those entities. Usecase is to enable accurate temperature settings on a Fahrenheit hot tub, controlled via RS485-UART. Rather than round tripped from F -> C -> C, with various floating point errors and weirdnesses, this just makes it stay F the entire way and work much more reliably.

Tests still need to be added where appropriate - that's on the todo - but the code has been validated. 

When esphome is updated, but core is not, as long as you do not set the temperature unit on a climate/water heater, everything works the same as it currently is. If you do set it, you will convert from F -> "F", as home assistant will think the incoming value from ESPHome is C, without reading the UOM. If ESPHome does not have F specified, it continues to default to C.

When HA is updated, but ESPHome is on an old version, it maintains legacy behavior of treating all climate/water_heaters as using C.

There are still some todo's, namely adding tests in every repo, and some other PR workitems, but the code is working and ready for early review.


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

https://github.com/home-assistant/core/pull/168261
https://github.com/esphome/aioesphomeapi/pull/1586
https://github.com/esphome/esphome/pull/15740
https://github.com/esphome/esphome-docs/pull/6463

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
