### PR TITLE
[lvgl] Document `on_update` trigger and new `trigger` option

### DIFF
--- a/src/content/docs/components/lvgl/widgets.mdx
+++ b/src/content/docs/components/lvgl/widgets.mdx
@@ -1850,9 +1850,9 @@ The tabs are indexed (zero-based) in the order they appear in the configuration 
 
 **Triggers:**
 
-- `on_value` [trigger](/automations/actions#actions-trigger) is activated when the tab value changes, either by user interaction or programmatically. The new value is returned in the variable `x`.
-- `on_change` [trigger](/automations/actions#actions-trigger) is activated when the tab value is changed by user interaction. The new value is returned in the variable `x`.
-- `on_update` [trigger](/automations/actions#actions-trigger) is activated when the tab is changed programmatically (e.g. via `lvgl.tabview.select`). The new value is returned in the variable `x`.
+- `on_value` [trigger](/automations/actions#actions-trigger) is activated when the tab value changes, either by user interaction or programmatically. The id of the new tab is returned in the variable `tab`.
+- `on_change` [trigger](/automations/actions#actions-trigger) is activated when the tab value is changed by user interaction. The id of the new tab is returned in the variable `tab`.
+- `on_update` [trigger](/automations/actions#actions-trigger) is activated when the tab is changed programmatically (e.g. via `lvgl.tabview.select`). The id of the new tab is returned in the variable `tab`.
 - [interaction](#lvgl-automation-triggers) LVGL event triggers.
 
 **Example:**

--- a/src/content/docs/components/lvgl/widgets.mdx
+++ b/src/content/docs/components/lvgl/widgets.mdx
@@ -356,6 +356,7 @@ By default the whole area of the widget is interactive. If the `adv_hittest` [fl
 
 - `on_value` [trigger](/automations/actions#actions-trigger) is activated when the arc value changes, either by user interaction or programmatically. The new value is returned in the variable `x`.
 - `on_change` [trigger](/automations/actions#actions-trigger) is activated when the arc value is changed by user interaction. The new value is returned in the variable `x`.
+- `on_update` [trigger](/automations/actions#actions-trigger) is activated when the arc value is changed programmatically (e.g. via `lvgl.arc.update`). The new value is returned in the variable `x`.
 - [interaction](#lvgl-automation-triggers) LVGL event triggers which also return the value in `x`.
 
 **Example:**
@@ -478,6 +479,7 @@ A notable state is `checked` (boolean) which can have different styles applied.
 
 - `on_change` [trigger](/automations/actions#actions-trigger) is activated after clicking. If `checkable` is `true`, the boolean variable `x`, representing the checked state, may be used by lambdas within this trigger.
 - `on_value` [trigger](/automations/actions#actions-trigger) is activated when the checked value changes, either by user interaction or programmatically. The new value is returned in the variable `x`.
+- `on_update` [trigger](/automations/actions#actions-trigger) is activated when the checked value is changed programmatically (e.g. via `lvgl.widget.update`). The new value is returned in the variable `x`.
 - [interaction](#lvgl-automation-triggers) LVGL event triggers.
 
 **Example:**
@@ -829,6 +831,7 @@ The checkbox widget is made internally from a *tick box* and a label. When the c
 
 - `on_change` [trigger](/automations/actions#actions-trigger) is activated when interactively toggling the checkbox. The boolean variable `x`, representing the checkbox's state, may be used by lambdas within this trigger.
 - `on_value` [trigger](/automations/actions#actions-trigger) is activated when the checkbox is toggled, either by user interaction or programmatically. The new value is returned in the variable `x`.
+- `on_update` [trigger](/automations/actions#actions-trigger) is activated when the checkbox is toggled programmatically (e.g. via `lvgl.checkbox.update`). The new value is returned in the variable `x`.
 - [interaction](#lvgl-automation-triggers) LVGL event triggers which also return the value in `x`.
 
 **Example:**
@@ -926,6 +929,7 @@ The Dropdown widget is built internally from a *button* part and a *list* part (
 
 - `on_change` [trigger](/automations/actions#actions-trigger) is activated only when the user selects an item from the list. The new selected index is returned in the variable `x`. The [interaction](#lvgl-automation-triggers) LVGL event triggers also apply, and they also return the selected index in `x`.
 - `on_value` [trigger](/automations/actions#actions-trigger) is activated the selection changes, either by user interaction or programmatically. The new value is returned in the variable `x`.
+- `on_update` [trigger](/automations/actions#actions-trigger) is activated when the selection is changed programmatically (e.g. via `lvgl.dropdown.update`). The new value is returned in the variable `x`.
 - `on_cancel` [trigger](/automations/actions#actions-trigger) is also activated when you close the dropdown without selecting an item from the list. The currently selected index is returned in the variable `x`.
 - [interaction](#lvgl-automation-triggers) LVGL event triggers which also return the value in `x`.
 
@@ -1538,6 +1542,7 @@ Roller allows you to simply select one option from a list by scrolling.
 
 - `on_change` [trigger](/automations/actions#actions-trigger) is activated only when the user selects an item from the list. The new selected index is returned in the variable `x`. The [interaction](#lvgl-automation-triggers) LVGL event triggers also apply, and they also return the selected index in `x`.
 - `on_value` [trigger](/automations/actions#actions-trigger) is activated the selection changes, either by user interaction or programmatically. The new value is returned in the variable `x`.
+- `on_update` [trigger](/automations/actions#actions-trigger) is activated when the selection is changed programmatically (e.g. via `lvgl.roller.update`). The new value is returned in the variable `x`.
 - [interaction](#lvgl-automation-triggers) LVGL event triggers which also return the selected index in `x`.
 
 **Example:**
@@ -1606,6 +1611,7 @@ If your slider is narrow, you can use `ext_click_area` styling property to incre
 
 - `on_value` [trigger](/automations/actions#actions-trigger) is activated when the slider value changes, either by user interaction or programmatically. The new value is returned in the variable `x`.
 - `on_change` [trigger](/automations/actions#actions-trigger) is activated when the slider value is changed by user interaction. The new value is returned in the variable `x`.
+- `on_update` [trigger](/automations/actions#actions-trigger) is activated when the slider value is changed programmatically (e.g. via `lvgl.slider.update`). The new value is returned in the variable `x`.
 - [interaction](#lvgl-automation-triggers) LVGL event triggers which also return the value in `x`.
 
 **Example:**
@@ -1682,6 +1688,7 @@ The spinbox contains a numeric value (as text) which can be increased or decreas
 **Triggers:**
 
 - `on_value` [trigger](/automations/actions#actions-trigger) is activated when the spinbox value changes, either by user interaction or programmatically. The new value is returned in the variable `x`.
+- `on_update` [trigger](/automations/actions#actions-trigger) is activated when the spinbox value is changed programmatically (e.g. via `lvgl.spinbox.update`). The new value is returned in the variable `x`.
 - [interaction](#lvgl-automation-triggers) LVGL event triggers which also return the value in `x`.
 
 **Example:**
@@ -1788,6 +1795,7 @@ The switch looks like a little slider and can be used to turn something on and o
 
 - `on_value` [trigger](/automations/actions#actions-trigger) is activated when the switch value changes, either by user interaction or programmatically. The new value is returned in the variable `x`.
 - `on_change` [trigger](/automations/actions#actions-trigger) is activated when the switch value is changed by user interaction. The new value is returned in the variable `x`.
+- `on_update` [trigger](/automations/actions#actions-trigger) is activated when the switch value is changed programmatically (e.g. via `lvgl.widget.update`). The new value is returned in the variable `x`.
 - [interaction](#lvgl-automation-triggers) LVGL event triggers which also return the value in `x`.
 
 **Example:**
@@ -1844,6 +1852,7 @@ The tabs are indexed (zero-based) in the order they appear in the configuration 
 
 - `on_value` [trigger](/automations/actions#actions-trigger) is activated when the tab value changes, either by user interaction or programmatically. The new value is returned in the variable `x`.
 - `on_change` [trigger](/automations/actions#actions-trigger) is activated when the tab value is changed by user interaction. The new value is returned in the variable `x`.
+- `on_update` [trigger](/automations/actions#actions-trigger) is activated when the tab is changed programmatically (e.g. via `lvgl.tabview.select`). The new value is returned in the variable `x`.
 - [interaction](#lvgl-automation-triggers) LVGL event triggers.
 
 **Example:**
@@ -1914,6 +1923,7 @@ The textarea is an extended label widget which displays a cursor and allows the 
 **Triggers:**
 
 - `on_value` [trigger](/automations/actions#actions-trigger) is activated on every keystroke.
+- `on_update` [trigger](/automations/actions#actions-trigger) is activated when the text is changed programmatically (e.g. via `lvgl.textarea.update`).
 - `on_ready` [trigger](/automations/actions#actions-trigger) is activated when `one_line` is configured as `true` and the newline character is received (Enter/Ready key on the keyboard).
 - [interaction](#lvgl-automation-triggers) LVGL event triggers.
 
@@ -1978,6 +1988,7 @@ If the tileview is screen sized, the user interface resembles what you may have 
 **Triggers:**
 
 - `on_value` [trigger](/automations/actions#actions-trigger) is activated when displayed tile changes. The new value is returned in the variable `tile` as the ID of the now-visible tile.
+- `on_update` [trigger](/automations/actions#actions-trigger) is activated when the tile is changed programmatically (e.g. via `lvgl.tileview.select`). The new value is returned in the variable `tile`.
 - [interaction](#lvgl-automation-triggers) LVGL event triggers.
 
 **Example:**
@@ -2221,6 +2232,7 @@ These triggers can be attached to any widget, but they will only be activated if
 ### Special events
 
 - `on_change`: The widget's value has changed (i.e. slider moved).
+- `on_update`: The widget's value has been changed programmatically (e.g. via an `lvgl.*.update` action). Only available for widgets that have a value.
 - `on_insert`: Text has been inserted into the widget.
 - `on_refresh`: Notify the widget to refresh something.
 - `on_ready`: A process has finished.

--- a/src/content/docs/components/number/lvgl.mdx
+++ b/src/content/docs/components/number/lvgl.mdx
@@ -12,7 +12,12 @@ Supported widgets are [`arc`](/components/lvgl/widgets#lvgl-widget-arc), [`bar`]
 
 - **widget** (**Required**): The ID of a supported widget configured in LVGL, which will reflect the state of the number.
 - **animated** (*Optional*, boolean): Whether to set the value of the widget with an animation (if supported by the widget). Defaults to `true`.
-- **update_on_release** (*Optional*, boolean): By default the number will publish a new value each time the value of the associated widget changes. If this option is `true` then the value will only be published when touch is released.
+- **trigger** (*Optional*, string): Specifies which events will cause the number to be updated with the widget's value. One of `on_change`, `on_update`, `on_value`, `on_release`. Defaults to `on_value`.
+  - `on_change`: Update only when the user interacts with the widget.
+  - `on_update`: Update only when the value is changed programmatically (e.g. via an `lvgl.*.update` action).
+  - `on_value`: Update on both user interaction and programmatic changes.
+  - `on_release`: Update only when the user releases the widget after interaction.
+- **update_on_release** (*Optional*, boolean): **Deprecated** — use `trigger: on_release` instead.
 - **restore_value**: (*Optional*, bool) Restore the value of the number from non-volatile memory when the device is restarted. Defaults to `false`.
 - All other variables from [Number](/components/number#config-number).
 
@@ -23,10 +28,11 @@ number:
   - platform: lvgl
     widget: slider_id
     name: LVGL Slider
+    trigger: on_release
 ```
 
 > [!NOTE]
-> Widget-specific actions (`lvgl.arc.update`, `lvgl.bar.update`, `lvgl.slider.update`, `lvgl.spinbox.update`, `lvgl.spinbox.decrement`, `lvgl.spinbox.increment`  ) will trigger correspponding component updates to be sent to Home Assistant.
+> Widget-specific actions (`lvgl.arc.update`, `lvgl.bar.update`, `lvgl.slider.update`, `lvgl.spinbox.update`, `lvgl.spinbox.decrement`, `lvgl.spinbox.increment`  ) will trigger corresponding component updates to be sent to Home Assistant.
 
 ## See Also
 

--- a/src/content/docs/components/number/lvgl.mdx
+++ b/src/content/docs/components/number/lvgl.mdx
@@ -32,7 +32,8 @@ number:
 ```
 
 > [!NOTE]
-> Widget-specific actions (`lvgl.arc.update`, `lvgl.bar.update`, `lvgl.slider.update`, `lvgl.spinbox.update`, `lvgl.spinbox.decrement`, `lvgl.spinbox.increment`  ) will trigger corresponding component updates to be sent to Home Assistant.
+> Widget-specific actions (`lvgl.arc.update`, `lvgl.bar.update`, `lvgl.slider.update`, `lvgl.spinbox.update`, `lvgl.spinbox.decrement`, `lvgl.spinbox.increment`  )
+> will trigger corresponding component updates to be sent to Home Assistant if the `trigger` is set to `on_value` (the default) or `on_update`.
 
 ## See Also
 

--- a/src/content/docs/components/sensor/lvgl.mdx
+++ b/src/content/docs/components/sensor/lvgl.mdx
@@ -28,7 +28,8 @@ sensor:
 ```
 
 > [!NOTE]
-> Widget-specific actions (`lvgl.arc.update`, `lvgl.bar.update`, `lvgl.slider.update`, `lvgl.spinbox.update`, `lvgl.spinbox.decrement`, `lvgl.spinbox.increment`  ) will trigger corresponding component updates to be sent to Home Assistant.
+> Widget-specific actions (`lvgl.arc.update`, `lvgl.bar.update`, `lvgl.slider.update`, `lvgl.spinbox.update`, `lvgl.spinbox.decrement`, `lvgl.spinbox.increment`  )
+> will trigger corresponding component updates to be sent to Home Assistant if the `trigger` is set to `on_value` (the default) or `on_update`.
 
 ## See Also
 

--- a/src/content/docs/components/sensor/lvgl.mdx
+++ b/src/content/docs/components/sensor/lvgl.mdx
@@ -11,6 +11,11 @@ Supported widgets are [`arc`](/components/lvgl/widgets#lvgl-widget-arc), [`bar`]
 ## Configuration variables
 
 - **widget** (**Required**): The ID of a supported widget configured in LVGL, which will reflect the state of the sensor.
+- **trigger** (*Optional*, string): Specifies which events will cause the sensor to be updated with the widget's value. One of `on_change`, `on_update`, `on_value`, `on_release`. Defaults to `on_value`.
+  - `on_change`: Update only when the user interacts with the widget.
+  - `on_update`: Update only when the value is changed programmatically (e.g. via an `lvgl.*.update` action).
+  - `on_value`: Update on both user interaction and programmatic changes.
+  - `on_release`: Update only when the user releases the widget after interaction.
 - All other variables from [Sensor](/components/sensor).
 
 Example:


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Documents `on_update` trigger, and `trigger` option for LVGL numbers and sensors.


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#16312

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
