### PR TITLE
2026.4.4

### DIFF
--- a/data/version.yaml
+++ b/data/version.yaml
@@ -1,2 +1,2 @@
-release: 2026.4.3
+release: 2026.4.4
 version: '2026.4'

--- a/src/content/docs/changelog/2026.4.0.mdx
+++ b/src/content/docs/changelog/2026.4.0.mdx
@@ -570,6 +570,22 @@ For detailed migration guides and API documentation, see the [ESPHome Developers
 
 </details>
 
+## Release 2026.4.4 - May 5
+
+<details>
+<summary></summary>
+
+- [automation] Fix codegen type for component.resume update_interval [esphome#16069](https://github.com/esphome/esphome/pull/16069) by [@bharvey88](https://github.com/bharvey88)
+- [mcp23xxx_base] Reject unsupported interrupt_pin options (inverted, allow_other_uses) [esphome#16149](https://github.com/esphome/esphome/pull/16149) by [@bdraco](https://github.com/bdraco)
+- [core] Strip \\?\ prefix from sys.executable for PlatformIO subprocess [esphome#16158](https://github.com/esphome/esphome/pull/16158) by [@jesserockz](https://github.com/jesserockz)
+- [esp32] Replace 512B stack buffer in printf wraps with picolibc cookie FILE [esphome#16170](https://github.com/esphome/esphome/pull/16170) by [@bdraco](https://github.com/bdraco)
+- [lvgl] Clamp values for meter line indicators [esphome#16180](https://github.com/esphome/esphome/pull/16180) by [@clydebarrow](https://github.com/clydebarrow)
+- [esp32] Drop printf wrap on IDF 6.0+ (picolibc no longer needs it) [esphome#16189](https://github.com/esphome/esphome/pull/16189) by [@bdraco](https://github.com/bdraco)
+- [api] Fall back to owning types for service array args used after a delay [esphome#16140](https://github.com/esphome/esphome/pull/16140) by [@bdraco](https://github.com/bdraco)
+- [api] Use safe_print for log output and fix safe_print bytes-repr fallback [esphome#16160](https://github.com/esphome/esphome/pull/16160) by [@jesserockz](https://github.com/jesserockz)
+
+</details>
+
 ## Full list of changes
 
 ### New Features

--- a/src/content/docs/guides/supporters.mdx
+++ b/src/content/docs/guides/supporters.mdx
@@ -2015,6 +2015,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Sebastian Lövdahl (@slovdahl)](https://github.com/slovdahl)
 - [SmartbobAutomatyka (@SmartbobAutomatyka)](https://github.com/SmartbobAutomatyka)
 - [smarthome-10 (@smarthome-10)](https://github.com/smarthome-10)
+- [SmartHomeGuys (@SmartHomeGuys)](https://github.com/SmartHomeGuys)
 - [Smartpadza (@Smartpadza)](https://github.com/Smartpadza)
 - [smischny (@smischny)](https://github.com/smischny)
 - [Jacob Masen-Smith (@smithjacobj)](https://github.com/smithjacobj)
@@ -2173,6 +2174,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Tim Niemueller (@timn)](https://github.com/timn)
 - [Timothy (@TimoPtr)](https://github.com/TimoPtr)
 - [Tim P (@timpur)](https://github.com/timpur)
+- [Tim (@timr49)](https://github.com/timr49)
 - [Tim Savage (@timsavage)](https://github.com/timsavage)
 - [Tinkerfish (@tinkerfish)](https://github.com/tinkerfish)
 - [TJ Horner (@tjhorner)](https://github.com/tjhorner)
@@ -2384,4 +2386,4 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Christian Zufferey (@zuzu59)](https://github.com/zuzu59)
 - [Zynth-dev (@Zynth-dev)](https://github.com/Zynth-dev)
 
-*This page was last updated April 28, 2026.*
+*This page was last updated May 5, 2026.*


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- Bump postcss from 8.5.8 to 8.5.12 [docs#6539](https://github.com/esphome/esphome-docs/pull/6539)
- Bump jsdom from 29.0.1 to 29.1.0 [docs#6541](https://github.com/esphome/esphome-docs/pull/6541)
- Add Radio Frequency Proxy ready-made project [docs#6559](https://github.com/esphome/esphome-docs/pull/6559)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
