### PR TITLE
2026.4.1

### DIFF
--- a/data/version.yaml
+++ b/data/version.yaml
@@ -1,2 +1,2 @@
-release: 2026.4.0
+release: 2026.4.1
 version: '2026.4'

--- a/src/content/docs/changelog/2026.4.0.mdx
+++ b/src/content/docs/changelog/2026.4.0.mdx
@@ -501,6 +501,41 @@ For detailed migration guides and API documentation, see the [ESPHome Developers
 
 {/* markdownlint-disable MD013 */}
 
+## Release 2026.4.1 - April 20
+
+<details>
+<summary></summary>
+
+- [core] Fix app_state_ status bits clobbered for non-looping components [esphome#15658](https://github.com/esphome/esphome/pull/15658) by [@bdraco](https://github.com/bdraco)
+- [core] Inline feed_wdt hot path with out-of-line slow path [esphome#15656](https://github.com/esphome/esphome/pull/15656) by [@bdraco](https://github.com/bdraco)
+- [st7789v] Fix swapped offset_width/offset_height in model presets [esphome#15755](https://github.com/esphome/esphome/pull/15755) by [@swoboda1337](https://github.com/swoboda1337)
+- [sx126x][sx127x] Fix frequency precision loss from float32 codegen [esphome#15753](https://github.com/esphome/esphome/pull/15753) by [@swoboda1337](https://github.com/swoboda1337)
+- Bump aioesphomeapi from 44.15.0 to 44.16.0 [esphome#15757](https://github.com/esphome/esphome/pull/15757) by [@dependabot[bot]](https://github.com/apps/dependabot)
+- [lvgl] Clean the build if lv_conf.h changes [esphome#15777](https://github.com/esphome/esphome/pull/15777) by [@clydebarrow](https://github.com/clydebarrow)
+- [mitsubishi_cn105] use HEAT_COOL mode to enable temperature slider [esphome#15748](https://github.com/esphome/esphome/pull/15748) by [@crnjan](https://github.com/crnjan)
+- [core] Diagnose missing cg.templatable in codegen for TEMPLATABLE_VALUE fields [esphome#15758](https://github.com/esphome/esphome/pull/15758) by [@bdraco](https://github.com/bdraco)
+- [time] Fix RTC is_valid() rejecting valid times after day_of_year cleanup [esphome#15763](https://github.com/esphome/esphome/pull/15763) by [@bdraco](https://github.com/bdraco)
+- [qmc5883l] Move per-update log line from DEBUG to VERBOSE [esphome#15781](https://github.com/esphome/esphome/pull/15781) by [@swoboda1337](https://github.com/swoboda1337)
+- [bundle] Force-resolve nested IncludeFile during file discovery [esphome#15762](https://github.com/esphome/esphome/pull/15762) by [@bdraco](https://github.com/bdraco)
+- [ili9xxx] Guard against null buffer in display_() when allocation fails [esphome#15786](https://github.com/esphome/esphome/pull/15786) by [@bdraco](https://github.com/bdraco)
+- [esp32] Accept unquoted minimum_chip_revision values [esphome#15785](https://github.com/esphome/esphome/pull/15785) by [@swoboda1337](https://github.com/swoboda1337)
+- [lvgl] Guard lv_image_set_src wrapper with LV_USE_IMAGE [esphome#15789](https://github.com/esphome/esphome/pull/15789) by [@swoboda1337](https://github.com/swoboda1337)
+- [mipi_spi] Drawing fixes for native display [esphome#15802](https://github.com/esphome/esphome/pull/15802) by [@clydebarrow](https://github.com/clydebarrow)
+- [image] Fix byte order handling [esphome#15800](https://github.com/esphome/esphome/pull/15800) by [@clydebarrow](https://github.com/clydebarrow)
+- [core] coerce set_interval(0) / update_interval: 0ms to 1ms [esphome#15799](https://github.com/esphome/esphome/pull/15799) by [@bdraco](https://github.com/bdraco)
+- [ethernet] Fix SPI3_HOST default breaking compile on variants without SPI3 [esphome#15809](https://github.com/esphome/esphome/pull/15809) by [@swoboda1337](https://github.com/swoboda1337)
+- [core] Fix DelayAction compile error with non-const reference args [esphome#15814](https://github.com/esphome/esphome/pull/15814) by [@bdraco](https://github.com/bdraco)
+- [esp32] Downgrade unneeded `ignore_pin_validation_error` to a warning [esphome#15811](https://github.com/esphome/esphome/pull/15811) by [@swoboda1337](https://github.com/swoboda1337)
+- [runtime_image] Fix RGB order [esphome#15813](https://github.com/esphome/esphome/pull/15813) by [@clydebarrow](https://github.com/clydebarrow)
+- [lvgl] Fix crash with snow on rotated display [esphome#15822](https://github.com/esphome/esphome/pull/15822) by [@clydebarrow](https://github.com/clydebarrow)
+- [core] Feed WDT unconditionally in main loop to fix empty-config panic [esphome#15830](https://github.com/esphome/esphome/pull/15830) by [@bdraco](https://github.com/bdraco)
+- Bump aioesphomeapi from 44.16.0 to 44.16.1 [esphome#15836](https://github.com/esphome/esphome/pull/15836) by [@dependabot[bot]](https://github.com/apps/dependabot)
+- [core] Default PollingComponent() to 1ms when codegen is bypassed [esphome#15831](https://github.com/esphome/esphome/pull/15831) by [@bdraco](https://github.com/bdraco)
+- [substitutions] Fix `substitutions: !include file.yaml` regression [esphome#15850](https://github.com/esphome/esphome/pull/15850) by [@bdraco](https://github.com/bdraco)
+- [packages] Improve error messages with include stack and fix missing path propagation [esphome#15844](https://github.com/esphome/esphome/pull/15844) by [@jpeletier](https://github.com/jpeletier)
+
+</details>
+
 ## Full list of changes
 
 ### New Features

--- a/src/content/docs/components/image.mdx
+++ b/src/content/docs/components/image.mdx
@@ -75,9 +75,10 @@ image:
   - `NONE`  : Every pixel converts to its nearest color.
   - `FLOYDSTEINBERG`  : Uses Floyd-Steinberg dither to approximate the original image luminosity levels.
 
-- **byte_order** (*Optional*, string): For RGB565 images, the pixels are converted to 16 bit values. By default these will be stored in big endian byte order (MSB first),
-  but you can override this by setting `byte_order` to `little_endian`. Options are `big_endian` (default) and `little_endian`.
+- **byte_order** (*Optional*, string): For RGB565 images, the pixels are converted to 16 bit values. By default these will be stored in little endian byte order (LSB first),
+  but you can override this by setting `byte_order` to `big_endian`. Options are `little_endian` (default) and `big_endian`.
   Not applicable to other image formats.
+  Images used in displays and LVGL are expected to be in little endian format.
 
 ## Setting defaults
 

--- a/src/content/docs/components/runtime_stats.mdx
+++ b/src/content/docs/components/runtime_stats.mdx
@@ -55,18 +55,46 @@ For each component, the following metrics are reported:
 
 Components are sorted by total execution time (descending) to highlight the most impactful components first.
 
+### Main loop metrics
+
+In addition to per-component timings, two main-loop lines are emitted in both the Period and Total sections. They describe the wall time spent in `Application::loop()` **excluding** the sleep/yield at the end of each iteration, so they reflect real work the CPU is doing for ESPHome — not idle time.
+
+**`main_loop:` line**
+
+- **iters**: Number of main-loop iterations observed in this window.
+- **active_avg**: Average per-iteration active time (loop start to just before yield/sleep).
+- **active_max**: Largest single-iteration active time seen (outliers often point to a component that blocked the loop).
+- **active_total**: Sum of per-iteration active time across the window — i.e. total non-sleeping CPU time in the main loop.
+- **overhead_total**: `active_total` minus the sum of all per-component `total` times. Represents time spent in the main loop that is *not* attributable to any single component (scheduler dispatch, inter-component bookkeeping, framework glue).
+
+**`main_loop_overhead_section:` line**
+
+Breaks `overhead_total` down into three buckets so you can tell *where* overhead is being spent:
+
+- **before**: Time inside `before_loop_tasks_` — scheduler dispatch and ISR `enable_loop` processing.
+- **tail**: Time inside `after_loop_tasks_` plus the small prefix before stats recording. Normally near zero.
+- **inter_component**: Residual per-iteration bookkeeping that runs between components (`set_current_component`, per-component timing guard construction/destruction, `feed_wdt_with_time` calls, the for-loop itself).
+
+A regression in `before` points at the scheduler or a component requesting `enable_loop` frequently from an ISR; a regression in `inter_component` points at the per-component dispatch path; `tail` should stay flat.
+
 ## Example Output
+
+In the example below, `overhead_total` is the difference between `active_total` and the sum of per-component `total` times — for the period section, `479.1ms − (300.0 + 40.0 + 10.4)ms = 128.7ms`. The three overhead-section buckets (`before + tail + inter_component`) sum back to `overhead_total`.
 
 ```text
 [09:55:52][I][runtime_stats:042]: Component Runtime Statistics
-[09:55:52][I][runtime_stats:043]: Period stats (last 60000ms):
-[09:55:52][I][runtime_stats:066]:   wifi: count=60, avg=0.50ms, max=5ms, total=30ms
-[09:55:52][I][runtime_stats:066]:   api: count=120, avg=0.01ms, max=1ms, total=1ms
-[09:55:52][I][runtime_stats:066]:   sensor: count=600, avg=0.00ms, max=1ms, total=2ms
-[09:55:52][I][runtime_stats:070]: Total stats (since boot):
-[09:55:52][I][runtime_stats:084]:   wifi: count=600, avg=0.45ms, max=5ms, total=270ms
-[09:55:52][I][runtime_stats:084]:   api: count=1200, avg=0.01ms, max=1ms, total=12ms
-[09:55:52][I][runtime_stats:084]:   sensor: count=6000, avg=0.00ms, max=1ms, total=20ms
+[09:55:52][I][runtime_stats:043]:  Period stats (last 60000ms): 3 active components
+[09:55:52][I][runtime_stats:066]:   wifi: count=60, avg=5.000ms, max=8.00ms, total=300.0ms
+[09:55:52][I][runtime_stats:066]:   api: count=120, avg=0.333ms, max=1.00ms, total=40.0ms
+[09:55:52][I][runtime_stats:066]:   sensor: count=600, avg=0.017ms, max=0.10ms, total=10.4ms
+[09:55:52][I][runtime_stats:068]:   main_loop: iters=7650, active_avg=0.063ms, active_max=10.67ms, active_total=479.1ms, overhead_total=128.7ms
+[09:55:52][I][runtime_stats:070]:   main_loop_overhead_section: before=45.0ms, tail=8.0ms, inter_component=75.7ms
+[09:55:52][I][runtime_stats:072]:  Total stats (since boot): 3 active components
+[09:55:52][I][runtime_stats:084]:   wifi: count=600, avg=5.000ms, max=8.00ms, total=3000.0ms
+[09:55:52][I][runtime_stats:084]:   api: count=1200, avg=0.333ms, max=1.00ms, total=400.0ms
+[09:55:52][I][runtime_stats:084]:   sensor: count=6000, avg=0.017ms, max=0.10ms, total=104.0ms
+[09:55:52][I][runtime_stats:094]:   main_loop: iters=76500, active_avg=0.063ms, active_max=14.30ms, active_total=4791.0ms, overhead_total=1287.0ms
+[09:55:52][I][runtime_stats:096]:   main_loop_overhead_section: before=450.0ms, tail=80.0ms, inter_component=757.0ms
 ```
 
 ## Use Cases

--- a/src/content/docs/guides/supporters.mdx
+++ b/src/content/docs/guides/supporters.mdx
@@ -270,6 +270,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [bisbastuner (@bisbastuner)](https://github.com/bisbastuner)
 - [Ryan Henderson (@bitflippersanonymous)](https://github.com/bitflippersanonymous)
 - [Brian Kaufman (@bkaufx)](https://github.com/bkaufx)
+- [Edvard Filistovič (@Bl00d-B0b)](https://github.com/Bl00d-B0b)
 - [JDavid (@blackhack)](https://github.com/blackhack)
 - [Paul Blacknell (@blacknell)](https://github.com/blacknell)
 - [blackshoals (@blackshoals)](https://github.com/blackshoals)
@@ -1116,6 +1117,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Jonathan V (@jonofmac)](https://github.com/jonofmac)
 - [jonOfrie (@jonOfrie)](https://github.com/jonOfrie)
 - [Joppy (@JoppyFurr)](https://github.com/JoppyFurr)
+- [JorgenSteen (@JorgenSteen)](https://github.com/JorgenSteen)
 - [Joris S (@Jorre05)](https://github.com/Jorre05)
 - [Jared Sanson (@jorticus)](https://github.com/jorticus)
 - [joseph douce (@josephdouce)](https://github.com/josephdouce)
@@ -2338,6 +2340,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Mike (@xsnoopy)](https://github.com/xsnoopy)
 - [WitchKing (@xvil)](https://github.com/xvil)
 - [Andrew Kroll (@xxxajk)](https://github.com/xxxajk)
+- [James Hodgkinson (@yaleman)](https://github.com/yaleman)
 - [Yaroslav (@Yarikx)](https://github.com/Yarikx)
 - [Marcin Jaworski (@yawor)](https://github.com/yawor)
 - [ychieux (@ychieux)](https://github.com/ychieux)
@@ -2375,4 +2378,4 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Christian Zufferey (@zuzu59)](https://github.com/zuzu59)
 - [Zynth-dev (@Zynth-dev)](https://github.com/Zynth-dev)
 
-*This page was last updated April 15, 2026.*
+*This page was last updated April 20, 2026.*


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- [esp32] Fix cpu_frequency docs: defaults and allowed values per variant [docs#6472](https://github.com/esphome/esphome-docs/pull/6472)
- [image] Document default byte order [docs#6477](https://github.com/esphome/esphome-docs/pull/6477)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
