### PR TITLE
[ac_dimmer] Zero-crossing interrupt type documentation

### DIFF
--- a/src/content/docs/components/output/ac_dimmer.mdx
+++ b/src/content/docs/components/output/ac_dimmer.mdx
@@ -32,6 +32,7 @@ output:
       mode:
         input: true
       inverted: yes
+    zero_cross_interrupt_type: FALLING
 
 light:
   - platform: monochromatic
@@ -50,8 +51,12 @@ light:
   doing so, `allow_other_uses` pin schema option **must** be set to `true` to
   avoid configuration errors due to pin reuse.
 
-- **method** (*Optional*): Set the method for dimming, can be:
+- **zero_cross_interrupt_type** (*Optional*): Set the interrupt type for the zero crossing interrupt, can be:
+  - `FALLING`  : (default) trigger on falling edges.
+  - `RISING`  : trigger on rising edges.
+  - `ANY`  : trigger on any edge.
 
+- **method** (*Optional*): Set the method for dimming, can be:
   - `leading pulse`  : (default) a short pulse to trigger a triac.
   - `leading`  : gate pin driven high until the zero cross is detected
   - `trailing`  : gate pin driven high from zero cross until dim period, this method

--- a/src/content/docs/components/output/ac_dimmer.mdx
+++ b/src/content/docs/components/output/ac_dimmer.mdx
@@ -31,8 +31,6 @@ output:
       number: GPIOXX
       mode:
         input: true
-      inverted: yes
-    zero_cross_interrupt_type: FALLING
 
 light:
   - platform: monochromatic


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#15862

## Checklist

- [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.
