### PR TITLE
Realign and style badge

### DIFF
--- a/src/components/SiteTitle.astro
+++ b/src/components/SiteTitle.astro
@@ -49,22 +49,22 @@ const { display: displayVersion, slug: changelogSlug } = cache.__esphomeVersion;
 
 <style>
   .version-badge {
-    align-self: center;
-    margin-left: 5px;
+    align-self: flex-end;
+    margin-left: 8px;
     padding: 0 4px;
     font-size: 10px;
     font-weight: 500;
     line-height: 15px;
     height: 15px;
     letter-spacing: 0.4px;
-    color: var(--sl-color-text-accent);
-    background-color: var(--sl-color-accent-low);
+    color: var(--sl-color-black);
+    background-color: var(--sl-color-bg-accent);
     border-radius: 4px;
     text-decoration: none;
     white-space: nowrap;
   }
   .version-badge:hover {
-    background-color: var(--sl-color-accent);
-    color: var(--sl-color-black);
+    background-color: var(--sl-color-accent-low);
+    color: var(--sl-color-text);
   }
 </style>

--- a/src/components/SiteTitle.astro
+++ b/src/components/SiteTitle.astro
@@ -62,6 +62,7 @@ const { display: displayVersion, slug: changelogSlug } = cache.__esphomeVersion;
     border-radius: 4px;
     text-decoration: none;
     white-space: nowrap;
+    transform: translateY(-4px);
   }
   .version-badge:hover {
     background-color: var(--sl-color-accent-low);


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
