### PR TITLE
[guides] Document `esphome upload --prebuilt-dir`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3096,9 +3096,9 @@
       "license": "MIT"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
-      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "funding": [
         {
           "type": "github",
@@ -3107,7 +3107,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "path-expression-matcher": "^1.1.3"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
       }
     },
     "node_modules/fast-xml-parser": {
@@ -6963,6 +6964,21 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/xmlchars": {

--- a/src/content/docs/guides/cli.mdx
+++ b/src/content/docs/guides/cli.mdx
@@ -165,6 +165,21 @@ basis, or set with this option at the time of uploading.
 : Specify the host port to use for legacy Over the Air uploads.
 
 
+**`--prebuilt-dir PATH`**
+: Advanced flag for the ESPHome dashboard's transparent install flow.
+Points the upload helpers at a directory of prebuilt artifacts shipped
+from a paired build server, instead of re-deriving paths from the local
+build tree. End users running `esphome upload` from a shell should not
+need this flag; build the device locally and let `esphome upload`
+resolve artifacts on its own. The dashboard uses it so a remote Install
+button works on a machine that doesn't compile firmware itself.
+
+Files are looked up by canonical basename inside `<PATH>` (`firmware.bin`,
+`firmware.uf2`, `bootloader.bin`, `partitions.bin`, `idedata.json`,
+`app_update.bin`); which files are required depends on the target platform
+and upload path.
+
+
 ### `clean-mqtt` Command
 
 The `esphome clean-mqtt <CONFIG>` cleans retained MQTT discovery messages from the MQTT broker.


### PR DESCRIPTION
## Description

Document the new `--prebuilt-dir PATH` flag on `esphome upload`. Frames it as
dashboard-internal advanced usage so end users running `esphome upload` from a
shell don't try to assemble a prebuilt directory by hand. The flag exists for
the dashboard's transparent install flow on a machine that doesn't compile
firmware itself.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#16348

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.