### PR TITLE
[ota] Add bootloader update functionality to ota component

### DIFF
--- a/src/content/docs/components/ota/esphome.mdx
+++ b/src/content/docs/components/ota/esphome.mdx
@@ -120,6 +120,31 @@ esphome upload --partition-table --file partitions.bin name-of-your-config.yaml
 > [!CAUTION]
 > When [converting a Tasmota ESP32 device to ESPHome](/guides/migrate_sonoff_tasmota), it is required to add `allow_partition_access: true` on the first ESPHome firmware you upload to the device. Regular OTA updates will not work until the partition table update is completed.
 
+## Updating the bootloader on ESP32
+
+On the ESP32 it is possible to update the bootloader with an OTA update. This feature can be used on devices that can't be flashed via serial and have an old bootloader which does not support OTA rollbacks and SRAM1 as IRAM. Before you can update the bootloader you need to add the option `allow_partition_access: true` to the config and install it to your device.
+
+```yaml
+ota:
+  - platform: esphome
+    allow_partition_access: true
+```
+
+> [!CAUTION]
+> There is a risk of bricking the device if the power is interrupted or the ESP is reset during a bootloader update, requiring serial flashing to repair it. Make sure you have a stable power supply. The update is usually completed within less than 15 seconds after running the `esphome upload` command.
+
+Open the ESPHome logs for detailed information about potential errors. To perform the bootloader update you can run the following command:
+
+```
+esphome upload --bootloader name-of-your-config.yaml
+```
+
+To upload a specific bootloader binary, you can run the command below.
+
+```
+esphome upload --bootloader --file bootloader.bin name-of-your-config.yaml
+```
+
 ## See Also
 
 - [Over-the-Air Updates](/components/ota/)

--- a/src/content/docs/components/ota/esphome.mdx
+++ b/src/content/docs/components/ota/esphome.mdx
@@ -122,7 +122,7 @@ esphome upload --partition-table --file partitions.bin name-of-your-config.yaml
 
 ## Updating the bootloader on ESP32
 
-On the ESP32 it is possible to update the bootloader with an OTA update. This feature can be used on devices that can't be flashed via serial and have an old bootloader which does not support OTA rollbacks and SRAM1 as IRAM. Before you can update the bootloader you need to add the option `allow_partition_access: true` to the config and install it to your device.
+On the ESP32 it is possible to replace the second-stage bootloader with an OTA update. This is most useful for devices that can't be flashed via serial and need a newer bootloader, for example to enable OTA rollback, SRAM1-as-IRAM, or to pick up bootloader changes from a newer ESP-IDF release. Before you can update the bootloader you need to add the option `allow_partition_access: true` to the config and install it to your device.
 
 ```yaml
 ota:
@@ -131,7 +131,7 @@ ota:
 ```
 
 > [!CAUTION]
-> There is a risk of bricking the device if the power is interrupted or the ESP is reset during a bootloader update, requiring serial flashing to repair it. Make sure you have a stable power supply. The update is usually completed within less than 15 seconds after running the `esphome upload` command.
+> There is a risk of bricking the device if the power is interrupted or the ESP is reset while the new bootloader is being copied to flash, requiring serial flashing to repair it. The danger window is short — only the few seconds between the `Starting bootloader update` and `Successfully installed the new bootloader` messages in the device's logs — but make sure you have a stable power supply during the upload, and have a USB cable handy in case recovery is needed.
 
 Open the ESPHome logs for detailed information about potential errors. To perform the bootloader update you can run the following command:
 
@@ -139,11 +139,16 @@ Open the ESPHome logs for detailed information about potential errors. To perfor
 esphome upload --bootloader name-of-your-config.yaml
 ```
 
-To upload a specific bootloader binary, you can run the command below.
+This uses the bootloader image produced by the most recent compile of your ESPHome configuration (`build/bootloader/bootloader.bin` for native ESP-IDF, `.pioenvs/<name>/bootloader.bin` for PlatformIO builds).
+
+To upload a different bootloader binary, for example one extracted from a separate ESP-IDF build tree, you can run:
 
 ```
 esphome upload --bootloader --file bootloader.bin name-of-your-config.yaml
 ```
+
+> [!NOTE]
+> After a successful bootloader update the device will **not** auto-reboot. The currently running app — loaded by the previous bootloader — keeps running so you can verify the device is healthy before committing to the new bootloader. The new bootloader takes effect on the next reboot. If the new bootloader fails to boot, the only recovery path is a serial flash, so reboot manually while physically present with a USB cable available.
 
 ## See Also
 

--- a/src/content/docs/components/ota/esphome.mdx
+++ b/src/content/docs/components/ota/esphome.mdx
@@ -131,7 +131,7 @@ ota:
 ```
 
 > [!CAUTION]
-> There is a risk of bricking the device if the power is interrupted or the ESP is reset during the bootloader update, requiring serial flashing to repair it. Make sure you have a stable power supply, and be ready to reflash via USB if it fails.
+> There is a risk of soft-bricking the device if the power is interrupted or the ESP is reset during the bootloader update, requiring serial flashing to recover it. Make sure you have a stable power supply, and be ready to reflash via USB if it fails.
 
 Open the ESPHome logs for detailed information about potential errors. To perform the bootloader update, run:
 

--- a/src/content/docs/components/ota/esphome.mdx
+++ b/src/content/docs/components/ota/esphome.mdx
@@ -27,7 +27,7 @@ ota:
 ## Configuration variables
 
 - **password** (*Optional*, string): The password to use for updates.
-- **allow_partition_access** (*Optional*, boolean): Only on `esp32`. Allow updating more partition types. Currently only used for updating the partition table. Defaults to `false`.
+- **allow_partition_access** (*Optional*, boolean): Only on `esp32`. Allow updating more partition types. Used for updating the partition table and the bootloader. Defaults to `false`.
 
 > [!IMPORTANT]
 > Always use strong, unique passwords for OTA updates. See the [Security Best Practices](/guides/security_best_practices#3-ota-password-protection) guide for more information.
@@ -122,7 +122,7 @@ esphome upload --partition-table --file partitions.bin name-of-your-config.yaml
 
 ## Updating the bootloader on ESP32
 
-On the ESP32 it is possible to replace the second-stage bootloader with an OTA update. This is most useful for devices that can't be flashed via serial and need a newer bootloader, for example to enable OTA rollback, SRAM1-as-IRAM, or to pick up bootloader changes from a newer ESP-IDF release. Before you can update the bootloader you need to add the option `allow_partition_access: true` to the config and install it to your device.
+On the ESP32 it is possible to update the bootloader with an OTA update. This is useful on devices that can't be flashed via serial and need a newer bootloader, for example to enable OTA rollback or SRAM1 as IRAM. Before you can update the bootloader you need to add the option `allow_partition_access: true` to the config and install it to your device.
 
 ```yaml
 ota:
@@ -131,24 +131,21 @@ ota:
 ```
 
 > [!CAUTION]
-> There is a risk of bricking the device if the power is interrupted or the ESP is reset while the new bootloader is being copied to flash, requiring serial flashing to repair it. The danger window is short — only the few seconds between the `Starting bootloader update` and `Successfully installed the new bootloader` messages in the device's logs — but make sure you have a stable power supply during the upload, and have a USB cable handy in case recovery is needed.
+> There is a risk of bricking the device if the power is interrupted or the ESP is reset during the bootloader update, requiring serial flashing to repair it. Make sure you have a stable power supply, and be ready to reflash via USB if it fails.
 
-Open the ESPHome logs for detailed information about potential errors. To perform the bootloader update you can run the following command:
+Open the ESPHome logs for detailed information about potential errors. To perform the bootloader update, run:
 
 ```
 esphome upload --bootloader name-of-your-config.yaml
 ```
 
-This uses the bootloader image produced by the most recent compile of your ESPHome configuration (`build/bootloader/bootloader.bin` for native ESP-IDF, `.pioenvs/<name>/bootloader.bin` for PlatformIO builds).
+Without `--file`, the bootloader image from the most recent compile is used (`build/bootloader/bootloader.bin` for native ESP-IDF, or `.pioenvs/<name>/bootloader.bin` for PlatformIO).
 
-To upload a different bootloader binary, for example one extracted from a separate ESP-IDF build tree, you can run:
+To upload a custom bootloader binary, run:
 
 ```
 esphome upload --bootloader --file bootloader.bin name-of-your-config.yaml
 ```
-
-> [!NOTE]
-> After a successful bootloader update the device will **not** auto-reboot. The currently running app — loaded by the previous bootloader — keeps running so you can verify the device is healthy before committing to the new bootloader. The new bootloader takes effect on the next reboot. If the new bootloader fails to boot, the only recovery path is a serial flash, so reboot manually while physically present with a USB cable available.
 
 ## See Also
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

https://deploy-preview-6580--esphome.netlify.app/components/ota/esphome/#updating-the-bootloader-on-esp32

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#16238

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
