### PR TITLE
[audio] Add audio codec configuration documentation

### DIFF
--- a/src/content/docs/components/audio.mdx
+++ b/src/content/docs/components/audio.mdx
@@ -41,12 +41,12 @@ audio:
   - **flac** (*Optional*): Enable and configure the [FLAC](https://github.com/esphome-libs/micro-flac) decoder.
 
     - **buffer_memory** (*Optional*, string): Where to allocate the FLAC working buffer (typically 16–64 KB for stereo
-      streams). One of `psram` or `internal`. Defaults to `psram`.
+      streams). One of `psram` or `internal`. Defaults to `psram` when available, otherwise `internal`.
 
   - **mp3** (*Optional*): Enable and configure the [MP3](https://github.com/esphome-libs/micro-mp3) decoder.
 
     - **buffer_memory** (*Optional*, string): Where to allocate the MP3 decoder state buffers. One of `psram` or
-      `internal`. Defaults to `psram`.
+      `internal`. Defaults to `psram` when available, otherwise `internal`.
 
   - **opus** (*Optional*): Enable and configure the [Opus](https://github.com/esphome-libs/micro-opus) decoder.
 
@@ -55,7 +55,8 @@ audio:
       where fixed-point decoding is faster.
 
     - **state_memory** (*Optional*, string): Where to allocate the Opus decoder state and other persistent buffers
-      (roughly 30–50 KB per instance plus shared tables). One of `psram` or `internal`. Defaults to `psram`.
+      (roughly 30–50 KB per instance plus shared tables). One of `psram` or `internal`. Defaults to `psram` when
+      available, otherwise `internal`.
 
     - **pseudostack** (*Optional*): Configures the Opus pseudostack — a working-memory buffer used heavily for
       temporary allocations during decode operations.
@@ -65,7 +66,7 @@ audio:
         global pseudostack is shared, which uses less memory but is not safe for concurrent use. Defaults to `true`.
 
       - **buffer_memory** (*Optional*, string): Where to allocate the pseudostack buffer. One of `psram` or `internal`.
-        Defaults to `psram`.
+        Defaults to `psram` when available, otherwise `internal`.
 
       - **size** (*Optional*, integer): Size of the pseudostack buffer, in bytes. Must be between `60000` and
         `240000`. Defaults to `120000` (120 KB), which can safely decode all stereo Opus files. Increase this value

--- a/src/content/docs/components/audio.mdx
+++ b/src/content/docs/components/audio.mdx
@@ -35,20 +35,22 @@ audio:
 
 ## Configuration variables
 
-- **codecs** (*Optional*): A mapping that enables and configures individual audio codecs. Each codec key may be left
-  empty to enable the codec with default settings, or populated with the per-codec options described below.
+- **codecs** (*Optional*, mapping): A mapping that enables and configures individual audio codecs. Each codec key may
+  be left empty to enable the codec with default settings, or populated with the per-codec options described below.
 
-  - **flac** (*Optional*): Enable and configure the [FLAC](https://github.com/esphome-libs/micro-flac) decoder.
+  - **flac** (*Optional*, mapping): Enable and configure the [FLAC](https://github.com/esphome-libs/micro-flac)
+    decoder.
 
     - **buffer_memory** (*Optional*, string): Where to allocate the FLAC working buffer (typically 16–64 KB for stereo
       streams). One of `psram` or `internal`. Defaults to `psram` when available, otherwise `internal`.
 
-  - **mp3** (*Optional*): Enable and configure the [MP3](https://github.com/esphome-libs/micro-mp3) decoder.
+  - **mp3** (*Optional*, mapping): Enable and configure the [MP3](https://github.com/esphome-libs/micro-mp3) decoder.
 
     - **buffer_memory** (*Optional*, string): Where to allocate the MP3 decoder state buffers. One of `psram` or
       `internal`. Defaults to `psram` when available, otherwise `internal`.
 
-  - **opus** (*Optional*): Enable and configure the [Opus](https://github.com/esphome-libs/micro-opus) decoder.
+  - **opus** (*Optional*, mapping): Enable and configure the [Opus](https://github.com/esphome-libs/micro-opus)
+    decoder.
 
     - **floating_point** (*Optional*, boolean): Use the floating-point Opus implementation instead of the fixed-point
       one. Defaults to `true` on the ESP32-S3 (whose FPU is fast enough to benefit) and `false` on other targets,
@@ -58,8 +60,8 @@ audio:
       (roughly 30–50 KB per instance plus shared tables). One of `psram` or `internal`. Defaults to `psram` when
       available, otherwise `internal`.
 
-    - **pseudostack** (*Optional*): Configures the Opus pseudostack — a working-memory buffer used heavily for
-      temporary allocations during decode operations.
+    - **pseudostack** (*Optional*, mapping): Configures the Opus pseudostack — a working-memory buffer used heavily
+      for temporary allocations during decode operations.
 
       - **threadsafe** (*Optional*, boolean): When `true`, each FreeRTOS task that uses Opus gets its own pseudostack
         via pthread thread-local storage; safe for concurrent decoding from multiple tasks. When `false`, a single

--- a/src/content/docs/components/audio.mdx
+++ b/src/content/docs/components/audio.mdx
@@ -7,7 +7,7 @@ sidebar:
 
 import APIRef from '@components/APIRef.astro';
 
-This component only works on ESP32 based chips using the ESP-IDF framework.
+This component only works on ESP32 based chips.
 
 The `audio` component lets you explicitly enable audio codecs and tune advanced options for each codec library. By
 default, codecs are enabled automatically by other components that need them. For example, configuring a

--- a/src/content/docs/components/audio.mdx
+++ b/src/content/docs/components/audio.mdx
@@ -74,7 +74,7 @@ audio:
         `240000`. Defaults to `120000` (120 KB), which can safely decode all stereo Opus files. Increase this value
         if you encounter "pseudostack overflow" errors.
 
-  - **wav** (*Optional*): Enable WAV decoding. Has no additional options.
+  - **wav** (*Optional*, mapping): Enable WAV decoding. Has no additional options.
 
 ## Memory Placement Tips
 

--- a/src/content/docs/components/audio.mdx
+++ b/src/content/docs/components/audio.mdx
@@ -1,0 +1,116 @@
+---
+title: "Audio Codec Configuration"
+description: "Instructions for configuring audio codecs in ESPHome."
+sidebar:
+  label: "Audio"
+---
+
+import APIRef from '@components/APIRef.astro';
+
+This component only works on ESP32 based chips using the ESP-IDF framework.
+
+The `audio` component lets you explicitly enable audio codecs and tune advanced options for each codec library. By
+default, codecs are enabled automatically by other components that need them. For example, configuring a
+[Speaker Media Player](/components/media_player/speaker/) with FLAC as the preferred format, or embedding an Opus
+[Audio File](/components/audio_file/). Most users do not need to configure this component at all.
+
+Use this component when you want to:
+
+- Build firmware with support for additional codecs that are not pulled in automatically.
+- Override the default memory placement of decoder buffers to reduce stutter at the start of playback or to free up
+  internal RAM.
+- Tune Opus-specific options such as the floating-point implementation or the pseudostack size.
+
+Enabling codecs through this component is **additive**: it cannot disable a codec that another component requires.
+
+```yaml
+# Example configuration entry
+audio:
+  codecs:
+    flac:
+    mp3:
+    opus:
+    wav:
+```
+
+## Configuration Variables
+
+- **codecs** (*Optional*): A mapping that enables and configures individual audio codecs. Each codec key may be left
+  empty to enable the codec with default settings, or populated with the per-codec options described below.
+
+  - **flac** (*Optional*): Enable and configure the [FLAC](https://github.com/esphome-libs/micro-flac) decoder.
+
+    - **buffer_memory** (*Optional*, string): Where to allocate the FLAC working buffer (typically 16–64 KB for stereo
+      streams). One of `psram` or `internal`. Defaults to `psram`.
+
+  - **mp3** (*Optional*): Enable and configure the [MP3](https://github.com/esphome-libs/micro-mp3) decoder.
+
+    - **buffer_memory** (*Optional*, string): Where to allocate the MP3 decoder state buffers. One of `psram` or
+      `internal`. Defaults to `psram`.
+
+  - **opus** (*Optional*): Enable and configure the [Opus](https://github.com/esphome-libs/micro-opus) decoder.
+
+    - **floating_point** (*Optional*, boolean): Use the floating-point Opus implementation instead of the fixed-point
+      one. Defaults to `true` on the ESP32-S3 (whose FPU is fast enough to benefit) and `false` on other targets,
+      where fixed-point decoding is faster.
+
+    - **state_memory** (*Optional*, string): Where to allocate the Opus decoder state and other persistent buffers
+      (roughly 30–50 KB per instance plus shared tables). One of `psram` or `internal`. Defaults to `psram`.
+
+    - **pseudostack** (*Optional*): Configures the Opus pseudostack — a working-memory buffer used heavily for
+      temporary allocations during decode operations.
+
+      - **threadsafe** (*Optional*, boolean): When `true`, each FreeRTOS task that uses Opus gets its own pseudostack
+        via pthread thread-local storage; safe for concurrent decoding from multiple tasks. When `false`, a single
+        global pseudostack is shared, which uses less memory but is not safe for concurrent use. Defaults to `true`.
+
+      - **buffer_memory** (*Optional*, string): Where to allocate the pseudostack buffer. One of `psram` or `internal`.
+        Defaults to `psram`.
+
+      - **size** (*Optional*, integer): Size of the pseudostack buffer, in bytes. Must be between `60000` and
+        `240000`. Defaults to `120000` (120 KB), which can safely decode all stereo Opus files. Increase this value
+        if you encounter "pseudostack overflow" errors.
+
+  - **wav** (*Optional*): Enable WAV decoding. Has no additional options.
+
+## Memory Placement Tips
+
+The decoder libraries prefer allocating large buffers in PSRAM and fall back to internal RAM if PSRAM is unavailable.
+This is generally the best choice on the ESP32-S3, which has fast PSRAM and a large cache.
+
+On the original ESP32, PSRAM access is significantly slower. If you have internal memory to spare, switching
+`buffer_memory` (and, for Opus, the pseudostack `buffer_memory`) to `internal` can reduce stuttering at the start of
+playback and lower overall CPU usage.
+
+> [!TIP]
+> If playback is fine after the first second or two but starts with audible glitches, try moving the relevant decoder
+> buffer to `internal` memory.
+
+## Advanced Example
+
+```yaml
+audio:
+  codecs:
+    flac:
+      buffer_memory: internal
+    mp3:
+      buffer_memory: psram
+    opus:
+      floating_point: false
+      state_memory: psram
+      pseudostack:
+        threadsafe: false
+        buffer_memory: internal
+        size: 80000
+    wav:
+```
+
+## See Also
+
+- [Audio File](/components/audio_file/)
+- [Speaker Media Player](/components/media_player/speaker/)
+- [micro-flac](https://github.com/esphome-libs/micro-flac)
+- [micro-mp3](https://github.com/esphome-libs/micro-mp3)
+- [micro-opus](https://github.com/esphome-libs/micro-opus)
+- [micro-wav](https://github.com/esphome-libs/micro-wav)
+- <APIRef text="audio.h" path="esphome/components/audio/audio.h" />

--- a/src/content/docs/components/audio.mdx
+++ b/src/content/docs/components/audio.mdx
@@ -33,7 +33,7 @@ audio:
     wav:
 ```
 
-## Configuration Variables
+## Configuration variables
 
 - **codecs** (*Optional*): A mapping that enables and configures individual audio codecs. Each codec key may be left
   empty to enable the codec with default settings, or populated with the per-codec options described below.

--- a/src/content/docs/components/index.mdx
+++ b/src/content/docs/components/index.mdx
@@ -1115,6 +1115,7 @@ ESPHome to cellular networks. **Does not encompass Wi-Fi.**
 ## Miscellaneous Components
 
 <ImgTable items={[
+  ["Audio", "/components/audio/", "music.svg", "dark-invert"],
   ["Audio File", "/components/audio_file/", "file-document-box.svg", "dark-invert"],
   ["Camera Encoder", "/components/camera/camera_encoder/", "camera.svg", "dark-invert"],
   ["ESP32 Camera", "/components/esp32_camera/", "camera.svg", "dark-invert"],

--- a/src/content/docs/components/media_player/speaker.mdx
+++ b/src/content/docs/components/media_player/speaker.mdx
@@ -35,7 +35,7 @@ media_player:
 - **announcement_pipeline** (**Required**, Pipeline Schema): Configuration settings for the announcement pipeline.
 
   - **speaker** (**Required**, [ID](/guides/configuration-types#id)): The [speaker](/components/speaker/) to output the audio.
-  - **format** (*Optional*, enum): The audio format Home Assistant will transcode audio to before sending it to the device. One of `FLAC`, `MP3`, `OPUS`, `WAV`, or `NONE`. `NONE` disables transcoding in Home Assistant; ESPHome will then compile support for all supported codecs (`FLAC`, `MP3`, `OPUS`, and `WAV`), which increases firmware size. Defaults to `FLAC`.
+  - **format** (*Optional*, enum): The audio format Home Assistant will transcode audio to before sending it to the device. One of `FLAC`, `MP3`, `OPUS`, `WAV`, or `NONE`. `NONE` disables transcoding in Home Assistant; ESPHome will then compile support for all supported codecs (`FLAC`, `MP3`, `OPUS`, and `WAV`), which increases firmware size. Use the [Audio](/components/audio/) component to enable additional codecs. Defaults to `FLAC`.
   - **sample_rate** (*Optional*, positive integer): Sample rate for the transcoded audio. Should be supported by the configured `speaker` component. Defaults to the speaker's sample rate. The `OPUS` codec only supports a `48000` sample rate.
   - **num_channels** (*Optional*, positive integer): Number of channels for the transcoded audio. Must be either `1` or `2`. Defaults to the speaker's number of channels.
 
@@ -183,6 +183,8 @@ In general, decoding FLAC has the lowest CPU usage, but requires a strong WiFi c
 
 Decoding OPUS is extremely CPU and memory intensive and may not even decode in real-time on an ESP32. It is only suitable for ESP32-S3 devices with PSRAM.
 
+If you experience stuttering at the start of playback, especially on the original ESP32, you can override where each decoder library allocates its working buffers using the [Audio](/components/audio/) component.
+
 Increasing the buffer size may reduce stuttering, but do not set it to the entire size of the external memory. Each pipeline allocates the configured amount, and this setting also does not take into account other smaller buffers allocated throughout the audio stack.
 
 Only set `task_stack_in_psram` to true if you have many components configured and your logs show that memory allocation failed. It is slower, especially if your PSRAM doesn't support `octal` mode.
@@ -205,6 +207,7 @@ If audio stutters, and your device has PSRAM, add ([Psram](/components/psram/) c
 
 ## See Also
 
+- [Audio](/components/audio/)
 - [Speaker Components](/components/speaker/)
 - [Mixer Speaker](/components/speaker/mixer/)
 - [Resampler Speaker](/components/speaker/resampler/)

--- a/src/content/docs/components/media_player/speaker.mdx
+++ b/src/content/docs/components/media_player/speaker.mdx
@@ -35,7 +35,7 @@ media_player:
 - **announcement_pipeline** (**Required**, Pipeline Schema): Configuration settings for the announcement pipeline.
 
   - **speaker** (**Required**, [ID](/guides/configuration-types#id)): The [speaker](/components/speaker/) to output the audio.
-  - **format** (*Optional*, enum): The audio format Home Assistant will transcode audio to before sending it to the device. One of `FLAC`, `MP3`, `OPUS`, `WAV`, or `NONE`. `NONE` disables transcoding in Home Assistant; ESPHome will then compile support for all supported codecs (`FLAC`, `MP3`, `OPUS`, and `WAV`), which increases firmware size. Use the [Audio](/components/audio/) component to enable additional codecs. Defaults to `FLAC`.
+  - **format** (*Optional*, enum): The audio format Home Assistant will transcode audio to before sending it to the device. One of `FLAC`, `MP3`, `OPUS`, `WAV`, or `NONE`. `NONE` disables transcoding in Home Assistant; ESPHome will then compile support for all supported codecs (`FLAC`, `MP3`, `OPUS`, and `WAV`), which increases firmware size. To compile in additional codecs without setting this to `NONE`, use the [Audio](/components/audio/) component. Defaults to `FLAC`.
   - **sample_rate** (*Optional*, positive integer): Sample rate for the transcoded audio. Should be supported by the configured `speaker` component. Defaults to the speaker's sample rate. The `OPUS` codec only supports a `48000` sample rate.
   - **num_channels** (*Optional*, positive integer): Number of channels for the transcoded audio. Must be either `1` or `2`. Defaults to the speaker's number of channels.
 

--- a/src/content/docs/components/media_player/speaker_source.mdx
+++ b/src/content/docs/components/media_player/speaker_source.mdx
@@ -42,7 +42,7 @@ media_player:
 
   - **speaker** (**Required**, [ID](/guides/configuration-types#id)): The [speaker](/components/speaker/) to output the audio.
   - **sources** (**Required**, list of [IDs](/guides/configuration-types#id)): A list of [media source](/components/media_source/) component IDs to use for this pipeline. At least one source is required. When a media URL is received, the pipeline finds the first source that can handle the URI prefix. Each source can only belong to one pipeline; if both pipelines need the same type of source, configure separate instances.
-  - **format** (*Optional*, enum): The audio format Home Assistant will transcode audio to before sending it to the device. One of `FLAC`, `MP3`, `OPUS`, `WAV`, or `NONE`. `NONE` disables transcoding in Home Assistant. Use the [Audio](/components/audio/) component to enable additional codecs. Defaults to `FLAC`.
+  - **format** (*Optional*, enum): The audio format Home Assistant will transcode audio to before sending it to the device. One of `FLAC`, `MP3`, `OPUS`, `WAV`, or `NONE`. `NONE` disables transcoding in Home Assistant; ESPHome will then compile support for all supported codecs (`FLAC`, `MP3`, `OPUS`, and `WAV`), which increases firmware size. To compile in additional codecs without setting this to `NONE`, use the [Audio](/components/audio/) component. Defaults to `FLAC`.
   - **sample_rate** (*Optional*, positive integer): Sample rate for the transcoded audio. Should be supported by the configured `speaker` component. Defaults to the speaker's sample rate. The `OPUS` codec only supports a `48000` sample rate.
   - **num_channels** (*Optional*, positive integer): Number of channels for the transcoded audio. Must be either `1` or `2`. Defaults to the speaker's number of channels.
 

--- a/src/content/docs/components/media_player/speaker_source.mdx
+++ b/src/content/docs/components/media_player/speaker_source.mdx
@@ -42,7 +42,7 @@ media_player:
 
   - **speaker** (**Required**, [ID](/guides/configuration-types#id)): The [speaker](/components/speaker/) to output the audio.
   - **sources** (**Required**, list of [IDs](/guides/configuration-types#id)): A list of [media source](/components/media_source/) component IDs to use for this pipeline. At least one source is required. When a media URL is received, the pipeline finds the first source that can handle the URI prefix. Each source can only belong to one pipeline; if both pipelines need the same type of source, configure separate instances.
-  - **format** (*Optional*, enum): The audio format Home Assistant will transcode audio to before sending it to the device. One of `FLAC`, `MP3`, `OPUS`, `WAV`, or `NONE`. `NONE` disables transcoding in Home Assistant. Defaults to `FLAC`.
+  - **format** (*Optional*, enum): The audio format Home Assistant will transcode audio to before sending it to the device. One of `FLAC`, `MP3`, `OPUS`, `WAV`, or `NONE`. `NONE` disables transcoding in Home Assistant. Use the [Audio](/components/audio/) component to enable additional codecs. Defaults to `FLAC`.
   - **sample_rate** (*Optional*, positive integer): Sample rate for the transcoded audio. Should be supported by the configured `speaker` component. Defaults to the speaker's sample rate. The `OPUS` codec only supports a `48000` sample rate.
   - **num_channels** (*Optional*, positive integer): Number of channels for the transcoded audio. Must be either `1` or `2`. Defaults to the speaker's number of channels.
 
@@ -145,6 +145,7 @@ When using the `media_player.play_media` action, the media URL is routed to the 
 
 ## See Also
 
+- [Audio](/components/audio/)
 - [Media Source Components](/components/media_source/)
 - [Audio File Media Source](/components/media_source/audio_file/)
 - [Speaker Components](/components/speaker/)


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Documents the ``audio`` component to enable specific codecs and to set advanced configuration options for the codec decoding libraries. 

Note that the defaults described in this document come from the individual librarys' Kconfig file default values. These are not set in the ESPHome component, so if a user doesn't configure an advanced option, then the library default is used.

**Related issue (if applicable):** not applicable

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#16166

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [x] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
