### PR TITLE
[image] Document default byte order

### DIFF
--- a/src/content/docs/components/image.mdx
+++ b/src/content/docs/components/image.mdx
@@ -76,7 +76,7 @@ image:
   - `FLOYDSTEINBERG`  : Uses Floyd-Steinberg dither to approximate the original image luminosity levels.
 
 - **byte_order** (*Optional*, string): For RGB565 images, the pixels are converted to 16 bit values. By default these will be stored in little endian byte order (LSB first),
-  but you can override this by setting `byte_order` to `little_endian`. Options are `little_endian` (default) and `big_endian`.
+  but you can override this by setting `byte_order` to `big_endian`. Options are `little_endian` (default) and `big_endian`.
   Not applicable to other image formats.
   Images used in displays and LVGL are expected to be in little endian format.
 

--- a/src/content/docs/components/image.mdx
+++ b/src/content/docs/components/image.mdx
@@ -75,9 +75,10 @@ image:
   - `NONE`  : Every pixel converts to its nearest color.
   - `FLOYDSTEINBERG`  : Uses Floyd-Steinberg dither to approximate the original image luminosity levels.
 
-- **byte_order** (*Optional*, string): For RGB565 images, the pixels are converted to 16 bit values. By default these will be stored in big endian byte order (MSB first),
-  but you can override this by setting `byte_order` to `little_endian`. Options are `big_endian` (default) and `little_endian`.
+- **byte_order** (*Optional*, string): For RGB565 images, the pixels are converted to 16 bit values. By default these will be stored in little endian byte order (LSB first),
+  but you can override this by setting `byte_order` to `little_endian`. Options are `little_endian` (default) and `big_endian`.
   Not applicable to other image formats.
+  Images used in displays and LVGL are expected to be in little endian format.
 
 ## Setting defaults
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#15800

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
