### PR TITLE
Add Content-Signal directive to robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -24,6 +24,7 @@
 # AND RELATED RIGHTS IN THE DIGITAL SINGLE MARKET.
 
 User-agent: *
+Content-Signal: search=yes, ai-input=yes, ai-train=no
 Allow: /
 
 Sitemap: https://esphome.io/sitemap-index.xml


### PR DESCRIPTION
## Description

Adds a `Content-Signal` directive to `public/robots.txt` to declare preferences for AI-related use of the documentation content. The commentary describing the content signals was already present in the file, but the actual directive was missing.

Chosen preferences:

- `search=yes` — allow traditional search indexing
- `ai-input=yes` — allow AI grounding / retrieval-augmented generation (live use in AI search answers)
- `ai-train=no` — disallow use of content for training or fine-tuning AI models

See https://contentsignals.org/ and https://datatracker.ietf.org/doc/draft-romm-aipref-contentsignals/ for the spec.

## Test result

Verified on the Netlify deploy preview at https://deploy-preview-6498--esphome.netlify.app/robots.txt — the served file contains the directive inside the `User-agent: *` group:

```
User-agent: *
Content-Signal: search=yes, ai-input=yes, ai-train=no
Allow: /
```

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- N/A

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.