### PR TITLE
Remove Arduino Port Extender link

### DIFF
--- a/src/content/docs/components/index.mdx
+++ b/src/content/docs/components/index.mdx
@@ -1122,7 +1122,6 @@ ESPHome to cellular networks. **Does not encompass Wi-Fi.**
 ## Cookbook
 
 <ImgTable items={[
-  ["Arduino Port Extender", "/cookbook/arduino_port_extender/", "arduino_logo.svg"],
   ["BME280 Environment extras", "/cookbook/bme280_environment/", "bme280.jpg"],
   ["EHMTX a matrix status/text display", "/cookbook/ehmtx/", "ehmtx.jpg"],
   ["ESP32 Water Leak Detector", "/cookbook/leak-detector-m5stickc/", "leak-detector-m5stickC_main_index.jpg"],


### PR DESCRIPTION
The link was pointing to a non-existant page.

<!-- markdownlint-disable -->

## Description

Removed link to arduino port extender, removed in commit 61b79e7296723a44e4a15803b317173f63669ef6.

## Checklist

- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.