### PR TITLE
[mipi_spi] Add Waveshare C6 LCD 1.47

### DIFF
--- a/src/content/docs/components/display/mipi_spi.mdx
+++ b/src/content/docs/components/display/mipi_spi.mdx
@@ -76,6 +76,7 @@ the pins used to interface to the display to be specified.
 | S3BOXLITE                            | Espressif | [https://www.espressif.com/en/products/devkits/esp32-s3-box-lite](https://www.espressif.com/en/products/devkits/esp32-s3-box-lite) |
 | WAVESHARE-4-TFT                      | Waveshare | [https://www.waveshare.com/4inch-tft-touch-shield.htm](https://www.waveshare.com/4inch-tft-touch-shield.htm) |
 | PICO-RESTOUCH-LCD-3.5                | Waveshare | [https://www.waveshare.com/pico-restouch-lcd-3.5.htm](https://www.waveshare.com/pico-restouch-lcd-3.5.htm) |
+| WAVESHARE-ESP32-C6-LCD-1.47          | Waveshare | [https://www.waveshare.com/wiki/ESP32-C6-LCD-1.47](https://www.waveshare.com/wiki/ESP32-C6-LCD-1.47) |
 | WAVESHARE-ESP32-S3-TOUCH-AMOLED-1.75 | Waveshare | [https://www.waveshare.com/esp32-s3-touch-amoled-1.75.htm](https://www.waveshare.com/esp32-s3-touch-amoled-1.75.htm) |
 | WAVESHARE-ESP32-S3-TOUCH-LCD-3.49    | Waveshare | [https://www.waveshare.com/esp32-s3-touch-lcd-3.49.htm](https://www.waveshare.com/esp32-s3-touch-lcd-3.49.htm) |
 | WT32-SC01-PLUS                       | Wireless-Tag | [https://www.wireless-tag.com/portfolio/wt32-sc01-plus/](https://www.wireless-tag.com/portfolio/wt32-sc01-plus/) |


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#15776

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
