### PR TITLE
[lvgl] Document additonal layout options

### DIFF
--- a/src/content/docs/components/lvgl/layouts.mdx
+++ b/src/content/docs/components/lvgl/layouts.mdx
@@ -197,8 +197,9 @@ number of widgets:
 - `layout: x<cols>` specifies the number of columns; the row count is computed as the number of widgets divided by
   the column count (rounded up).
 
-For example, with five widgets, `layout: x3` produces a 2-row by 3-column grid, and `layout: 2x` produces a
-2-row by 3-column grid as well. If there are no widgets, the missing dimension defaults to `1`.
+For example, with five widgets, both `layout: x3` and `layout: 2x` will produce a 2-row by 3-column grid.
+
+If there are no widgets, the missing dimension defaults to `1`.
 
 **Configuration variables (must be placed under the layout key):**
 

--- a/src/content/docs/components/lvgl/layouts.mdx
+++ b/src/content/docs/components/lvgl/layouts.mdx
@@ -27,7 +27,7 @@ calculations.
 
 ### Configuration variables
 
-- **layout** (*Optional*, dict): One of `HORIZONTAL`, `VERTICAL` or a dictionary describing the layout configuration:
+- **layout** (*Optional*, dict): One of `HORIZONTAL`, `VERTICAL`, a grid shorthand, or a dictionary describing the layout configuration:
   - **type** (*Optional*, string): `FLEX`, `GRID` or `NONE`. Defaults to `NONE`.
   - Further options from below depending on the chosen type.
 
@@ -179,22 +179,43 @@ Two or more widgets may not be explicitly assigned the same row and column posit
 
 The configuration `layout: <rows>x<cols>` is a shorthand for a grid layout with the specified number of rows and
 columns, with all rows and columns of equal size. For example `layout: 2x3` is a shorthand for
-`layout: { type: grid, grid_rows: [2], grid_columns: [3] }` with
-`FR(1)` set for all rows and columns.
+
+`layout: {type: grid, grid_rows: [FR(1), FR(1)], grid_columns: [FR(1), FR(1), FR(1)], grid_cell_x_align: center, grid_cell_y_align: center}`.
+
+Either dimension may be omitted from the shorthand; the missing dimension will be calculated from the configured
+number of widgets:
+
+- `layout: <rows>x` specifies the number of rows; the column count is computed as the number of widgets divided by
+  the row count (rounded up).
+- `layout: x<cols>` specifies the number of columns; the row count is computed as the number of widgets divided by
+  the column count (rounded up).
+
+For example, with five widgets, `layout: x3` produces a 2-row by 3-column grid, while `layout: 2x` produces a
+2-row by 3-column grid as well. If there are no widgets, the missing dimension defaults to `1`.
 
 **Configuration variables (must be placed under the layout key):**
 
-- **grid_rows** (**Required**): The number of rows in the grid, expressed a list of values in pixels, `CONTENT` or
-  `FR(n)` (free units, where `n` is a proportional integer value).
-- **grid_columns** (**Required**): The number of columns in the grid, expressed a list of values in pixels, `CONTENT` or
-  `FR(n)` (free units, where `n` is a proportional integer value).
-- **grid_row_align** (*Optional*, string): How to align the row. Works only when `grid_rows` is given in pixels.
-  Possible options below.
-- **grid_column_align** (*Optional*, string): How to align the column. Works only when `grid_columns` is given in
-  pixels. Possible options below.
+- **grid_rows** (*Optional*): The rows in the grid, given either as a list of values in pixels, `CONTENT` or
+  `FR(n)` (free units, where `n` is a proportional integer value), or as a single positive integer specifying the
+  number of equal-size `FR(1)` rows. May be omitted if `grid_columns` is specified, in which case the row count is
+  derived from the number of widgets.
+- **grid_columns** (*Optional*): The columns in the grid, given either as a list of values in pixels, `CONTENT` or
+  `FR(n)` (free units, where `n` is a proportional integer value), or as a single positive integer specifying the
+  number of equal-size `FR(1)` columns. May be omitted if `grid_rows` is specified, in which case the column count
+  is derived from the number of widgets.
+- **grid_row_align** (*Optional*, string): How to align the row. It has no effect if `FR(n)` is used for any row size
+  since any free space will be allocated to a row. Possible options below.
+- **grid_column_align** (*Optional*, string): How to align the column. It has no effect if `FR(n)` is used for any
+  column size since any free space will be allocated to a column. Possible options below.
 - **pad_row** (*Optional*, int16): Set the padding between the rows, in pixels.
 - **pad_column** (*Optional*, int16): Set the padding between the columns, in pixels.
 - **multiple_widgets_per_cell** (*Optional*, bool): If true, multiple widgets can be placed in the same cell. Defaults to `false`.
+- **grid_cell_x_align** (*Optional*, string): A default value for `grid_cell_x_align` for cells. Will default to `center`
+  if a shorthand layout is used. Can be overridden on individual widgets.
+- **grid_cell_y_align** (*Optional*, string): A default value for `grid_cell_y_align` for cells. Will default to `center`
+  if a shorthand layout is used. Can be overridden on individual widgets.
+
+At least one of `grid_rows` and `grid_columns` must be specified.
 
 In a grid layout, all child widgets placed on the grid have additional configuration options available:
 

--- a/src/content/docs/components/lvgl/layouts.mdx
+++ b/src/content/docs/components/lvgl/layouts.mdx
@@ -180,7 +180,14 @@ Two or more widgets may not be explicitly assigned the same row and column posit
 The configuration `layout: <rows>x<cols>` is a shorthand for a grid layout with the specified number of rows and
 columns, with all rows and columns of equal size. For example `layout: 2x3` is a shorthand for
 
-`layout: {type: grid, grid_rows: [FR(1), FR(1)], grid_columns: [FR(1), FR(1), FR(1)], grid_cell_x_align: center, grid_cell_y_align: center}`.
+```yaml
+layout:
+  type: grid
+  grid_rows: [FR(1), FR(1)]
+  grid_columns: [FR(1), FR(1), FR(1)]
+  grid_cell_x_align: center
+  grid_cell_y_align: center
+```
 
 Either dimension may be omitted from the shorthand; the missing dimension will be calculated from the configured
 number of widgets:
@@ -215,7 +222,8 @@ For example, with five widgets, `layout: x3` produces a 2-row by 3-column grid, 
 - **grid_cell_y_align** (*Optional*, string): A default value for `grid_cell_y_align` for cells. Will default to `center`
   if a shorthand layout is used. Can be overridden on individual widgets.
 
-At least one of `grid_rows` and `grid_columns` must be specified.
+At least one of `grid_rows` and `grid_columns` must be specified. The number of rows and number of columns must
+both be greater than zero.
 
 In a grid layout, all child widgets placed on the grid have additional configuration options available:
 

--- a/src/content/docs/components/lvgl/layouts.mdx
+++ b/src/content/docs/components/lvgl/layouts.mdx
@@ -197,7 +197,7 @@ number of widgets:
 - `layout: x<cols>` specifies the number of columns; the row count is computed as the number of widgets divided by
   the column count (rounded up).
 
-For example, with five widgets, `layout: x3` produces a 2-row by 3-column grid, while `layout: 2x` produces a
+For example, with five widgets, `layout: x3` produces a 2-row by 3-column grid, and `layout: 2x` produces a
 2-row by 3-column grid as well. If there are no widgets, the missing dimension defaults to `1`.
 
 **Configuration variables (must be placed under the layout key):**


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#16041

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
