### PR TITLE
Auto-approve and merge ImgBot PRs once CI passes

### DIFF
--- a/.github/workflows/imgbot-auto-merge.yml
+++ b/.github/workflows/imgbot-auto-merge.yml
@@ -1,0 +1,49 @@
+name: ImgBot Auto Merge
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'imgbot[bot]'
+    steps:
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.ESPHOME_GITHUB_APP_CLIENT_ID }}
+          private-key: ${{ secrets.ESPHOME_GITHUB_APP_PRIVATE_KEY }}
+
+      - name: Verify only image files are changed
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          if ! files=$(gh pr view "$PR_URL" --json files --jq '.files[].path'); then
+            echo "::error::Failed to fetch PR files."
+            exit 1
+          fi
+          if [ -z "$files" ]; then
+            echo "::error::PR has no changed files."
+            exit 1
+          fi
+          non_image=$(printf '%s\n' "$files" | grep -viE '\.(png|jpe?g|gif|svg|webp)$' || true)
+          if [ -n "$non_image" ]; then
+            echo "::error::PR touches non-image files; refusing to auto-merge:"
+            printf '%s\n' "$non_image"
+            exit 1
+          fi
+
+      - name: Approve and enable auto-merge
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          gh pr review --approve "$PR_URL"
+          gh pr merge --auto --squash "$PR_URL"

--- a/.github/workflows/imgbot-auto-merge.yml
+++ b/.github/workflows/imgbot-auto-merge.yml
@@ -2,11 +2,11 @@ name: ImgBot Auto Merge
 
 on:
   pull_request_target:
-    types: [opened, reopened]
+    types: [opened, reopened, synchronize]
 
 permissions:
   pull-requests: write
-  contents: write
+  contents: read
 
 jobs:
   auto-merge:
@@ -23,9 +23,25 @@ jobs:
       - name: Verify only image files are changed
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_URL: ${{ github.event.pull_request.html_url }}
         run: |
-          if ! files=$(gh pr view "$PR_URL" --json files --jq '.files[].path'); then
+          if ! files=$(gh api graphql \
+            -F owner="$OWNER" -F repo="$REPO" -F pr="$PR_NUMBER" \
+            -f query='query($owner:String!,$repo:String!,$pr:Int!,$endCursor:String){
+              repository(owner:$owner,name:$repo){
+                pullRequest(number:$pr){
+                  files(first:100,after:$endCursor){
+                    pageInfo{hasNextPage endCursor}
+                    nodes{path}
+                  }
+                }
+              }
+            }' \
+            --paginate \
+            --jq '.data.repository.pullRequest.files.nodes[].path'); then
             echo "::error::Failed to fetch PR files."
             exit 1
           fi
@@ -37,6 +53,8 @@ jobs:
           if [ -n "$non_image" ]; then
             echo "::error::PR touches non-image files; refusing to auto-merge:"
             printf '%s\n' "$non_image"
+            echo "Disabling auto-merge in case it was enabled by a prior run."
+            gh pr merge --disable-auto "$PR_URL" || true
             exit 1
           fi
 


### PR DESCRIPTION
## Description

Adds a workflow that watches for PRs opened by `imgbot[bot]`, approves them with the ESPHome GitHub App, and enables GitHub's native auto-merge (squash). GitHub holds the merge until the existing `Build` and `Lint` checks pass, so CI remains the gate.

To stop a hypothetical compromised ImgBot from sneaking arbitrary content through, a guard step first lists every changed file via `gh pr view --json files` and fails the job if any path doesn't end in `.png`, `.jpg`/`.jpeg`, `.gif`, `.svg`, or `.webp`.

Reuses the same `pull_request_target` + `actions/create-github-app-token` pattern as `auto-label-pr.yml`. No PR code is checked out or executed.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing \`component_name\` with your component name in **lower_case** format with **underscores** (e.g., \`bme280\`, \`sht3x\`, \`dallas_temp\`):

   \`\`\`
   @esphomebot generate image component_name
   \`\`\`

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the \`/public/images/\` folder of this repository.

4. Use the image in your component's index table entry in \`/src/content/docs/components/index.mdx\`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

\`\`\`
@esphomebot generate image dht22
\`\`\`

**Note:** All images used in ImgTable components must be placed in \`/public/images/\` as the component resolves them to absolute paths.

</details>