### PR TITLE
[safe_mode] Allow recovering soft-bricked devices via reboot to recovery partition

### DIFF
--- a/src/content/docs/components/safe_mode.mdx
+++ b/src/content/docs/components/safe_mode.mdx
@@ -59,6 +59,17 @@ on_...:
     - safe_mode.mark_successful
 ```
 
+## Rebooting to the recovery app on ESP32
+
+If safe_mode detects that OTA updates are impossible because of the partition layout on the device,
+the message `OTA updates are impossible` will appear in the config section of the logs, followed by the suggested next step.
+
+In case a valid recovery app is found but OTA is impossible with the current app, invoking safe mode will automatically reboot to it.
+Depending on the recovery app's features this can allow you to install an OTA update and recover your soft-bricked device.
+The recovery app can for example be a previous version of ESPHome or the Tasmota safeboot app. It is recommended to
+[update the partition table](/components/ota/esphome/#updating-the-partition-table-on-esp32) while recovering your device
+to make future OTA updates possible.
+
 ## See Also
 
 - [Safe Mode Button](/components/button/safe_mode/)


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description
https://deploy-preview-6596--esphome.netlify.app/components/safe_mode/#rebooting-to-the-recovery-app-on-esp32

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#16339

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
