### PR TITLE
[openthread] Add doc for new SRP/DNS64 disabler flags

### DIFF
--- a/src/content/docs/components/openthread.mdx
+++ b/src/content/docs/components/openthread.mdx
@@ -73,6 +73,13 @@ openthread:
   Range depends on the chip variant: ESP32-C5/C6 from ``-15dBm`` to ``20dBm``, ESP32-H2 from ``-24dBm`` to ``20dBm``.
   Defaults to the platform default (typically ``0dBm``). Ensure the configured value complies with local regulatory limits.
 
+- **enable_dns64** (*Optional*, bool): Whether Thread DNS64 client is started during setup, allowing to perform e.g. Thread DNS lookups via Thread API.
+Disabling this may reduce footprint by few KB.
+If unsure, leave enabled. Defaults to `true`
+- **enable_srp** (*Optional*, bool): Whether Thread services shall be published via SRP on Thread radio network (i.e. mDNS in LAN). See below for details.
+Disabling this may reduce footprint by up to 100 KB.
+If unsure, leave enabled. Defaults to `true`
+
 ## Dataset TLV Configuration
 
 It is also possible to supply the entire dataset TLVs from the Thread information in Home Assistant and the individual values will be automatically extracted from it.
@@ -121,10 +128,25 @@ esp32:
     log_level: INFO
 ```
 
+## Service Registration Protocol (SRP)
+
+If enabled above, this package will first start the `OpenThreadSrpComponent` to register all services as stored in the MDNS component via OpenThread *Service Registration Protocol* (SRP).
+Usually, a Thread border router runs an SRP server and will republish SRP service lists received in the radio network via mDNS/DNS-SD into backbone LAN.
+This allows other LAN nodes to find Thread devices via service name.
+Consequently, disabling SRP will also prevent mDNS/DNS-SD device lookup in the LAN.
+
+However, often "Home Assistant over Thread" protocol setups do not require mDNS, unlike Matter setups.
+Instead, static IPs of ESPHome nodes may be used in Home Assistant to communicate directly,
+and nodes may be reidentified via MAC (relating to Thread EUI64).
+
+> [!NOTE]
+> Before disabling SRP/mDNS: See generic [FAQ: Notes on disabling MDNS](/guides/faq/#notes-on-disabling-mdns) for extensive hints and warnings.
+
 ## See Also
 
 - [OpenThread Info Text Sensor](/components/text_sensor/openthread_info/)
 - [Network component](/components/network/)
 - [ESP32 Platform](/components/esp32/)
+- [MDNS component](/components/mdns/)
 - [https://openthread.io/](https://openthread.io/)
 - <APIRef text="openthread.h" path="openthread/openthread.h" />


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#15752

## Checklist

- [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
