### PR TITLE
[sendspin] Remove IDF restriction

### DIFF
--- a/src/content/docs/components/media_player/sendspin.mdx
+++ b/src/content/docs/components/media_player/sendspin.mdx
@@ -10,7 +10,7 @@ The `sendspin` media player platform exposes controls for an entire [Sendspin](/
 > [!IMPORTANT]
 > This platform does not produce any audio on the device. It only sends playback and volume commands to the Sendspin server, which applies them to every player in the active group. Commands like play/pause, volume, mute, shuffle, repeat, and next/previous track are forwarded to the group as a whole.
 
-The Sendspin [hub](/components/sendspin/) must be configured on the same device. This platform only works on ESP32-based chips using the [ESP-IDF framework](/components/esp32#esp32-framework).
+The Sendspin [hub](/components/sendspin/) must be configured on the same device. This platform only works on ESP32-based chips.
 
 ```yaml
 # Example configuration entry

--- a/src/content/docs/components/media_source/sendspin.mdx
+++ b/src/content/docs/components/media_source/sendspin.mdx
@@ -9,7 +9,7 @@ The `sendspin` media source platform plays synchronized audio from a [Sendspin](
 group through a [Speaker Source Media Player](/components/media_player/speaker_source/). The Sendspin
 [hub](/components/sendspin/) must be configured on the same device.
 
-This platform only works on ESP32-based chips using the [ESP-IDF framework](/components/esp32#esp32-framework).
+This platform only works on ESP32-based chips.
 
 ```yaml
 # Example configuration entry

--- a/src/content/docs/components/sendspin.mdx
+++ b/src/content/docs/components/sendspin.mdx
@@ -17,7 +17,7 @@ server is present on the network, it will connect to the device and begin
 sending group state updates, but audio playback, control, and metadata require
 the corresponding child components to be configured as well.
 
-This platform only works on ESP32-based chips using the [ESP-IDF framework](/components/esp32#esp32-framework).
+This platform only works on ESP32-based chips.
 
 > [!WARNING]
 > The Sendspin protocol is not yet finalized and this component is considered


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Since Arduino is now a component, Sendspin should work on Arduino builds.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** not applicable

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
