### PR TITLE
2026.4.2

### DIFF
--- a/data/version.yaml
+++ b/data/version.yaml
@@ -1,2 +1,2 @@
-release: 2026.4.1
+release: 2026.4.2
 version: '2026.4'

--- a/src/content/docs/changelog/2026.4.0.mdx
+++ b/src/content/docs/changelog/2026.4.0.mdx
@@ -536,6 +536,23 @@ For detailed migration guides and API documentation, see the [ESPHome Developers
 
 </details>
 
+## Release 2026.4.2 - April 23
+
+<details>
+<summary></summary>
+
+- [lvgl] Fix format of hello world page [esphome#15868](https://github.com/esphome/esphome/pull/15868) by [@clydebarrow](https://github.com/clydebarrow)
+- [lvgl] Fix overloads for setting images on styles [esphome#15864](https://github.com/esphome/esphome/pull/15864) by [@clydebarrow](https://github.com/clydebarrow)
+- [lvgl] Fix update of textarea attached to keyboard [esphome#15866](https://github.com/esphome/esphome/pull/15866) by [@clydebarrow](https://github.com/clydebarrow)
+- [image] Fix rodata bloat for multi-frame RGB565+alpha animations [esphome#15873](https://github.com/esphome/esphome/pull/15873) by [@swoboda1337](https://github.com/swoboda1337)
+- [core] Fix Pvariable placement new losing subclass identity [esphome#15881](https://github.com/esphome/esphome/pull/15881) by [@swoboda1337](https://github.com/swoboda1337)
+- [ld2412] Fix null deref in set_basic_config when entities unconfigured [esphome#15893](https://github.com/esphome/esphome/pull/15893) by [@swoboda1337](https://github.com/swoboda1337)
+- [esp32] Add Secure Boot V1 ECDSA signing scheme for pre-rev-3.0 ESP32 [esphome#15882](https://github.com/esphome/esphome/pull/15882) by [@kbx81](https://github.com/kbx81) (new-feature)
+- [io_expanders] Self-heal interrupt-driven expanders when INT stays asserted across the read [esphome#15923](https://github.com/esphome/esphome/pull/15923) by [@swoboda1337](https://github.com/swoboda1337)
+- [usb_uart] Derive TX output chunk count from `buffer_size` config [esphome#15909](https://github.com/esphome/esphome/pull/15909) by [@kbx81](https://github.com/kbx81)
+
+</details>
+
 ## Full list of changes
 
 ### New Features

--- a/src/content/docs/components/api.mdx
+++ b/src/content/docs/components/api.mdx
@@ -49,11 +49,20 @@ api:
 - **listen_backlog** (*Optional*, int): The maximum number of pending connections in the listen queue. Must be between 1 and 10.
   Defaults to `1` for ESP8266/RP2040, `4` for ESP32 and other platforms. Lower values use less memory but may reject connections during bursts.
 - **max_connections** (*Optional*, int): The maximum number of simultaneous API connections allowed. Must be between 1 and 20.
-  Defaults to `4` for ESP8266/RP2040, `8` for ESP32 and other platforms. Each connection uses approximately 500-1000 bytes of RAM.
+  Defaults to:
+  - `4` for ESP8266/RP2040,
+  - `5` for ESP32/BK72xx/RTL87xx/LN882x,
+  - `8` for the host platform.
 
   > [!NOTE]
-  > Each API connection consumes approximately 500–1000 bytes of RAM while connected. ESP8266 and RP2040 devices have limited
-  > RAM available (ESP8266 typically has around 40KB of free RAM after boot, but this can drop to under 20KB once sensors and other components are configured; RP2040 uses LWIP raw sockets with similar constraints), so be careful not to set this value too high or it may cause out-of-memory crashes.
+  > `max_connections` is baked into the compiled firmware as a compile-time constant — the
+  > connection slots are statically allocated, so every slot costs a small amount of static RAM
+  > whether it is used or not, and the firmware must be re-flashed to change the value.
+  > In addition, each active API connection consumes approximately 500–1000 bytes of RAM while
+  > connected. ESP8266 and RP2040 devices have limited RAM available (ESP8266 typically has around
+  > 40KB of free RAM after boot, but this can drop to under 20KB once sensors and other components
+  > are configured; RP2040 uses LWIP raw sockets with similar constraints), so be careful not to
+  > set this value too high or it may cause out-of-memory crashes.
   > The defaults are set to balance memory usage with allowing multiple simultaneous connections.
 
 - **max_send_queue** (*Optional*, int): The maximum number of messages that can be queued for sending per connection before the connection is dropped. Must be between 1 and 64.

--- a/src/content/docs/components/esp32.mdx
+++ b/src/content/docs/components/esp32.mdx
@@ -395,34 +395,50 @@ esp32:
 
 - **signed_ota_verification** (*Optional*, mapping): Enable
   [Signed App Verification Without Hardware Secure Boot](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/security/secure-boot-v2.html#signed-app-verification-without-hardware-secure-boot).
-  When configured, OTA firmware updates are verified using a cryptographic signature. The public key is embedded in
-  the running firmware's signature block and used to verify the signature of any incoming OTA update. This protects
+  When configured, OTA firmware updates are verified using a cryptographic signature. This protects
   against tampered firmware from network-based attacks without requiring hardware Secure Boot (eFuse).
+  Both Secure Boot V2 (RSA-3072 or ECDSA-V2) and Secure Boot V1 (ECDSA) signing schemes are supported.
   Contains the following options:
 
   - **signing_key** (*Optional*, filename): Path to a PEM-encoded private signing key. When provided, the firmware
     is **automatically signed during build** using `espsecure`. This is the simplest workflow — the public key is
     derived automatically and embedded in the signature block. **Mutually exclusive with `verification_key`.**
-  - **verification_key** (*Optional*, filename): Path to a PEM-encoded public verification key. When provided, the
+  - **verification_key** (*Optional*, filename): Path to a public verification key. When provided, the
     public key is embedded for verification but the binary is **not signed during build**. You must sign the firmware
-    externally (typically by way of `espsecure.py sign-data --version 2 --keyfile private.pem firmware.bin`) before
-    flashing. This is useful for CI/CD pipelines where the private key is stored in a secure vault.
+    externally before flashing. This is useful for CI/CD pipelines where the private key is stored in a secure vault.
     **Mutually exclusive with `signing_key`.**
-  - **signing_scheme** (*Optional*, string): The signing algorithm. One of `rsa3072` or `ecdsa256`. Defaults to
-    `rsa3072`. **Not all schemes are supported on all variants** — see the table below.
 
-    | Variant | `rsa3072` | `ecdsa256` |
-    |---------|-----------|------------|
-    | ESP32 (rev 3+) | yes | no |
-    | ESP32-S2 | yes | no |
-    | ESP32-S3 | yes | no |
-    | ESP32-C2 | no | yes |
-    | ESP32-C3 | yes | no |
-    | ESP32-C5 | yes | yes |
-    | ESP32-C6 | yes | yes |
-    | ESP32-C61 | no | yes |
-    | ESP32-H2 | yes | yes |
-    | ESP32-P4 | yes | yes |
+    > [!NOTE]
+    > The verification key format depends on the signing scheme:
+    > - For `rsa3072` and `ecdsa256` (Secure Boot V2): PEM-encoded public key.
+    > - For `ecdsa_v1` (Secure Boot V1): Raw binary format (`.bin`). Extract from a PEM private key using:
+    >   `espsecure.py extract_public_key --keyfile private.pem public_key.bin`
+
+  - **signing_scheme** (*Optional*, string): The signing algorithm. One of `rsa3072`, `ecdsa256`, or `ecdsa_v1`.
+    Defaults to `rsa3072`. **Not all schemes are supported on all variants** — see the table below.
+
+    - `rsa3072`: RSA-3072 (Secure Boot V2). Recommended for most variants.
+    - `ecdsa256`: ECDSA with NIST P-256 (Secure Boot V2). For variants without RSA support.
+    - `ecdsa_v1`: ECDSA with NIST P-256 (Secure Boot V1). **Only for the original ESP32** — use this for
+      chips prior to revision 3.0 that do not support Secure Boot V2.
+
+    | Variant | `rsa3072` | `ecdsa256` | `ecdsa_v1` |
+    |---------|-----------|------------|------------|
+    | ESP32 (rev 3.0+) | yes | no | yes |
+    | ESP32 (rev < 3.0) | no | no | yes |
+    | ESP32-S2 | yes | no | no |
+    | ESP32-S3 | yes | no | no |
+    | ESP32-C2 | no | yes | no |
+    | ESP32-C3 | yes | no | no |
+    | ESP32-C5 | yes | yes | no |
+    | ESP32-C6 | yes | yes | no |
+    | ESP32-C61 | no | yes | no |
+    | ESP32-H2 | yes | yes | no |
+    | ESP32-P4 | yes | yes | no |
+
+    > [!NOTE]
+    > Using `rsa3072` on the original ESP32 requires setting `minimum_chip_revision: "3.0"` or higher
+    > (Secure Boot V2 RSA is only available on ESP32 chip revision 3.0+). For older chip revisions, use `ecdsa_v1`.
 
   > [!WARNING]
   > **Keep your signing key safe!** If you lose the private signing key, you will **not be able to OTA update** any
@@ -436,8 +452,11 @@ esp32:
   To generate a signing key, use the `espsecure.py` tool from ESP-IDF:
 
   ```bash
-  # Generate an RSA-3072 signing key
-  espsecure.py generate_signing_key --version 2 --scheme rsa3072 secure_boot_signing_key.pem
+  # Generate an RSA-3072 signing key (Secure Boot V2 — most variants)
+  espsecure.py generate-signing-key --version 2 --scheme rsa3072 secure_boot_signing_key.pem
+
+  # Generate an ECDSA signing key (Secure Boot V1 — original ESP32 pre-rev 3.0)
+  espsecure.py generate-signing-key --version 1 secure_boot_signing_key.pem
 
   # Extract the public verification key (for the verification_key workflow)
   espsecure.py extract_public_key --keyfile secure_boot_signing_key.pem secure_boot_verification_key.pem

--- a/src/content/docs/guides/supporters.mdx
+++ b/src/content/docs/guides/supporters.mdx
@@ -659,6 +659,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [egandro (@egandro)](https://github.com/egandro)
 - [Erwin Kooi (@egeltje)](https://github.com/egeltje)
 - [Maxime Michel (@Egglestron)](https://github.com/Egglestron)
+- [Egor Vorontsov (@egormanga)](https://github.com/egormanga)
 - [Eike (@ei-ke)](https://github.com/ei-ke)
 - [Elazar Leibovich (@elazarl)](https://github.com/elazarl)
 - [Mike Eldridge (@eldridge)](https://github.com/eldridge)
@@ -925,6 +926,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Marcel Hoppe (@hobbypunk90)](https://github.com/hobbypunk90)
 - [Sebastian Raff (@hobbyquaker)](https://github.com/hobbyquaker)
 - [Eric Hoffmann (@Hofferic)](https://github.com/Hofferic)
+- [Home Automation Things (@homeautomationthings)](https://github.com/homeautomationthings)
 - [MoA (@honomoa)](https://github.com/honomoa)
 - [Hopperpop (@Hopperpop)](https://github.com/Hopperpop)
 - [Ilia Sotnikov (@hostcc)](https://github.com/hostcc)
@@ -1068,6 +1070,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Joel Goguen (@jgoguen)](https://github.com/jgoguen)
 - [Yuval Brik (@jhamhader)](https://github.com/jhamhader)
 - [Joe (@jhansche)](https://github.com/jhansche)
+- [Johan Henkens (@jhenkens)](https://github.com/jhenkens)
 - [Jan Pieter Waagmeester (@jieter)](https://github.com/jieter)
 - [Jim Bauwens (@jimbauwens)](https://github.com/jimbauwens)
 - [jimtng (@jimtng)](https://github.com/jimtng)
@@ -1731,6 +1734,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [pille (@pille)](https://github.com/pille)
 - [Jakub Augustynowicz (@pingwiniasty)](https://github.com/pingwiniasty)
 - [Piotr Kubiak (@piotr-kubiak)](https://github.com/piotr-kubiak)
+- [pipacsba (@pipacsba)](https://github.com/pipacsba)
 - [Tommy van der Vorst (@pixelspark)](https://github.com/pixelspark)
 - [pixiandreas (@pixiandreas)](https://github.com/pixiandreas)
 - [Paul Webster (@pjwebster)](https://github.com/pjwebster)
@@ -2378,4 +2382,4 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Christian Zufferey (@zuzu59)](https://github.com/zuzu59)
 - [Zynth-dev (@Zynth-dev)](https://github.com/Zynth-dev)
 
-*This page was last updated April 20, 2026.*
+*This page was last updated April 23, 2026.*


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- Remove Arduino Port Extender link [docs#6489](https://github.com/esphome/esphome-docs/pull/6489)
- Add Link response headers for agent discovery [docs#6492](https://github.com/esphome/esphome-docs/pull/6492)
- Add Content-Signal directive to robots.txt [docs#6498](https://github.com/esphome/esphome-docs/pull/6498)
- [esp32] Document Secure Boot V1 ECDSA signing scheme [docs#6500](https://github.com/esphome/esphome-docs/pull/6500)
- [troubleshooting] Update crash reporting docs for ESP32, ESP8266, and RP2040 [docs#6473](https://github.com/esphome/esphome-docs/pull/6473)
- Document blocking warning and fix runtime_stats wall time docs [docs#6380](https://github.com/esphome/esphome-docs/pull/6380)
- [api] Document new max_connections defaults [docs#6502](https://github.com/esphome/esphome-docs/pull/6502)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
