### PR TITLE
Add Indoor air quality monitor project to DIY guide

### DIFF
--- a/src/content/docs/guides/diy.mdx
+++ b/src/content/docs/guides/diy.mdx
@@ -139,4 +139,5 @@ unless it's truly exceptional, etc.
 - [ESPHome IKEA VINDRIKTNING](https://github.com/DzurisHome/ESPHome-IKEA-VINDRIKTNING) by [@DzurisHome](https://github.com/DzurisHome)
 - [ESPHome Refoss P11](https://github.com/DzurisHome/ESPHome-Refoss-P11) by [@DzurisHome](https://github.com/DzurisHome)
 - [ESPHome Tethercell Battery](https://github.com/w00dst0ck/esphome-tethercell) by [@w00dst0ck](https://github.com/w00dst0ck)
+- [Indoor air quality monitor (CO2, PM, VOC, NOx, temp/humidity, light)](https://github.com/Verstreubulator/aq-monitor) by [@Verstreubulator](https://github.com/Verstreubulator)
 {/* markdownlint-enable MD013 */}


### PR DESCRIPTION
Adding a project to the Sample Configurations section of the DIY guide.

The project is an ESPHome-based indoor air quality monitor for Home Assistant - covers CO2, PM, VOC, NOx, temp/humidity, and ambient light. Repo: https://github.com/Verstreubulator/aq-monitor

This is a documentation-only addition (one bullet appended to the existing list), so I have removed the unrelated PR template sections. There is no related issue and no matching PR in the esphome repo.