### PR TITLE
[mapping] Add doc for default_value

### DIFF
--- a/src/content/docs/components/lvgl/widgets.mdx
+++ b/src/content/docs/components/lvgl/widgets.mdx
@@ -204,6 +204,13 @@ which allows use of [strftime](http://www.cplusplus.com/reference/ctime/strftime
 When formatting a single floating point value, it is possible to provide a substitute string to be used when the
 value is `nan` or `inf`. The substitute string is specified with the `if_nan` option.
 
+The text may also be looked up from a [Mapping](/components/mapping/) component by specifying a `mapping` ID and a `value`
+(the lookup key). The mapping must have a `to` type of `string`. The `value` can be either a literal or a lambda, and
+should match the `from` type of the mapping.
+
+- **mapping** (**Required**, [ID](/guides/configuration-types#id)): The ID of a `mapping` component whose `to` type is `string`.
+- **value** (**Required**, templatable): The key to look up in the mapping.
+
 **Examples:**
 
 ```yaml
@@ -244,6 +251,16 @@ on_...:
         format: "%.1f"
         args: [id(sensor_id).state]
         if_nan: "N/A"
+  - lvgl.label.update:
+      id: label_id
+      text:
+        mapping: string_map    # a mapping component with `to: string`
+        value: 2               # literal key
+  - lvgl.label.update:
+      id: label_id
+      text:
+        mapping: string_map
+        value: !lambda return id(my_sensor).state;
 ```
 
 For styling text, see the properties of the [`label`](#lvgl-widget-label) widget.
@@ -981,7 +998,11 @@ Images are the basic widgets used to display images.
 
 **Configuration variables:**
 
-- **src** (**Required**, [image](/components/image#display-image)): The ID of an existing image configuration.
+- **src** (**Required**): The image to display. May be specified in one of two ways:
+  - An [image](/components/image#display-image) ID referring to an existing image configuration.
+  - A [Mapping](/components/mapping/) lookup, by providing a dict with the following keys. The referenced mapping must have a `to` type of `image`.
+    - **mapping** (**Required**, [ID](/guides/configuration-types#id)): The ID of a `mapping` component whose `to` type is `image`.
+    - **value** (**Required**, templatable): The key to look up in the mapping.
 - **rotation** (*Optional*, 0-360): Rotation of the image. Defaults to `0.0`. (The deprecated name `angle` is also accepted.)
 - **antialias** (*Optional*): The quality of the rotation or scale transformation. When anti-aliasing is enabled, the transformations are higher quality but slower. Defaults to `false`.
 - **offset_x** (*Optional*): Add a horizontal offset to the image position.
@@ -1020,6 +1041,12 @@ on_...:
   - lvgl.image.update:
       id: img_id
       src: cat_image_bowtie
+  # Select the image via a mapping component lookup
+  - lvgl.image.update:
+      id: img_id
+      src:
+        mapping: image_map     # a mapping component with `to: image`
+        value: 0               # literal key; may also be a lambda
 ```
 
 > [!NOTE]

--- a/src/content/docs/components/lvgl/widgets.mdx
+++ b/src/content/docs/components/lvgl/widgets.mdx
@@ -204,13 +204,6 @@ which allows use of [strftime](http://www.cplusplus.com/reference/ctime/strftime
 When formatting a single floating point value, it is possible to provide a substitute string to be used when the
 value is `nan` or `inf`. The substitute string is specified with the `if_nan` option.
 
-The text may also be looked up from a [Mapping](/components/mapping/) component by specifying a `mapping` ID and a `value`
-(the lookup key). The mapping must have a `to` type of `string`. The `value` can be either a literal or a lambda, and
-should match the `from` type of the mapping.
-
-- **mapping** (**Required**, [ID](/guides/configuration-types#id)): The ID of a `mapping` component whose `to` type is `string`.
-- **value** (**Required**, templatable): The key to look up in the mapping.
-
 **Examples:**
 
 ```yaml
@@ -251,16 +244,6 @@ on_...:
         format: "%.1f"
         args: [id(sensor_id).state]
         if_nan: "N/A"
-  - lvgl.label.update:
-      id: label_id
-      text:
-        mapping: string_map    # a mapping component with `to: string`
-        value: 2               # literal key
-  - lvgl.label.update:
-      id: label_id
-      text:
-        mapping: string_map
-        value: !lambda return id(my_sensor).state;
 ```
 
 For styling text, see the properties of the [`label`](#lvgl-widget-label) widget.
@@ -998,11 +981,7 @@ Images are the basic widgets used to display images.
 
 **Configuration variables:**
 
-- **src** (**Required**): The image to display. May be specified in one of two ways:
-  - An [image](/components/image#display-image) ID referring to an existing image configuration.
-  - A [Mapping](/components/mapping/) lookup, by providing a dict with the following keys. The referenced mapping must have a `to` type of `image`.
-    - **mapping** (**Required**, [ID](/guides/configuration-types#id)): The ID of a `mapping` component whose `to` type is `image`.
-    - **value** (**Required**, templatable): The key to look up in the mapping.
+- **src** (**Required**, [image](/components/image#display-image)): The ID of an existing image configuration.
 - **rotation** (*Optional*, 0-360): Rotation of the image. Defaults to `0.0`. (The deprecated name `angle` is also accepted.)
 - **antialias** (*Optional*): The quality of the rotation or scale transformation. When anti-aliasing is enabled, the transformations are higher quality but slower. Defaults to `false`.
 - **offset_x** (*Optional*): Add a horizontal offset to the image position.
@@ -1041,12 +1020,6 @@ on_...:
   - lvgl.image.update:
       id: img_id
       src: cat_image_bowtie
-  # Select the image via a mapping component lookup
-  - lvgl.image.update:
-      id: img_id
-      src:
-        mapping: image_map     # a mapping component with `to: image`
-        value: 0               # literal key; may also be a lambda
 ```
 
 > [!NOTE]

--- a/src/content/docs/components/mapping.mdx
+++ b/src/content/docs/components/mapping.mdx
@@ -12,9 +12,23 @@ mapping:
   - id: weather_icon
     from: string
     to: image
+    default_value: unknown_weather_img
     entries:
       clear-night: clear_night_img
       cloudy: cloudy_img
+
+  - id: day_map
+    from: int
+    to: string
+    entries:
+      1: DIM
+      2: LUN
+      3: MAR
+      4: MER
+      5: JEU
+      6: VEN
+      7: SAM
+    default_value: "---"
 
  # Using the mapping in an automation
 text_sensor:
@@ -35,6 +49,7 @@ text_sensor:
 - **from** (**Required**, string): The type of the keys in the mapping. Can be one of `string` or `int`.
 - **to** (**Required**, string): The type of values in the map. May be one of `string` or `int` or a class specifier as discussed below.
 - **entries** (**Required**, dict): A list of key-value pairs that define the mapping. The keys must be of the type specified in the `from` field, and the values must be of the type specified in the `to` field.
+- **default_value** (*Optional*, value): A default value that will be returned if a key is not found in the mapping. The type of this value must match the `to` type.
 
 ## Mapping to a class
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#15861

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
