### PR TITLE
Update DFU component documentation and reset_pin details

### DIFF
--- a/src/content/docs/components/nrf52.mdx
+++ b/src/content/docs/components/nrf52.mdx
@@ -72,9 +72,9 @@ There are two ways to reference GPIO pins:
 
 ## DFU (Device Firmware Update)
 
-The `dfu` component enables automatic entry into **DFU (Device Firmware Update)** mode by monitoring
-the USB CDC serial connection. When a host opens the port at **1200 baud**, the component triggers
-a reset via a GPIO pin to put the device into DFU mode.
+The `dfu` component enables automatic entry into **DFU (Device Firmware Update)** mode by monitoring                                                                                       
+the USB CDC serial connection. When a host opens the port at **1200 baud**, the component triggers                                                                                         
+a reset to put the device into DFU mode.
 
 ESPHome uses this component internally when uploading firmware via:
 
@@ -83,6 +83,15 @@ esphome upload d.yaml
 ```
 
 ### Example Configuration
+
+ Without a reset pin (uses software reset):                                                                                                                                                 
+
+```yaml                                                                                                                                                                                    
+nrf52:                                                   
+  dfu: true
+```
+
+With a dedicated reset pin:
 
 ```yaml
 nrf52:
@@ -94,7 +103,9 @@ nrf52:
 
 ### Configuration variables
 
-- **reset_pin** (*Required*, [Pin](/guides/configuration-types#pin)): The pin to use for trigger a hardware reset. This pin should be connected to the MCU's reset line or to a circuit that causes the bootloader to enter DFU mode after reset.
+- **reset_pin** (*Optional*, [Pin](/guides/configuration-types#pin)): The pin to use to trigger a hardware reset.
+  This pin should be connected to the MCU's reset line or to a circuit that causes the bootloader to enter DFU mode after reset.
+  When omitted, a software reset (`sys_reboot`) is used instead.
 
 ## REGOUT0
 

--- a/src/content/docs/components/nrf52.mdx
+++ b/src/content/docs/components/nrf52.mdx
@@ -86,8 +86,8 @@ esphome upload d.yaml
 
  Without a reset pin (uses software reset):                                                                                                                                                 
 
-```yaml                                                                                                                                                                                    
-nrf52:                                                   
+```yaml
+nrf52
   dfu: true
 ```
 

--- a/src/content/docs/components/nrf52.mdx
+++ b/src/content/docs/components/nrf52.mdx
@@ -105,7 +105,7 @@ nrf52:
 
 - **reset_pin** (*Optional*, [Pin](/guides/configuration-types#pin)): The pin to use to trigger a hardware reset.
   This pin should be connected to the MCU's reset line or to a circuit that causes the bootloader to enter DFU mode after reset.
-  When omitted, a software reset (`sys_reboot`) is used instead.
+  When omitted, a software reset is used instead.
 
 ## REGOUT0
 

--- a/src/content/docs/components/nrf52.mdx
+++ b/src/content/docs/components/nrf52.mdx
@@ -84,12 +84,17 @@ esphome upload d.yaml
 
 ### Example Configuration
 
- Without a reset pin (uses software reset):                                                                                                                                                 
+Without a reset pin (uses software reset):
 
 ```yaml
-nrf52
+nrf52:
   dfu: true
 ```
+
+> [!NOTE]
+> The pinless path issues a software reset and triggers the bootloader via the
+> retained `GPREGRET` register. It is less reliable than the dedicated reset
+> pin and the upload may need to be retried.
 
 With a dedicated reset pin:
 

--- a/src/content/docs/components/nrf52.mdx
+++ b/src/content/docs/components/nrf52.mdx
@@ -72,8 +72,8 @@ There are two ways to reference GPIO pins:
 
 ## DFU (Device Firmware Update)
 
-The `dfu` component enables automatic entry into **DFU (Device Firmware Update)** mode by monitoring                                                                                       
-the USB CDC serial connection. When a host opens the port at **1200 baud**, the component triggers                                                                                         
+The `dfu` component enables automatic entry into **DFU (Device Firmware Update)** mode by monitoring
+the USB CDC serial connection. When a host opens the port at **1200 baud**, the component triggers
 a reset to put the device into DFU mode.
 
 ESPHome uses this component internally when uploading firmware via:


### PR DESCRIPTION
Clarified the description of the 'dfu' component and updated the configuration variable for 'reset_pin' to indicate it is optional.

<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- https://github.com/esphome/esphome/pull/11684

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
