### PR TITLE
Copy link to clipboard on click

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -306,6 +306,7 @@ export default defineConfig({
           }
 
           document.addEventListener('click', function(e) {
+            if (!(e.target instanceof Element)) return;
             const anchor = e.target.closest('a.sl-anchor-link');
             if (!anchor) return;
             if (

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -335,37 +335,37 @@ export default defineConfig({
           function showLinkCopiedToast(anchor) {
             const existing = document.getElementById('sl-link-toast');
             if (existing) existing.remove();
-              const rect = anchor.getBoundingClientRect();
+            const rect = anchor.getBoundingClientRect();
 
-              const toast = document.createElement('div');
-              toast.id = 'sl-link-toast';
-              toast.setAttribute('role', 'status');
-              toast.setAttribute('aria-live', 'polite');
-              toast.setAttribute('aria-atomic', 'true');
-              toast.textContent = 'Link copied to clipboard';
-              toast.style.cssText = [
-                'position:fixed',
-                'top:' + (rect.top + rect.height / 2 - 14) + 'px',
-                'left:' + (rect.right + 8) + 'px',
-                'background:var(--sl-color-gray-1)',
-                'color:var(--sl-color-gray-6)',
-                'padding:0.25rem 0.75rem',
-                'border-radius:999px',
-                'font-size:0.8rem',
-                'white-space:nowrap',
-                'box-shadow:0 2px 8px rgba(0,0,0,0.2)',
-                'z-index:9999',
-                'opacity:1',
-                'transition:opacity 0.4s ease',
-                'pointer-events:none',
-              ].join(';');
-              document.body.appendChild(toast);
+            const toast = document.createElement('div');
+            toast.id = 'sl-link-toast';
+            toast.setAttribute('role', 'status');
+            toast.setAttribute('aria-live', 'polite');
+            toast.setAttribute('aria-atomic', 'true');
+            toast.textContent = 'Link copied to clipboard';
+            toast.style.cssText = [
+              'position:fixed',
+              'top:' + (rect.top + rect.height / 2 - 14) + 'px',
+              'left:' + (rect.right + 8) + 'px',
+              'background:var(--sl-color-gray-1)',
+              'color:var(--sl-color-gray-6)',
+              'padding:0.25rem 0.75rem',
+              'border-radius:999px',
+              'font-size:0.8rem',
+              'white-space:nowrap',
+              'box-shadow:0 2px 8px rgba(0,0,0,0.2)',
+              'z-index:9999',
+              'opacity:1',
+              'transition:opacity 0.4s ease',
+              'pointer-events:none',
+            ].join(';');
+            document.body.appendChild(toast);
 
-              // If it overflows the right edge, flip it to the left of the icon
-              const toastRect = toast.getBoundingClientRect();
-              if (toastRect.right > window.innerWidth - 8) {
-                toast.style.left = (rect.left - toastRect.width - 8) + 'px';
-              }
+            // If it overflows the right edge, flip it to the left of the icon
+            const toastRect = toast.getBoundingClientRect();
+            if (toastRect.right > window.innerWidth - 8) {
+              toast.style.left = (rect.left - toastRect.width - 8) + 'px';
+            }
 
             setTimeout(function() {
               toast.style.opacity = '0';

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -267,13 +267,67 @@ export default defineConfig({
               }
             }
           });
+
+          function fallbackCopyText(text) {
+            return new Promise(function(resolve, reject) {
+              try {
+                const textarea = document.createElement('textarea');
+                textarea.value = text;
+                textarea.setAttribute('readonly', '');
+                textarea.style.position = 'fixed';
+                textarea.style.top = '-9999px';
+                textarea.style.left = '-9999px';
+                document.body.appendChild(textarea);
+                textarea.focus();
+                textarea.select();
+
+                const copied = document.execCommand('copy');
+                textarea.remove();
+
+                if (copied) {
+                  resolve();
+                } else {
+                  reject(new Error('Fallback copy failed'));
+                }
+              } catch (err) {
+                reject(err);
+              }
+            });
+          }
+
+          function copyText(text) {
+            if (navigator.clipboard && typeof navigator.clipboard.writeText === 'function') {
+              return navigator.clipboard.writeText(text).catch(function() {
+                return fallbackCopyText(text);
+              });
+            }
+
+            return fallbackCopyText(text);
+          }
+
           document.addEventListener('click', function(e) {
             const anchor = e.target.closest('a.sl-anchor-link');
             if (!anchor) return;
+            if (
+              e.button !== 0 ||
+              e.metaKey ||
+              e.ctrlKey ||
+              e.shiftKey ||
+              e.altKey
+            ) {
+              return;
+            }
             e.preventDefault();
             const url = anchor.href;
-            navigator.clipboard.writeText(url).then(function() {
+            copyText(url).then(function() {
               showLinkCopiedToast(anchor);
+            }).catch(function() {
+              const targetUrl = new URL(anchor.href, window.location.href);
+              if (targetUrl.hash) {
+                window.location.hash = targetUrl.hash;
+              } else {
+                window.location.assign(anchor.href);
+              }
             });
           });
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -293,7 +293,7 @@ export default defineConfig({
                 'top:' + (rect.top + rect.height / 2 - 14) + 'px',
                 'left:' + (rect.right + 8) + 'px',
                 'background:var(--sl-color-gray-1)',
-                'color:var(--sl-color-gray-7)',
+                'color:var(--sl-color-gray-6)',
                 'padding:0.25rem 0.75rem',
                 'border-radius:999px',
                 'font-size:0.8rem',

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -266,7 +266,54 @@ export default defineConfig({
                 firstResult.click();
               }
             }
-          });`,
+          });
+          document.addEventListener('click', function(e) {
+            const anchor = e.target.closest('a.sl-anchor-link');
+            if (!anchor) return;
+            e.preventDefault();
+            const url = new URL(anchor.getAttribute('href'), location.href).href;
+            navigator.clipboard.writeText(url).then(function() {
+              showLinkCopiedToast(anchor);
+            });
+          });
+
+          function showLinkCopiedToast(anchor) {
+            const existing = document.getElementById('sl-link-toast');
+            if (existing) existing.remove();
+              const rect = anchor.getBoundingClientRect();
+
+              const toast = document.createElement('div');
+              toast.id = 'sl-link-toast';
+              toast.textContent = 'Link copied';
+              toast.style.cssText = [
+                'position:fixed',
+                'top:' + (rect.top + rect.height / 2 - 14) + 'px',
+                'left:' + (rect.right + 8) + 'px',
+                'background:var(--sl-color-gray-1)',
+                'color:var(--sl-color-gray-7)',
+                'padding:0.25rem 0.75rem',
+                'border-radius:999px',
+                'font-size:0.8rem',
+                'white-space:nowrap',
+                'box-shadow:0 2px 8px rgba(0,0,0,0.2)',
+                'z-index:9999',
+                'opacity:1',
+                'transition:opacity 0.4s ease',
+                'pointer-events:none',
+              ].join(';');
+              document.body.appendChild(toast);
+
+              // If it overflows the right edge, flip it to the left of the icon
+              const toastRect = toast.getBoundingClientRect();
+              if (toastRect.right > window.innerWidth - 8) {
+                toast.style.left = (rect.left - toastRect.width - 8) + 'px';
+              }
+
+            setTimeout(function() {
+              toast.style.opacity = '0';
+              setTimeout(function() { toast.remove(); }, 400);
+            }, 2000);
+          }`,
         },
         {
           tag: "meta",

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -271,7 +271,7 @@ export default defineConfig({
             const anchor = e.target.closest('a.sl-anchor-link');
             if (!anchor) return;
             e.preventDefault();
-            const url = new URL(anchor.getAttribute('href'), location.href).href;
+            const url = anchor.href;
             navigator.clipboard.writeText(url).then(function() {
               showLinkCopiedToast(anchor);
             });
@@ -284,6 +284,9 @@ export default defineConfig({
 
               const toast = document.createElement('div');
               toast.id = 'sl-link-toast';
+              toast.setAttribute('role', 'status');
+              toast.setAttribute('aria-live', 'polite');
+              toast.setAttribute('aria-atomic', 'true');
               toast.textContent = 'Link copied to clipboard';
               toast.style.cssText = [
                 'position:fixed',

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -284,7 +284,7 @@ export default defineConfig({
 
               const toast = document.createElement('div');
               toast.id = 'sl-link-toast';
-              toast.textContent = 'Link copied';
+              toast.textContent = 'Link copied to clipboard';
               toast.style.cssText = [
                 'position:fixed',
                 'top:' + (rect.top + rect.height / 2 - 14) + 'px',


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Previous site would copy anchor links beside headings directly to clipboard on click.
This reverted with Astro migration to just navigating to the link (usually resulting in the page jumping) which populated the browser bar with the link, then having to select and copy that.

This PR restores the immediate copy, with a toast notification so the user knows what just happened, making the copy one-click and avoiding unwanted page scrolling.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
