### PR TITLE
[esp32] Note that some OEM modules cap at 160MHz

### DIFF
--- a/src/content/docs/components/esp32.mdx
+++ b/src/content/docs/components/esp32.mdx
@@ -45,6 +45,12 @@ esp32:
   - ESP32-H2: `16MHz`, `32MHz`, `48MHz`, `64MHz`, `96MHz`
   - ESP32-P4: `40MHz`, `360MHz`, `400MHz` (engineering samples are limited to `360MHz`)
 
+  Some ESP32 modules -- typically OEM/single-core variants found in commercial
+  devices (e.g. certain Xiaomi lamps) -- are rated only up to `160MHz` even though
+  they identify as ESP32. If your device hangs, resets, or fails to boot after
+  flashing at the default (maximum) frequency, set `cpu_frequency: 160MHz` (or
+  lower) to work around this.
+
 - **partitions** (*Optional*, filename or list): A partition table CSV file or a list of custom partitions to add.
   See [Partitions](#esp32-partitions).
 


### PR DESCRIPTION
## Description

**Related issue (if applicable):** Follow-up to feedback on #6483

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- N/A (docs-only)

Adds a short note under the \`cpu_frequency\` docs on the ESP32 platform page covering OEM/single-core variants found in some commercial devices (e.g. certain Xiaomi lamps) that identify as ESP32 but are rated only up to 160 MHz. With 2026.4.0 raising the default CPU frequency to the chip maximum, those modules may hang or reset on first boot, and \`cpu_frequency: 160MHz\` is the fix.

## Checklist

- [ ] I am merging into \`next\` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into \`current\` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in \`/src/content/docs/components/index.mdx\` when creating new documents for new components or cookbook.