### PR TITLE
[host][ota] Document host platform OTA support

### DIFF
--- a/src/content/docs/components/host.mdx
+++ b/src/content/docs/components/host.mdx
@@ -44,6 +44,11 @@ supervisor (`systemd`, a wrapper script, etc.) sees the same process continuing 
 This is primarily intended for development, integration testing, and CI; the same code path that runs on real
 microcontrollers can be exercised end-to-end without flashing hardware.
 
+> [!CAUTION]
+> The OTA endpoint can overwrite the running executable. Set an
+> [OTA password](/components/ota/esphome/#configuration-variables) and either bind the host to a trusted
+> interface only or restrict port `8082` with a firewall rule.
+
 ## See Also
 
 - [SDL display](/components/display/sdl#sdl)

--- a/src/content/docs/components/host.mdx
+++ b/src/content/docs/components/host.mdx
@@ -33,8 +33,20 @@ host:
 
 The `esphome run yourfile.yaml` command will compile and automatically run the build file on the `host` platform.
 
+## Over-the-Air Updates
+
+The host platform supports [OTA updates](/components/ota/esphome/) via the `esphome` OTA platform on port `8082` (by
+default). When an OTA upload completes successfully, the new binary is validated (matching ELF on Linux or thin Mach-O
+on macOS, with the same architecture as the running executable), atomically renamed over the running binary's path,
+and the process replaces itself with the new image via `execv()`. The PID is preserved across the swap, so any
+supervisor (`systemd`, a wrapper script, etc.) sees the same process continuing to run.
+
+This is primarily intended for development, integration testing, and CI; the same code path that runs on real
+microcontrollers can be exercised end-to-end without flashing hardware.
+
 ## See Also
 
 - [SDL display](/components/display/sdl#sdl)
 - [ESPHome Core Configuration](/components/esphome/)
 - [Host Time Source](/components/time/host/)
+- [ESPHome OTA Updates](/components/ota/esphome/)

--- a/src/content/docs/components/ota/esphome.mdx
+++ b/src/content/docs/components/ota/esphome.mdx
@@ -38,6 +38,7 @@ ota:
   - `8266` for the ESP8266
   - `2040` for the RP2040
   - `8892` for Beken chips
+  - `8082` for the [host platform](/components/host/)
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID used for code generation.
 - **version** (*Optional*, int): Version of OTA protocol to use. Version 2 is more stable. To downgrade to legacy
    ESPHome, the device should be updated with OTA version 1 first. Defaults to `2`.


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Documents the new host platform OTA support added in esphome/esphome#16304.

The host platform now has a working `esphome` OTA backend (replaces the previous error-returning stub). After a successful OTA upload the new binary is validated against the running executable's format/architecture (ELF on Linux, thin Mach-O on macOS), atomically renamed over `argv[0]`, and the process replaces itself via `execv()`. PID is preserved across the swap.

This is primarily intended to enable end-to-end integration testing of OTA changes (the highest-risk regression surface in ESPHome) without requiring real hardware. A working host OTA also lets developers exercise the full OTA path locally.

### Doc changes

- `components/ota/esphome.mdx` — adds `8082` as the default port for the host platform.
- `components/host.mdx` — adds a brief "Over-the-Air Updates" section describing the validation and re-exec behavior, with cross-link to the esphome OTA platform docs.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#16304

## Checklist

- [x] I am merging into \`next\` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into \`current\` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in \`/src/content/docs/components/index.mdx\` when creating new documents for new components or cookbook.