### PR TITLE
[haier] Added haier select component documentation

### DIFF
--- a/src/content/docs/components/climate/haier.mdx
+++ b/src/content/docs/components/climate/haier.mdx
@@ -312,6 +312,7 @@ on_...:
 - [Haier Climate Binary Sensors](/components/binary_sensor/haier/)
 - [Haier Climate Text Sensors](/components/text_sensor/haier/)
 - [Haier Climate Buttons](/components/button/haier/)
+- [Haier Climate Select](/components/select/haier/)
 - [Haier Climate Switches](/components/switch/haier/)
 - [Climate Component](/components/climate/)
 - <APIRef text="haier_base.h" path="haier/climate/haier_base.h" />

--- a/src/content/docs/components/select/haier.mdx
+++ b/src/content/docs/components/select/haier.mdx
@@ -1,0 +1,44 @@
+---
+title: Haier Climate Select
+description: Instructions for setting up additional select components for Haier climate devices.
+---
+
+Select components to support vertical and horizontal airflow direction settings for Haier AC.
+
+## Vertical airflow select
+
+```yaml
+select:
+  - platform: haier
+    haier_id: ${device_id}
+    vertical_airflow:
+      name: ${device_name} airflow vertical
+```
+
+## Horizontal airflow select
+
+```yaml
+select:
+  - platform: haier
+    haier_id: ${device_id}
+    horizontal_airflow:
+      name: ${device_name} airflow horizontal
+```
+
+Configuration variables
+
+- **haier_id** (**Required**): The ID of the Haier climate component.
+- **horizontal_airflow** (*Optional*):  
+  (supported only by hOn) Select component to control horizontal airflow mode (if supported by AC).  
+  This select has no state while horizontal swing is enabled.  
+  All options from `Select`.
+
+- **vertical_airflow** (*Optional*):  
+  (supported only by hOn) Select component to control vertical airflow mode (if supported by AC).  
+  This select has no state while vertical swing is enabled.  
+  All options from `Select`.
+
+## See Also
+
+- [Haier Climate](/components/climate/haier)
+


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Added documentation for new Haier select component

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist

- [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
