### PR TITLE
[wifi] Document phy_mode option for ESP8266

### DIFF
--- a/src/content/docs/components/wifi.mdx
+++ b/src/content/docs/components/wifi.mdx
@@ -132,6 +132,12 @@ wifi:
   Possible values are `AUTO` (use both 2.4 GHz and 5 GHz), `2.4GHZ` (2.4 GHz only), and `5GHZ` (5 GHz only).
   If not specified, it defaults to `AUTO`.
 
+- **phy_mode** (*Optional*, string): Only on `esp8266`. Pins the radio to a specific 802.11 PHY mode.
+  Possible values are `11B`, `11G`, and `11N`. If not specified, the default SDK behavior (auto-select)
+  is used. Some routers misbehave with ESP8266 802.11n associations (for example, repeated
+  disassociations or `lwIP error -16` while applying the hostname); setting `phy_mode: 11G` is a known
+  workaround for those cases.
+
 - **post_connect_roaming** (*Optional*, bool): Enable basic post-connect
   roaming for stationary devices. After connecting to a non-hidden network,
   the device will periodically check for better access points with the same

--- a/src/content/docs/components/wifi.mdx
+++ b/src/content/docs/components/wifi.mdx
@@ -135,8 +135,7 @@ wifi:
 - **phy_mode** (*Optional*, string): Only on `esp8266`. Pins the radio to a specific 802.11 PHY mode.
   Possible values are `11B`, `11G`, and `11N`. If not specified, the default SDK behavior (auto-select)
   is used. Some routers misbehave with ESP8266 802.11n associations (for example, repeated
-  disassociations or `lwIP error -16` while applying the hostname); setting `phy_mode: 11G` is a known
-  workaround for those cases.
+  disassociations); setting `phy_mode: 11G` is a known workaround for those cases.
 
 - **post_connect_roaming** (*Optional*, bool): Enable basic post-connect
   roaming for stationary devices. After connecting to a non-hidden network,

--- a/src/content/docs/components/wifi.mdx
+++ b/src/content/docs/components/wifi.mdx
@@ -133,9 +133,9 @@ wifi:
   If not specified, it defaults to `AUTO`.
 
 - **phy_mode** (*Optional*, string): Only on `esp8266`. Pins the radio to a specific 802.11 PHY mode.
-  Possible values are `11B`, `11G`, and `11N`. If not specified, the default SDK behavior (auto-select)
-  is used. Some routers misbehave with ESP8266 802.11n associations (for example, repeated
-  disassociations); setting `phy_mode: 11G` is a known workaround for those cases.
+  Possible values are `AUTO`, `11B`, `11G`, and `11N`. Defaults to `AUTO`, which leaves the SDK at
+  its default behavior. There is a known compatibility issue of ESP8266 devices 802.11n with some
+  routers; you can work around it by limiting the ESP to 802.11g with `phy_mode: 11G`.
 
 - **post_connect_roaming** (*Optional*, bool): Enable basic post-connect
   roaming for stationary devices. After connecting to a non-hidden network,

--- a/src/content/docs/components/wifi.mdx
+++ b/src/content/docs/components/wifi.mdx
@@ -134,8 +134,8 @@ wifi:
 
 - **phy_mode** (*Optional*, string): Only on `esp8266`. Pins the radio to a specific 802.11 PHY mode.
   Possible values are `AUTO`, `11B`, `11G`, and `11N`. Defaults to `AUTO`, which leaves the SDK at
-  its default behavior. There is a known compatibility issue of ESP8266 devices 802.11n with some
-  routers; you can work around it by limiting the ESP to 802.11g with `phy_mode: 11G`.
+  its default behavior. There is a known compatibility issue with some routers when ESP8266 devices use
+  802.11n; you can work around it by limiting the ESP to 802.11g with `phy_mode: 11G`.
 
 - **post_connect_roaming** (*Optional*, bool): Enable basic post-connect
   roaming for stationary devices. After connecting to a non-hidden network,


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Documents the new `phy_mode` option on the WiFi component for ESP8266, which lets users pin the radio to `11B`, `11G`, or `11N` from YAML. Useful for working around routers that misbehave with ESP8266 802.11n associations (e.g. lwIP `error -16` while applying the hostname).

**Related issue (if applicable):** related to https://github.com/ratgdo/esphome-ratgdo/issues/541

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#16055

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>