### PR TITLE
[nextion] Replace `connect_info` vector with fixed-size field parser,…

### DIFF
--- a/src/content/docs/components/display/nextion.mdx
+++ b/src/content/docs/components/display/nextion.mdx
@@ -130,9 +130,6 @@ display:
   This helps prevent memory overflows or boot-time crashes in complex setups that issue a large number of commands
   in rapid succession. If not set, the queue size is unlimited.
 
-- **dump_device_info** (*Optional*, boolean): Shows device information (model, firmware version, serial number, flash size) in the configuration dump.
-  When disabled, device info is only logged during connection establishment to save memory. Defaults to `false`.
-
 <span id="display-nextion_lambda"></span>
 
 ## Rendering Lambda


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Replaces the heap-allocated `std::vector<std::string> connect_info` parser in `check_connect_()` with direct field extraction into fixed-size members, eliminating all heap allocations from the `comok` response parsing.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#16059

## Checklist

- [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
