### PR TITLE
[sensor] Document 24 h cap on throttle_average period

### DIFF
--- a/src/content/docs/components/sensor/filter/throttle_average.mdx
+++ b/src/content/docs/components/sensor/filter/throttle_average.mdx
@@ -13,3 +13,7 @@ An average over the `specified time period`, potentially throttling incoming val
 For example a `throttle_average: 60s` will push out a value every 60 seconds, in case at least one sensor value is received within these 60 seconds.
 
 In comparison to the `throttle` filter, it won't discard any values. In comparison to the `sliding_window_moving_average` filter, it supports variable sensor reporting rates without influencing the filter reporting interval (except for the first edge case).
+
+:::note
+The `throttle_average` time period is capped at 24 hours. Configurations specifying a longer period will be rejected at validation time. Multi-day rolling averages are better served by other aggregation strategies (for example, computing the average in Home Assistant) since accumulating a single running sum over many days suffers from floating-point precision loss.
+:::

--- a/src/content/docs/components/sensor/filter/throttle_average.mdx
+++ b/src/content/docs/components/sensor/filter/throttle_average.mdx
@@ -14,6 +14,5 @@ For example a `throttle_average: 60s` will push out a value every 60 seconds, in
 
 In comparison to the `throttle` filter, it won't discard any values. In comparison to the `sliding_window_moving_average` filter, it supports variable sensor reporting rates without influencing the filter reporting interval (except for the first edge case).
 
-:::note
-The `throttle_average` time period is capped at 24 hours. Configurations specifying a longer period will be rejected at validation time. Multi-day rolling averages are better served by other aggregation strategies (for example, computing the average in Home Assistant) since accumulating a single running sum over many days suffers from floating-point precision loss.
-:::
+> [!NOTE]
+> The `throttle_average` time period is capped at 24 hours. Configurations specifying a longer period will be rejected at validation time. Multi-day rolling averages are better served by other aggregation strategies (for example, computing the average in Home Assistant) since accumulating a single running sum over many days suffers from floating-point precision loss.


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Adds a note to the `throttle_average` filter page documenting the 24 h cap on the time period, introduced in the matching code PR. Configurations specifying a longer period are now rejected at validation time.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#16169

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.