### PR TITLE
[sensor] Document alternate ntc calibration

### DIFF
--- a/src/content/docs/components/sensor/filter/to_ntc_temperature.mdx
+++ b/src/content/docs/components/sensor/filter/to_ntc_temperature.mdx
@@ -13,9 +13,10 @@ Configuration variables:
 - **calibration** (**Required**): calibration data.
 
 A resistance/temperature characteristic curve is required to use this filter.
-If you have the datasheet of the thermistor, you can look at its "B-constant" and
-reference temperature/resistance. For example [this product](https://www.adafruit.com/product/372)
-would have the following calibration configuration.
+If you have the data sheet of the thermistor, you can look at its
+"B-constant" and reference temperature/resistance. For example,
+[this product](https://www.adafruit.com/product/372) would have the
+following calibration configuration.
 
 ```yaml
 # Example configuration entry

--- a/src/content/docs/components/sensor/filter/to_ntc_temperature.mdx
+++ b/src/content/docs/components/sensor/filter/to_ntc_temperature.mdx
@@ -13,6 +13,26 @@ Configuration variables:
 - **calibration** (**Required**): calibration data.
 
 A resistance/temperature characteristic curve is required to use this filter.
+If you have the datasheet of the thermistor, you can look at its "B-constant" and
+reference temperature/resistance. For example [this product](https://www.adafruit.com/product/372)
+would have the following calibration configuration.
+
+```yaml
+# Example configuration entry
+- platform: template
+  id: to_ntc_temperature_sensor1
+  unit_of_measurement: "°C"
+  lambda: |-
+    return id(some_sensor).get_state();
+  update_interval: 1s
+  filters:
+    - to_ntc_temperature:
+        calibration:
+          b_constant: 3950
+          reference_temperature: 25°C
+          reference_resistance: 10kOhm
+```
+
 This can be taken from a corresponding diagram in a data sheet. If you do not
 have access to the data sheet or want to calculate these values yourself, you
 must first measure three resistance values at different temperatures.


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#15937

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
