### PR TITLE
[api] Document new max_connections defaults

### DIFF
--- a/src/content/docs/components/api.mdx
+++ b/src/content/docs/components/api.mdx
@@ -54,17 +54,15 @@ api:
   - `5` for ESP32/BK72xx/RTL87xx/LN882x,
   - `8` for the host platform.
 
-  Each connection uses approximately 500–1000 bytes of RAM.
-
   > [!NOTE]
-  > `max_connections` is baked into the compiled firmware as a compile-time constant (the
-  > connection slots are statically allocated), so every slot counts against static RAM whether it
-  > is used or not. Raise this value only if you actually need more than the default number of
-  > simultaneous clients — the firmware must be re-flashed to change it.
-
-  > [!NOTE]
-  > Each API connection consumes approximately 500–1000 bytes of RAM while connected. ESP8266 and RP2040 devices have limited
-  > RAM available (ESP8266 typically has around 40KB of free RAM after boot, but this can drop to under 20KB once sensors and other components are configured; RP2040 uses LWIP raw sockets with similar constraints), so be careful not to set this value too high or it may cause out-of-memory crashes.
+  > `max_connections` is baked into the compiled firmware as a compile-time constant — the
+  > connection slots are statically allocated, so every slot costs a small amount of static RAM
+  > whether it is used or not, and the firmware must be re-flashed to change the value.
+  > In addition, each active API connection consumes approximately 500–1000 bytes of RAM while
+  > connected. ESP8266 and RP2040 devices have limited RAM available (ESP8266 typically has around
+  > 40KB of free RAM after boot, but this can drop to under 20KB once sensors and other components
+  > are configured; RP2040 uses LWIP raw sockets with similar constraints), so be careful not to
+  > set this value too high or it may cause out-of-memory crashes.
   > The defaults are set to balance memory usage with allowing multiple simultaneous connections.
 
 - **max_send_queue** (*Optional*, int): The maximum number of messages that can be queued for sending per connection before the connection is dropped. Must be between 1 and 64.

--- a/src/content/docs/components/api.mdx
+++ b/src/content/docs/components/api.mdx
@@ -49,7 +49,18 @@ api:
 - **listen_backlog** (*Optional*, int): The maximum number of pending connections in the listen queue. Must be between 1 and 10.
   Defaults to `1` for ESP8266/RP2040, `4` for ESP32 and other platforms. Lower values use less memory but may reject connections during bursts.
 - **max_connections** (*Optional*, int): The maximum number of simultaneous API connections allowed. Must be between 1 and 20.
-  Defaults to `4` for ESP8266/RP2040, `8` for ESP32 and other platforms. Each connection uses approximately 500-1000 bytes of RAM.
+  Defaults to:
+  - `4` for ESP8266/RP2040,
+  - `5` for ESP32/BK72xx/RTL87xx/LN882x,
+  - `8` for the host platform.
+
+  Each connection uses approximately 500–1000 bytes of RAM.
+
+  > [!NOTE]
+  > `max_connections` is baked into the compiled firmware as a compile-time constant (the
+  > connection slots are statically allocated), so every slot counts against static RAM whether it
+  > is used or not. Raise this value only if you actually need more than the default number of
+  > simultaneous clients — the firmware must be re-flashed to change it.
 
   > [!NOTE]
   > Each API connection consumes approximately 500–1000 bytes of RAM while connected. ESP8266 and RP2040 devices have limited


### PR DESCRIPTION
# Description

Updates the `max_connections` documentation to reflect the new defaults landing in esphome/esphome#15889:

| Platform | Old default | New default |
|---|---|---|
| ESP8266 / RP2040 | 4 | 4 (unchanged) |
| ESP32 / BK72xx / RTL87xx / LN882x | 8 | **5** |
| host | 8 | 8 (unchanged) |

Also adds a note that `max_connections` is now a **compile-time constant** — the client slots are statically allocated via `std::array`, so every slot costs static RAM whether it is used or not, and changing the value requires a re-flash.

## Related PR

- esphome/esphome#15889