### PR TITLE
[bluetooth_proxy] Update information about the nvs partition

### DIFF
--- a/src/content/docs/components/bluetooth_proxy.mdx
+++ b/src/content/docs/components/bluetooth_proxy.mdx
@@ -187,8 +187,10 @@ bluetooth_proxy:
 If you experience memory issues, consider the following:
 
 - **Framework:** The `esp-idf` framework is recommended over `arduino` as it uses less memory.
-  When switching frameworks, update the device with a serial cable as the partition table differs.
-  [OTA](/components/ota) updates will not change the partition table.
+- **NVS Partition Size:** If you last updated your ESP32 via serial before 2022.12.0 on `esp-idf`
+  or before 2026.4.0 on `arduino` it is recommended to update your partition table to increase the
+  NVS partition size. You can do this by updating the device with a serial cable once or through an
+  [OTA partition table update](/components/ota/esphome/#updating-the-partition-table-on-esp32).
 - **Web Server:** The [Web Server](/components/web_server) component uses additional RAM.
   Disabling it can help if you experience memory-related issues.
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description
- Remove the obsolete information that partition tables are different between arduino and esp-idf
- Add note about when a partition table update is needed and how to do it

https://deploy-preview-6571--esphome.netlify.app/components/bluetooth_proxy/#memory-issues

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#15780

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
