### PR TITLE
Clarify spdif_mode and S/PDIF format descriptions

### DIFF
--- a/src/content/docs/components/speaker/i2s_audio.mdx
+++ b/src/content/docs/components/speaker/i2s_audio.mdx
@@ -52,12 +52,12 @@ speaker:
 
 - **buffer_duration** (*Optional*, [Time](/guides/configuration-types#time)): The duration of the internal ring buffer. Larger values can reduce stuttering but uses more memory. Defaults to `500ms`.
 - **timeout** (*Optional*, [Time](/guides/configuration-types#time)): How long to wait after finishing playback before releasing the bus. Set to `never` to never stop the speaker due to a timeout. Defaults to `500ms`. **Note:** With `spdif_mode: true` (see below), buffer underflows are filled with silence frames until the specified interval elapses; this maintains the SPDIF signal to prevent the receiver from detecting a loss of signal/source change, which may otherwise lengthen gaps of silence.
-- **spdif_mode** (*Optional*, boolean): Enable SPDIF (Sony/Philips Digital Interface Format) mode for digital audio output. When enabled, the speaker outputs a SPDIF-encoded bitstream suitable for optical (TOSLINK) or coaxial digital audio transmission. Defaults to `false`.
+- **spdif_mode** (*Optional*, boolean): Enable S/PDIF (Sony/Philips Digital Interface) mode for digital audio output. When enabled, the speaker outputs a SPDIF-encoded bitstream format suitable for optical (TOSLINK optical fiber connector) or coaxial digital audio transmission. Defaults to `false`.
 - All other options from [Speaker Component](/components/speaker#config-speaker).
 
 ## SPDIF Mode
 
-SPDIF (Sony/Philips Digital Interface Format) mode enables digital audio transmission over optical (TOSLINK) or coaxial connections. This mode encodes PCM audio data into a SPDIF bitstream that can be received by soundbars, A/V receivers, DACs, and other digital audio equipment.
+SPDIF mode enables S/PDIF (Sony/Philips Digital Interface) digital audio transmission over optical (TOSLINK) or coaxial digital audio connections. This mode encodes PCM audio data format into a SPDIF bitstream that can be received by soundbars, A/V receivers, DACs, and other digital audio equipment.
 
 ### Hardware Setup
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Updated the description of spdif_mode and  S/PDIF format for clarity. 

OCD-nitpicking but the fact is that while the mode is called "SPDIF mode" in ESPHome code, that format and specification is called "S/PDIF" written with an hyphen between Sony and Philips because it is an abriviation of "Sony/Philips Digital Interface". 

* https://en.wikipedia.org/wiki/S/PDIF

Regardless is can be a good idea to write it both ways in the documentaton to make it easier to find when searching 

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
