### PR TITLE
[sdm_meter] Document chunk_size option

### DIFF
--- a/src/content/docs/components/sensor/sdm_meter.mdx
+++ b/src/content/docs/components/sensor/sdm_meter.mdx
@@ -122,6 +122,13 @@ sensor:
 - **address** (*Optional*, int): The address of the sensor if multiple sensors are attached to
   the same UART bus. You will need to set the address of each device manually. Defaults to `1`.
 
+- **chunk_size** (*Optional*, int): Split the 80-register bulk read into smaller chunks of this many
+  registers each, accumulating the results before publishing. Defaults to `80` (single request,
+  original behaviour). Set to a smaller value (for example `16`) for SDM meter firmwares that
+  truncate large responses on the wire, or that return wrong/phantom values for very small reads.
+  The optimum value is device-specific; `16` is a reasonable starting point for affected SDM630
+  variants. Range: `1` to `80`.
+
 ## See Also
 
 - [Sensor Filters](/components/sensor#sensor-filters)


### PR DESCRIPTION
## Description

Documents the new `chunk_size` configuration variable on the `sdm_meter` sensor platform.

## Related code PR

Companion to esphome/esphome#15854 (single commit on `feat/sdm_meter-chunked-reads`, against `dev`).

## Why

Some SDM meter firmwares (observed on an SDM630-Modbus V2 in service for several years) either truncate responses to the 80-register bulk read before the trailing CRC bytes, or return wrong/phantom values for very small reads. Splitting the read into N-register chunks sits under the truncation ceiling while staying in the meter's "bulk mode" where register-map semantics are correct.

Default remains `80` (single request, byte-identical to existing behaviour). Users with an affected meter opt in to e.g. `chunk_size: 16`.

## What changed

One new bullet under "Configuration variables" on `src/content/docs/components/sensor/sdm_meter.mdx`. No image or structural changes.

## Testing

Ran on production hardware (ESP32 + MAX485 + SDM630-Modbus V2) since 2026-04-17. Chunked reads with `chunk_size: 16` are stable across multiple days of polling.

CODEOWNERS of the component: @polyfaces, @jesserockz.