### PR TITLE
[senx5] Add actions for restart, measurement-RHT only and normal

### DIFF
--- a/src/content/docs/components/sensor/sen5x.mdx
+++ b/src/content/docs/components/sensor/sen5x.mdx
@@ -201,8 +201,67 @@ This [action](/automations/actions#all-actions) manually starts fan-cleaning.
 ```yaml
 on_...:
   then:
-    - sen5x.start_fan_autoclean: sen54
+    - sen5x.start_fan_autoclean: my_sen5x
 ```
+
+## Restart
+
+A restart reinitializes the device and resets internal states such as the automatic
+fan-cleaning interval.
+
+### `sen5x.start_restart` Action
+
+This [action](/automations/actions#all-actions) restarts the Sen5x sensor.
+
+```yaml
+on_...:
+  then:
+    - sen5x.start_restart: my_sen5x
+```
+
+## Measurement Modes
+
+### `sen5x.start_measurements` Action
+
+In this mode, all available measurements are active:
+
+* Particulate Matter (PM)
+* Temperature and Humidity
+* VOC (SEN54/SEN55)
+* NOx (SEN55)
+
+This is the default operating mode of the sensor.
+
+This [action](/automations/actions#all-actions) starts measurements in **normal mode**.
+
+```yaml
+on_...:
+  then:
+    - sen5x.start_measurements: my_sen5x
+```
+
+### `sen5x.start_measurements_rht_only` Action
+
+In this mode:
+
+* Only **temperature and humidity** measurements are active
+* The internal fan is **disabled**
+* No particulate matter (PM), VOC, or NOx measurements are performed
+
+This mode can be useful for:
+
+* Reducing noise (e.g., during nighttime)
+* Lowering power consumption
+* Applications where only climate data is required
+
+This [action](/automations/actions#all-actions) starts measurements in **RHT-only mode**.
+
+```yaml
+on_...:
+  then:
+    - sen5x.start_measurements_rht_only: my_sen5x
+```
+
 
 ## See Also
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Adds new actions to the sen5x component:

restart
start_measurements (normal mode)
start_measurements_rht_only (RHT-only mode)
This allows switching measurement modes at runtime via automations.

Use case:
During nighttime, the fan can be disabled by switching to RHT-only mode,
reducing noise and power consumption while still measuring temperature and humidity.

**Related issue (if applicable):** 

- N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#16257

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
