### PR TITLE
[lvgl] Document passing coordinates in triggers

### DIFF
--- a/src/content/docs/components/lvgl/widgets.mdx
+++ b/src/content/docs/components/lvgl/widgets.mdx
@@ -2248,9 +2248,12 @@ These triggers can be attached to any widget, but they will only be activated if
 - `on_all_events`: Will be triggered on any event sent to the widget - mostly useful for debugging.
 
 These triggers can be applied directly to any widget in the LVGL configuration.
-For the widgets having a value, the triggers return the current value in variable `x`; this variable may be used in lambdas defined within those triggers.
+For the widgets having a value, the triggers receive the current value in parameter `x`; this variable may be used in lambdas defined within those triggers.
 
-Each trigger also deliver an `event` parameter, which is a pointer to the LVGL C type `lv_event_t`.
+Triggers relating to a touch event (`on_press`, `on_release` and `on_pressing`) also receive the coordinates of the event
+in a parameter `point` of type `lv_point_t` (with members `x` and `y`), which may be used in lambdas defined within those triggers.
+
+Each trigger also receives an `event` parameter, which is a pointer to the LVGL C type `lv_event_t`.
 This may be used in lambdas defined within those triggers. Refer to the [LVGL documentation](https://docs.lvgl.io/9.5/common-widget-features/events.html) for more information.
 
 There are additional triggers for pages - each page may have an `on_load` and `on_unload` trigger. These will be called
@@ -2268,6 +2271,9 @@ when the page becomes active or inactive respectively.
 - slider:
     ...
     on_release:
+      - logger.log:
+          format: "Slider released at value: %d, coordinates: (%d, %d)"
+          args: [x, point.x, point.y]
       - light.turn_on:
           id: display_backlight
           transition_length: 0ms

--- a/src/content/docs/components/lvgl/widgets.mdx
+++ b/src/content/docs/components/lvgl/widgets.mdx
@@ -2248,13 +2248,18 @@ These triggers can be attached to any widget, but they will only be activated if
 - `on_all_events`: Will be triggered on any event sent to the widget - mostly useful for debugging.
 
 These triggers can be applied directly to any widget in the LVGL configuration.
-For the widgets having a value, the triggers receive the current value in parameter `x`; this variable may be used in lambdas defined within those triggers.
+Parameters passed to the triggers depend on the event type. These parameters may be used in lambdas defined within
+those triggers, includng text format arguments.
+
+For any widget that have a value, all its triggers receive the current widget value in parameter `x`;
+this value may be used in lambdas defined within those triggers.
+
+Any widget not having a value will receive a parameter `obj` which is a pointer to the LVGL C type `lv_obj_t` of the widget which received the event.
 
 Triggers relating to a touch event (`on_press`, `on_release` and `on_pressing`) also receive the coordinates of the event
-in a parameter `point` of type `lv_point_t` (with members `x` and `y`), which may be used in lambdas defined within those triggers.
+in a parameter `point` of type `lv_point_t` (with members `x` and `y`).
 
-Each trigger also receives an `event` parameter, which is a pointer to the LVGL C type `lv_event_t`.
-This may be used in lambdas defined within those triggers. Refer to the [LVGL documentation](https://docs.lvgl.io/9.5/common-widget-features/events.html) for more information.
+Finally each trigger receives an `event` parameter, which is a pointer to the LVGL C type `lv_event_t`.
 
 There are additional triggers for pages - each page may have an `on_load` and `on_unload` trigger. These will be called
 when the page becomes active or inactive respectively.

--- a/src/content/docs/components/lvgl/widgets.mdx
+++ b/src/content/docs/components/lvgl/widgets.mdx
@@ -2251,8 +2251,7 @@ These triggers can be applied directly to any widget in the LVGL configuration.
 Parameters passed to the triggers depend on the event type. These parameters may be used in lambdas defined within
 those triggers, includng text format arguments.
 
-For any widget that have a value, all its triggers receive the current widget value in parameter `x`;
-this value may be used in lambdas defined within those triggers.
+For any widget that have a value, all its triggers receive the current widget value in parameter `x` (a `float`).
 
 Any widget not having a value will receive a parameter `obj` which is a pointer to the LVGL C type `lv_obj_t` of the widget which received the event.
 
@@ -2277,7 +2276,7 @@ when the page becomes active or inactive respectively.
     ...
     on_release:
       - logger.log:
-          format: "Slider released at value: %d, coordinates: (%d, %d)"
+          format: "Slider released at value: %.0f, coordinates: (%d, %d)"
           args: [x, point.x, point.y]
       - light.turn_on:
           id: display_backlight


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#16272

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
