### PR TITLE
[tinyusb] Add `tinyusb_keyboard` docs

### DIFF
--- a/src/content/docs/components/index.mdx
+++ b/src/content/docs/components/index.mdx
@@ -171,6 +171,7 @@ Create update entities simplifying management of OTA updates.
   ["OpenTherm", "/components/opentherm/", "opentherm.png"],
   ["SPI Bus", "/components/spi/", "spi.svg"],
   ["TinyUSB", "/components/tinyusb/", "usb.svg", "dark-invert"],
+  ["TinyUSB Keyboard", "/components/tinyusb_keyboard/", "usb.svg", "dark-invert"],
   ["UART", "/components/uart/", "uart.svg"],
   ["USB CDC-ACM", "/components/usb_cdc_acm/", "usb.svg", "dark-invert"],
   ["USB Host", "/components/usb_host/", "usb.svg", "dark-invert"],

--- a/src/content/docs/components/tinyusb_keyboard.mdx
+++ b/src/content/docs/components/tinyusb_keyboard.mdx
@@ -59,7 +59,7 @@ binary_sensor:
 
 ## Actions
 
-### `tinyusb_keyboard.press`
+### `tinyusb_keyboard.press` Action
 
 This is an [Action](/automations/actions#all-actions) for pressing a specific key.
 
@@ -77,7 +77,7 @@ Configuration variables:
 - **modifiers** (*Optional*, uint8): An optional modifier byte.
 
 
-### `tinyusb_keyboard.release`
+### `tinyusb_keyboard.release` Action
 
 This is an [Action](/automations/actions#all-actions) for releasing all non media keys.
 
@@ -91,7 +91,7 @@ Configuration variables:
 - **id** (**Required**, [ID](/guides/configuration-types#id)): The ID of the tinyusb_keyboard instance.
 
 
-### `tinyusb_keyboard.media_press`
+### `tinyusb_keyboard.media_press` Action
 
 This is an [Action](/automations/actions#all-actions) for pressing a media keys
 
@@ -106,7 +106,7 @@ Configuration variables:
 - **id** (**Required**, [ID](/guides/configuration-types#id)): The ID of the tinyusb_keyboard instance.
 - **usage** (**Required**, uint16): The media key to press represented by a two-byte usage.
 
-### `tinyusb_keyboard.media_release`
+### `tinyusb_keyboard.media_release` Action
 
 This is an [Action](/automations/actions#all-actions) for releasing all media keys.
 

--- a/src/content/docs/components/tinyusb_keyboard.mdx
+++ b/src/content/docs/components/tinyusb_keyboard.mdx
@@ -79,7 +79,7 @@ Configuration variables:
 
 ### `tinyusb_keyboard.release` Action
 
-This is an [Action](/automations/actions#all-actions) for releasing all non media keys.
+This is an [Action](/automations/actions#all-actions) for releasing all non-media keys.
 
 ```yaml
 - tinyusb_keyboard.release:
@@ -93,10 +93,10 @@ Configuration variables:
 
 ### `tinyusb_keyboard.media_press` Action
 
-This is an [Action](/automations/actions#all-actions) for pressing a media keys
+This is an [Action](/automations/actions#all-actions) for pressing a media key.
 
 ```yaml
-- tinyusb_keyboard.release:
+- tinyusb_keyboard.media_press:
     id: kb
     usage: 0xE9
 ```

--- a/src/content/docs/components/tinyusb_keyboard.mdx
+++ b/src/content/docs/components/tinyusb_keyboard.mdx
@@ -73,7 +73,7 @@ This is an [Action](/automations/actions#all-actions) for pressing a specific ke
 Configuration variables:
 
 - **id** (**Required**, [ID](/guides/configuration-types#id)): The ID of the tinyusb_keyboard instance.
-- **key** (**Required**, string): The key to press.
+- **key** (**Required**, string): The key to press. a-z and 0-9 is currently supported.
 - **modifiers** (*Optional*, uint8): An optional modifier byte.
 
 

--- a/src/content/docs/components/tinyusb_keyboard.mdx
+++ b/src/content/docs/components/tinyusb_keyboard.mdx
@@ -1,0 +1,120 @@
+---
+description: "Instructions for extending TinyUSB with keyboard functionality within ESPHome"
+title: "TinyUSB Keyboard"
+---
+
+
+The `tinyusb_keyboard` component expands the existing TinyUSB functionality with basic support for HID.
+
+[TinyUSB](/components/tinyusb/) is required to use the component.
+
+It is currently supported on the following ESP32 microcontroller variants:
+
+- ESP32-P4
+- ESP32-S2
+- ESP32-S3
+
+It supports pressing and releasing both regular keys and media keys using the following actions:
+
+- `tinyusb_keyboard.press`
+- `tinyusb_keyboard.release`
+- `tinyusb_keyboard.media_press`
+- `tinyusb_keyboard.media_release`
+
+```yaml
+# Example configuration entry
+tinyusb:
+
+tinyusb_keyboard:
+  id: kb
+
+binary_sensor:
+  - platform: gpio
+    pin: 13
+    name: "Shift + H Button"
+    on_press:
+      - tinyusb_keyboard.press:
+          id: kb
+          key: "h"
+          modifiers: 0x02  # Left Shift
+    on_release:
+      - tinyusb_keyboard.release:
+          id: kb
+
+  - platform: gpio
+    pin: 14
+    name: "Volume Up Button"
+    on_press:
+      - tinyusb_keyboard.media_press:
+          id: kb
+          usage: 0xE9  # Volume Up
+    on_release:
+      - tinyusb_keyboard.media_release:
+          id: kb
+```
+
+## Configuration variables
+
+- **id** (*Optional*, [ID](/guides/configuration-types#config-id)): Manually specify the ID for this component.
+
+## Actions
+
+### `tinyusb_keyboard.press`
+
+This is an [Action](/automations/actions#all-actions) for pressing a specific key.
+
+```yaml
+- tinyusb_keyboard.press:
+    id: kb
+    key: "h"
+    modifiers: 0x02  # Left Shift
+```
+
+Configuration variables:
+
+- **id** (**Required**, [ID](/guides/configuration-types#id)): The ID of the tinyusb_keyboard instance.
+- **key** (**Required**, string): The key to press.
+- **modifiers** (*Optional*, uint8): An optional modifier byte.
+
+
+### `tinyusb_keyboard.release`
+
+This is an [Action](/automations/actions#all-actions) for releasing all non media keys.
+
+```yaml
+- tinyusb_keyboard.release:
+    id: kb
+```
+
+Configuration variables:
+
+- **id** (**Required**, [ID](/guides/configuration-types#id)): The ID of the tinyusb_keyboard instance.
+
+
+### `tinyusb_keyboard.media_press`
+
+This is an [Action](/automations/actions#all-actions) for pressing a media keys
+
+```yaml
+- tinyusb_keyboard.release:
+    id: kb
+    usage: 0xE9
+```
+
+Configuration variables:
+
+- **id** (**Required**, [ID](/guides/configuration-types#id)): The ID of the tinyusb_keyboard instance.
+- **usage** (**Required**, uint16): The media key to press represented by a two-byte usage.
+
+### `tinyusb_keyboard.media_release`
+
+This is an [Action](/automations/actions#all-actions) for releasing all media keys.
+
+```yaml
+- tinyusb_keyboard.media_release:
+    id: kb
+```
+
+Configuration variables:
+
+- **id** (**Required**, [ID](/guides/configuration-types#id)): The ID of the tinyusb_keyboard instance.


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Add basic documentation for the `tinyusb_keyboard` component.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- https://github.com/esphome/esphome/pull/16079

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [x] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
