### PR TITLE
[output] Document USE_OUTPUT_FLOAT_POWER_SCALING gating for lambda use

### DIFF
--- a/src/content/docs/components/output/index.mdx
+++ b/src/content/docs/components/output/index.mdx
@@ -147,11 +147,11 @@ on_...:
 > ```
 >
 > Calling `set_min_power()` from a lambda requires that runtime power scaling be
-> compiled in. Beginning with 2026.5.0 it is only compiled in when at least one
-> output entry sets `min_power`, `max_power`, or `zero_means_zero`, **or** when
-> any `output.set_min_power` / `output.set_max_power` action is registered. If
-> your config uses neither, add e.g. `min_power: 0%` to one output to opt in
-> — the build otherwise fails with a `static_assert` pointing at the lambda.
+> compiled in. It is only compiled in when at least one output entry sets
+> `min_power`, `max_power`, or `zero_means_zero`, **or** when any
+> `output.set_min_power` / `output.set_max_power` action is registered. If your
+> config uses neither, add e.g. `min_power: 0%` to one output to opt in — the
+> build otherwise fails with a `static_assert` pointing at the lambda.
 
 <span id="output-set_max_power_action"></span>
 

--- a/src/content/docs/components/output/index.mdx
+++ b/src/content/docs/components/output/index.mdx
@@ -145,6 +145,13 @@ on_...:
 > // range is 0.0 (off) to 1.0 (on)
 > id(light_1).set_min_power(0.2);
 > ```
+>
+> Calling `set_min_power()` from a lambda requires that runtime power scaling be
+> compiled in. Beginning with 2026.5.0 it is only compiled in when at least one
+> output entry sets `min_power`, `max_power`, or `zero_means_zero`, **or** when
+> any `output.set_min_power` / `output.set_max_power` action is registered. If
+> your config uses neither, add e.g. `min_power: 0%` to one output to opt in
+> — the build otherwise fails with a `static_assert` pointing at the lambda.
 
 <span id="output-set_max_power_action"></span>
 
@@ -173,6 +180,10 @@ on_...:
 > // range is 0.0 (off) to 1.0 (on)
 > id(light_1).set_max_power(0.8);
 > ```
+>
+> Calling `set_max_power()` from a lambda requires that runtime power scaling be
+> compiled in (see the note under `output.set_min_power` above). Adding e.g.
+> `max_power: 100%` to one output entry is enough to opt in.
 
 ## See Also
 


### PR DESCRIPTION
## Description

Add a note to the `output.set_min_power` / `output.set_max_power` action sections explaining the new compile-time gating of runtime power scaling on `FloatOutput`. The matching code PR (esphome/esphome#15998) only compiles in the scaling fields when the YAML actually opts in (any `min_power` / `max_power` / `zero_means_zero` key, or any `output.set_min_power` / `output.set_max_power` automation). Saves ~12 bytes per PWM/DAC/LEDC channel and ~250 bytes of flash per binary on devices that don't use scaling.

The lambda form of those setters (`id(light_1).set_min_power(0.2);`) is documented on this page, so users who call them directly from a `lambda:` block — without also having a YAML key or action that opts in — need a one-line YAML change to enable the feature. The static_assert in the matching code PR points at the lambda call site with the migration instruction inline, but documenting the path here as well.

## Breaking change scope (for users)

**You are affected only if all three of these are true:**

1. You do **not** set `min_power`, `max_power`, or `zero_means_zero` on any of your outputs in YAML, **and**
2. You do **not** use the `output.set_min_power` or `output.set_max_power` automations anywhere, **and**
3. You **do** call `id(...).set_min_power(...)`, `id(...).set_max_power(...)`, or `id(...).set_zero_means_zero(...)` directly from a `lambda:`.

If any of those is false, your config is unaffected and behaves exactly as before.

If all three are true, your build will fail with a clear error at the lambda telling you exactly what to add. **The fix is one line of YAML** — add this to any one output:

```yaml
output:
  - platform: esp8266_pwm
    id: out
    pin: 4
    min_power: 0%        # ← add this (or max_power: 100%, or zero_means_zero: true)
```

`min_power: 0%` and `max_power: 100%` are the existing defaults, so this changes no runtime behavior — it just tells ESPHome "compile in runtime power scaling so my lambda can use it."

You'll see this error if you're affected:

```
error: static assertion failed: set_min_power() requires USE_OUTPUT_FLOAT_POWER_SCALING.
To enable it, add 'min_power: 0%' (or any value) to one output entry in your YAML — the
codegen will then keep the scaling fields.
```

The error points at the line of your lambda that called the method, so it's easy to find.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#15998

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.
