### PR TITLE
Add Link response headers for agent discovery

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -27,6 +27,7 @@
   [headers.values]
     Cache-Control = "public, max-age=3600, stale-while-revalidate=86400"
     Cloudflare-CDN-Cache-Control = "public, max-age=604800, stale-while-revalidate=86400"
+    Link = '''</sitemap-index.xml>; rel="sitemap", </components.json>; rel="describedby"; type="application/json"'''
 
 # Fingerprinted assets (Astro build output in /_astro/) - 1 year, immutable
 [[headers]]

--- a/netlify.toml
+++ b/netlify.toml
@@ -27,7 +27,7 @@
   [headers.values]
     Cache-Control = "public, max-age=3600, stale-while-revalidate=86400"
     Cloudflare-CDN-Cache-Control = "public, max-age=604800, stale-while-revalidate=86400"
-    Link = '''</sitemap-index.xml>; rel="sitemap", </components.json>; rel="describedby"; type="application/json"'''
+    Link = '</sitemap-index.xml>; rel="index"; type="application/xml", </components.json>; rel="describedby"; type="application/json"'
 
 # Fingerprinted assets (Astro build output in /_astro/) - 1 year, immutable
 [[headers]]


### PR DESCRIPTION
## Description

Adds `Link` response headers on all routes (via the catch-all `/*` rule in `netlify.toml`) to advertise agent-discoverable resources per RFC 8288:

- `</sitemap-index.xml>; rel="sitemap"` — points agents at the sitemap generated by `@astrojs/sitemap`
- `</components.json>; rel="describedby"; type="application/json"` — points at the machine-readable component catalog built by the `componentsJson` integration

This addresses a failing `linkHeaders` check reported by the [isitagentready.com](https://isitagentready.com) scanner: `"No Link header present in response"`.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- N/A

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.