### PR TITLE
[sendspin] Document the new decode_memory option

### DIFF
--- a/src/content/docs/components/media_source/sendspin.mdx
+++ b/src/content/docs/components/media_source/sendspin.mdx
@@ -54,6 +54,8 @@ media_player:
 - **task_stack_in_psram** (*Optional*, boolean): If `true`, the FreeRTOS playback task stack is
   allocated in PSRAM instead of internal RAM. Requires the [psram](/components/psram/) component.
   Defaults to `false`.
+- **decode_memory** (*Optional*, string): Preferred location for the audio decoder's transfer
+  buffer. One of `psram` or `internal`. Allocating in `internal` can reduce playback stuttering at the start of a stream on devices with slower PSRAM at the cost of using more internal RAM. Has minimal benefit on the ESP32-S3. Defaults to `psram`.
 - All other options from [Media Source](/components/media_source/).
 
 > [!TIP]

--- a/src/content/docs/components/media_source/sendspin.mdx
+++ b/src/content/docs/components/media_source/sendspin.mdx
@@ -55,7 +55,9 @@ media_player:
   allocated in PSRAM instead of internal RAM. Requires the [psram](/components/psram/) component.
   Defaults to `false`.
 - **decode_memory** (*Optional*, string): Preferred location for the audio decoder's transfer
-  buffer. One of `psram` or `internal`. Allocating in `internal` can reduce playback stuttering at the start of a stream on devices with slower PSRAM at the cost of using more internal RAM. Has minimal benefit on the ESP32-S3. Defaults to `psram`.
+  buffer. One of `psram` or `internal`. Allocating in `internal` can reduce playback stuttering
+  at the start of a stream on devices with slower PSRAM at the cost of using more internal RAM.
+  Has minimal benefit on the ESP32-S3. Defaults to `psram`.
 - All other options from [Media Source](/components/media_source/).
 
 > [!TIP]


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Documents the new ``decoder_memory`` option in the Sendspin media source.

**Related issue (if applicable):** not applicable

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#16178

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
