### PR TITLE
[lvgl] Update line widget documentation

### DIFF
--- a/src/content/docs/components/lvgl/widgets.mdx
+++ b/src/content/docs/components/lvgl/widgets.mdx
@@ -1222,7 +1222,7 @@ but also more complex shapes like polygons or zig-zag lines.
 
 - **line_color** (*Optional*, [color](/components/lvgl#lvgl-color)): Color for the line.
 - **line_width** (*Optional*, int16): Set the width of the line in pixels.
-- **points** (**Required**, list): A list of `x, y` integer pairs for point coordinates (origin from top left of parent)
+- **points** (**Required**, list): A list of `x, y` pairs of point coordinates (origin from top left of parent)
 - **line_rounded** (*Optional*, boolean): Make the end points of the line rounded. `true` rounded, `false` perpendicular line ending.
 - **line_dash_gap** (*Optional*, int16): Set the width of the gap between the dashes in the line (in pixels).
 - **line_dash_width** (*Optional*, int16): Set the width of the dashes in the line (in pixels).
@@ -1246,6 +1246,8 @@ The points list may be defined with constants in the form `x, y` or as a list of
 ```yaml
 # Example widget:
 - line:
+    width: 100%
+    height: 100%
     points:
       - 5%, 5%
       - 70, 70

--- a/src/content/docs/components/lvgl/widgets.mdx
+++ b/src/content/docs/components/lvgl/widgets.mdx
@@ -1211,7 +1211,10 @@ Check out [A numeric input keypad](/cookbook/lvgl#lvgl-cookbook-keypad) in the C
 
 ### `line`
 
-The line widget is capable of drawing straight lines between a set of points.
+The line widget is capable of drawing straight lines between a set of points. Points are expressed in pixels or
+percentages relative to the top left corner of the widget. The line is drawn between the points in the order they
+are defined in the configuration. The line widget can be used to draw simple shapes like triangles or rectangles,
+but also more complex shapes like polygons or zig-zag lines.
 
 <Image src={lvglLineImg} layout="constrained" alt="" />
 
@@ -1225,7 +1228,10 @@ The line widget is capable of drawing straight lines between a set of points.
 - **line_dash_width** (*Optional*, int16): Set the width of the dashes in the line (in pixels).
 - Style options from [Style properties](/components/lvgl#lvgl-styling), all the typical background properties and line style properties.
 
-By default, the Line widget width and height dimensions are set to `SIZE_CONTENT`. This means it will automatically set its size to fit all the points. If the size is set explicitly, parts of the line may not be visible.
+By default, the Line widget width and height dimensions are set to `SIZE_CONTENT`, which means it will automatically set
+its size to fit all the points. If the size is set explicitly, parts of the line outside the widget's area will be clipped.
+Setting the size explicitly also allows you to use percentage values in the points list. Use of percentages without
+a set size will not draw anything useful.
 
 The points list may be defined with constants in the form `x, y` or as a list of dictionaries with `x` and `y` keys. The latter allows for more complex point definitions, such as using a lambda function to calculate the coordinates.
 
@@ -1241,7 +1247,7 @@ The points list may be defined with constants in the form `x, y` or as a list of
 # Example widget:
 - line:
     points:
-      - 5, 5
+      - 5%, 5%
       - 70, 70
       - 120, 10
       - x: !lambda return random_uint32() % 100;


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#16209

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
