### PR TITLE
[haier] Fix YAML indentation and document airflow action parameters

### DIFF
--- a/src/content/docs/components/binary_sensor/haier.mdx
+++ b/src/content/docs/components/binary_sensor/haier.mdx
@@ -30,7 +30,7 @@ binary_sensor:
 
 ## Configuration variables
 
-- **haier_id** (**Required**, [ID](/guides/configuration-types#id)): The id of haier climate component
+- **haier_id** (**Required**, [ID](/guides/configuration-types#id)): The ID of the Haier climate component.
 - **compressor_status** (*Optional*): A binary sensor that indicates Haier climate compressor activity.
   All options from [Binary Sensor](/components/binary_sensor#config-binary_sensor).
 

--- a/src/content/docs/components/button/haier.mdx
+++ b/src/content/docs/components/button/haier.mdx
@@ -18,7 +18,7 @@ button:
 
 ## Configuration variables
 
-- **haier_id** (**Required**, [ID](/guides/configuration-types#id)): The id of Haier climate component
+- **haier_id** (**Required**, [ID](/guides/configuration-types#id)): The ID of the Haier climate component.
 - **self_cleaning** (*Optional*): A button that starts Haier climate self cleaning.
   All options from [Button](/components/button#config-button).
 

--- a/src/content/docs/components/climate/haier.mdx
+++ b/src/content/docs/components/climate/haier.mdx
@@ -61,39 +61,39 @@ climate:
       max_temperature: 30 °C
       temperature_step: 1 °C
     supported_modes:
-    - 'OFF'
-    - HEAT_COOL
-    - COOL
-    - HEAT
-    - DRY
-    - FAN_ONLY
+      - 'OFF'
+      - HEAT_COOL
+      - COOL
+      - HEAT
+      - DRY
+      - FAN_ONLY
     supported_swing_modes:
-    - 'OFF'
-    - VERTICAL
-    - HORIZONTAL
-    - BOTH
-  supported_presets:
-    - AWAY
-    - BOOST
-    - SLEEP
-  on_alarm_start:
-    then:
-      - logger.log:
-          level: WARN
-          format: "Alarm activated. Code: %d. Message: \"%s\""
-          args: [ code, message]
-  on_alarm_end:
-    then:
-      - logger.log:
-          level: INFO
-          format: "Alarm deactivated. Code: %d. Message: \"%s\""
-          args: [ code, message]
-  on_status_message:
-    then:
-      - logger.log:
-          level: INFO
-          format: "New status message received, size=%d, subcmd=%02X%02X"
-          args: [ 'data_size', 'data[0]', 'data[1]' ]
+      - 'OFF'
+      - VERTICAL
+      - HORIZONTAL
+      - BOTH
+    supported_presets:
+      - AWAY
+      - BOOST
+      - SLEEP
+    on_alarm_start:
+      then:
+        - logger.log:
+            level: WARN
+            format: "Alarm activated. Code: %d. Message: \"%s\""
+            args: ['code', 'message']
+    on_alarm_end:
+      then:
+        - logger.log:
+            level: INFO
+            format: "Alarm deactivated. Code: %d. Message: \"%s\""
+            args: ['code', 'message']
+    on_status_message:
+      then:
+        - logger.log:
+            level: INFO
+            format: "New status message received, size=%d, subcmd=%02X%02X"
+            args: ['data_size', 'data[0]', 'data[1]']
 ```
 
 ## Configuration variables
@@ -101,7 +101,7 @@ climate:
 - **uart_id** (*Optional*, [ID](/guides/configuration-types#id)): ID of the UART port to communicate with AC.
 - **protocol** (*Optional*, string): Defines communication protocol with AC. Possible values: `hon` or `smartair2`. The default value is `smartair2`.
 - **wifi_signal** (*Optional*, boolean): If `true` - send wifi signal level to AC.
-- **answer_timeout** (*Optional*, [Time](/guides/configuration-types#time)): Responce timeout. The default value is `200ms`.
+- **answer_timeout** (*Optional*, [Time](/guides/configuration-types#time)): Response timeout. The default value is `200ms`.
 - **alternative_swing_control** (*Optional*, boolean): (supported by smartAir2 only) If `true` - use alternative values to control swing mode. Use only if the original control method is not working for your AC.
 - **status_message_header_size** (*Optional*, int): (supported only by hOn) Define the header size of the status message. Can be used to handle some protocol variations. Use only if you are sure what you are doing. The default value: `0`.
 - **control_packet_size** (*Optional*, int): (supported only by hOn) Define the size of the control packet. Can help with some newer models of ACs that use bigger packets. The default value: `10`.
@@ -123,7 +123,7 @@ climate:
 
 ### `on_alarm_start` Trigger
 
-This automation will be triggered when a new alarm is activated by AC. The error code of the alarm will be given in the variable `code` (`uint8_t`  ), error message in the variable `message` (`const char *`  ). Those variables can be used in [lambdas](/automations/templates#config-lambda).
+This automation will be triggered when a new alarm is activated by AC. The error code of the alarm will be given in the variable `code` (`uint8_t`), error message in the variable `message` (`const char *`). Those variables can be used in [lambdas](/automations/templates#config-lambda).
 
 ```yaml
 climate:
@@ -133,14 +133,14 @@ climate:
         - logger.log:
             level: WARN
             format: "Alarm activated. Code: %d. Message: \"%s\""
-            args: [ 'code', 'message' ]
+            args: ['code', 'message']
 ```
 
 <span id="haier-on_alarm_end"></span>
 
 ### `on_alarm_end` Trigger
 
-This automation will be triggered when a previously activated alarm is deactivated by AC. The error code of the alarm will be given in the variable `code` (`uint8_t`  ), error message in the variable `message` (`const char *`  ). Those variables can be used in [lambdas](/automations/templates#config-lambda).
+This automation will be triggered when a previously activated alarm is deactivated by AC. The error code of the alarm will be given in the variable `code` (`uint8_t`), error message in the variable `message` (`const char *`). Those variables can be used in [lambdas](/automations/templates#config-lambda).
 
 ```yaml
 climate:
@@ -150,15 +150,15 @@ climate:
         - logger.log:
             level: INFO
             format: "Alarm deactivated. Code: %d. Message: \"%s\""
-            args: [ 'code', 'message' ]
+            args: ['code', 'message']
 ```
 
 <span id="haier-on_status_message"></span>
 
 ### `on_status_message` Trigger
 
-This automation will be triggered when component receives new status packet from AC. Raw message binary (without header and checksum) will be provided in the variable `data` (`const char *`  ), message length in the variable `data_size` (`uint8_t`  ). Those variables can be used in [lambdas](/automations/templates#config-lambda).
-This trigger can be used to support some features that unique for the model and not supported by others.
+This automation will be triggered when component receives new status packet from AC. Raw message binary (without header and checksum) will be provided in the variable `data` (`const char *`), message length in the variable `data_size` (`uint8_t`). Those variables can be used in [lambdas](/automations/templates#config-lambda).
+This trigger can be used to support some features that are unique to the model and not supported by others.
 
 ```yaml
 climate:
@@ -168,7 +168,7 @@ climate:
         - logger.log:
             level: INFO
             format: "New status message received, size=%d, subcmd=%02X%02X"
-            args: [ 'data_size', 'data[0]', 'data[1]' ]
+            args: ['data_size', 'data[0]', 'data[1]']
 ```
 
 ### `climate.haier.power_on` Action
@@ -183,7 +183,7 @@ on_...:
 
 ### `climate.haier.power_off` Action
 
-This action turns AC power off
+This action turns AC power off.
 
 ```yaml
 on_...:
@@ -193,7 +193,7 @@ on_...:
 
 ### `climate.haier.power_toggle` Action
 
-This action toggles AC power
+This action toggles AC power.
 
 ```yaml
 on_...:
@@ -263,27 +263,37 @@ on_...:
 
 ### `climate.haier.set_vertical_airflow` Action
 
-(supported only by hOn) Set direction for vertical airflow if the vertical swing is disabled. Possible values: Health_Up, Max_Up, Up, Center, Down, Health_Down.
+(supported only by hOn) Set direction for vertical airflow if the vertical swing is disabled.
 
 ```yaml
 on_...:
   then:
     - climate.haier.set_vertical_airflow:
-      id: device_id
-      vertical_airflow: Up
+        id: device_id
+        vertical_airflow: Up
 ```
+
+Configuration variables:
+
+- **id** (**Required**, [ID](/guides/configuration-types#id)): The ID of the Haier climate component.
+- **vertical_airflow** (**Required**, string, [templatable](/automations/templates)): The vertical airflow direction. Possible values: `Health_Up`, `Max_Up`, `Up`, `Center`, `Down`, `Health_Down`.
 
 ### `climate.haier.set_horizontal_airflow` Action
 
-(supported only by hOn) Set direction for horizontal airflow if the horizontal swing is disabled. Possible values: `Max_Left`, `Left`, `Center`, `Right`, `Max_Right`.
+(supported only by hOn) Set direction for horizontal airflow if the horizontal swing is disabled.
 
 ```yaml
 on_...:
   then:
     - climate.haier.set_horizontal_airflow:
-      id: device_id
-      vertical_airflow: Right
+        id: device_id
+        horizontal_airflow: Right
 ```
+
+Configuration variables:
+
+- **id** (**Required**, [ID](/guides/configuration-types#id)): The ID of the Haier climate component.
+- **horizontal_airflow** (**Required**, string, [templatable](/automations/templates)): The horizontal airflow direction. Possible values: `Max_Left`, `Left`, `Center`, `Right`, `Max_Right`.
 
 ### `climate.haier.start_self_cleaning` Action
 

--- a/src/content/docs/components/sensor/haier.mdx
+++ b/src/content/docs/components/sensor/haier.mdx
@@ -40,7 +40,7 @@ sensor:
 
 ## Configuration variables
 
-- **haier_id** (**Required**, [ID](/guides/configuration-types#id)): The id of haier climate component
+- **haier_id** (**Required**, [ID](/guides/configuration-types#id)): The ID of the Haier climate component.
 - **outdoor_temperature** (*Optional*): Temperature sensor for outdoor temperature.
   All options from [Sensor](/components/sensor).
 

--- a/src/content/docs/components/switch/haier.mdx
+++ b/src/content/docs/components/switch/haier.mdx
@@ -9,6 +9,7 @@ Additional switches to support additional features for Haier AC.
 # Example configuration entry
 switch:
   - platform: haier
+    haier_id: haier_ac
     beeper:
       name: Haier beeper
     health_mode:
@@ -21,7 +22,7 @@ switch:
 
 ## Configuration variables
 
-- **haier_id** (**Required**, [ID](/guides/configuration-types#id)): The id of Haier climate component
+- **haier_id** (**Required**, [ID](/guides/configuration-types#id)): The ID of the Haier climate component.
 - **beeper** (*Optional*): (supported only by hOn) A switch that enables or disables Haier climate sound feedback.
   All options from [Switch](/components/switch#config-switch).
 

--- a/src/content/docs/components/text_sensor/haier.mdx
+++ b/src/content/docs/components/text_sensor/haier.mdx
@@ -20,7 +20,7 @@ text_sensor:
 
 ## Configuration variables
 
-- **haier_id** (**Required**, [ID](/guides/configuration-types#id)): The id of haier climate component
+- **haier_id** (**Required**, [ID](/guides/configuration-types#id)): The ID of the Haier climate component.
 - **appliance_name** (*Optional*): A text sensor that indicates Haier appliance name.
   All options from [Text Sensor](/components/text_sensor#config-text_sensor).
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Cleans up the six Haier component docs to be consistent and to fix mistakes that would prevent the examples from working.

- **climate/haier.mdx**: re-indented `supported_modes`, `supported_swing_modes`, `supported_presets`, `on_alarm_start`, `on_alarm_end`, and `on_status_message` so they are nested under the `- platform: haier` list item (the example wouldn't have parsed before). Standardized `args:` list style throughout. Fixed `climate.haier.set_horizontal_airflow` example which used the wrong parameter name (`vertical_airflow`) and the wrong indentation. Added `Configuration variables:` lists for `set_vertical_airflow` and `set_horizontal_airflow` (the two actions that take more than just `id`). Fixed `Responce` → `Response`, `that unique` → `that are unique`, and missing periods on a couple of action descriptions.
- **switch/haier.mdx**: added missing `haier_id: haier_ac` to the example (it is marked **Required** in the config-variables section).
- **All five auxiliary docs** (sensor, binary_sensor, text_sensor, button, switch): normalized the `haier_id` description to `The ID of the Haier climate component.` (was inconsistent: lowercase "haier" in three of the five files, no trailing period in any of them).

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.