### PR TITLE
[sdl] Document `centered_on_display`

### DIFF
--- a/src/content/docs/components/display/sdl.mdx
+++ b/src/content/docs/components/display/sdl.mdx
@@ -39,9 +39,11 @@ display:
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID used for code generation.
 - **window_options** (*Optional*): Options that affect how the display renders on the host system. All default to false, except position, which defaults to SDL's undefined position
 
-  - **position** (*Optional*):
+  - **position** (*Optional*): May not be used with `centered_on_display`.
     - **x** (**Required**, int): X position of the display window in pixels
     - **y** (**Required**, int): Y position of the display window in pixels
+  - **centered_on_display** (*Optional*, int): For use with multiple display screens.
+    Center the window on the specified display number. Display numbering starts at 0. May not be used with `position`.
   - **borderless** (*Optional*, boolean): Whether to draw the display window with or without borders
   - **always_on_top** (*Optional*, boolean): Whether to always draw the display window above other windows or not
   - **fullscreen** (*Optional*, boolean): Whether to draw the display window in fullscreen or not. This may resize the resolution of the host display to match the SDL display dimensions

--- a/src/content/docs/components/display/sdl.mdx
+++ b/src/content/docs/components/display/sdl.mdx
@@ -39,11 +39,12 @@ display:
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID used for code generation.
 - **window_options** (*Optional*): Options that affect how the display renders on the host system. All default to false, except position, which defaults to SDL's undefined position
 
-  - **position** (*Optional*): May not be used with `centered_on_display`.
-    - **x** (**Required**, int): X position of the display window in pixels
-    - **y** (**Required**, int): Y position of the display window in pixels
-  - **centered_on_display** (*Optional*, int): For use with multiple display screens.
-    Center the window on the specified display number. Display numbering starts at 0. May not be used with `position`.
+  - **position** (*Optional*): Specify the position of the display window on the host system.
+    If not specified, SDL will choose a default position. Either `x` and `y` or `centered_on_display` may be used, but not together.
+    - **x** (*Optional*, int): X position of the display window in pixels
+    - **y** (*Optional*, int): Y position of the display window in pixels
+    - **centered_on_display** (*Optional*, int): For use with multiple display screens.
+      Centers the window on the specified display number. Display numbering starts at 0. May not be used with `x` or `y`.
   - **borderless** (*Optional*, boolean): Whether to draw the display window with or without borders
   - **always_on_top** (*Optional*, boolean): Whether to always draw the display window above other windows or not
   - **fullscreen** (*Optional*, boolean): Whether to draw the display window in fullscreen or not. This may resize the resolution of the host display to match the SDL display dimensions
@@ -52,21 +53,20 @@ display:
 
 > [!NOTE]
 > To build with this display you must have the
-> [SDL2](https://wiki.libsdl.org/SDL2/Installation) package installed. The Sodium encryption library will
-> also be required for any API calls. See below for installation hints.
+> [SDL2](https://wiki.libsdl.org/SDL2/Installation) package installed.
 
 ## MacOS SDL2 Installation
 
 The easiest way to install SDL2 on MacOS is using `homebrew`  :
 
 ```sh
-brew install sdl2 libsodium
+brew install sdl2
 ```
 
 It may also be necessary to run the command:
 
 ```sh
-brew link sdl2 libsodium
+brew link sdl2
 ```
 
 To ensure that the files are symlinked correctly.
@@ -80,7 +80,7 @@ On Debian/Ubuntu derived Linux systems you can install with `apt`  ; also check 
 tools installed, and you must be using a desktop system with a graphic display.
 
 ```sh
-apt install libsdl2-dev libsodium-dev build-essential git
+apt install libsdl2-dev build-essential git
 ```
 
 You can check installation with the command `sdl2-config --libs --cflags`.


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#16363

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
