### PR TITLE
[mipi_rgb]Add sunton 5 and 7 inch models

### DIFF
--- a/src/content/docs/components/display/mipi_rgb.mdx
+++ b/src/content/docs/components/display/mipi_rgb.mdx
@@ -46,8 +46,8 @@ option is `model`.
 | T-RGB-2.1                    | ST7701s     | Lilygo       | [https://lilygo.cc/products/t-rgb](https://lilygo.cc/products/t-rgb)                               |
 | T-RGB-2.8                    | ST7701s     | Lilygo       | [https://lilygo.cc/products/t-rgb](https://lilygo.cc/products/t-rgb)                               |
 | SEEED-INDICATOR-D1           | ST7701s     | Seeed Studio | [https://www.seeedstudio.com/SenseCAP-Indicator-D1L-p-5646.html](https://www.seeedstudio.com/SenseCAP-Indicator-D1L-p-5646.html) |
-| SUNTON_8048S050              | RPI         | Sunton       | [https://www.makerfabs.com/sunton-esp32-s3-5-inch-ips-with-touch.html](https://www.makerfabs.com/sunton-esp32-s3-5-inch-ips-with-touch.html)  |
-| SUNTON_8048S070              | RPI         | Sunton       | [https://www.makerfabs.com/sunton-esp32-s3-7-inch-tn-display-with-touch.html](https://www.makerfabs.com/sunton-esp32-s3-7-inch-tn-display-with-touch.html) |
+| ESP32-8048S050              | RPI         | Sunton       | [https://www.makerfabs.com/sunton-esp32-s3-5-inch-ips-with-touch.html](https://www.makerfabs.com/sunton-esp32-s3-5-inch-ips-with-touch.html)  |
+| ESP32-8048S070              | RPI         | Sunton       | [https://www.makerfabs.com/sunton-esp32-s3-7-inch-tn-display-with-touch.html](https://www.makerfabs.com/sunton-esp32-s3-7-inch-tn-display-with-touch.html) |
 | ESP32-S3-TOUCH-LCD-4.3       | RPI         | Waveshare    | [https://www.waveshare.com/esp32-s3-touch-lcd-4.3.htm](https://www.waveshare.com/esp32-s3-touch-lcd-4.3.htm)           |
 | ESP32-S3-TOUCH-LCD-7-800X480 | RPI         | Waveshare    | [https://www.waveshare.com/esp32-s3-touch-lcd-7.htm](https://www.waveshare.com/esp32-s3-touch-lcd-7.htm)             |
 | WAVESHARE-3.16-320X820       | ST7701s     | Waveshare    | [https://www.waveshare.com/esp32-s3-lcd-3.16.htm](https://www.waveshare.com/esp32-s3-lcd-3.16.htm)                |

--- a/src/content/docs/components/display/mipi_rgb.mdx
+++ b/src/content/docs/components/display/mipi_rgb.mdx
@@ -46,6 +46,8 @@ option is `model`.
 | T-RGB-2.1                    | ST7701s     | Lilygo       | [https://lilygo.cc/products/t-rgb](https://lilygo.cc/products/t-rgb)                               |
 | T-RGB-2.8                    | ST7701s     | Lilygo       | [https://lilygo.cc/products/t-rgb](https://lilygo.cc/products/t-rgb)                               |
 | SEEED-INDICATOR-D1           | ST7701s     | Seeed Studio | [https://www.seeedstudio.com/SenseCAP-Indicator-D1L-p-5646.html](https://www.seeedstudio.com/SenseCAP-Indicator-D1L-p-5646.html) |
+| SUNTON_8048S050              | RPI         | Sunton       | [https://www.makerfabs.com/sunton-esp32-s3-5-inch-ips-with-touch.html](https://www.makerfabs.com/sunton-esp32-s3-5-inch-ips-with-touch.html)  |
+| SUNTON_8048S070              | RPI         | Sunton       | [https://www.makerfabs.com/sunton-esp32-s3-7-inch-tn-display-with-touch.html](https://www.makerfabs.com/sunton-esp32-s3-7-inch-tn-display-with-touch.html) |
 | ESP32-S3-TOUCH-LCD-4.3       | RPI         | Waveshare    | [https://www.waveshare.com/esp32-s3-touch-lcd-4.3.htm](https://www.waveshare.com/esp32-s3-touch-lcd-4.3.htm)           |
 | ESP32-S3-TOUCH-LCD-7-800X480 | RPI         | Waveshare    | [https://www.waveshare.com/esp32-s3-touch-lcd-7.htm](https://www.waveshare.com/esp32-s3-touch-lcd-7.htm)             |
 | WAVESHARE-3.16-320X820       | ST7701s     | Waveshare    | [https://www.waveshare.com/esp32-s3-lcd-3.16.htm](https://www.waveshare.com/esp32-s3-lcd-3.16.htm)                |


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Add documentation for sunton 5 and 7 inch displays

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#15858

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
