### PR TITLE
[mipi_dsi] Add Seeed reTerminal D1001

### DIFF
--- a/src/content/docs/components/display/mipi_dsi.mdx
+++ b/src/content/docs/components/display/mipi_dsi.mdx
@@ -71,7 +71,7 @@ will set the correct pins and dimensions for the display.
 | JC8012P4A1             | Guition        | [JC8012P4A1 product page](https://aliexpress.com/item/1005008789890066.html)                                     |
 | M5STACK-TAB5           | M5Stack        | [TAB5 product page](https://shop.m5stack.com/products/m5stack-tab5-iot-development-kit-esp32-p4)                 |
 | M5STACK-TAB5-V2        | M5Stack        | [TAB5-V2 product page](https://shop.m5stack.com/products/m5stack-tab5-iot-development-kit-esp32-p4)              |
-| SEEED-RETERMINAL-D1001 | Seeed Studio   | [D1001 product page](https://www.seeedstudio.com/reTerminal-D1001-p-6729.html) |
+| SEEED-RETERMINAL-D1001 | Seeed Studio   | [D1001 product page](https://www.seeedstudio.com/reTerminal-D1001-p-6729.html)                                |
 | WAVESHARE-P4-NANO-10.1 | Waveshare      | [P4-NANO-10.1 product page](https://www.waveshare.com/esp32-p4-nano.htm?sku=29031)                               |
 | WAVESHARE-P4-86-PANEL  | Waveshare      | [P4-86-PANEL product page](https://www.waveshare.com/esp32-p4-wifi6-touch-lcd-4b.htm?sku=31570)                  |
 | WAVESHARE-ESP32-P4-WIFI6-TOUCH-LCD-7B   | Waveshare | [P4-WIFI6-TOUCH-LCD-7B product page](https://www.waveshare.com/wiki/ESP32-P4-WIFI6-Touch-LCD-7B)     |

--- a/src/content/docs/components/display/mipi_dsi.mdx
+++ b/src/content/docs/components/display/mipi_dsi.mdx
@@ -71,7 +71,7 @@ will set the correct pins and dimensions for the display.
 | JC8012P4A1             | Guition        | [JC8012P4A1 product page](https://aliexpress.com/item/1005008789890066.html)                                     |
 | M5STACK-TAB5           | M5Stack        | [TAB5 product page](https://shop.m5stack.com/products/m5stack-tab5-iot-development-kit-esp32-p4)                 |
 | M5STACK-TAB5-V2        | M5Stack        | [TAB5-V2 product page](https://shop.m5stack.com/products/m5stack-tab5-iot-development-kit-esp32-p4)              |
-| SEEED-RETERMINAL-D1001 | Seeed Studio   | [D1001 product page](https://www.seeedstudio.com/reTerminal-D1001-p-6729.html)                                |
+| SEEED-RETERMINAL-D1001 | Seeed Studio   | [D1001 product page](https://www.seeedstudio.com/reTerminal-D1001-p-6729.html)                                  |
 | WAVESHARE-P4-NANO-10.1 | Waveshare      | [P4-NANO-10.1 product page](https://www.waveshare.com/esp32-p4-nano.htm?sku=29031)                               |
 | WAVESHARE-P4-86-PANEL  | Waveshare      | [P4-86-PANEL product page](https://www.waveshare.com/esp32-p4-wifi6-touch-lcd-4b.htm?sku=31570)                  |
 | WAVESHARE-ESP32-P4-WIFI6-TOUCH-LCD-7B   | Waveshare | [P4-WIFI6-TOUCH-LCD-7B product page](https://www.waveshare.com/wiki/ESP32-P4-WIFI6-Touch-LCD-7B)     |

--- a/src/content/docs/components/display/mipi_dsi.mdx
+++ b/src/content/docs/components/display/mipi_dsi.mdx
@@ -71,7 +71,7 @@ will set the correct pins and dimensions for the display.
 | JC8012P4A1             | Guition        | [JC8012P4A1 product page](https://aliexpress.com/item/1005008789890066.html)                                     |
 | M5STACK-TAB5           | M5Stack        | [TAB5 product page](https://shop.m5stack.com/products/m5stack-tab5-iot-development-kit-esp32-p4)                 |
 | M5STACK-TAB5-V2        | M5Stack        | [TAB5-V2 product page](https://shop.m5stack.com/products/m5stack-tab5-iot-development-kit-esp32-p4)              |
-| SEEED-RETERMINAL-D1001 | Seeed Studio   | [D1001 product page](https://www.seeedstudio.com/reTerminal-D1001-p-6729.html)                                                                   |
+| SEEED-RETERMINAL-D1001 | Seeed Studio   | [D1001 product page](https://www.seeedstudio.com/reTerminal-D1001-p-6729.html) |
 | WAVESHARE-P4-NANO-10.1 | Waveshare      | [P4-NANO-10.1 product page](https://www.waveshare.com/esp32-p4-nano.htm?sku=29031)                               |
 | WAVESHARE-P4-86-PANEL  | Waveshare      | [P4-86-PANEL product page](https://www.waveshare.com/esp32-p4-wifi6-touch-lcd-4b.htm?sku=31570)                  |
 | WAVESHARE-ESP32-P4-WIFI6-TOUCH-LCD-7B   | Waveshare | [P4-WIFI6-TOUCH-LCD-7B product page](https://www.waveshare.com/wiki/ESP32-P4-WIFI6-Touch-LCD-7B)     |

--- a/src/content/docs/components/display/mipi_dsi.mdx
+++ b/src/content/docs/components/display/mipi_dsi.mdx
@@ -71,7 +71,7 @@ will set the correct pins and dimensions for the display.
 | JC8012P4A1             | Guition        | [JC8012P4A1 product page](https://aliexpress.com/item/1005008789890066.html)                                     |
 | M5STACK-TAB5           | M5Stack        | [TAB5 product page](https://shop.m5stack.com/products/m5stack-tab5-iot-development-kit-esp32-p4)                 |
 | M5STACK-TAB5-V2        | M5Stack        | [TAB5-V2 product page](https://shop.m5stack.com/products/m5stack-tab5-iot-development-kit-esp32-p4)              |
-| SEEED-RETERMINAL-D1001 | Seeed Studio   | [D1001 product page](https://www.seeedstudio.com/reTerminal-D1001-p-6729.html)                                  |
+| SEEED-RETERMINAL-D1001 | Seeed Studio   | [D1001 product page](https://www.seeedstudio.com/reTerminal-D1001-p-6729.html)                                   |
 | WAVESHARE-P4-NANO-10.1 | Waveshare      | [P4-NANO-10.1 product page](https://www.waveshare.com/esp32-p4-nano.htm?sku=29031)                               |
 | WAVESHARE-P4-86-PANEL  | Waveshare      | [P4-86-PANEL product page](https://www.waveshare.com/esp32-p4-wifi6-touch-lcd-4b.htm?sku=31570)                  |
 | WAVESHARE-ESP32-P4-WIFI6-TOUCH-LCD-7B   | Waveshare | [P4-WIFI6-TOUCH-LCD-7B product page](https://www.waveshare.com/wiki/ESP32-P4-WIFI6-Touch-LCD-7B)     |

--- a/src/content/docs/components/display/mipi_dsi.mdx
+++ b/src/content/docs/components/display/mipi_dsi.mdx
@@ -71,6 +71,7 @@ will set the correct pins and dimensions for the display.
 | JC8012P4A1             | Guition        | [JC8012P4A1 product page](https://aliexpress.com/item/1005008789890066.html)                                     |
 | M5STACK-TAB5           | M5Stack        | [TAB5 product page](https://shop.m5stack.com/products/m5stack-tab5-iot-development-kit-esp32-p4)                 |
 | M5STACK-TAB5-V2        | M5Stack        | [TAB5-V2 product page](https://shop.m5stack.com/products/m5stack-tab5-iot-development-kit-esp32-p4)              |
+| SEEED-RETERMINAL-D1001 | Seeed Studio   | [D1001 product page](https://www.seeedstudio.com/reTerminal-D1001-p-6729.html)                                                                   |
 | WAVESHARE-P4-NANO-10.1 | Waveshare      | [P4-NANO-10.1 product page](https://www.waveshare.com/esp32-p4-nano.htm?sku=29031)                               |
 | WAVESHARE-P4-86-PANEL  | Waveshare      | [P4-86-PANEL product page](https://www.waveshare.com/esp32-p4-wifi6-touch-lcd-4b.htm?sku=31570)                  |
 | WAVESHARE-ESP32-P4-WIFI6-TOUCH-LCD-7B   | Waveshare | [P4-WIFI6-TOUCH-LCD-7B product page](https://www.waveshare.com/wiki/ESP32-P4-WIFI6-Touch-LCD-7B)     |


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#15867

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
