### PR TITLE
2026.4.3

### DIFF
--- a/data/version.yaml
+++ b/data/version.yaml
@@ -1,2 +1,2 @@
-release: 2026.4.2
+release: 2026.4.3
 version: '2026.4'

--- a/src/content/docs/changelog/2026.4.0.mdx
+++ b/src/content/docs/changelog/2026.4.0.mdx
@@ -553,6 +553,23 @@ For detailed migration guides and API documentation, see the [ESPHome Developers
 
 </details>
 
+## Release 2026.4.3 - April 28
+
+<details>
+<summary></summary>
+
+- [lvgl] Triggers on tabview tabs fix [esphome#15935](https://github.com/esphome/esphome/pull/15935) by [@clydebarrow](https://github.com/clydebarrow)
+- [time] Handle Windows EINVAL when validating POSIX TZ strings [esphome#15934](https://github.com/esphome/esphome/pull/15934) by [@jesserockz](https://github.com/jesserockz)
+- [deep_sleep] Fix sleep_duration codegen type to uint32_t [esphome#15965](https://github.com/esphome/esphome/pull/15965) by [@bdraco](https://github.com/bdraco)
+- [wifi] Fix stale wifi.connected after state transition [esphome#15966](https://github.com/esphome/esphome/pull/15966) by [@bdraco](https://github.com/bdraco)
+- [rotary_encoder][at581x] Fix templatable int field types [esphome#16015](https://github.com/esphome/esphome/pull/16015) by [@bdraco](https://github.com/bdraco)
+- [esp32][wifi] Fix bootloop and WiFi connection issue if nvs partition is missing or has non-default label [esphome#16025](https://github.com/esphome/esphome/pull/16025) by [@Mat931](https://github.com/Mat931)
+- [nextion] Unify TFT upload ack timeout to 5000ms [esphome#15960](https://github.com/esphome/esphome/pull/15960) by [@edwardtfn](https://github.com/edwardtfn)
+- [esp32_touch] Feed wdt [esphome#16066](https://github.com/esphome/esphome/pull/16066) by [@jesserockz](https://github.com/jesserockz)
+- [image] Fix RGB565+alpha rendering for multi-frame animations [esphome#16017](https://github.com/esphome/esphome/pull/16017) by [@bdraco](https://github.com/bdraco)
+
+</details>
+
 ## Full list of changes
 
 ### New Features

--- a/src/content/docs/guides/supporters.mdx
+++ b/src/content/docs/guides/supporters.mdx
@@ -983,6 +983,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Ivo Roefs (@ironirc)](https://github.com/ironirc)
 - [irtimaled (@irtimaled)](https://github.com/irtimaled)
 - [isystemsautomation (@isystemsautomation)](https://github.com/isystemsautomation)
+- [isystemsautomation-com-dev (@isystemsautomation-com-dev)](https://github.com/isystemsautomation-com-dev)
 - [Ingo Theiss (@itn3rd77)](https://github.com/itn3rd77)
 - [itpeters (@itpeters)](https://github.com/itpeters)
 - [Harper Andrews (@ItsHarper)](https://github.com/ItsHarper)
@@ -1213,6 +1214,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [KoenBreeman (@KoenBreeman)](https://github.com/KoenBreeman)
 - [Koen Vervloesem (@koenvervloesem)](https://github.com/koenvervloesem)
 - [kokangit (@kokangit)](https://github.com/kokangit)
+- [Darafei Praliaskouski (@Komzpa)](https://github.com/Komzpa)
 - [Petr Vraník (@konikvranik)](https://github.com/konikvranik)
 - [konsulten (@konsulten)](https://github.com/konsulten)
 - [korellas (@korellas)](https://github.com/korellas)
@@ -2382,4 +2384,4 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Christian Zufferey (@zuzu59)](https://github.com/zuzu59)
 - [Zynth-dev (@Zynth-dev)](https://github.com/Zynth-dev)
 
-*This page was last updated April 23, 2026.*
+*This page was last updated April 28, 2026.*


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- Refresh the 404 page [docs#6510](https://github.com/esphome/esphome-docs/pull/6510)
- Bump fast-xml-parser and @astrojs/rss [docs#6511](https://github.com/esphome/esphome-docs/pull/6511)
- Bump actions/setup-node from 6.3.0 to 6.4.0 [docs#6499](https://github.com/esphome/esphome-docs/pull/6499)
- Bump actions/create-github-app-token from 3.0.0 to 3.1.1 [docs#6444](https://github.com/esphome/esphome-docs/pull/6444)
- Bump actions/upload-artifact from 7.0.0 to 7.0.1 [docs#6445](https://github.com/esphome/esphome-docs/pull/6445)
- Use client id from org vars for GitHub App token [docs#6516](https://github.com/esphome/esphome-docs/pull/6516)
- Bump astro from 6.0.8 to 6.1.8 [docs#6504](https://github.com/esphome/esphome-docs/pull/6504)
- Bump astro from 6.0.8 to 6.1.4 [docs#6403](https://github.com/esphome/esphome-docs/pull/6403)
- Bump actions/github-script from 8.0.0 to 9.0.0 [docs#6434](https://github.com/esphome/esphome-docs/pull/6434)
- [ci] Auto-close PRs opened from a fork's current or next branch [docs#6518](https://github.com/esphome/esphome-docs/pull/6518)
- Bump katex from 0.16.40 to 0.16.45 [docs#6394](https://github.com/esphome/esphome-docs/pull/6394)
- [search] Enter goes to first result [docs#6538](https://github.com/esphome/esphome-docs/pull/6538)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
