### PR TITLE
[uart] Document clock_source option

### DIFF
--- a/src/content/docs/components/uart.mdx
+++ b/src/content/docs/components/uart.mdx
@@ -74,8 +74,18 @@ uart:
 - **data_bits** (*Optional*, int): The number of data bits used on the UART bus. Options: 5 to 8. Defaults to 8.
 - **parity** (*Optional*): The parity used on the UART bus. Options: `NONE`, `EVEN`, `ODD`. Defaults to `NONE`.
 - **stop_bits** (*Optional*, int): The number of stop bits to send. Options: 1, 2. Defaults to 1.
+- **clock_source** (*Optional*): ESP32 only. The clock source driving the UART peripheral. Options: `DEFAULT`, `APB`,
+  `XTAL`, `RTC`, `REF_TICK`. Defaults to `DEFAULT`. See the note below about dynamic frequency scaling.
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID for this UART hub if you need multiple UART hubs.
 - **debug** (*Optional*, mapping): Options for debugging communication on the UART hub, see [Debugging](#uart-debugging).
+
+> [!NOTE]
+> The default UART clock source on most ESP32 variants tracks the APB clock. When ESP-IDF Dynamic Frequency Scaling
+> is enabled (for example via `CONFIG_PM_ENABLE` and `CONFIG_PM_DFS_INIT_AUTO`), the APB clock changes frequency at
+> runtime, which drifts the UART baud rate and corrupts communication. Setting `clock_source` to `XTAL` or `REF_TICK`
+> sources the UART from a clock that is independent of APB, keeping the baud rate stable. Available clock sources
+> differ by ESP32 variant (`XTAL` on the C-series, S3 and similar; `REF_TICK` only on the original ESP32 and S2); an
+> unsupported selection falls back to the default.
 
 <span id="uart-hardware_uarts"></span>
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

Documents the new `clock_source` option for the UART component. Adds the configuration variable entry (`DEFAULT`, `APB`, `XTAL`, `RTC`, `REF_TICK`) and a note explaining the dynamic frequency scaling rationale: with ESP-IDF DFS enabled, the APB-derived UART clock drifts the baud rate, and selecting `XTAL` or `REF_TICK` sources the UART from an APB-independent clock to keep it stable.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#16486

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
