### PR TITLE
[lvgl] Document PRESSED option for binary sensor

### DIFF
--- a/src/content/docs/components/binary_sensor/lvgl.mdx
+++ b/src/content/docs/components/binary_sensor/lvgl.mdx
@@ -6,20 +6,32 @@ title: "LVGL Binary Sensor"
 The `lvgl` binary sensor platform creates a binary sensor from an LVGL widget
 and requires [LVGL](/components/lvgl/) to be configured.
 
-Supported widget is [`button`](/components/lvgl/widgets#lvgl-widget-button). A single binary sensor supports only a single widget; in other words, it's not possible to have multiple widgets associated with a single ESPHome binary sensor component.
+Any widget that supports the `pressed` or `checked` [state](/components/lvgl/widgets#lvgl-widgetproperty-state) can be used; in particular, [`button`](/components/lvgl/widgets#lvgl-widget-button), [`buttonmatrix`](/components/lvgl/widgets#lvgl-widget-buttonmatrix), [`checkbox`](/components/lvgl/widgets#lvgl-widget-checkbox) and [`switch`](/components/lvgl/widgets#lvgl-widget-switch). A single binary sensor supports only a single widget; in other words, it's not possible to have multiple widgets associated with a single ESPHome binary sensor component.
 
 ## Configuration variables
 
 - **widget** (**Required**): The ID of a supported widget configured in LVGL, which will reflect the state of the binary sensor.
+- **state** (*Optional*, string): Which widget state to report. One of:
+  - `PRESSED` (default): The binary sensor is `on` while the widget is being pressed (momentary).
+  - `CHECKED`: The binary sensor reflects the `checked` (toggled) state of the widget.
+    This is useful for `checkable` buttons, `checkbox` and `switch` widgets, where the binary sensor follows the
+    toggle state and updates whenever it changes (either by user interaction or programmatically through `lvgl.widget.update`).
 - All other variables from [Binary Sensor](/components/binary_sensor#config-binary_sensor).
 
-Example:
+Examples:
 
 ```yaml
+# Momentary push button - reports pressed state
 binary_sensor:
   - platform: lvgl
     widget: btn_id
     name: LVGL push button
+
+# Toggle/checkable widget - reports checked state
+  - platform: lvgl
+    widget: switch_id
+    state: CHECKED
+    name: LVGL switch state
 ```
 
 ## See Also


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#16073

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
