### PR TITLE
[sx126x] document cold sleep option for set_mode_sleep

### DIFF
--- a/src/content/docs/components/sx126x.mdx
+++ b/src/content/docs/components/sx126x.mdx
@@ -177,6 +177,23 @@ on_...:
   - sx126x.set_mode_sleep
 ```
 
+By default the radio enters warm sleep — config registers are retained so that
+on wake it is ready for `set_mode_rx` / `set_mode_tx` again. For battery-powered
+nodes that pair the radio with ESP32 deep sleep, `cold: true` switches to cold
+sleep (~0.6&nbsp;µA, vs ~600&nbsp;µA warm). Cold sleep does not retain config,
+so any wake path must reset the radio and call `configure()` again — the natural
+way to do this is to let the ESP32 reboot from deep sleep, which re-runs the
+component's `setup()`.
+
+- **cold** (*Optional*, [templatable](/automations/templates), boolean): If true,
+  enter cold sleep instead of warm sleep. Defaults to `false`.
+
+```yaml
+on_...:
+  - sx126x.set_mode_sleep:
+      cold: true
+```
+
 ### `sx126x.set_mode_standby` Action
 
 This [action](/automations/actions#all-actions) sets the `sx126x` mode to standby.

--- a/src/content/docs/components/sx126x.mdx
+++ b/src/content/docs/components/sx126x.mdx
@@ -171,19 +171,13 @@ on_...:
 ### `sx126x.set_mode_sleep` Action
 
 This [action](/automations/actions#all-actions) sets the `sx126x` mode to sleep.
-
-```yaml
-on_...:
-  - sx126x.set_mode_sleep
-```
-
 By default the radio enters warm sleep — config registers are retained so that
 on wake it is ready for `sx126x.set_mode_rx` / `sx126x.set_mode_tx` again. For
-battery-powered nodes that pair the radio with ESP32 deep sleep, `cold: true`
+battery-powered nodes that pair the radio with deep sleep, `cold: true`
 switches to cold sleep (~0.6&nbsp;µA, vs ~600&nbsp;µA warm). Cold sleep does
-not retain config, so the radio must be reinitialized on wake. With ESP32
-deep sleep this happens automatically — the device reboots on wake and the
-component reinitializes the radio during startup.
+not retain config, so the radio must be reinitialized on wake. With deep sleep
+this happens automatically — the device reboots on wake and the component
+reinitializes the radio during startup.
 
 ```yaml
 on_...:

--- a/src/content/docs/components/sx126x.mdx
+++ b/src/content/docs/components/sx126x.mdx
@@ -185,14 +185,16 @@ not retain config, so the radio must be reinitialized on wake. With ESP32
 deep sleep this happens automatically — the device reboots on wake and the
 component reinitializes the radio during startup.
 
-- **cold** (*Optional*, [templatable](/automations/templates), boolean): If true,
-  enter cold sleep instead of warm sleep. Defaults to `false`.
-
 ```yaml
 on_...:
   - sx126x.set_mode_sleep:
       cold: true
 ```
+
+#### Configuration variables
+
+- **cold** (*Optional*, [templatable](/automations/templates), boolean): If true,
+  enter cold sleep instead of warm sleep. Defaults to `false`.
 
 ### `sx126x.set_mode_standby` Action
 

--- a/src/content/docs/components/sx126x.mdx
+++ b/src/content/docs/components/sx126x.mdx
@@ -178,12 +178,12 @@ on_...:
 ```
 
 By default the radio enters warm sleep — config registers are retained so that
-on wake it is ready for `set_mode_rx` / `set_mode_tx` again. For battery-powered
-nodes that pair the radio with ESP32 deep sleep, `cold: true` switches to cold
-sleep (~0.6&nbsp;µA, vs ~600&nbsp;µA warm). Cold sleep does not retain config,
-so any wake path must reset the radio and call `configure()` again — the natural
-way to do this is to let the ESP32 reboot from deep sleep, which re-runs the
-component's `setup()`.
+on wake it is ready for `sx126x.set_mode_rx` / `sx126x.set_mode_tx` again. For
+battery-powered nodes that pair the radio with ESP32 deep sleep, `cold: true`
+switches to cold sleep (~0.6&nbsp;µA, vs ~600&nbsp;µA warm). Cold sleep does
+not retain config, so the radio must be reinitialized on wake. With ESP32
+deep sleep this happens automatically — the device reboots on wake and the
+component reinitializes the radio during startup.
 
 - **cold** (*Optional*, [templatable](/automations/templates), boolean): If true,
   enter cold sleep instead of warm sleep. Defaults to `false`.


### PR DESCRIPTION
## Description:

Documents the new \`cold:\` option on \`sx126x.set_mode_sleep\` and notes the
config-not-retained tradeoff so users know cold sleep is intended to be paired
with ESP32 deep sleep (which re-runs the component's \`setup()\` on wake).

**Related links:**

- esphome/esphome#16144
- https://github.com/orgs/esphome/discussions/3638

## Pull request in [esphome](https://github.com/esphome/esphome) with the underlying change:

- esphome/esphome#16144

## Checklist:

  - [ ] Branch: \`current\` ← \`current\` is for changes to existing features and small adjustments to documentation (will be released with the next ESPHome release)
  - [x] Branch: \`next\` ← \`next\` is for changes and new documentation that will only apply to the next ESPHome release. Existing documentation must still be valid.
  - [x] Link added in \`/index.rst\` when creating new documents for new components or cookbook (n/a — editing existing page).