### PR TITLE
Use client id from org vars for GitHub App token

### DIFF
--- a/.github/workflows/auto-label-pr.yml
+++ b/.github/workflows/auto-label-pr.yml
@@ -32,7 +32,7 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          app-id: ${{ secrets.ESPHOME_GITHUB_APP_ID }}
+          client-id: ${{ vars.ESPHOME_GITHUB_APP_CLIENT_ID }}
           private-key: ${{ secrets.ESPHOME_GITHUB_APP_PRIVATE_KEY }}
 
       - name: Auto Label PR


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Switch the `auto-label-pr` workflow from passing the numeric app id via `app-id: ${{ secrets.ESPHOME_GITHUB_APP_ID }}` to using the dedicated `client-id:` input sourced from `vars.ESPHOME_GITHUB_APP_CLIENT_ID`.

Client IDs aren't sensitive, so they belong in Actions **variables** rather than secrets. The private key remains a secret.

Requires the org-level Actions variable `ESPHOME_GITHUB_APP_CLIENT_ID` to be set to the `esphome[bot]` App's client id before this merges (or the workflow's next run will fail to generate a token).

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- N/A

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.