### PR TITLE
[ci] Auto-close PRs opened from a fork's current or next branch

### DIFF
--- a/.github/workflows/close-pr-from-fork-default-branch.yml
+++ b/.github/workflows/close-pr-from-fork-default-branch.yml
@@ -1,0 +1,73 @@
+name: Close PR From Fork Default Branch
+
+on:
+  # pull_request_target is required so we have permission to comment and close PRs from forks.
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  close:
+    name: Close PR opened from fork's current/next branch
+    runs-on: ubuntu-latest
+    if: >-
+      github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+      && (github.event.pull_request.head.ref == 'current' || github.event.pull_request.head.ref == 'next')
+    steps:
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const prNumber = context.payload.pull_request.number;
+            const author = context.payload.pull_request.user.login;
+            const headRef = context.payload.pull_request.head.ref;
+            const baseRef = context.payload.pull_request.base.ref;
+            const headRepo = context.payload.pull_request.head.repo.full_name;
+
+            const body = [
+              `Hi @${author}, thanks for opening a pull request! :tada:`,
+              ``,
+              `It looks like this PR was opened from the \`${headRef}\` branch of your fork (\`${headRepo}\`), which is a protected upstream branch (\`current\` = live docs, \`next\` = docs for the upcoming release). Working directly on \`${headRef}\` in your fork causes a few problems:`,
+              ``,
+              `- Your fork's \`${headRef}\` branch will permanently diverge from \`esphome/esphome-docs:${headRef}\`, making it hard to keep your fork in sync.`,
+              `- Any additional commits you push to \`${headRef}\` will be added to this PR, so you can't easily work on multiple changes at once.`,
+              `- Pushing maintainer fixes to your branch is awkward, since it means committing directly to your fork's \`${headRef}\` branch.`,
+              `- Local collaboration becomes painful — \`${headRef}\` in a checkout is ambiguous between upstream and your fork, and maintainers end up with naming collisions when fetching the branch.`,
+              ``,
+              `Please re-open this as a new PR from a dedicated feature branch. The usual flow looks like:`,
+              ``,
+              `\`\`\`bash`,
+              `# Make sure your fork's ${headRef} is up to date with upstream`,
+              `git remote add upstream https://github.com/${owner}/${repo}.git  # if you haven't already`,
+              `git fetch upstream`,
+              `git checkout ${headRef}`,
+              `git reset --hard upstream/${headRef}`,
+              `git push --force-with-lease origin ${headRef}`,
+              ``,
+              `# Create a new branch for your change and cherry-pick / re-apply your commits there`,
+              `git checkout -b my-docs-branch upstream/${baseRef}`,
+              `# ...re-apply your changes, then:`,
+              `git push origin my-docs-branch`,
+              `\`\`\``,
+              ``,
+              `Then open a new pull request from \`my-docs-branch\` into \`${owner}/${repo}:${baseRef}\`.`,
+              ``,
+              `Closing this PR for now — sorry for the friction, and thanks again for contributing! :heart:`,
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: prNumber,
+              body,
+            });
+
+            await github.rest.pulls.update({
+              owner,
+              repo,
+              pull_number: prNumber,
+              state: 'closed',
+            });


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Adds a GitHub Actions workflow that automatically closes newly opened (or reopened) pull requests that come from a fork's `current` or `next` branch, and posts a friendly comment explaining the problem and how to move the work to a feature branch.

**Scope:** only affects *newly opened* or reopened PRs. Existing open PRs from a fork's `current`/`next` branch are **not** touched — no back-fill, no retroactive closing.

Working directly on the fork's `current` or `next` branch causes several recurring issues for contributors:

- Their fork's branch permanently diverges from `esphome/esphome-docs:current` / `:next`, making it hard to keep the fork in sync.
- Any additional commits pushed to `current`/`next` end up tacked onto the open PR, so they can't easily work on multiple changes at once.
- Pushing maintainer fixes is awkward, since it means committing directly to the contributor's fork's `current`/`next` branch.
- Local collaboration becomes painful — `current`/`next` in a checkout is ambiguous between upstream and the contributor's fork, and maintainers end up with naming collisions when fetching the branch.

The workflow:

- Triggers on `pull_request_target` for `opened` and `reopened` only — existing open PRs are left alone.
- Runs only when the PR is from a fork **and** `head.ref` is exactly `current` or `next`, so internal branches are untouched even if named that way.
- Uses `pull_request_target` for write access, but only runs `actions/github-script` with no checkout of PR code — no untrusted code executes.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#15957

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>