### PR TITLE
[logger] document crlf_line_endings

### DIFF
--- a/src/content/docs/components/logger.mdx
+++ b/src/content/docs/components/logger.mdx
@@ -74,6 +74,8 @@ Advanced settings:
 - **early_message** (*Optional*, boolean): Displays early debug information, such as the boot reason.
    Only on nRF52.
 
+- **crlf_line_endings** (*Optional*, boolean): Use CRLF (`\r\n`) line endings instead of LF (`\n`). This is required for some serial terminal programs (e.g., PuTTY) to display logs correctly. Defaults to `false` (LF line endings).
+
 <span id="logger-hardware_uarts"></span>
 
 ## Hardware UARTs


### PR DESCRIPTION

<!-- markdownlint-disable -->

## Description

[discussion esphome/esphome#3624](https://github.com/orgs/esphome/discussions/3624)

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes:**

- esphome/esphome#15851

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

