### PR TITLE
[esp32] Fix cpu_frequency docs: defaults and allowed values per variant

### DIFF
--- a/src/content/docs/components/esp32.mdx
+++ b/src/content/docs/components/esp32.mdx
@@ -38,12 +38,12 @@ esp32:
 - **cpu_frequency** (*Optional*, string): The CPU frequency to use. Defaults to the maximum supported
   frequency for the variant. The allowed values depend on the variant:
 
-  - `esp32`, `esp32s2`, `esp32s3`, `esp32c5`: `80MHz`, `160MHz`, `240MHz`
-  - `esp32c2`: `80MHz`, `120MHz`
-  - `esp32c3`: `80MHz`, `160MHz`
-  - `esp32c6`, `esp32c61`: `80MHz`, `120MHz`, `160MHz`
-  - `esp32h2`: `16MHz`, `32MHz`, `48MHz`, `64MHz`, `96MHz`
-  - `esp32p4`: `40MHz`, `360MHz`, `400MHz` (engineering samples are limited to `360MHz`)
+  - ESP32, ESP32-S2, ESP32-S3, ESP32-C5: `80MHz`, `160MHz`, `240MHz`
+  - ESP32-C2: `80MHz`, `120MHz`
+  - ESP32-C3: `80MHz`, `160MHz`
+  - ESP32-C6, ESP32-C61: `80MHz`, `120MHz`, `160MHz`
+  - ESP32-H2: `16MHz`, `32MHz`, `48MHz`, `64MHz`, `96MHz`
+  - ESP32-P4: `40MHz`, `360MHz`, `400MHz` (engineering samples are limited to `360MHz`)
 
 - **partitions** (*Optional*, filename or list): A partition table CSV file or a list of custom partitions to add.
   See [Partitions](#esp32-partitions).

--- a/src/content/docs/components/esp32.mdx
+++ b/src/content/docs/components/esp32.mdx
@@ -35,8 +35,15 @@ esp32:
   `4MB`, `8MB`, `16MB` or `32MB`. Defaults to `4MB`. **Warning: specifying a size larger than that available
   on your board will cause the ESP32 to fail to boot.**
 
-- **cpu_frequency** (*Optional*, string): The CPU frequency to use. One of `40MHz`, `80MHz`, `160MHz`, `240MHz`,
-  `360MHz` or `400MHz`. Defaults to `160MHz`. Not all values are available for all chips.
+- **cpu_frequency** (*Optional*, string): The CPU frequency to use. Defaults to the maximum supported
+  frequency for the variant. The allowed values depend on the variant:
+
+  - `esp32`, `esp32s2`, `esp32s3`, `esp32c5`: `80MHz`, `160MHz`, `240MHz`
+  - `esp32c2`: `80MHz`, `120MHz`
+  - `esp32c3`: `80MHz`, `160MHz`
+  - `esp32c6`, `esp32c61`: `80MHz`, `120MHz`, `160MHz`
+  - `esp32h2`: `16MHz`, `32MHz`, `48MHz`, `64MHz`, `96MHz`
+  - `esp32p4`: `40MHz`, `360MHz`, `400MHz` (engineering samples are limited to `360MHz`)
 
 - **partitions** (*Optional*, filename or list): A partition table CSV file or a list of custom partitions to add.
   See [Partitions](#esp32-partitions).


### PR DESCRIPTION
## Description

The `cpu_frequency` configuration variable documentation for the ESP32 component was incorrect in two ways:

1. **Default value was wrong.** The docs said it defaults to `160MHz`, but the code in `esphome/components/esp32/__init__.py` actually defaults to the maximum supported frequency for the variant (see `set_core_data()` which picks `choices[-1]`). `160MHz` only happens to be the max for `esp32c3`, `esp32c6`, and `esp32c61`.

2. **Allowed values list was incomplete.** The docs listed `40MHz`, `80MHz`, `160MHz`, `240MHz`, `360MHz`, `400MHz`, but the code also accepts `16MHz`, `32MHz`, `48MHz`, `64MHz`, `96MHz`, and `120MHz` depending on the variant (notably `esp32h2` uses `16`–`96MHz` and `esp32c2`/`c6`/`c61` support `120MHz`).

This PR rewrites the `cpu_frequency` entry to:

- State that the default is the maximum supported frequency for the variant.
- Break the allowed values down per variant so users can see exactly what applies to their chip.
- Note that ESP32-P4 engineering samples are limited to `360MHz` (the `engineering_sample` option is documented separately above).

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- N/A

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.