### PR TITLE
2026.4.5

### DIFF
--- a/data/version.yaml
+++ b/data/version.yaml
@@ -1,2 +1,2 @@
-release: 2026.4.4
+release: 2026.4.5
 version: '2026.4'

--- a/src/content/docs/changelog/2026.4.0.mdx
+++ b/src/content/docs/changelog/2026.4.0.mdx
@@ -586,6 +586,19 @@ For detailed migration guides and API documentation, see the [ESPHome Developers
 
 </details>
 
+## Release 2026.4.5 - May 7
+
+<details>
+<summary></summary>
+
+- [ha-addon] Add opt-in toggle for the new ESPHome Device Builder [esphome#16247](https://github.com/esphome/esphome/pull/16247) by [@jesserockz](https://github.com/jesserockz)
+- [bundle] Include secrets.yaml when `!secret` keys are quoted [esphome#16271](https://github.com/esphome/esphome/pull/16271) by [@bdraco](https://github.com/bdraco)
+- [substitutions] Fix sibling references inside dict-valued substitutions [esphome#16273](https://github.com/esphome/esphome/pull/16273) by [@bdraco](https://github.com/bdraco)
+- [core] Fix WiFi connection in safe mode [esphome#16269](https://github.com/esphome/esphome/pull/16269) by [@Mat931](https://github.com/Mat931)
+- [nextion] Fix text sensor state not updated on string response [esphome#16280](https://github.com/esphome/esphome/pull/16280) by [@edwardtfn](https://github.com/edwardtfn)
+
+</details>
+
 ## Full list of changes
 
 ### New Features

--- a/src/content/docs/guides/supporters.mdx
+++ b/src/content/docs/guides/supporters.mdx
@@ -2386,4 +2386,4 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Christian Zufferey (@zuzu59)](https://github.com/zuzu59)
 - [Zynth-dev (@Zynth-dev)](https://github.com/Zynth-dev)
 
-*This page was last updated May 5, 2026.*
+*This page was last updated May 7, 2026.*


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- Fix formatting issue in servo.mdx documentation [docs#6496](https://github.com/esphome/esphome-docs/pull/6496)
- Update micro_wake_word.mdx [docs#6450](https://github.com/esphome/esphome-docs/pull/6450)
- Bump jsdom from 29.1.0 to 29.1.1 [docs#6561](https://github.com/esphome/esphome-docs/pull/6561)
- Removed wrong Wikipedia link (S0 Interface ) in power_meter.mdx [docs#6557](https://github.com/esphome/esphome-docs/pull/6557)
- Bump astro from 6.1.9 to 6.2.2 [docs#6573](https://github.com/esphome/esphome-docs/pull/6573)
- Bump @astrojs/starlight from 0.38.2 to 0.38.5 [docs#6576](https://github.com/esphome/esphome-docs/pull/6576)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
