### PR TITLE
[esp32] docs for add watchdog_timeout configuration variable

### DIFF
--- a/src/content/docs/components/esp32.mdx
+++ b/src/content/docs/components/esp32.mdx
@@ -50,6 +50,9 @@ esp32:
 
 - **framework** (*Optional*): Options for the underlying framework used by ESPHome. See [Framework](#esp32-framework).
 
+- **watchdog_timeout** (*Optional*, [Time](/guides/configuration-types#time)): The timeout to apply to the main loop task
+  When the device hangs for that period of time without feeding the watchdog, it will reboot. Defaults to `5s`, valid range is 5s to 60s.
+
 ## Variants
 
 ESPHome supports the following ESP32 variants. Use the `variant` configuration option to select the correct one

--- a/src/content/docs/components/esp32.mdx
+++ b/src/content/docs/components/esp32.mdx
@@ -51,7 +51,7 @@ esp32:
 - **framework** (*Optional*): Options for the underlying framework used by ESPHome. See [Framework](#esp32-framework).
 
 - **watchdog_timeout** (*Optional*, [Time](/guides/configuration-types#time)): The timeout to apply to the main loop task
-  When the device hangs for that period of time without feeding the watchdog, it will reboot. Defaults to `5s`, valid range is 5s to 60s.
+  When the device hangs for that period of time without feeding the watchdog, it will reboot. Defaults to `5s`, valid range is `5s` to `60s`.
 
 ## Variants
 

--- a/src/content/docs/components/esp32.mdx
+++ b/src/content/docs/components/esp32.mdx
@@ -54,7 +54,7 @@ esp32:
   ESP-IDF task watchdog. If a subscribed task fails to feed the watchdog within this period, the device
   will reboot. Useful for power-managed devices or long blocking operations that need extended watchdog
   windows. Defaults to `5s`, valid range is `5s` to `60s`. Note: OTA updates temporarily raise the
-  watchdog to 15s when the configured timeout is below that threshold.
+  watchdog to `15s` when the configured timeout is below that threshold.
 
 ## Variants
 

--- a/src/content/docs/components/esp32.mdx
+++ b/src/content/docs/components/esp32.mdx
@@ -50,8 +50,11 @@ esp32:
 
 - **framework** (*Optional*): Options for the underlying framework used by ESPHome. See [Framework](#esp32-framework).
 
-- **watchdog_timeout** (*Optional*, [Time](/guides/configuration-types#time)): The timeout to apply to the main loop task
-  When the device hangs for that period of time without feeding the watchdog, it will reboot. Defaults to `5s`, valid range is `5s` to `60s`.
+- **watchdog_timeout** (*Optional*, [Time](/guides/configuration-types#time)): The timeout applied to the
+  ESP-IDF task watchdog. If a subscribed task fails to feed the watchdog within this period, the device
+  will reboot. Useful for power-managed devices or long blocking operations that need extended watchdog
+  windows. Defaults to `5s`, valid range is `5s` to `60s`. Note: OTA updates temporarily raise the
+  watchdog to 15s when the configured timeout is below that threshold.
 
 ## Variants
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description
Add watchdog_timeout configuration variable to set the idf sdk option CONFIG_ESP_TASK_WDT_TIMEOUT_S

This allows setting the watchdog timeout for esp32 devices with a value from 5 seconds to 60 seconds. This is useful for power managed devices that often need the watchdog timeout extended.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#15908

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
