### PR TITLE
[mitsubishi_cn105] use HEAT_COOL mode to enable temperature slider

### DIFF
--- a/src/content/docs/components/climate/mitsubishi_cn105.mdx
+++ b/src/content/docs/components/climate/mitsubishi_cn105.mdx
@@ -76,7 +76,7 @@ climate:
 
 - Target temperature range: `16 °C` to `31 °C`
 - Current temperature reporting
-- Modes: `OFF`, `AUTO`, `HEAT`, `COOL`, `DRY`, `FAN_ONLY`
+- Modes: `OFF`, `HEAT`, `COOL`, `DRY`, `FAN_ONLY`, `HEAT_COOL` (called `AUTO` by Mitsubishi)
 - Fan modes: `AUTO`, `QUIET`, `LOW`, `MEDIUM`, `MIDDLE`, `HIGH`
 
 > [!NOTE]


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Rename AUTO mode to HEAT_COOL and clarify that Mitsubishi refers to it as AUTO.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#15748

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.
