### PR TITLE
Update water heater index.mdx for method calls

### DIFF
--- a/src/content/docs/components/water_heater/index.mdx
+++ b/src/content/docs/components/water_heater/index.mdx
@@ -121,7 +121,7 @@ From [lambdas](/automations/templates#config-lambda), you can access the current
 - `current_temperature` : Retrieve the current measured temperature of the water (float).
 
 ```cpp
-    if (id(my_boiler).current_temperature < 40.0) {
+    if (id(my_boiler).get_current_temperature() < 40.0) {
       // Water is cold
     }
 ```
@@ -131,9 +131,9 @@ From [lambdas](/automations/templates#config-lambda), you can access the current
 - `mode` : Retrieve the current operation mode.
 
 ```cpp
-    if (id(my_boiler).mode == water_heater::WATER_HEATER_MODE_ECO) {
+    if (id(my_boiler).get_mode() == water_heater::WATER_HEATER_MODE_ECO) {
       // Boiler is in ECO mode
-    } else if (id(my_boiler).mode == water_heater::WATER_HEATER_MODE_PERFORMANCE) {
+    } else if (id(my_boiler).get_mode() == water_heater::WATER_HEATER_MODE_PERFORMANCE) {
       // Boiler is in PERFORMANCE mode
     }
 ```


### PR DESCRIPTION
This pull request updates the usage examples in the water heater component documentation to use get methods instead of direct property access. This reflects a change in the API for interacting with the water heater component from lambdas.

Most important changes:

**Documentation update for API usage:**

* Updated code examples to use `get_current_temperature()` instead of accessing `current_temperature` directly.
* Updated code examples to use `get_mode()` instead of accessing the `mode` property directly.<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.