### PR TITLE
Fix formatting issue in servo.mdx documentation

### DIFF
--- a/src/content/docs/components/servo.mdx
+++ b/src/content/docs/components/servo.mdx
@@ -58,7 +58,7 @@ Advanced Options:
   This is useful if you have an absolute servo motor and it goes back to its 0 position at startup.
   Defaults to `false`.
 
-- **auto_detach_time** (*Optional*, [Time](/guides/configuration-types#time)): The time after reaching the target value when the servo will be detached`, if set to zero, servo will not be detached. Defaults to`0s`.
+- **auto_detach_time** (*Optional*, [Time](/guides/configuration-types#time)): The time after reaching the target value when the servo will be detached, if set to zero, servo will not be detached. Defaults to `0s`.
 - **transition_length** (*Optional*, [Time](/guides/configuration-types#time)): The time needed for a full movement (-1.0 to 1.0). This will effectively limit the speed of the servo, the larger the value, the slowest the servo will move. Defaults to `0s`.
   This can slow down the servo to avoid loud noises or just make the movement not jerking.
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Remove an extra backtick and add a missing space.

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.
