### PR TITLE
[voice_assistant] Document second microphone option

### DIFF
--- a/src/content/docs/components/voice_assistant.mdx
+++ b/src/content/docs/components/voice_assistant.mdx
@@ -28,12 +28,10 @@ voice_assistant:
 
 ## Configuration variables
 
-- **microphone** (*Optional*, [Microphone Source Configuration](/components/microphone#config-microphone-source)): The
-  [microphone](/components/microphone/) settings to use for input.
-
-- **microphone2** (*Optional*, [Microphone Source Configuration](/components/microphone#config-microphone-source)): An
-  optional second [microphone](/components/microphone/) source carrying less-processed audio. When configured, audio from
-  both sources is streamed to Home Assistant. See [Second microphone channel](#second-microphone-channel) below.
+- **microphone** (*Optional*, [Microphone Source Configuration](/components/microphone#config-microphone-source) or list
+  of them): The [microphone](/components/microphone/) settings to use for input. A single source may be provided
+  directly, or up to two sources may be provided as a list. When two sources are configured, audio from both is streamed
+  to Home Assistant; see [Second microphone channel](#second-microphone-channel) below.
 
 - **micro_wake_word** (*Optional*, [ID](/guides/configuration-types#id)): The [micro_wake_word](/components/micro_wake_word/)
   component used for wake word detection. Configuring this allows Home Assistant to change which wake word model is enabled.
@@ -175,20 +173,19 @@ Returns true if the voice assistant is currently connected to Home Assistant.
 
 ## Second microphone channel
 
-A second microphone source may be provided via `microphone2`. When it's configured, audio from both `microphone` and
-`microphone2` is streamed to Home Assistant. The idea is that `microphone` carries the more-processed audio (gain, noise
-suppression, etc.) while `microphone2` carries less-processed audio; Home Assistant can then use whichever channel works
-best for each stage of the voice pipeline.
+A second microphone source may be provided by passing a list of two sources to `microphone`. When two are configured,
+audio from both is streamed to Home Assistant. The first source carries the more-processed audio (gain,
+noise suppression, etc.) while the second carries less-processed audio. Home Assistant uses whichever channel
+works best for each stage of the voice pipeline.
 
 ```yaml
 voice_assistant:
   id: va
   microphone:
-    microphone: i2s_mics
-    channels: 0
-  microphone2:
-    microphone: i2s_mics
-    channels: 1
+    - microphone: i2s_mics
+      channels: 0
+    - microphone: i2s_mics
+      channels: 1
 ```
 
 > [!NOTE]

--- a/src/content/docs/components/voice_assistant.mdx
+++ b/src/content/docs/components/voice_assistant.mdx
@@ -31,6 +31,10 @@ voice_assistant:
 - **microphone** (*Optional*, [Microphone Source Configuration](/components/microphone#config-microphone-source)): The
   [microphone](/components/microphone/) settings to use for input.
 
+- **microphone2** (*Optional*, [Microphone Source Configuration](/components/microphone#config-microphone-source)): An
+  optional second [microphone](/components/microphone/) source carrying less-processed audio. When configured, audio from
+  both sources is streamed to Home Assistant. See [Second microphone channel](#second-microphone-channel) below.
+
 - **micro_wake_word** (*Optional*, [ID](/guides/configuration-types#id)): The [micro_wake_word](/components/micro_wake_word/)
   component used for wake word detection. Configuring this allows Home Assistant to change which wake word model is enabled.
 
@@ -168,6 +172,28 @@ Returns true if the voice assistant is currently running.
 ### `voice_assistant.connected` Condition
 
 Returns true if the voice assistant is currently connected to Home Assistant.
+
+## Second microphone channel
+
+A second microphone source may be provided via `microphone2`. When it's configured, audio from both `microphone` and
+`microphone2` is streamed to Home Assistant. The idea is that `microphone` carries the more-processed audio (gain, noise
+suppression, etc.) while `microphone2` carries less-processed audio; Home Assistant can then use whichever channel works
+best for each stage of the voice pipeline.
+
+```yaml
+voice_assistant:
+  id: va
+  microphone:
+    microphone: i2s_mics
+    channels: 0
+  microphone2:
+    microphone: i2s_mics
+    channels: 1
+```
+
+> [!NOTE]
+> Both microphone sources must use the same audio format that's required for `microphone` (16 kHz, 16 bits per sample,
+> mono). Home Assistant 2026.6.0 or later is required to make use of the second channel; older versions simply ignore it.
 
 ## Wake word detection
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Documents the second microphone option for sending less processed audio to HA.

**Related issue (if applicable):** not applicable

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#16265

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
