### PR TITLE
[esp32_ble] Add `use_psram` option to offload BT memory allocation to SPIRAM

### DIFF
--- a/content/components/esp32_ble.md
+++ b/content/components/esp32_ble.md
@@ -86,6 +86,8 @@ esp32_ble:
 > [!NOTE]
 > The `max_notifications` option controls the `CONFIG_BT_GATTC_NOTIF_REG_MAX` ESP-IDF setting. This limit is per GATT client interface, not per connection. If you're using ESPHome as a Bluetooth proxy with multiple devices that have many characteristics requiring notifications, you may need to increase this value. The error `status=128` in logs indicates you've hit this limit.
 
+- **use_psram** (*Optional*, boolean): Requests that the Bluetooth stack allocate its memory buffers from PSRAM instead of internal RAM, freeing approximately 40 kB for other uses. Defaults to `false`. Requires PSRAM to be configured.
+
 ## `ble.disable` Action
 
 This action turns off the BLE interface on demand.


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Adds a `use_psram` option to the `esp32_ble` component, mirroring the equivalent option already present in the `wifi` component. When enabled on a board with PSRAM configured, this directs Bluedroid to allocate its memory from SPIRAM first and to use dynamic (heap-based) environment memory tables, freeing approximately 40 kB of internal RAM that the BLE stack would otherwise hold statically.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#15644

## Checklist

- [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above. or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ``` @esphomebot generate image component_name ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
