### PR TITLE
[ir_rf_proxy] Document on_control trigger and CC1101 integration pattern

### DIFF
--- a/src/content/docs/components/ir_rf_proxy.mdx
+++ b/src/content/docs/components/ir_rf_proxy.mdx
@@ -189,12 +189,11 @@ radio_frequency:
 
 The triggers used above:
 
-- [`remote_transmitter.on_transmit`](/components/remote_transmitter#on_transmit-trigger) — fires before each
-  transmission. Call [`cc1101.begin_tx`](/components/cc1101#cc1101begin_tx-action) here to put the chip into TX
-  state.
-- [`remote_transmitter.on_complete`](/components/remote_transmitter#on_complete-trigger) — fires after a
-  transmission finishes. Call [`cc1101.begin_rx`](/components/cc1101#cc1101begin_rx-action) here to return the
-  chip to RX state (idle listening).
+- `on_transmit` on [`remote_transmitter`](/components/remote_transmitter) — fires before each transmission. Call
+  [`cc1101.begin_tx`](/components/cc1101#cc1101begin_tx-action) here to put the chip into TX state.
+- `on_complete` on [`remote_transmitter`](/components/remote_transmitter) — fires after a transmission finishes.
+  Call [`cc1101.begin_rx`](/components/cc1101#cc1101begin_rx-action) here to return the chip to RX state (idle
+  listening).
 - `on_control` on the `radio_frequency` entity — fires when a transmit request arrives, before the underlying
   transmission begins. The call object (`x`) exposes `get_frequency()`, `get_modulation()`, and
   `get_repeat_count()` — use this trigger for per-call adjustments such as retuning the chip to the requested

--- a/src/content/docs/components/ir_rf_proxy.mdx
+++ b/src/content/docs/components/ir_rf_proxy.mdx
@@ -138,6 +138,83 @@ radio_frequency:
 > `100%`. RF hardware handles its own modulation; applying a carrier duty cycle would corrupt the signal. A validation
 > error will occur if `carrier_duty_percent` is set to any other value.
 
+### Using a CC1101 (or other RF front-end)
+
+To use a programmable RF chip like the [CC1101](/components/cc1101) with the radio frequency platform, wire its
+state-control actions to `remote_transmitter`'s `on_transmit` / `on_complete` triggers. The example below shows
+the recommended dual-pin configuration (CC1101 GDO0 → `remote_transmitter`, CC1101 GDO2 → `remote_receiver`).
+For single-pin variants, see the [CC1101 docs](/components/cc1101#integration-with-remote-receivertransmitter)
+(open-drain on ESP32, auto-switching on ESP8266) — the pin configuration changes, but the trigger wiring shown
+here is the same.
+
+```yaml
+spi:
+  clk_pin: GPIOXX
+  mosi_pin: GPIOXX
+  miso_pin: GPIOXX
+
+cc1101:
+  id: cc1101_radio
+  cs_pin: GPIOXX
+  frequency: 433.92MHz
+  modulation_type: ASK/OOK
+  output_power: 10
+
+# CC1101 GDO0 (Module Pin 3) wired to GPIOXX
+remote_transmitter:
+  id: rf_tx
+  pin: GPIOXX
+  carrier_duty_percent: 100%
+  on_transmit:
+    then:
+      - cc1101.begin_tx: cc1101_radio
+  on_complete:
+    then:
+      - cc1101.begin_rx: cc1101_radio
+
+# CC1101 GDO2 (Module Pin 8) wired to GPIOXX
+remote_receiver:
+  id: rf_rx
+  pin: GPIOXX
+
+radio_frequency:
+  - platform: ir_rf_proxy
+    name: 433.92MHz Transmitter
+    frequency: 433.92MHz
+    remote_transmitter_id: rf_tx
+    # Optional: retune the CC1101 when an API request specifies a different
+    # carrier frequency.  `x` is the radio_frequency call object.
+    on_control:
+      then:
+        - if:
+            condition:
+              lambda: "return x.get_frequency().has_value() && *x.get_frequency() > 0;"
+            then:
+              - cc1101.set_frequency:
+                  id: cc1101_radio
+                  value: !lambda "return *x.get_frequency();"
+  - platform: ir_rf_proxy
+    name: 433.92MHz Receiver
+    frequency: 433.92MHz
+    remote_receiver_id: rf_rx
+```
+
+The triggers used above:
+
+- [`remote_transmitter.on_transmit`](/components/remote_transmitter#on_transmit-trigger) — fires before each
+  transmission. Call [`cc1101.begin_tx`](/components/cc1101#cc1101begin_tx-action) here to put the chip into TX
+  state.
+- [`remote_transmitter.on_complete`](/components/remote_transmitter#on_complete-trigger) — fires after a
+  transmission finishes. Call [`cc1101.begin_rx`](/components/cc1101#cc1101begin_rx-action) here to return the
+  chip to RX state (idle listening).
+- `on_control` on the `radio_frequency` entity — fires when a transmit request arrives, before the underlying
+  transmission begins. The call object (`x`) exposes `get_frequency()`, `get_modulation()`, and
+  `get_repeat_count()` — use this trigger for per-call adjustments such as retuning the chip to the requested
+  carrier frequency.
+
+The same wiring pattern applies to other RF front-ends (SX127x, custom external components) — substitute
+the chip's equivalent state-change actions for `cc1101.begin_tx` / `cc1101.begin_rx`.
+
 ## How It Works
 
 The IR/RF proxy component creates API-accessible entities that can be controlled from Home Assistant or other API

--- a/src/content/docs/components/ir_rf_proxy.mdx
+++ b/src/content/docs/components/ir_rf_proxy.mdx
@@ -143,24 +143,12 @@ radio_frequency:
 To use a programmable RF chip like the [CC1101](/components/cc1101) with the radio frequency platform, wire its
 state-control actions to `remote_transmitter`'s `on_transmit` / `on_complete` triggers. The example below shows
 the recommended dual-pin configuration (CC1101 GDO0 → `remote_transmitter`, CC1101 GDO2 → `remote_receiver`).
-For single-pin variants, see the [CC1101 docs](/components/cc1101#integration-with-remote-receivertransmitter)
-(open-drain on ESP32, auto-switching on ESP8266) — the pin configuration changes, but the trigger wiring shown
-here is the same.
+For single-pin variants or for more detail, see the
+[CC1101 docs](/components/cc1101#integration-with-remote-receivertransmitter) (open-drain on ESP32,
+auto-switching on ESP8266) — the pin configuration changes, but the trigger wiring shown here is the same.
 
 ```yaml
-spi:
-  clk_pin: GPIOXX
-  mosi_pin: GPIOXX
-  miso_pin: GPIOXX
-
-cc1101:
-  id: cc1101_radio
-  cs_pin: GPIOXX
-  frequency: 433.92MHz
-  modulation_type: ASK/OOK
-  output_power: 10
-
-# CC1101 GDO0 (Module Pin 3) wired to GPIOXX
+# CC1101 GDO0 wired to one GPIO pin
 remote_transmitter:
   id: rf_tx
   pin: GPIOXX
@@ -172,14 +160,14 @@ remote_transmitter:
     then:
       - cc1101.begin_rx: cc1101_radio
 
-# CC1101 GDO2 (Module Pin 8) wired to GPIOXX
+# CC1101 GDO2 wired to a second GPIO pin
 remote_receiver:
   id: rf_rx
   pin: GPIOXX
 
 radio_frequency:
   - platform: ir_rf_proxy
-    name: 433.92MHz Transmitter
+    name: RF Proxy Transmitter
     frequency: 433.92MHz
     remote_transmitter_id: rf_tx
     # Optional: retune the CC1101 when an API request specifies a different
@@ -194,7 +182,7 @@ radio_frequency:
                   id: cc1101_radio
                   value: !lambda "return *x.get_frequency();"
   - platform: ir_rf_proxy
-    name: 433.92MHz Receiver
+    name: RF Proxy Receiver
     frequency: 433.92MHz
     remote_receiver_id: rf_rx
 ```


### PR DESCRIPTION
## Description

Adds a "Using a CC1101 (or other RF front-end)" section to the `ir_rf_proxy` docs showing how to wire a programmable RF chip via `remote_transmitter`'s `on_transmit` / `on_complete` triggers and the new `on_control` trigger on the `radio_frequency` entity.

The example uses the recommended dual-pin CC1101 wiring and demonstrates retuning the chip per-transmit via `on_control` and `cc1101.set_frequency`. Points users at the CC1101 docs for single-pin variants (open-drain on ESP32, auto-switching on ESP8266) — the trigger wiring shown here applies the same way.

**Related issue (if applicable):** n/a

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#16368

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.