### PR TITLE
[logger] Clarify esp8266_store_log_strings_in_flash option

### DIFF
--- a/src/content/docs/components/logger.mdx
+++ b/src/content/docs/components/logger.mdx
@@ -52,8 +52,15 @@ Advanced settings:
 - **hardware_uart** (*Optional*, string): The Hardware UART to use for logging. The default varies depending on
    the specific processor/chip and framework you are using. See the [table below](#logger-default_hardware_interfaces).
 
-- **esp8266_store_log_strings_in_flash** (*Optional*, boolean): If set to false, disables storing
-   log strings in the flash section of the device (uses more memory). Defaults to true.
+- **esp8266_store_log_strings_in_flash** (*Optional*, boolean): **ESP8266 only.** Compile-time
+   setting that controls where log format strings are placed in the firmware image. When `true`
+   (the default), log format strings are kept in flash (via `PROGMEM`) and read on demand. When
+   `false`, they are copied into RAM at boot, which uses significantly more of the ESP8266's
+   limited RAM but avoids the small flash-read cost each time a log message is formatted.
+   Defaults to `true`, and it is almost always the right choice to leave it that way: this
+   setting does not affect runtime log output or log levels, only the storage location of the
+   string data. There is no flash-wear concern because program flash is only written during
+   OTA updates, not at runtime.
 
 - **on_message** (*Optional*, [Automation](/automations)): An action to be
    performed when a message is to be logged. The variables `int level`, `const char* tag` and

--- a/src/content/docs/components/logger.mdx
+++ b/src/content/docs/components/logger.mdx
@@ -53,14 +53,11 @@ Advanced settings:
    the specific processor/chip and framework you are using. See the [table below](#logger-default_hardware_interfaces).
 
 - **esp8266_store_log_strings_in_flash** (*Optional*, boolean): **ESP8266 only.** Compile-time
-   setting that controls where log format strings are placed in the firmware image. When `true`
-   (the default), log format strings are kept in flash (via `PROGMEM`) and read on demand. When
-   `false`, they are copied into RAM at boot, which uses significantly more of the ESP8266's
-   limited RAM but avoids the small flash-read cost each time a log message is formatted.
-   Defaults to `true`, and it is almost always the right choice to leave it that way: this
-   setting does not affect runtime log output or log levels, only the storage location of the
-   string data. There is no flash-wear concern because program flash is only written during
-   OTA updates, not at runtime.
+   setting for where log format strings live. When `true` (default), they stay in flash via
+   `PROGMEM`; when `false`, they are copied into RAM, which uses significantly more of the
+   ESP8266's limited RAM. Does not affect runtime log output or levels, and there is no
+   flash-wear concern (program flash is only written during OTA). Leave at the default unless
+   you have a specific reason not to.
 
 - **on_message** (*Optional*, [Automation](/automations)): An action to be
    performed when a message is to be logged. The variables `int level`, `const char* tag` and


### PR DESCRIPTION
## Description

Expand the description of the `esp8266_store_log_strings_in_flash` option to address a recurring misunderstanding: it is a compile-time setting that controls where log format string *data* lives in the firmware image (flash via `PROGMEM` vs. RAM), not a runtime toggle for log output or log levels.

The previous one-sentence description ("If set to false, disables storing log strings in the flash section of the device (uses more memory). Defaults to true.") led at least one user to believe this was a runtime log-output setting and to disable it on ~20 ESP8266 devices in production, motivated by an incorrect concern about flash wear (see esphome/esphome#16373 discussion). The expanded text now:

- States explicitly that it is ESP8266-only and compile-time.
- Explains what each value actually does and the cost (RAM use vs. small flash-read cost per log format).
- Notes that the default is almost always the right choice on the RAM-constrained ESP8266.
- Clarifies there is no flash-wear concern, because program flash is only written during OTA, not at runtime.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- N/A

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.