### PR TITLE
[debug] Document iram sensor

### DIFF
--- a/src/content/docs/components/debug.mdx
+++ b/src/content/docs/components/debug.mdx
@@ -46,6 +46,8 @@ sensor:
       name: "Loop Time"
     psram:
       name: "Free PSRAM"
+    iram:
+      name: "Free IRAM"
     cpu_frequency:
       name: "CPU Frequency"
 ```
@@ -95,6 +97,8 @@ sensor:
 - **loop_time** (*Optional*): Reports the longest time between successive iterations of the main loop. All options from [Sensor](/components/sensor).
 
 - **psram** (*Optional*): Reports the free PSRAM in bytes. Only available on ESP32. All options from [Sensor](/components/sensor).
+
+- **iram** (*Optional*): Reports the free IRAM (instruction RAM) in bytes. Only available on ESP32. All options from [Sensor](/components/sensor).
 
 - **cpu_frequency** (*Optional*): Reports the CPU frequency in Hz. All options from [Sensor](/components/sensor).
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Documents the new `iram` sensor for the `debug` component. It reports the free IRAM (instruction RAM) in bytes on ESP32, queried via `heap_caps_get_free_size(MALLOC_CAP_IRAM_8BIT)`.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#15742

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.