### PR TITLE
[faq] Document cpu_frequency as brownout mitigation

### DIFF
--- a/src/content/docs/guides/faq.mdx
+++ b/src/content/docs/guides/faq.mdx
@@ -459,11 +459,13 @@ wifi:
 
 2. **Lower the CPU frequency** -- on the ESP32, current draw scales roughly with clock speed. If you cannot
    change the upstream power hardware (e.g. a modded consumer device or a board wired into an existing circuit),
-   dropping the CPU frequency can keep transient current within what the regulator can supply:
+   dropping the CPU frequency can keep transient current within what the regulator can supply. The allowed
+   values are variant-specific; see [`cpu_frequency`](/components/esp32/#configuration-variables) on the ESP32
+   platform page for the values supported by your chip:
 
 ```yaml
 esp32:
-  cpu_frequency: 160MHz  # or 80MHz on variants that support it
+  cpu_frequency: 160MHz
 ```
 
 3. **Use a quality power supply** -- a dedicated 5V/2A supply with a short, thick USB cable.

--- a/src/content/docs/guides/faq.mdx
+++ b/src/content/docs/guides/faq.mdx
@@ -450,7 +450,8 @@ current can spike to 300-500mA. The most common causes:
 
 ### Quick fixes
 
-1. **Reduce WiFi transmit power** -- this is the most effective single change:
+1. **Reduce WiFi transmit power** -- this is the most effective single change. See
+   [`output_power`](/components/wifi/#configuration-variables) on the WiFi component page for the full range:
 
 ```yaml
 wifi:

--- a/src/content/docs/guides/faq.mdx
+++ b/src/content/docs/guides/faq.mdx
@@ -457,9 +457,18 @@ wifi:
   output_power: 13dB  # default is 20dB
 ```
 
-2. **Use a quality power supply** -- a dedicated 5V/2A supply with a short, thick USB cable.
+2. **Lower the CPU frequency** -- on the ESP32, current draw scales roughly with clock speed. If you cannot
+   change the upstream power hardware (e.g. a modded consumer device or a board wired into an existing circuit),
+   dropping the CPU frequency can keep transient current within what the regulator can supply:
 
-3. **Add a capacitor** -- a 100-1000µF electrolytic capacitor across the 3.3V and GND pins can absorb brief current spikes.
+```yaml
+esp32:
+  cpu_frequency: 160MHz  # or 80MHz on variants that support it
+```
+
+3. **Use a quality power supply** -- a dedicated 5V/2A supply with a short, thick USB cable.
+
+4. **Add a capacitor** -- a 100-1000µF electrolytic capacitor across the 3.3V and GND pins can absorb brief current spikes.
 
 ## Component states not restored after reboot
 


### PR DESCRIPTION
## Description

**Related issue (if applicable):** 

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- N/A (docs-only)

Adds lowering \`cpu_frequency\` as a mitigation to the "Brownout detector was triggered" FAQ entry.

With 2026.4.0 the default CPU frequency on ESP32 was raised to 240 MHz. Users whose upstream power hardware (regulators, long/thin wiring, modded consumer devices wired into existing circuits) was sized around the previous 160 MHz default can now see brownouts after an OTA update, sometimes requiring serial recovery. Documenting the \`cpu_frequency\` knob here gives affected users a YAML-only fix that sits alongside the existing WiFi output_power, PSU, and capacitor suggestions.

## Checklist

- [ ] I am merging into \`next\` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into \`current\` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in \`/src/content/docs/components/index.mdx\` when creating new documents for new components or cookbook.

-fixes https://github.com/esphome/esphome/issues/15849