### PR TITLE
Add EnumOptions component to standardize enum value docs

### DIFF
--- a/src/components/EnumOptions.astro
+++ b/src/components/EnumOptions.astro
@@ -1,0 +1,71 @@
+---
+import { micromark } from "micromark";
+
+interface EnumOptionDetail {
+  value: string;
+  description?: string;
+}
+
+type EnumOption = string | EnumOptionDetail;
+
+interface Props {
+  options: EnumOption[];
+  default?: string;
+  inline?: boolean;
+}
+
+const { options, default: defaultValue, inline = false } = Astro.props;
+
+const items: EnumOptionDetail[] = options.map((o) =>
+  typeof o === "string" ? { value: o } : o,
+);
+
+if (inline && items.some((o) => o.description)) {
+  throw new Error(
+    "EnumOptions: `inline` cannot be used together with per-option descriptions. " +
+      "Remove `inline` or drop the descriptions.",
+  );
+}
+
+function renderInlineMarkdown(md: string): string {
+  return micromark(md).replace(/^<p>/, "").replace(/<\/p>\s*$/, "");
+}
+---
+
+{
+  inline ? (
+    <span class="enum-options-inline">
+      One of{" "}
+      {items.map(({ value }, i) => {
+        const isLast = i === items.length - 1;
+        const isFirst = i === 0;
+        let sep = "";
+        if (!isFirst) {
+          if (items.length === 2) sep = " or ";
+          else if (isLast) sep = ", or ";
+          else sep = ", ";
+        }
+        return (
+          <>
+            {sep}
+            <code>{value}</code>
+            {value === defaultValue ? <em> (default)</em> : null}
+          </>
+        );
+      })}
+      .
+    </span>
+  ) : (
+    <ul class="enum-options">
+      {items.map(({ value, description }) => (
+        <li>
+          <code>{value}</code>
+          {value === defaultValue ? <em> (default)</em> : null}
+          {description ? (
+            <Fragment set:html={" &mdash; " + renderInlineMarkdown(description)} />
+          ) : null}
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/src/components/EnumOptions.astro
+++ b/src/components/EnumOptions.astro
@@ -3,6 +3,7 @@ import { micromark } from "micromark";
 
 interface EnumOptionDetail {
   value: string;
+  aliases?: string[];
   description?: string;
 }
 
@@ -36,7 +37,7 @@ function renderInlineMarkdown(md: string): string {
   inline ? (
     <span class="enum-options-inline">
       One of{" "}
-      {items.map(({ value }, i) => {
+      {items.map(({ value, aliases }, i) => {
         const isLast = i === items.length - 1;
         const isFirst = i === 0;
         let sep = "";
@@ -49,6 +50,12 @@ function renderInlineMarkdown(md: string): string {
           <>
             {sep}
             <code>{value}</code>
+            {aliases?.map((a) => (
+              <>
+                {" / "}
+                <code>{a}</code>
+              </>
+            ))}
             {value === defaultValue ? <em> (default)</em> : null}
           </>
         );
@@ -57,9 +64,15 @@ function renderInlineMarkdown(md: string): string {
     </span>
   ) : (
     <ul class="enum-options">
-      {items.map(({ value, description }) => (
+      {items.map(({ value, aliases, description }) => (
         <li>
           <code>{value}</code>
+          {aliases?.map((a) => (
+            <>
+              {" / "}
+              <code>{a}</code>
+            </>
+          ))}
           {value === defaultValue ? <em> (default)</em> : null}
           {description ? (
             <Fragment set:html={" &mdash; " + renderInlineMarkdown(description)} />

--- a/src/components/EnumOptions.astro
+++ b/src/components/EnumOptions.astro
@@ -2,23 +2,23 @@
 import { micromark } from "micromark";
 
 interface EnumOptionDetail {
-  value: string;
-  aliases?: string[];
+  value: string | number;
+  aliases?: (string | number)[];
   description?: string;
 }
 
-type EnumOption = string | EnumOptionDetail;
+type EnumOption = string | number | EnumOptionDetail;
 
 interface Props {
   options: EnumOption[];
-  default?: string;
+  default?: string | number;
   inline?: boolean;
 }
 
 const { options, default: defaultValue, inline = false } = Astro.props;
 
 const items: EnumOptionDetail[] = options.map((o) =>
-  typeof o === "string" ? { value: o } : o,
+  typeof o === "string" || typeof o === "number" ? { value: o } : o,
 );
 
 if (inline && items.some((o) => o.description)) {

--- a/src/content/docs/components/alarm_control_panel/template.mdx
+++ b/src/content/docs/components/alarm_control_panel/template.mdx
@@ -4,6 +4,7 @@ title: "Template Alarm Control Panel"
 ---
 
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 The `template` alarm control panel platform allows you to turn your binary sensors into a state machine
 managed alarm control panel.
@@ -42,8 +43,8 @@ alarm_control_panel:
     state.
   - **bypass_auto** (*Optional*, boolean): This binary sensor will be automatically bypassed if left on/open at the
     time of arming.
-  - **trigger_mode** (*Optional*, string): Sets the trigger mode for this sensor. One of `delayed`, `instant`,
-    `instant_always`, or `delayed_follower`. (`delayed` is the default if not specified)
+  - **trigger_mode** (*Optional*, string): Sets the trigger mode for this sensor.
+    <EnumOptions options={["delayed", "instant", "instant_always", "delayed_follower"]} default="delayed" />
   - **chime** (*Optional*, boolean): When set `true`, the chime callback will be called whenever the sensor goes from
     closed to open. (`false` is the default if not specified)
 

--- a/src/content/docs/components/audio_adc/es7210.mdx
+++ b/src/content/docs/components/audio_adc/es7210.mdx
@@ -3,6 +3,7 @@ description: "Instructions for using ESPHome's ES7210 platform to configure micr
 title: "ES7210"
 ---
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 
 The `es7210` platform allows your ESPHome devices to use the ES7210 high performance four channel audio ADC
@@ -21,12 +22,11 @@ audio_adc:
 
 ## Configuration variables
 
-- **bits_per_sample** (*Optional*, enum): The bit depth of the audio samples. One of `16bit`, `24bit` or `32bit`.
-  Defaults to `16bit`.
+- **bits_per_sample** (*Optional*, enum): The bit depth of the audio samples.
+  <EnumOptions inline options={["16bit", "24bit", "32bit"]} default="16bit" />
 
-- **mic_gain** (*Optional*, enum): The gain applied to the ADC microphones. One of `0DB`, `3DB`, `6DB`, `9DB`,
-  `12DB`, `15DB`, `18DB`, `21DB`, `24DB`, `27DB`, `30DB`, `33DB`, `34.5DB`, `36DB`, or `37.5DB`.
-  Defaults to `24DB`.
+- **mic_gain** (*Optional*, enum): The gain applied to the ADC microphones.
+  <EnumOptions inline options={["0DB", "3DB", "6DB", "9DB", "12DB", "15DB", "18DB", "21DB", "24DB", "27DB", "30DB", "33DB", "34.5DB", "36DB", "37.5DB"]} default="24DB" />
 
 - **sample_rate** (*Optional*, positive integer): I2S sample rate. Defaults to `16000`.
 - **address** (*Optional*, int): The I²C address of the driver. Defaults to `0x40`.

--- a/src/content/docs/components/audio_adc/es7243e.mdx
+++ b/src/content/docs/components/audio_adc/es7243e.mdx
@@ -3,6 +3,7 @@ description: "Instructions for using ESPHome's ES7243E platform to configure mic
 title: "ES7243E"
 ---
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 
 The `es7243e` platform allows your ESPHome devices to use the ES7243E high performance four channel audio ADC
@@ -21,9 +22,8 @@ audio_adc:
 
 ## Configuration variables
 
-- **mic_gain** (*Optional*, enum): The gain applied to the ADC microphones. One of `0DB`, `3DB`, `6DB`, `9DB`,
-  `12DB`, `15DB`, `18DB`, `21DB`, `24DB`, `27DB`, `30DB`, `33DB`, `34.5DB`, `36DB`, or `37.5DB`.
-  Defaults to `24DB`.
+- **mic_gain** (*Optional*, enum): The gain applied to the ADC microphones.
+  <EnumOptions inline options={["0DB", "3DB", "6DB", "9DB", "12DB", "15DB", "18DB", "21DB", "24DB", "27DB", "30DB", "33DB", "34.5DB", "36DB", "37.5DB"]} default="24DB" />
 
 - **address** (*Optional*, int): The I²C address of the driver. Defaults to `0x40`.
 - **i2c_id** (*Optional*): The ID of the [I²C bus](/components/i2c) the ES7243e is connected to.

--- a/src/content/docs/components/audio_dac/es8311.mdx
+++ b/src/content/docs/components/audio_dac/es8311.mdx
@@ -3,6 +3,7 @@ description: "Instructions for using ESPHome's ES8311 audio DAC platform to play
 title: "ES8311"
 ---
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 
 The `es8311` platform allows your ESPHome devices to use the ES8311 low power mono audio codec.
@@ -21,11 +22,13 @@ audio_dac:
 
 ## Configuration variables
 
-- **bits_per_sample** (*Optional*, enum): The bit depth of the audio samples. One of `16bit`, `24bit`, or `32bit`. Defaults to `16bit`.
+- **bits_per_sample** (*Optional*, enum): The bit depth of the audio samples.
+  <EnumOptions options={["16bit", "24bit", "32bit"]} default="16bit" />
 - **sample_rate** (*Optional*, positive integer): I2S sample rate. Defaults to `16000`.
 - **use_mclk** (*Optional*, bool): Use the MCLK signal to control the clock. Defaults to `True`.
 - **use_microphone** (*Optional*, bool): Configure the codec's ADC to use PDM microphone input instead of analog. Defaults to False.
-- **mic_gain** (*Optional*, enum): The gain applied to the ADC microphones. One of `0DB`, `6DB`, `12DB`, `18DB`, `24DB`, `30DB`, `36DB`, `42DB`. Defaults to `42DB`.
+- **mic_gain** (*Optional*, enum): The gain applied to the ADC microphones.
+  <EnumOptions inline options={["0DB", "6DB", "12DB", "18DB", "24DB", "30DB", "36DB", "42DB"]} default="42DB" />
 - **address** (*Optional*, int): The I²C address of the driver. Defaults to `0x18`.
 - **i2c_id** (*Optional*): The ID of the [I²C bus](/components/i2c) the ES8311 is connected to.
 - All other options from [Audio DAC](/components/audio_dac#config-audio_dac).

--- a/src/content/docs/components/audio_file/index.mdx
+++ b/src/content/docs/components/audio_file/index.mdx
@@ -6,6 +6,7 @@ sidebar:
 ---
 
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 This component only works on ESP32 based chips.
 
@@ -45,7 +46,7 @@ audio_file:
 
   - **Typed form**:
 
-    - **type** (**Required**, string): Either `local` or `web`.
+    - **type** (**Required**, string): <EnumOptions inline options={["local", "web"]} />
 
     **Local files**:
 

--- a/src/content/docs/components/binary_sensor/gpio.mdx
+++ b/src/content/docs/components/binary_sensor/gpio.mdx
@@ -5,6 +5,7 @@ title: "GPIO Binary Sensor"
 
 import { Image } from 'astro:assets';
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 <span id="gpio-binary-sensor"></span>
 
@@ -55,11 +56,15 @@ binary_sensor:
   for LibreTiny-based platforms (BK72xx, RTL87xx, LN882x) due to hardware limitations. Only supported
   on internal GPIO pins.
 
-- **interrupt_type** (*Optional*, string): The type of interrupt to use. One of:
-
-  - `ANY` (default): Trigger on any edge change (high to low or low to high)
-  - `RISING`  : Trigger only on rising edge (low to high)
-  - `FALLING`  : Trigger only on falling edge (high to low)
+- **interrupt_type** (*Optional*, string): The type of interrupt to use.
+  <EnumOptions
+    options={[
+      { value: "ANY", description: "Trigger on any edge change (high to low or low to high)" },
+      { value: "RISING", description: "Trigger only on rising edge (low to high)" },
+      { value: "FALLING", description: "Trigger only on falling edge (high to low)" },
+    ]}
+    default="ANY"
+  />
 
 - All other options from [Binary Sensor](/components/binary_sensor#config-binary_sensor).
 

--- a/src/content/docs/components/binary_sensor/qwiic_pir.mdx
+++ b/src/content/docs/components/binary_sensor/qwiic_pir.mdx
@@ -6,6 +6,7 @@ title: "Qwiic PIR Motion Binary Sensor"
 import { Image } from 'astro:assets';
 import Figure from '@components/Figure.astro';
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 The Qwiic PIR Motion binary sensor allows you to use your Qwiic PIR ([EKMC4607112K based](https://www.sparkfun.com/products/17374), [EKMB1107112 based](https://www.sparkfun.com/products/17375), [firmware documentation](https://github.com/sparkfun/Qwiic_PIR))
 sensors from SparkFun with ESPHome.
@@ -34,7 +35,8 @@ binary_sensor:
 
 ## Configuration variables
 
-- **debounce_mode** (*Optional*, enum): How the component debounces the motion sensor's signal. Must be one of `HYBRID`, `NATIVE`, or `RAW`. See [Debounce Modes](#debounce-modes) for details. Defaults to `HYBRID`.
+- **debounce_mode** (*Optional*, enum): How the component debounces the motion sensor's signal. See [Debounce Modes](#debounce-modes) for details.
+  <EnumOptions options={["HYBRID", "NATIVE", "RAW"]} default="HYBRID" />
 - **debounce** (*Optional*, [Time](/guides/configuration-types#time)): Only valid when using `NATIVE` debounce mode. Configures the debounce time on the sensor to reduce noise and false detections. Defaults to `1ms`.
 
 - All other options from [Binary Sensor](/components/binary_sensor#config-binary_sensor).

--- a/src/content/docs/components/ble_nus.mdx
+++ b/src/content/docs/components/ble_nus.mdx
@@ -2,6 +2,7 @@
 description: "Nordic UART Service (NUS)"
 title: "Nordic UART Service (NUS)"
 ---
+import EnumOptions from '@components/EnumOptions.astro';
 
 The BLE NUS component provides a Bluetooth Low Energy UART interface based on the Nordic UART Service.
 It can be used to stream logs or enable custom bidirectional communication with ESPHome.
@@ -14,8 +15,8 @@ ble_nus:
 
 ## Configuration variables
 
-- **type** (*Optional*, string): Mode of operation. One of `logs` or `uart`.
-  `logs` streams ESPHome logs. `uart` provides bi-directional communication. Defaults to `logs`.
+- **type** (*Optional*, string): Mode of operation. `logs` streams ESPHome logs. `uart` provides bi-directional communication.
+  <EnumOptions inline options={["logs", "uart"]} default="logs" />
 - **rx_buffer_size** (*Optional*, int): Size of the receive buffer in bytes. Range: 160-8192. Defaults to `512`.
   Valid only for mode `uart`.
 - **tx_buffer_size** (*Optional*, int): Size of the transmit buffer in bytes. Range: 160-8192. Defaults to `512`.

--- a/src/content/docs/components/canbus/esp32_can.mdx
+++ b/src/content/docs/components/canbus/esp32_can.mdx
@@ -7,6 +7,7 @@ import { Image } from 'astro:assets';
 import canbusEsp325vImg from './images/canbus_esp32_5v.png';
 import canbusEsp323v3Img from './images/canbus_esp32_3v3.png';
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 <span id="esp32-can"></span>
 
@@ -30,10 +31,14 @@ canbus:
 
 - **rx_pin** (**Required**, [Pin](/guides/configuration-types#pin)): Receive pin.
 - **tx_pin** (**Required**, [Pin](/guides/configuration-types#pin)): Transmit pin.
-- **mode** (*Optional*, enum): Operating mode. One of:
-
-  - `NORMAL`: Normal operation, sends ACK signals. *(default)*
-  - `LISTENONLY`: Receive data only, no ACK signals sent.
+- **mode** (*Optional*, enum): Operating mode.
+  <EnumOptions
+    options={[
+      { value: "NORMAL", description: "Normal operation, sends ACK signals." },
+      { value: "LISTENONLY", description: "Receive data only, no ACK signals sent." },
+    ]}
+    default="NORMAL"
+  />
 
 - **rx_queue_len** (*Optional*, int): Length of RX queue.
 - **tx_queue_len** (*Optional*, int): Length of TX queue, 0 to disable.

--- a/src/content/docs/components/canbus/mcp2515.mdx
+++ b/src/content/docs/components/canbus/mcp2515.mdx
@@ -7,6 +7,7 @@ import { Image } from 'astro:assets';
 import canbusMcp2515ResistorImg from './images/canbus_mcp2515_resistor.png';
 import canbusMcp2515Txs0108eImg from './images/canbus_mcp2515_txs0108e.png';
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 The MCP2515 communicates with ESPHome via the [SPI bus](/components/spi); to use it, you must have at least one
 [SPI bus](/components/spi) with both the `mosi_pin` and `miso_pin` defined in your ESPHome configuration.
@@ -46,8 +47,8 @@ canbus:
 - **cs_pin** (**Required**, [Pin Schema](/guides/configuration-types#pin-schema)): Is used to signal to a SPI device when it should
   listen for data on the SPI bus. Each SPI device has its own `CS` line. Sometimes also called `SS`.
 
-- **clock** (*Optional*, enum): The frequency of the clock crystal used on the MCP2515 device. One of `8MHZ`,
-  `12MHZ`, `16MHZ` or `20MHZ`. Defaults to `8MHZ`.
+- **clock** (*Optional*, enum): The frequency of the clock crystal used on the MCP2515 device.
+  <EnumOptions options={["8MHZ", "12MHZ", "16MHZ", "20MHZ"]} default="8MHZ" />
 
 - **mode** (*Optional*, enum): Operating mode. One of:
 

--- a/src/content/docs/components/canbus/mcp2515.mdx
+++ b/src/content/docs/components/canbus/mcp2515.mdx
@@ -50,11 +50,15 @@ canbus:
 - **clock** (*Optional*, enum): The frequency of the clock crystal used on the MCP2515 device.
   <EnumOptions options={["8MHZ", "12MHZ", "16MHZ", "20MHZ"]} default="8MHZ" />
 
-- **mode** (*Optional*, enum): Operating mode. One of:
-
-  - `NORMAL`  : Normal operation. *(default)*
-  - `LOOPBACK`  : Loopback mode is useful for testing your connections to/from the device.
-  - `LISTENONLY`  : Receive data only.
+- **mode** (*Optional*, enum): Operating mode.
+  <EnumOptions
+    options={[
+      { value: "NORMAL", description: "Normal operation." },
+      { value: "LOOPBACK", description: "Loopback mode is useful for testing your connections to/from the device." },
+      { value: "LISTENONLY", description: "Receive data only." },
+    ]}
+    default="NORMAL"
+  />
 
 - All other options from [Canbus](/components/canbus#config-canbus).
 

--- a/src/content/docs/components/ch422g.mdx
+++ b/src/content/docs/components/ch422g.mdx
@@ -3,6 +3,7 @@ description: "Instructions for setting up CH422G digital port expanders in ESPHo
 title: "CH422G I/O Expander"
 ---
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 
 The CH422G component allows you to use the **CH422G** I/O expander in ESPHome.
@@ -42,7 +43,8 @@ switch:
 - **ch422g** (**Required**, [ID](/guides/configuration-types#id)): The id of the `ch422g` component of the pin.
 - **number** (**Required**, int): The pin number. Valid numbers are 0-11.
 - **inverted** (*Optional*, boolean): If the pin state should be inverted. Defaults to `false`.
-- **mode** (*Optional*, string): A pin mode to set the pin at. One of `INPUT` or `OUTPUT`, or `OUTPUT_OPEN_DRAIN`.
+- **mode** (*Optional*, string): A pin mode to set the pin at.
+  <EnumOptions inline options={["INPUT", "OUTPUT", "OUTPUT_OPEN_DRAIN"]} />
 
 Open drain mode is supported only on pins 8-11. Input is supported only on pins 0-7.
 

--- a/src/content/docs/components/ch423.mdx
+++ b/src/content/docs/components/ch423.mdx
@@ -5,6 +5,7 @@ title: "CH423 I/O Expander"
 
 import APIClass from '@components/APIClass.astro';
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 The CH423 component allows you to use the **CH423** I/O expander in ESPHome.
 It uses an [I²C Bus](/components/i2c) for communication. The I²C address is not configurable as the CH423 has a separate address for each internal register.
@@ -47,7 +48,8 @@ switch:
 - **ch423** (**Required**, [ID](/guides/configuration-types#id)): The id of the `ch423` component of the pin.
 - **number** (**Required**, int): The pin number. Valid numbers are 0-23.
 - **inverted** (*Optional*, boolean): If the pin state should be inverted. Defaults to `false`.
-- **mode** (*Optional*, string): A pin mode to set the pin at. One of `INPUT`, `OUTPUT`, or `OUTPUT_OPEN_DRAIN`.
+- **mode** (*Optional*, string): A pin mode to set the pin at.
+  <EnumOptions inline options={["INPUT", "OUTPUT", "OUTPUT_OPEN_DRAIN"]} />
 
 ## Pin mode restrictions
 

--- a/src/content/docs/components/climate/climate_ir.mdx
+++ b/src/content/docs/components/climate/climate_ir.mdx
@@ -6,6 +6,7 @@ title: "IR Remote Climate"
 import { Image } from 'astro:assets';
 import climateUiImg from './images/climate-ui.png';
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 This climate component allows you to control compatible AC units by sending an infrared (IR)
 control signal, just as the unit's handheld remote controller would.
@@ -132,14 +133,7 @@ The Daikin ARC remotes (`daikin_arc` climate, `daikin_arc417`, `daikin_arc480` p
 ### `gree`
 
 - **model** (**Required**, string): GREE has a few different protocols depending on model. One of these will likely work for you:
-
-  - `generic`
-  - `yan`
-  - `yaa`
-  - `yac`
-  - `yac1fb9`
-  - `yx1ff`
-  - `yag`
+  <EnumOptions options={["generic", "yan", "yaa", "yac", "yac1fb9", "yx1ff", "yag"]} />
 
 ```yaml
 # Example configuration entry for climate only

--- a/src/content/docs/components/climate/haier.mdx
+++ b/src/content/docs/components/climate/haier.mdx
@@ -8,6 +8,7 @@ import Figure from '@components/Figure.astro';
 import usbPinoutImg from './images/usb_pinout.png';
 import haierPinoutImg from './images/haier_pinout.jpg';
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 This is an implementation of the ESPHome component to control HVAC on the base of the SmartAir2 and hOn Haier protocols (AC that is controlled by the hOn or SmartAir2 application).
 
@@ -99,7 +100,8 @@ climate:
 ## Configuration variables
 
 - **uart_id** (*Optional*, [ID](/guides/configuration-types#id)): ID of the UART port to communicate with AC.
-- **protocol** (*Optional*, string): Defines communication protocol with AC. Possible values: `hon` or `smartair2`. The default value is `smartair2`.
+- **protocol** (*Optional*, string): Defines communication protocol with AC.
+  <EnumOptions options={["hon", "smartair2"]} default="smartair2" />
 - **wifi_signal** (*Optional*, boolean): If `true` - send wifi signal level to AC.
 - **answer_timeout** (*Optional*, [Time](/guides/configuration-types#time)): Response timeout. The default value is `200ms`.
 - **alternative_swing_control** (*Optional*, boolean): (supported by smartAir2 only) If `true` - use alternative values to control swing mode. Use only if the original control method is not working for your AC.
@@ -109,8 +111,10 @@ climate:
 - **control_method** (*Optional*, list): (supported only by hOn) Defines control method (should be supported by AC). Supported values: `MONITOR_ONLY` - no control, just monitor status, `SET_GROUP_PARAMETERS` - set all AC parameters with one command (default method), `SET_SINGLE_PARAMETER` - set each parameter individually (this method is supported by some new ceiling ACs like AD71S2SM3FA)
 - **display** (*Optional*, boolean): Can be used to set the AC display off.
 - **beeper** (*Optional*, boolean): Can be used to disable beeping on commands from AC. Supported only by hOn protocol.
-- **supported_modes** (*Optional*, list): Can be used to disable some of AC modes. Possible values: `'OFF'`, `HEAT_COOL`, `COOL`, `HEAT`, `DRY`, `FAN_ONLY`.
-- **supported_swing_modes** (*Optional*, list): Can be used to disable some swing modes if your AC does not support it. Possible values: `'OFF'`, `VERTICAL`, `HORIZONTAL`, `BOTH`.
+- **supported_modes** (*Optional*, list): Can be used to disable some of AC modes.
+  <EnumOptions options={["'OFF'", "HEAT_COOL", "COOL", "HEAT", "DRY", "FAN_ONLY"]} />
+- **supported_swing_modes** (*Optional*, list): Can be used to disable some swing modes if your AC does not support it.
+  <EnumOptions options={["'OFF'", "VERTICAL", "HORIZONTAL", "BOTH"]} />
 - **supported_presets** (*Optional*, list): Can be used to disable some presets. Possible values for smartair2 are: `AWAY`, `BOOST`, `COMFORT`. Possible values for hOn are: `AWAY`, `BOOST`, `SLEEP`. `AWAY` preset can be enabled only in `HEAT` mode, it is disabled by default.
 - **on_alarm_start** (*Optional*, [Automation](/automations)): (supported only by hOn) Automation to perform when AC activates a new alarm. See [`on_alarm_start` Trigger](#haier-on_alarm_start).
 - **on_alarm_end** (*Optional*, [Automation](/automations)): (supported only by hOn) Automation to perform when AC deactivates a new alarm. See [`on_alarm_end` Trigger](#haier-on_alarm_end).
@@ -276,7 +280,8 @@ on_...:
 Configuration variables:
 
 - **id** (**Required**, [ID](/guides/configuration-types#id)): The ID of the Haier climate component.
-- **vertical_airflow** (**Required**, string, [templatable](/automations/templates)): The vertical airflow direction. Possible values: `Health_Up`, `Max_Up`, `Up`, `Center`, `Down`, `Health_Down`.
+- **vertical_airflow** (**Required**, string, [templatable](/automations/templates)): The vertical airflow direction.
+  <EnumOptions options={["Health_Up", "Max_Up", "Up", "Center", "Down", "Health_Down"]} />
 
 ### `climate.haier.set_horizontal_airflow` Action
 
@@ -293,7 +298,8 @@ on_...:
 Configuration variables:
 
 - **id** (**Required**, [ID](/guides/configuration-types#id)): The ID of the Haier climate component.
-- **horizontal_airflow** (**Required**, string, [templatable](/automations/templates)): The horizontal airflow direction. Possible values: `Max_Left`, `Left`, `Center`, `Right`, `Max_Right`.
+- **horizontal_airflow** (**Required**, string, [templatable](/automations/templates)): The horizontal airflow direction.
+  <EnumOptions options={["Max_Left", "Left", "Center", "Right", "Max_Right"]} />
 
 ### `climate.haier.start_self_cleaning` Action
 

--- a/src/content/docs/components/climate/midea.mdx
+++ b/src/content/docs/components/climate/midea.mdx
@@ -3,6 +3,7 @@ description: "Instructions for setting up a Midea climate device"
 title: "Midea Air Conditioner"
 ---
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 
 The `midea` component creates a Midea air conditioner climate device.
@@ -78,11 +79,15 @@ climate:
   Defaults to `True`.
 
 - **beeper** (*Optional*, boolean): Beeper feedback on command. Defaults to `False`.
-- **supported_modes** (*Optional*, list): List of supported modes. Possible values are: `HEAT_COOL`, `COOL`, `HEAT`, `DRY`, `FAN_ONLY`.
-- **custom_fan_modes** (*Optional*, list): List of supported custom fan modes. Possible values are: `SILENT`, `TURBO`.
-- **supported_presets** (*Optional*, list): List of supported presets. Possible values are: `ECO`, `BOOST`, `SLEEP`.
+- **supported_modes** (*Optional*, list): List of supported modes.
+  <EnumOptions options={["HEAT_COOL", "COOL", "HEAT", "DRY", "FAN_ONLY"]} />
+- **custom_fan_modes** (*Optional*, list): List of supported custom fan modes.
+  <EnumOptions options={["SILENT", "TURBO"]} />
+- **supported_presets** (*Optional*, list): List of supported presets.
+  <EnumOptions options={["ECO", "BOOST", "SLEEP"]} />
 - **custom_presets** (*Optional*, list): List of supported custom presets. Possible values are: `FREEZE_PROTECTION`.
-- **supported_swing_modes** (*Optional*, list): List of supported swing modes. Possible values are: `VERTICAL`, `HORIZONTAL`, `BOTH`.
+- **supported_swing_modes** (*Optional*, list): List of supported swing modes.
+  <EnumOptions options={["VERTICAL", "HORIZONTAL", "BOTH"]} />
 - **outdoor_temperature** (*Optional*): The information for the outdoor temperature
   sensor.
 

--- a/src/content/docs/components/datetime/template.mdx
+++ b/src/content/docs/components/datetime/template.mdx
@@ -3,6 +3,7 @@ description: "Instructions for setting up template datetime with ESPHome."
 title: "Template Datetime"
 ---
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 
 The `template` datetime platform allows you to create a datetime with templated values
@@ -40,7 +41,7 @@ datetime:
 
 ## Configuration variables
 
-- **type** (**Required**, enum): The type of the datetime. Can be one of `date` or `time`.
+- **type** (**Required**, enum): The type of the datetime. <EnumOptions inline options={["date", "time"]} />
 - **lambda** (*Optional*, [lambda](/automations/templates#config-lambda)):
   Lambda to be evaluated every update interval to get the current value of the datetime.
 

--- a/src/content/docs/components/datetime/template.mdx
+++ b/src/content/docs/components/datetime/template.mdx
@@ -41,7 +41,7 @@ datetime:
 
 ## Configuration variables
 
-- **type** (**Required**, enum): The type of the datetime. <EnumOptions inline options={["date", "time"]} />
+- **type** (**Required**, enum): The type of the datetime. <EnumOptions inline options={["date", "time", "datetime"]} />
 - **lambda** (*Optional*, [lambda](/automations/templates#config-lambda)):
   Lambda to be evaluated every update interval to get the current value of the datetime.
 

--- a/src/content/docs/components/deep_sleep.mdx
+++ b/src/content/docs/components/deep_sleep.mdx
@@ -66,8 +66,9 @@ Advanced features:
   wake up on multiple pins. This cannot be used together with wakeup pin.
 
   - **pins** (**Required**, list of pin numbers): The pins to wake up on.
-- **mode** (**Required**): The mode to use for the wakeup source.
-    <EnumOptions options={[
+  - **mode** (**Required**): The mode to use for the wakeup source.
+    <EnumOptions
+      options={[
         { value: "ANY_LOW", description: "wake up when any selected pin is LOW (ESP32-C5/C6/C61/H2/P4/S2/S3 only)" },
         { value: "ALL_LOW", description: "wake up when all selected pins are LOW (ESP32 only)" },
         { value: "ANY_HIGH", description: "wake up when any selected pin is HIGH" },

--- a/src/content/docs/components/deep_sleep.mdx
+++ b/src/content/docs/components/deep_sleep.mdx
@@ -3,6 +3,7 @@ description: "Instructions for setting up the deep sleep support for minimizing 
 title: "Deep Sleep Component"
 ---
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 
 <span id="deep_sleep-component"></span>
@@ -65,10 +66,13 @@ Advanced features:
   wake up on multiple pins. This cannot be used together with wakeup pin.
 
   - **pins** (**Required**, list of pin numbers): The pins to wake up on.
-  - **mode** (**Required**): The mode to use for the wakeup source. Must be one of:
-    - `ANY_LOW`: wake up when any selected pin is LOW (ESP32‑C5/C6/C61/H2/P4/S2/S3 only)
-    - `ALL_LOW`: wake up when all selected pins are LOW (ESP32 only)
-    - `ANY_HIGH`: wake up when any selected pin is HIGH
+- **mode** (**Required**): The mode to use for the wakeup source.
+    <EnumOptions options={[
+        { value: "ANY_LOW", description: "wake up when any selected pin is LOW (ESP32-C5/C6/C61/H2/P4/S2/S3 only)" },
+        { value: "ALL_LOW", description: "wake up when all selected pins are LOW (ESP32 only)" },
+        { value: "ANY_HIGH", description: "wake up when any selected pin is HIGH" },
+      ]}
+    />
 
 > [!NOTE]
 > Only one deep sleep component may be configured.

--- a/src/content/docs/components/display/addressable_light.mdx
+++ b/src/content/docs/components/display/addressable_light.mdx
@@ -9,6 +9,7 @@ import addressableLightPixelMapDefaultImg from './images/addressable_light_pixel
 import addressableLightPixelMap8x32Img from './images/addressable_light_pixel_map_8x32.png';
 import APIClass from '@components/APIClass.astro';
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 The `addressable_light` display platform allows to display text and graphics on an addressable
 light that has been arranged in a display matrix.
@@ -53,7 +54,8 @@ display:
 - **width** (**Required**, int): The width of the LED matrix in pixels.
 - **height** (**Required**, int): The height of the LED matrix in pixels.
 - **rotation** (*Optional*): Set the rotation of the display. Everything you draw in `lambda:` will be rotated
-  by this option. One of `0°` (default), `90°`, `180°`, `270°`.
+  by this option.
+  <EnumOptions inline options={["0°", "90°", "180°", "270°"]} default="0°" />
 
 - **update_interval** (*Optional*, [Time](/guides/configuration-types#time)): The interval to call the lambda to update the display.
   Defaults to `16ms`.

--- a/src/content/docs/components/display/epaper_spi.mdx
+++ b/src/content/docs/components/display/epaper_spi.mdx
@@ -3,6 +3,7 @@ description: "Instructions for setting up ePaper SPI displays in ESPHome."
 title: "ePaper SPI Display"
 ---
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 
 The `epaper_spi` display platform provides a new ePaper display component architecture
@@ -84,7 +85,8 @@ but can be overridden if needed.
   - **width** (**Required**, int): Specifies width of display.
 
 - **rotation** (*Optional*, int): Set the rotation of the display. Everything you draw in `lambda:` will be rotated
-  by this option. One of `0°` (default), `90°`, `180°`, `270°`.
+  by this option.
+  <EnumOptions inline options={["0°", "90°", "180°", "270°"]} default="0°" />
 - **transform** (*Optional*, dict): If `rotation` is not sufficient, use this to transform the display. Options are:
   - **mirror_x** (**Required**, boolean): If true, mirror the x axis.
   - **mirror_y** (**Required**, boolean): If true, mirror the y axis.

--- a/src/content/docs/components/display/hub75.mdx
+++ b/src/content/docs/components/display/hub75.mdx
@@ -3,6 +3,7 @@ description: "Instructions for setting up HUB75 RGB LED matrix displays."
 title: "HUB75 RGB LED Matrix Display"
 ---
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 
 The `hub75` display platform allows you to use HUB75 RGB LED matrix panels with ESPHome. This component uses a high-performance DMA-based driver that provides efficient, low-CPU-overhead driving of LED matrix panels.
@@ -166,46 +167,61 @@ For creating larger displays by chaining multiple panels:
 
 - **layout_rows** (*Optional*, int): Number of panels arranged vertically. Defaults to `1`.
 - **layout_cols** (*Optional*, int): Number of panels arranged horizontally. Defaults to `1`.
-- **layout** (*Optional*, enum): Physical panel chaining pattern. Defaults to `HORIZONTAL`. One of:
-  - `HORIZONTAL` - Simple left-to-right horizontal chain (single row)
-  - `TOP_LEFT_DOWN` - Serpentine: start top-left, rows top→bottom
-  - `TOP_RIGHT_DOWN` - Serpentine: start top-right, rows top→bottom
-  - `BOTTOM_LEFT_UP` - Serpentine: start bottom-left, rows bottom→top
-  - `BOTTOM_RIGHT_UP` - Serpentine: start bottom-right, rows bottom→top
-  - `TOP_LEFT_DOWN_ZIGZAG` - Zigzag: start top-left (all panels upright)
-  - `TOP_RIGHT_DOWN_ZIGZAG` - Zigzag: start top-right (all panels upright)
-  - `BOTTOM_LEFT_UP_ZIGZAG` - Zigzag: start bottom-left (all panels upright)
-  - `BOTTOM_RIGHT_UP_ZIGZAG` - Zigzag: start bottom-right (all panels upright)
+- **layout** (*Optional*, enum): Physical panel chaining pattern.
+  <EnumOptions default="HORIZONTAL"
+    options={[
+      { value: "HORIZONTAL", description: "Simple left-to-right horizontal chain (single row)" },
+      { value: "TOP_LEFT_DOWN", description: "Serpentine: start top-left, rows top→bottom" },
+      { value: "TOP_RIGHT_DOWN", description: "Serpentine: start top-right, rows top→bottom" },
+      { value: "BOTTOM_LEFT_UP", description: "Serpentine: start bottom-left, rows bottom→top" },
+      { value: "BOTTOM_RIGHT_UP", description: "Serpentine: start bottom-right, rows bottom→top" },
+      { value: "TOP_LEFT_DOWN_ZIGZAG", description: "Zigzag: start top-left (all panels upright)" },
+      { value: "TOP_RIGHT_DOWN_ZIGZAG", description: "Zigzag: start top-right (all panels upright)" },
+      { value: "BOTTOM_LEFT_UP_ZIGZAG", description: "Zigzag: start bottom-left (all panels upright)" },
+      { value: "BOTTOM_RIGHT_UP_ZIGZAG", description: "Zigzag: start bottom-right (all panels upright)" },
+    ]}
+  />
 
 > [!NOTE]
 > The total display size will be `panel_width × layout_cols` by `panel_height × layout_rows` pixels.
 
 ### Panel Hardware (Optional)
 
-- **scan_wiring** (*Optional*, enum): Panel scan wiring pattern. Defaults to `STANDARD_TWO_SCAN`. One of:
-  - `STANDARD_TWO_SCAN` - Standard 1/16 or 1/32 scan (most common)
-  - `SCAN_1_4_16PX_HIGH` - 1/4 scan for 16px high panels
-  - `SCAN_1_8_32PX_HIGH` - 1/8 scan for 32px high panels
-  - `SCAN_1_8_32PX_FULL` - 1/8 scan for 32px high panels where the segment width is the full length of the panel
-  - `SCAN_1_8_40PX_HIGH` - 1/8 scan for 40px high panels
-  - `SCAN_1_8_64PX_HIGH` - 1/8 scan for 64px high panels
+- **scan_wiring** (*Optional*, enum): Panel scan wiring pattern.
+  <EnumOptions default="STANDARD_TWO_SCAN"
+    options={[
+      { value: "STANDARD_TWO_SCAN", description: "Standard 1/16 or 1/32 scan (most common)" },
+      { value: "SCAN_1_4_16PX_HIGH", description: "1/4 scan for 16px high panels" },
+      { value: "SCAN_1_8_32PX_HIGH", description: "1/8 scan for 32px high panels" },
+      { value: "SCAN_1_8_32PX_FULL", description: "1/8 scan for 32px high panels where the segment width is the full length of the panel" },
+      { value: "SCAN_1_8_40PX_HIGH", description: "1/8 scan for 40px high panels" },
+      { value: "SCAN_1_8_64PX_HIGH", description: "1/8 scan for 64px high panels" },
+    ]}
+  />
 
-- **shift_driver** (*Optional*, enum): LED shift register driver chip type. Defaults to `GENERIC`. One of:
-  - `GENERIC` - Standard shift register (default)
-  - `FM6124` - FM6124 driver
-  - `FM6126A` - FM6126A / ICN2038S driver (very common)
-  - `ICN2038S` - Alias for FM6126A
-  - `MBI5124` - MBI5124 driver (requires `clock_phase: true`)
-  - `DP3246` - DP3246 driver
+- **shift_driver** (*Optional*, enum): LED shift register driver chip type.
+  <EnumOptions default="GENERIC"
+    options={[
+      { value: "GENERIC", description: "Standard shift register (default)" },
+      { value: "FM6124", description: "FM6124 driver" },
+      { value: "FM6126A", description: "FM6126A / ICN2038S driver (very common)" },
+      { value: "ICN2038S", description: "Alias for FM6126A" },
+      { value: "MBI5124", description: "MBI5124 driver (requires `clock_phase: true`)" },
+      { value: "DP3246", description: "DP3246 driver" },
+    ]}
+  />
 
 ### Display Configuration (Optional)
 
 - **brightness** (*Optional*, int): Initial brightness level (0-255). Defaults to `128`.
 - **bit_depth** (*Optional*, int): Color bit depth (4-12). Higher values = better color accuracy but slower refresh. Defaults to `8`.
-- **gamma_correct** (*Optional*, enum): Gamma correction mode. One of:
-  - `LINEAR` - No gamma correction (raw values)
-  - `CIE1931` - CIE 1931 perceptual curve (recommended for most displays)
-  - `GAMMA_2_2` - Standard 2.2 gamma curve
+- **gamma_correct** (*Optional*, enum): Gamma correction mode.
+  <EnumOptions options={[
+      { value: "LINEAR", description: "No gamma correction (raw values)" },
+      { value: "CIE1931", description: "CIE 1931 perceptual curve (recommended for most displays)" },
+      { value: "GAMMA_2_2", description: "Standard 2.2 gamma curve" },
+    ]}
+  />
 - **double_buffer** (*Optional*, boolean): Enable double buffering to prevent tearing. Defaults to `false`. Set to `false` when using LVGL.
 - **update_interval** (*Optional*, [Time](/guides/configuration-types#time)): Display update frequency. Defaults to `16ms` (~60 FPS). Set to `never` when using LVGL.
 - **min_refresh_rate** (*Optional*, int): Minimum panel refresh rate in Hz (40-200). The panel may refresh faster than this, but won't go slower. Auto-calculated from `update_interval` (defaults to 60 Hz when `update_interval: never`). Rarely needs to be set manually.
@@ -231,11 +247,15 @@ For creating larger displays by chaining multiple panels:
 
 ### Advanced Timing (Optional)
 
-- **clock_speed** (*Optional*, enum): Output clock speed. Defaults to `20MHZ`. One of:
-  - `8MHZ` - 8 MHz
-  - `10MHZ` - 10 MHz
-  - `16MHZ` - 16 MHz
-  - `20MHZ` - 20 MHz (default)
+- **clock_speed** (*Optional*, enum): Output clock speed.
+  <EnumOptions default="20MHZ"
+    options={[
+      { value: "8MHZ", description: "8 MHz" },
+      { value: "10MHZ", description: "10 MHz" },
+      { value: "16MHZ", description: "16 MHz" },
+      { value: "20MHZ", description: "20 MHz (default)" },
+    ]}
+  />
 
 - **latch_blanking** (*Optional*, int): Number of clock cycles OE is blanked during LAT pulse. Defaults to `1`.
 - **clock_phase** (*Optional*, boolean): Invert clock phase. Defaults to `false`. Required to be `true` for MBI5124 driver.

--- a/src/content/docs/components/display/hub75.mdx
+++ b/src/content/docs/components/display/hub75.mdx
@@ -154,7 +154,8 @@ display:
 
 ### Board Configuration (Recommended)
 
-- **board** (*Optional*, string): Board preset name. One of: `adafruit-matrix-portal-s3`, `apollo-automation-m1-rev4`, `apollo-automation-m1-rev6`, `huidu-hd-wf2`. When specified, automatically configures all pin mappings.
+- **board** (*Optional*, string): Board preset name. When specified, automatically configures all pin mappings.
+  <EnumOptions options={["adafruit-matrix-portal-s3", "apollo-automation-m1-rev4", "apollo-automation-m1-rev6", "huidu-hd-wf2"]} />
 
 ### Panel Dimensions (Required)
 

--- a/src/content/docs/components/display/hub75.mdx
+++ b/src/content/docs/components/display/hub75.mdx
@@ -155,7 +155,7 @@ display:
 ### Board Configuration (Recommended)
 
 - **board** (*Optional*, string): Board preset name. When specified, automatically configures all pin mappings.
-  <EnumOptions options={["adafruit-matrix-portal-s3", "apollo-automation-m1-rev4", "apollo-automation-m1-rev6", "huidu-hd-wf2"]} />
+  <EnumOptions options={["adafruit-matrix-portal-s3", "apollo-automation-m1-rev4", "apollo-automation-m1-rev6", "huidu-hd-wf1", "huidu-hd-wf2", "esp32-trinity"]} />
 
 ### Panel Dimensions (Required)
 

--- a/src/content/docs/components/display/max7219digit.mdx
+++ b/src/content/docs/components/display/max7219digit.mdx
@@ -7,6 +7,7 @@ import { Image } from 'astro:assets';
 import Figure from '@components/Figure.astro';
 import max7219digitImg from './images/max7219digit.png';
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 The `max7219` display platform allows you to use MAX7219 digit with ESPHome. Please note that this component
 is *only* for the digit "matrix" display, for the 7 segment display see [Max7219](/components/display/max7219/).
@@ -48,11 +49,12 @@ display:
 - **num_chips** (*Optional*, int): The number of chips you wish to use for daisy chaining. Defaults to
   `4`.
 
-- **rotate_chip** (*Optional*): Rotates every 8x8 chip. Valid values are `0`, `90`, `180` and `270`.
-  Defaults to `0`.
+- **rotate_chip** (*Optional*): Rotates every 8x8 chip.
+  <EnumOptions inline options={["0", "90", "180", "270"]} default="0" />
 
 - **scroll_enable** (*Optional*, boolean): Turn scroll mode on when content does not fit. Defaults to `true`.
-- **scroll_mode** (*Optional*): Set the scroll mode. One of `CONTINUOUS` or `STOP`. Defaults to `CONTINUOUS`
+- **scroll_mode** (*Optional*): Set the scroll mode.
+  <EnumOptions options={["CONTINUOUS", "STOP"]} default="CONTINUOUS" />
 
   - `CONTINUOUS`  : Always scrolls and the text repeats continuously, you might need to add some
 
@@ -78,7 +80,8 @@ display:
 
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID used for code generation.
 - **num_chip_lines** (*Optional*, int): Number of lines if you want to use the displays in Multiline Mode. Defaults to `1` Example: [https://github.com/esphome/esphome/pull/1622#issue-836179156](https://github.com/esphome/esphome/pull/1622#issue-836179156)
-- **chip_lines_style** (*Optional*): How are the lines in Multiline Mode connected? Possible values are `zigzag` and `snake`. Defaults to `snake`
+- **chip_lines_style** (*Optional*): How are the lines in Multiline Mode connected?
+  <EnumOptions inline options={["zigzag", "snake"]} default="snake" />
 - **flip_x** (*Optional*, boolean): Flip the horizontal axis on the screen. Defaults to `false`.
 
 ## Actions

--- a/src/content/docs/components/display/waveshare_epaper.mdx
+++ b/src/content/docs/components/display/waveshare_epaper.mdx
@@ -9,6 +9,7 @@ import waveshareEpaperFullImg from './images/waveshare_epaper-full.jpg';
 import waveshareEpaper7colorAcepFullImg from './images/waveshare_epaper_7color_acep-full.jpg';
 import waveshareEpaperPinsImg from './images/waveshare_epaper-pins.jpg';
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 The `waveshare_epaper` display platform allows you to use
 some E-Paper displays sold by [Waveshare](https://www.waveshare.com/product/displays/e-paper.htm)
@@ -150,7 +151,8 @@ lambda: |-
   The 2.13" B74 and V2 display variants require the reset pin.
 
 - **rotation** (*Optional*): Set the rotation of the display. Everything you draw in `lambda:` will be rotated
-  by this option. One of `0°` (default), `90°`, `180°`, `270°`.
+  by this option.
+  <EnumOptions inline options={["0°", "90°", "180°", "270°"]} default="0°" />
 
 - **full_update_every** (*Optional*, int): E-Paper displays have two modes of switching to the next image: A partial
   update that only changes the pixels that have changed and a full update mode that first clears the entire display

--- a/src/content/docs/components/esp32.mdx
+++ b/src/content/docs/components/esp32.mdx
@@ -2,6 +2,7 @@
 description: "Configuration for the ESP32 platform for ESPHome."
 title: "ESP32 Platform"
 ---
+import EnumOptions from '@components/EnumOptions.astro';
 
 This component contains platform-specific options for the ESP32 platform.
 
@@ -13,9 +14,8 @@ esp32:
 
 ## Configuration variables
 
-- **variant** (*Optional*, string): The ESP32 mcu/chip to use for this device configuration. One of `esp32`,
-  `esp32s2`, `esp32s3`, `esp32c2`, `esp32c3`, `esp32c5`, `esp32c6`, `esp32c61`, `esp32h2` or `esp32p4`.
-  This must match the hardware in use, or it will fail to flash.
+- **variant** (*Optional*, string): The ESP32 mcu/chip to use for this device configuration. This must match the hardware in use, or it will fail to flash.
+  <EnumOptions inline options={["esp32", "esp32s2", "esp32s3", "esp32c2", "esp32c3", "esp32c5", "esp32c6", "esp32c61", "esp32h2", "esp32p4"]} />
 
 - **board** (*Optional*, string): The PlatformIO board ID that should be used. Choose the appropriate board from
   [this list](https://registry.platformio.org/platforms/platformio/espressif32/boards) (the icon next
@@ -31,9 +31,8 @@ esp32:
   sample silicon (rev < 3.0). When using `variant: esp32p4` without specifying a `board`, a warning is logged
   if this option is not explicitly set. Defaults to `false`.
 
-- **flash_size** (*Optional*, string): The amount of flash memory available on the ESP32 board/module. One of `2MB`,
-  `4MB`, `8MB`, `16MB` or `32MB`. Defaults to `4MB`. **Warning: specifying a size larger than that available
-  on your board will cause the ESP32 to fail to boot.**
+- **flash_size** (*Optional*, string): The amount of flash memory available on the ESP32 board/module. **Warning: specifying a size larger than that available on your board will cause the ESP32 to fail to boot.**
+  <EnumOptions inline options={["2MB", "4MB", "8MB", "16MB", "32MB"]} default="4MB" />
 
 - **cpu_frequency** (*Optional*, string): The CPU frequency to use. Defaults to the maximum supported
   frequency for the variant. The allowed values depend on the variant:
@@ -287,7 +286,8 @@ esp32:
 
 ### Configuration variables
 
-- **type** (*Optional*, string): The framework type, either `esp-idf` or `arduino`. Defaults to `esp-idf` for all ESP32 variants.
+- **type** (*Optional*, string): The framework type. Defaults to `esp-idf` for all ESP32 variants.
+  <EnumOptions options={["esp-idf", "arduino"]} />
 
 - **version** (*Optional*, string): The base framework version number to use, from
   [ESP32 ESP-IDF releases](https://github.com/espressif/esp-idf/releases) or
@@ -317,8 +317,8 @@ esp32:
   [compiler options](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/kconfig.html#compiler-options)
   to set in the ESP-IDF project.
 
-- **log_level** (*Optional*, string): Log level of the framework, one of `ERROR` (default), `NONE`, `WARN`, `INFO`,
-  `DEBUG` or `VERBOSE`.
+- **log_level** (*Optional*, string): Log level of the framework.
+  <EnumOptions options={["ERROR", "NONE", "WARN", "INFO", "DEBUG", "VERBOSE"]} default="ERROR" />
 
 - **advanced** (*Optional*, mapping): See [Advanced Configuration](#esp32-advanced_configuration) below.
 - **components** (*Optional*, list of components): See [IDF Components](#esp32-idf_components) below.
@@ -327,16 +327,11 @@ esp32:
 
 ## Advanced Configuration
 
-- **assertion_level** (*Optional*, enum): One of `ENABLE` (default), `SILENT` or `DISABLE`. Changing away from
-  the default will reduce the size of the compiled binary, albeit at the expense of ease of troubleshooting. See
-  [Espressif's documentation](https://docs.espressif.com/projects/esp-idf/en/v5.3.3/esp32/api-reference/kconfig.html#config-compiler-optimization-assertion-level)
-  for more information.
+- **assertion_level** (*Optional*, enum). Changing away from the default will reduce the size of the compiled binary, albeit at the expense of ease of troubleshooting. See [Espressif's documentation](https://docs.espressif.com/projects/esp-idf/en/v5.3.3/esp32/api-reference/kconfig.html#config-compiler-optimization-assertion-level) for more information.
+  <EnumOptions options={["ENABLE", "SILENT", "DISABLE"]} default="ENABLE" />
 
-- **compiler_optimization** (*Optional*, enum): One of `SIZE` (default), `PERF`, `NONE` or `DEBUG`. Changing
-  away from the default will increase the size of the compiled binary but may increase performance or allow for easier
-  troubleshooting. See
-  [Espressif's documentation](https://docs.espressif.com/projects/esp-idf/en/v5.3.3/esp32/api-reference/kconfig.html#config-compiler-optimization)
-  for more information.
+- **compiler_optimization** (*Optional*, enum). Changing away from the default will increase the size of the compiled binary but may increase performance or allow for easier troubleshooting. See [Espressif's documentation](https://docs.espressif.com/projects/esp-idf/en/v5.3.3/esp32/api-reference/kconfig.html#config-compiler-optimization) for more information.
+  <EnumOptions options={["SIZE", "PERF", "NONE", "DEBUG"]} default="SIZE" />
 
 - **enable_lwip_assert** (*Optional*, boolean): Can be set to `false` to reduce the size of the compiled binary by
   disabling LWIP assertions. Defaults to `true` (as recommended by Espressif). See
@@ -355,7 +350,8 @@ esp32:
   `Base MAC address from BLK0 of EFUSE CRC error`. **Valid only on original ESP32 with** `esp-idf` **framework.**
 
 - **minimum_chip_revision** (*Optional*, string): Sets the minimum ESP32 chip revision required for the firmware.
-  One of `0.0`, `1.0`, `1.1`, `2.0`, `3.0`, or `3.1`. **Valid only on original ESP32.**
+  **Valid only on original ESP32.**
+  <EnumOptions options={["0.0", "1.0", "1.1", "2.0", "3.0", "3.1"]} />
 
   Setting this to `3.0` or higher reduces flash size by excluding workaround code for older chip bugs. For PSRAM
   users, it also saves significant IRAM by keeping C library functions in ROM instead of recompiling them with
@@ -420,8 +416,8 @@ esp32:
     > - For `ecdsa_v1` (Secure Boot V1): Raw binary format (`.bin`). Extract from a PEM private key using:
     >   `espsecure.py extract_public_key --keyfile private.pem public_key.bin`
 
-  - **signing_scheme** (*Optional*, string): The signing algorithm. One of `rsa3072`, `ecdsa256`, or `ecdsa_v1`.
-    Defaults to `rsa3072`. **Not all schemes are supported on all variants** — see the table below.
+  - **signing_scheme** (*Optional*, string): The signing algorithm. **Not all schemes are supported on all variants** — see the table below.
+    <EnumOptions options={["rsa3072", "ecdsa256", "ecdsa_v1"]} default="rsa3072" />
 
     - `rsa3072`: RSA-3072 (Secure Boot V2). Recommended for most variants.
     - `ecdsa256`: ECDSA with NIST P-256 (Secure Boot V2). For variants without RSA support.
@@ -779,8 +775,8 @@ esp32:
 ### Configuration Variables
 
 - **name** (*Required*, string): Name of the partition. Cannot be any of the reserved names: `nvs`, `app0`, `app1`, `otadata`, `eeprom`, `spiffs`, `phy_init`.
-- **type** (*Required*, string or integer): Partition type. One of `app` or `data`, or a custom type as an integer between 0x40 and 0xFE.
-- **subtype** (*Required*, string or integer): Partition subtype. For `app` type: `factory` or `test`. For `data` type: `nvs`, `nvs_keys`, `spiffs`, `coredump`, `efuse`, `fat`, `undefined`, or `littlefs`. Can also be an integer between 0x0 and 0xFE.
+- **type** (*Required*, string or integer): Partition type. One of `app`, `data`, or a custom type as an integer between `0x40` and `0xFE`.
+- **subtype** (*Required*, string or integer): Partition subtype. For `app` type: `factory` or `test`. For `data` type: `nvs`, `nvs_keys`, `spiffs`, `coredump`, `efuse`, `fat`, `undefined`, or `littlefs`. Can also be an integer between `0x0` and `0xFE`.
 - **size** (*Required*, integer): Partition size in bytes. Must be 4KB (0x1000) aligned.
 
 ## GPIO Pin Numbering

--- a/src/content/docs/components/esp32_camera_web_server.mdx
+++ b/src/content/docs/components/esp32_camera_web_server.mdx
@@ -3,6 +3,7 @@ description: "Instructions for setting up the ESP32 Camera Web Server in ESPHome
 title: "ESP32 Camera Web Server Component"
 ---
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 
 The `esp32_camera_web_server` component allows you to use expose web server of
@@ -25,10 +26,7 @@ esp32_camera_web_server:
 
 - **port** (**Required**, string): The serving port.
 - **mode** (**Required**, string): The operation mode.
-  One of these values:
-
-  - `snapshot`
-  - `stream`
+  <EnumOptions options={["snapshot", "stream"]} />
 
 ## Integrating the mjpeg web service into an NVR
 

--- a/src/content/docs/components/esp8266.mdx
+++ b/src/content/docs/components/esp8266.mdx
@@ -2,6 +2,7 @@
 description: "Configuration for the ESP8266 platform for ESPHome."
 title: "ESP8266 Platform"
 ---
+import EnumOptions from '@components/EnumOptions.astro';
 
 This component contains platform-specific options for the ESP8266 platform.
 
@@ -34,7 +35,8 @@ esp8266:
   - **platform_version** (*Optional*, string): The version of the [platformio/espressif8266](https://github.com/platformio/platform-espressif8266/releases/) package to use.
 
 - **restore_from_flash** (*Optional*, boolean): Whether to store some persistent preferences in flash memory. Defaults to `false`.
-- **board_flash_mode** (*Optional*, string): The SPI mode of the flash chip. One of `qio`, `qout`, `dio` and `dout`. Defaults to `dout` for compatibility with all chips. Note: on the next OTA update the actual flash mode is automatically detected and changed to the appropriate one.
+- **board_flash_mode** (*Optional*, string): The SPI mode of the flash chip. Defaults to `dout` for compatibility with all chips. Note: on the next OTA update the actual flash mode is automatically detected and changed to the appropriate one.
+  <EnumOptions options={["qio", "qout", "dio", "dout"]} />
 - **early_pin_init** (*Optional*, boolean): Specifies whether pins should be initialised as early as possible to known values. Recommended value is `false` where switches are involved, as these will toggle when updating the firmware or when restarting the device. Defaults to `true`.
 - **enable_serial** (*Optional*, boolean): Force-enable the Arduino `Serial` object (UART0) for use in lambdas or external libraries. Most users will never need this option, as the `logger` and `uart` components automatically enable the required Serial objects. Only use this if you directly access `Serial` in a lambda and get a compilation error. Use the [UART component](/components/uart) instead when possible, as it works across all platforms. Defaults to automatic detection.
 - **enable_serial1** (*Optional*, boolean): Force-enable the Arduino `Serial1` object (UART1) for use in lambdas or external libraries. Most users will never need this option, as the `logger` and `uart` components automatically enable the required Serial objects. Only use this if you directly access `Serial1` in a lambda and get a compilation error. Use the [UART component](/components/uart) instead when possible, as it works across all platforms. Defaults to automatic detection.

--- a/src/content/docs/components/esp8266.mdx
+++ b/src/content/docs/components/esp8266.mdx
@@ -35,8 +35,8 @@ esp8266:
   - **platform_version** (*Optional*, string): The version of the [platformio/espressif8266](https://github.com/platformio/platform-espressif8266/releases/) package to use.
 
 - **restore_from_flash** (*Optional*, boolean): Whether to store some persistent preferences in flash memory. Defaults to `false`.
-- **board_flash_mode** (*Optional*, string): The SPI mode of the flash chip. Defaults to `dout` for compatibility with all chips. Note: on the next OTA update the actual flash mode is automatically detected and changed to the appropriate one.
-  <EnumOptions options={["qio", "qout", "dio", "dout"]} />
+- **board_flash_mode** (*Optional*, string): The SPI mode of the flash chip. Note: on the next OTA update the actual flash mode is automatically detected and changed to the appropriate one.
+  <EnumOptions options={["qio", "qout", "dio", "dout"]} default="dout" />
 - **early_pin_init** (*Optional*, boolean): Specifies whether pins should be initialised as early as possible to known values. Recommended value is `false` where switches are involved, as these will toggle when updating the firmware or when restarting the device. Defaults to `true`.
 - **enable_serial** (*Optional*, boolean): Force-enable the Arduino `Serial` object (UART0) for use in lambdas or external libraries. Most users will never need this option, as the `logger` and `uart` components automatically enable the required Serial objects. Only use this if you directly access `Serial` in a lambda and get a compilation error. Use the [UART component](/components/uart) instead when possible, as it works across all platforms. Defaults to automatic detection.
 - **enable_serial1** (*Optional*, boolean): Force-enable the Arduino `Serial1` object (UART1) for use in lambdas or external libraries. Most users will never need this option, as the `logger` and `uart` components automatically enable the required Serial objects. Only use this if you directly access `Serial1` in a lambda and get a compilation error. Use the [UART component](/components/uart) instead when possible, as it works across all platforms. Defaults to automatic detection.

--- a/src/content/docs/components/ethernet.mdx
+++ b/src/content/docs/components/ethernet.mdx
@@ -88,11 +88,13 @@ ethernet:
 - **clk** (**Required**, mapping):
 
   - **pin** (**Required**, [Pin](/guides/configuration-types#pin)): The RMII clock pin.
-  - **mode** (**Required**, string): The clock mode of the data lines. See your board's
-    datasheet for more details. Must be one of the following values:
-
-    - `CLK_EXT_IN` - External clock
-    - `CLK_OUT` - Internal clock
+  - **mode** (**Required**, string): The clock mode of the data lines. See your board's datasheet for more details.
+    <EnumOptions
+      options={[
+        { value: "CLK_EXT_IN", description: "External clock" },
+        { value: "CLK_OUT", description: "Internal clock" },
+      ]}
+    />
 
 - **phy_addr** (*Optional*, int): The PHY addr type of the Ethernet controller. Defaults to 0.
 - **phy_registers** (*Optional*, mapping): Arbitrary PHY register values to set after Ethernet initialization.

--- a/src/content/docs/components/ethernet.mdx
+++ b/src/content/docs/components/ethernet.mdx
@@ -3,6 +3,7 @@ description: "Instructions for setting up the Ethernet configuration for your ES
 title: "Ethernet Component"
 ---
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 
 This ESPHome component enables *wired* Ethernet connections for ESP32 and RP2040 boards.
@@ -122,7 +123,7 @@ ethernet:
   set the time interval for periodic polling. Minimum is 1ms; defaults to 10ms. ESP32 only.
   Older frameworks may not support this variable. See below for details.
 - **interface** (*Optional*, string): Controls which ESP-IDF SPI implementation should be used.
-  Value may be either `spi2` or `spi3`.
+  <EnumOptions options={["spi2", "spi3"]} />
 
 On ESP32, the `interrupt_pin` and `polling_interval` options control how the SPI Ethernet
 chip is polled. On RP2040, the arduino-pico framework handles packet processing automatically.

--- a/src/content/docs/components/external_components.mdx
+++ b/src/content/docs/components/external_components.mdx
@@ -2,6 +2,7 @@
 description: "Instructions for setting up ESPHome External Components."
 title: "External Components"
 ---
+import EnumOptions from '@components/EnumOptions.astro';
 
 You can easily import community or personal components using the external components feature.
 Bundled components can be overridden using this feature.
@@ -44,7 +45,7 @@ external_components:
 - **source**: The location of the components you want to retrieve. See [Local](#external-components_local)
   and [external-components_git](#external-components_git).
 
-  - **type** (**Required**): Repository type. One of `local`, `git`.
+  - **type** (**Required**): Repository type. <EnumOptions inline options={["local", "git"]} />
 
   git options:
 

--- a/src/content/docs/components/fan/hbridge.mdx
+++ b/src/content/docs/components/fan/hbridge.mdx
@@ -8,6 +8,7 @@ import Figure from '@components/Figure.astro';
 import l298nModuleImg from './images/L298N_module.jpg';
 import fanUiImg from './images/fan-ui.png';
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 The `hbridge` fan platform allows you to use a compatible *h-bridge* (L298N, DRV8871, MX1508, BTS7960, L9110S, DRV8833, TB6612, etc.) to control a fan (or motor/solenoid).
 
@@ -44,7 +45,13 @@ fan:
   [float output](/components/output/) connected to the Enable pin of the h-bridge (if h-bridge uses enable).
 
 - **decay_mode** (*Optional*, string): The decay mode you want to use with
-  the h-bridge. Either `slow` (coasting) or `fast` (braking). Defaults to `slow`.
+  the h-bridge.
+  <EnumOptions default="slow"
+    options={[
+      { value: "slow", description: "coasting" },
+      { value: "fast", description: "braking" },
+    ]}
+  />
 
 - **speed_count** (*Optional*, int): Set the number of supported discrete speed levels. The value is used
   to calculate the percentages for each speed. E.g. `2` means that you have 50% and 100% while `100`

--- a/src/content/docs/components/graph.mdx
+++ b/src/content/docs/components/graph.mdx
@@ -5,6 +5,7 @@ title: "Graph Component"
 
 import { Image } from 'astro:assets';
 import displayRenderingGraphImg from './images/display_rendering_graph.png';
+import EnumOptions from '@components/EnumOptions.astro';
 
 <span id="display-graphs"></span>
 
@@ -70,7 +71,8 @@ Trace specific fields:
 
 - **sensor** (*Optional*, [ID](/guides/configuration-types#id)): The sensor value to plot
 - **line_thickness** (*Optional*): Defaults to 3
-- **line_type** (*Optional*): Specifies the plot line-type. Can be one of the following: `SOLID`, `DOTTED`, `DASHED`. Defaults to `SOLID`.
+- **line_type** (*Optional*): Specifies the plot line-type.
+  <EnumOptions inline options={["SOLID", "DOTTED", "DASHED"]} default="SOLID" />
 - **continuous** (*Optional*): connects the individual points to make a continuous line. Defaults to `false`.
 - **color** (*Optional*): Sets the color of the sensor trace.
 

--- a/src/content/docs/components/image.mdx
+++ b/src/content/docs/components/image.mdx
@@ -2,6 +2,7 @@
 description: "Instructions to display static images on ESPHome"
 title: "Images"
 ---
+import EnumOptions from '@components/EnumOptions.astro';
 
 <span id="display-image"></span>
 
@@ -67,7 +68,8 @@ image:
   - `RGB565`  : Lossy RGB color stored. Uses 2 bytes per pixel, 3 with an alpha channel.
   - `RGB`  : Full RGB color stored. Uses 3 bytes per pixel, 4 with an alpha channel.
 
-- **transparency** (*Optional*): If set the alpha channel of the input image will be taken into account. The possible values are `opaque` (default), `chroma_key` and `alpha_channel`. Binary images do not support `alpha_channel`. See discussion on transparency below.
+- **transparency** (*Optional*): If set the alpha channel of the input image will be taken into account. The. Binary images do not support `alpha_channel`. See discussion on transparency below.
+  <EnumOptions options={["opaque", "chroma_key", "alpha_channel"]} default="opaque" />
 - **invert_alpha** (*Optional*, boolean): Applicable to binary and grayscale only, this will invert the colors, i.e. make black white and vice versa. Useful for e-ink displays. Defaults to `false`.
 
 - **dither** (*Optional*): Specifies which dither method used to process the image, only used in GRAYSCALE and BINARY type image. Defaults to `NONE`. You can read more about it on the [Pillow documentation](https://pillow.readthedocs.io/en/stable/reference/Image.html?highlight=Dither#PIL.Image.Image.convert) and on [Wikipedia](https://en.wikipedia.org/wiki/Dither).

--- a/src/content/docs/components/image.mdx
+++ b/src/content/docs/components/image.mdx
@@ -68,7 +68,7 @@ image:
   - `RGB565`  : Lossy RGB color stored. Uses 2 bytes per pixel, 3 with an alpha channel.
   - `RGB`  : Full RGB color stored. Uses 3 bytes per pixel, 4 with an alpha channel.
 
-- **transparency** (*Optional*): If set the alpha channel of the input image will be taken into account. The. Binary images do not support `alpha_channel`. See discussion on transparency below.
+- **transparency** (*Optional*): If set, the alpha channel of the input image will be taken into account. Binary images do not support `alpha_channel`. See discussion on transparency below.
   <EnumOptions options={["opaque", "chroma_key", "alpha_channel"]} default="opaque" />
 - **invert_alpha** (*Optional*, boolean): Applicable to binary and grayscale only, this will invert the colors, i.e. make black white and vice versa. Useful for e-ink displays. Defaults to `false`.
 

--- a/src/content/docs/components/libretiny.mdx
+++ b/src/content/docs/components/libretiny.mdx
@@ -2,6 +2,7 @@
 description: "Configuration for the LibreTiny platform for ESPHome."
 title: "LibreTiny Platform"
 ---
+import EnumOptions from '@components/EnumOptions.astro';
 
 This component contains platform-specific options for the [LibreTiny](https://docs.libretiny.eu/) platform.
 It provides support for the following microcontrollers, commonly used in Tuya devices, amongst others:
@@ -52,9 +53,8 @@ ln882x:
   - [Advanced options](#advanced-options)
 
 - **family** (*Optional*, string): The family of LibreTiny-supported microcontrollers that is used on this board.
-  One of `bk7231n`, `bk7231t`, `rtl8710b`, `rtl8720c`, `bk7251`, `bk7231q`, `ln882hki`.
-  Defaults to the variant that is detected from the board, if a board that's unknown to ESPHome is used,
-  this option is mandatory. **It's recommended not to include this option**.
+  Defaults to the variant that is detected from the board, if a board that's unknown to ESPHome is used, this option is mandatory. **It's recommended not to include this option**.
+  <EnumOptions options={["bk7231n", "bk7231t", "rtl8710b", "rtl8720c", "bk7251", "bk7231q", "ln882hki"]} />
 
 > [!NOTE]
 > Support for the LibreTiny platform is still in development and there could be issues or missing components.
@@ -185,8 +185,18 @@ bk72xx:
 
 - **loglevel** (*Optional*, string): Logging level for LibreTiny core. Controls the output of logging messages
   from the core (doesn't affect ESPHome logger!). *These messages are only visible on the physical UART*.
-  One of `verbose`, `trace` (same as `verbose`  ), `debug`, `info`,
-  `warn` (default), `error`, `fatal`, `none`.
+  <EnumOptions default="warn"
+    options={[
+      { value: "verbose" },
+      { value: "trace", description: "same as `verbose`" },
+      { value: "debug" },
+      { value: "info" },
+      { value: "warn" },
+      { value: "error" },
+      { value: "fatal" },
+      { value: "none" },
+    ]}
+  />
 
 - **debug** (*Optional*, string or string list): Modules to enable LibreTiny debugging for.
   Refer to [LibreTiny/Configuration](https://docs.libretiny.eu/link/config-debug)

--- a/src/content/docs/components/light/rp2040_pio_led_strip.mdx
+++ b/src/content/docs/components/light/rp2040_pio_led_strip.mdx
@@ -23,7 +23,7 @@ light:
 - **pin** (**Required**, [Pin](/guides/configuration-types#pin)): The pin for the data line of the light.
 - **num_leds** (**Required**, int): The number of LEDs in the strip.
 - **pio** (**Required**, int): The PIO peripheral to use. If using multiple strips, you can use up to 4 strips per PIO.
-  <EnumOptions options={["0", "1"]} />
+  <EnumOptions options={[0, 1]} />
 
 - **chipset** (*Optional*, enum): The chipset to apply known timings from.
   - `WS2812`

--- a/src/content/docs/components/light/rp2040_pio_led_strip.mdx
+++ b/src/content/docs/components/light/rp2040_pio_led_strip.mdx
@@ -2,6 +2,7 @@
 description: "Instructions for setting up addressable lights like NEOPIXEL on an RP2040 using the PIO peripheral."
 title: "RP2040 PIO LED Strip"
 ---
+import EnumOptions from '@components/EnumOptions.astro';
 
 This is a component using the RP2040 PIO peripheral to drive most addressable LED strips.
 
@@ -21,7 +22,8 @@ light:
 
 - **pin** (**Required**, [Pin](/guides/configuration-types#pin)): The pin for the data line of the light.
 - **num_leds** (**Required**, int): The number of LEDs in the strip.
-- **pio** (**Required**, int): The PIO peripheral to use. If using multiple strips, you can use up to 4 strips per PIO. Must be one of `0` or `1`.
+- **pio** (**Required**, int): The PIO peripheral to use. If using multiple strips, you can use up to 4 strips per PIO.
+  <EnumOptions options={["0", "1"]} />
 
 - **chipset** (*Optional*, enum): The chipset to apply known timings from.
   - `WS2812`

--- a/src/content/docs/components/light/spi_led_strip.mdx
+++ b/src/content/docs/components/light/spi_led_strip.mdx
@@ -6,6 +6,7 @@ title: "SPI LED Strip Light"
 import { Image } from 'astro:assets';
 import rgbDetailImg from './images/rgb-detail.jpg';
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 The `spi_led_strip` light platform drives one or more SPI interfaced RGB LEDs. These LEDs are often used in strips, where
 each LED is individually addressable. This component requires an SPI interface to be configured.
@@ -38,7 +39,8 @@ perceived intensity of different colors will generally vary. This can be done by
 ## Configuration variables
 
 - **num_leds** (*Optional*, int): The number of LEDs attached. The default is 1.
-- **data_rate** (*Optional*): Set the data rate of the SPI interface to the display. One of `80MHz`, `40MHz`, `20MHz`, `10MHz`, `5MHz`, `2MHz`, `1MHz` (default), `200kHz`, `75kHz` or `1kHz`.
+- **data_rate** (*Optional*): Set the data rate of the SPI interface to the display.
+  <EnumOptions inline options={["80MHz", "40MHz", "20MHz", "10MHz", "5MHz", "2MHz", "1MHz", "200kHz", "75kHz", "1kHz"]} default="1MHz" />
 - All other options from [Light](/components/light#config-light).
 
 You may also need to configure an `output` GPIO pin to control power to the LEDs, depending on your hardware. The

--- a/src/content/docs/components/mapping.mdx
+++ b/src/content/docs/components/mapping.mdx
@@ -35,8 +35,7 @@ text_sensor:
 
 - **from** (**Required**, string): The type of the keys in the mapping.
   <EnumOptions inline options={["string", "int"]} />
-- **to** (**Required**, string): The type of values in the map. a class specifier as discussed below.
-  <EnumOptions inline options={["string", "int"]} />
+- **to** (**Required**, string): The type of values in the map. May be one of `string`, `int`, or a class specifier as discussed below.
 - **entries** (**Required**, dict): A list of key-value pairs that define the mapping. The keys must be of the type specified in the `from` field, and the values must be of the type specified in the `to` field.
 
 ## Mapping to a class

--- a/src/content/docs/components/mapping.mdx
+++ b/src/content/docs/components/mapping.mdx
@@ -2,6 +2,7 @@
 description: "Mapping Component"
 title: "Mapping Component"
 ---
+import EnumOptions from '@components/EnumOptions.astro';
 
 The `mapping` component allows you to create a map or dictionary that allows a one-to-one translation from keys to
 values. This enables e.g. mapping a string to a number or vice versa, or mapping a string such as a weather condition to an image.
@@ -32,8 +33,10 @@ text_sensor:
 - **id** (**Required**, [ID](/guides/configuration-types#id)): Give the mapping an ID so that you can refer
   to it later in [lambdas](/automations/templates#config-lambda).
 
-- **from** (**Required**, string): The type of the keys in the mapping. Can be one of `string` or `int`.
-- **to** (**Required**, string): The type of values in the map. May be one of `string` or `int` or a class specifier as discussed below.
+- **from** (**Required**, string): The type of the keys in the mapping.
+  <EnumOptions inline options={["string", "int"]} />
+- **to** (**Required**, string): The type of values in the map. a class specifier as discussed below.
+  <EnumOptions inline options={["string", "int"]} />
 - **entries** (**Required**, dict): A list of key-value pairs that define the mapping. The keys must be of the type specified in the `from` field, and the values must be of the type specified in the `to` field.
 
 ## Mapping to a class

--- a/src/content/docs/components/media_player/speaker.mdx
+++ b/src/content/docs/components/media_player/speaker.mdx
@@ -40,7 +40,7 @@ media_player:
     <EnumOptions options={["FLAC", "MP3", "OPUS", "WAV", "NONE"]} default="FLAC" />
   - **sample_rate** (*Optional*, positive integer): Sample rate for the transcoded audio. Should be supported by the configured `speaker` component. Defaults to the speaker's sample rate. The `OPUS` codec only supports a `48000` sample rate.
   - **num_channels** (*Optional*, positive integer): Number of channels for the transcoded audio. Defaults to the speaker's number of channels.
-    <EnumOptions inline options={["1", "2"]} />
+    <EnumOptions inline options={[1, 2]} />
 
 - **media_pipeline** (*Optional*, Pipeline Schema): Configuration settings for the media pipeline. Same options as the `announcement_pipeline`.
 - **buffer_size** (*Optional*, positive integer): The buffer size in bytes for each pipeline. Must be between `4000` and `4000000`. Defaults to `1000000`.

--- a/src/content/docs/components/media_player/speaker.mdx
+++ b/src/content/docs/components/media_player/speaker.mdx
@@ -2,6 +2,7 @@
 description: "Instructions for setting up a speaker media player in ESPHome."
 title: "Speaker Audio Media Player"
 ---
+import EnumOptions from '@components/EnumOptions.astro';
 
 The `speaker` media player platform allows you to play on-device and online audio media via [speaker components](/components/speaker/).
 
@@ -35,13 +36,22 @@ media_player:
 - **announcement_pipeline** (**Required**, Pipeline Schema): Configuration settings for the announcement pipeline.
 
   - **speaker** (**Required**, [ID](/guides/configuration-types#id)): The [speaker](/components/speaker/) to output the audio.
-  - **format** (*Optional*, enum): The audio format Home Assistant will transcode audio to before sending it to the device. One of `FLAC`, `MP3`, `OPUS`, `WAV`, or `NONE`. `NONE` disables transcoding in Home Assistant. Defaults to `FLAC`.
+  - **format** (*Optional*, enum): The audio format Home Assistant will transcode audio to before sending it to the device. `NONE` disables transcoding in Home Assistant.
+    <EnumOptions options={["FLAC", "MP3", "OPUS", "WAV", "NONE"]} default="FLAC" />
   - **sample_rate** (*Optional*, positive integer): Sample rate for the transcoded audio. Should be supported by the configured `speaker` component. Defaults to the speaker's sample rate. The `OPUS` codec only supports a `48000` sample rate.
-  - **num_channels** (*Optional*, positive integer): Number of channels for the transcoded audio. Must be either `1` or `2`. Defaults to the speaker's number of channels.
+  - **num_channels** (*Optional*, positive integer): Number of channels for the transcoded audio. Defaults to the speaker's number of channels.
+    <EnumOptions inline options={["1", "2"]} />
 
 - **media_pipeline** (*Optional*, Pipeline Schema): Configuration settings for the media pipeline. Same options as the `announcement_pipeline`.
 - **buffer_size** (*Optional*, positive integer): The buffer size in bytes for each pipeline. Must be between `4000` and `4000000`. Defaults to `1000000`.
-- **codec_support_enabled** (*Optional*, enum): Controls which audio codecs (MP3, FLAC, Opus) are compiled. One of `ALL` (all available codecs are supported), `NEEDED` (only codecs needed to play the pipelines' preferred formats and included files), or `NONE` (only supports WAV files). Defaults to `NEEDED`.
+- **codec_support_enabled** (*Optional*, enum): Controls which audio codecs (MP3, FLAC, Opus) are compiled.
+  <EnumOptions default="NEEDED"
+    options={[
+      { value: "ALL", description: "all available codecs are supported" },
+      { value: "NEEDED", description: "only codecs needed to play the pipelines' preferred formats and included files" },
+      { value: "NONE", description: "only supports WAV files" },
+    ]}
+  />
 - **task_stack_in_psram** (*Optional*, boolean): Run the audio tasks in external memory. Defaults to `false`.
 - **volume_increment** (*Optional*, percentage): Increment amount that the `media_player.volume_up` and `media_player.volume_down` actions will increase or decrease volume by. Defaults to `5%`.
 - **volume_initial** (*Optional*, percentage): The default volume that mediaplayer uses for first boot where a volume has not been previously saved. Defaults to `50%`.

--- a/src/content/docs/components/media_player/speaker_source.mdx
+++ b/src/content/docs/components/media_player/speaker_source.mdx
@@ -2,6 +2,7 @@
 description: "Instructions for setting up a speaker source media player in ESPHome."
 title: "Speaker Source Media Player"
 ---
+import EnumOptions from '@components/EnumOptions.astro';
 
 The `speaker_source` media player platform orchestrates [media source](/components/media_source/) components that produce audio. When a media URL is received, the platform routes it to the appropriate source based on the URI prefix. For example, a URL starting with `audio-file://` is handled by the [Audio File media source](/components/media_source/audio_file/).
 
@@ -42,9 +43,11 @@ media_player:
 
   - **speaker** (**Required**, [ID](/guides/configuration-types#id)): The [speaker](/components/speaker/) to output the audio.
   - **sources** (**Required**, list of [IDs](/guides/configuration-types#id)): A list of [media source](/components/media_source/) component IDs to use for this pipeline. At least one source is required. When a media URL is received, the pipeline finds the first source that can handle the URI prefix. Each source can only belong to one pipeline; if both pipelines need the same type of source, configure separate instances.
-  - **format** (*Optional*, enum): The audio format Home Assistant will transcode audio to before sending it to the device. One of `FLAC`, `MP3`, `OPUS`, `WAV`, or `NONE`. `NONE` disables transcoding in Home Assistant. Defaults to `FLAC`.
+  - **format** (*Optional*, enum): The audio format Home Assistant will transcode audio to before sending it to the device. `NONE` disables transcoding in Home Assistant.
+    <EnumOptions options={["FLAC", "MP3", "OPUS", "WAV", "NONE"]} default="FLAC" />
   - **sample_rate** (*Optional*, positive integer): Sample rate for the transcoded audio. Should be supported by the configured `speaker` component. Defaults to the speaker's sample rate. The `OPUS` codec only supports a `48000` sample rate.
-  - **num_channels** (*Optional*, positive integer): Number of channels for the transcoded audio. Must be either `1` or `2`. Defaults to the speaker's number of channels.
+  - **num_channels** (*Optional*, positive integer): Number of channels for the transcoded audio. Defaults to the speaker's number of channels.
+    <EnumOptions options={["1", "2"]} />
 
 - **announcement_pipeline** (*Optional*, Pipeline Schema): Configuration settings for the announcement pipeline. Same options as `media_pipeline`. Must use a different speaker than `media_pipeline`.
 - **volume_increment** (*Optional*, percentage): Increment amount that the `media_player.volume_up` and `media_player.volume_down` actions will increase or decrease volume by. Defaults to `5%`.
@@ -134,7 +137,8 @@ on_...:
 Configuration variables:
 
 - **id** (**Required**, [ID](/guides/configuration-types#id)): The speaker source media player to control.
-- **pipeline** (**Required**, enum): Which pipeline to set the delay for. One of `media` or `announcement`.
+- **pipeline** (**Required**, enum): Which pipeline to set the delay for.
+  <EnumOptions options={["media", "announcement"]} />
 - **delay** (**Required**, [Time](/guides/configuration-types#time), [templatable](/automations/templates)): The delay between playlist tracks.
 
 ### Base Media Player Actions

--- a/src/content/docs/components/media_player/speaker_source.mdx
+++ b/src/content/docs/components/media_player/speaker_source.mdx
@@ -47,7 +47,7 @@ media_player:
     <EnumOptions options={["FLAC", "MP3", "OPUS", "WAV", "NONE"]} default="FLAC" />
   - **sample_rate** (*Optional*, positive integer): Sample rate for the transcoded audio. Should be supported by the configured `speaker` component. Defaults to the speaker's sample rate. The `OPUS` codec only supports a `48000` sample rate.
   - **num_channels** (*Optional*, positive integer): Number of channels for the transcoded audio. Defaults to the speaker's number of channels.
-    <EnumOptions options={["1", "2"]} />
+    <EnumOptions options={[1, 2]} />
 
 - **announcement_pipeline** (*Optional*, Pipeline Schema): Configuration settings for the announcement pipeline. Same options as `media_pipeline`. Must use a different speaker than `media_pipeline`.
 - **volume_increment** (*Optional*, percentage): Increment amount that the `media_player.volume_up` and `media_player.volume_down` actions will increase or decrease volume by. Defaults to `5%`.

--- a/src/content/docs/components/microphone/i2s_audio.mdx
+++ b/src/content/docs/components/microphone/i2s_audio.mdx
@@ -2,6 +2,7 @@
 description: "Instructions for setting up I²S based microphones in ESPHome."
 title: "I²S Audio Microphone"
 ---
+import EnumOptions from '@components/EnumOptions.astro';
 
 The `i2s_audio` microphone platform allows you to receive audio via the [I2S Audio](/components/i2s_audio/).
 
@@ -35,15 +36,24 @@ microphone:
   - `external`  : Use an external ADC connected to the I²S bus.
   - `internal`  : Use the internal ADC of the ESP32. Only supported on ESP32, no variant support.
 
-- **channel** (*Optional*, enum): The channel of the microphone. One of `left`, `right`, or `stereo`. If `stereo`, the output data will
-  be twice as big, with each right sample followed by a left sample. Defaults to `right`.
+- **channel** (*Optional*, enum): The channel of the microphone. If `stereo`, the output data will be twice as big, with each right sample followed by a left sample.
+  <EnumOptions options={["left", "right", "stereo"]} default="right" />
 
 - **sample_rate** (*Optional*, positive integer): I2S sample rate. Defaults to `16000`.
-- **bits_per_sample** (*Optional*, enum): The bit depth of audio samples representing real data received from the microphone. One of `8bit`, `16bit`, `24bit`, or `32bit`. Defaults to `32bit`.
-- **bits_per_channel** (*Optional*, enum): The bit depth of audio samples actually read from the microphone. One of `8bit`, `16bit`, `24bit`, or `32bit`. Defaults to `32bit`. Setting is ignored if the legacy driver is not used.
-- **mclk_multiple** (*Optional*, enum): The multiple of the MCLK frequency to the sample rate. Must be divisible by 3 if using 24 bits per sample. One of `128`, `256`, `384`, `512`. Defaults to `256`.
+- **bits_per_sample** (*Optional*, enum): The bit depth of audio samples representing real data received from the microphone.
+  <EnumOptions options={["8bit", "16bit", "24bit", "32bit"]} default="32bit" />
+- **bits_per_channel** (*Optional*, enum): The bit depth of audio samples actually read from the microphone. Setting is ignored if the legacy driver is not used.
+  <EnumOptions options={["8bit", "16bit", "24bit", "32bit"]} default="32bit" />
+- **mclk_multiple** (*Optional*, enum): The multiple of the MCLK frequency to the sample rate. Must be divisible by 3 if using 24 bits per sample.
+  <EnumOptions options={["128", "256", "384", "512"]} default="256" />
 - **use_apll** (*Optional*, boolean): I2S using APLL as main I2S clock, enable it to get accurate clock. Defaults to `false`.
-- **i2s_mode** (*Optional*, enum): The I²S mode to use. One of `primary` (clock driven by the host) or `secondary` (clock driven by the attached device). Defaults to `primary`.
+- **i2s_mode** (*Optional*, enum): The I²S mode to use.
+  <EnumOptions default="primary"
+    options={[
+      { value: "primary", description: "clock driven by the host" },
+      { value: "secondary", description: "clock driven by the attached device" },
+    ]}
+  />
 - **i2s_audio_id** (*Optional*, [ID](/guides/configuration-types#id)): The ID of the [I²S Audio](/components/i2s_audio#i2s_audio) you wish to use for this microphone.
 - **correct_dc_offset** (*Optional*, boolean): Corrects a DC offset for microphones where the audio signal's average amplitude is not 0. Defaults to `false`.
 - All other options from [Microphone](/components/microphone#config-microphone)

--- a/src/content/docs/components/mqtt.mdx
+++ b/src/content/docs/components/mqtt.mdx
@@ -6,6 +6,7 @@ title: "MQTT Client Component"
 import { Image } from 'astro:assets';
 import mqttAvailabilityImg from './images/mqtt-availability.png';
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 The MQTT Client Component sets up the MQTT connection to your broker.
 If you are connecting to Home Assistant, you may prefer to use the native API,
@@ -58,14 +59,23 @@ mqtt:
   Assistant's MQTT discovery. Should not contain trailing slash.
   Defaults to `homeassistant`.
 
-- **discovery_unique_id_generator** (*Optional*, string): The unique_id generator
-  to use. Can be one of `legacy` or `mac`. Defaults to `legacy`, which
-  generates unique_id in format `ESP<component_type><default_object_id>`.
-  `mac` generator uses format `<mac_address>-<component_type>-<fnv1_hash(friendly_name)>`.
+- **discovery_unique_id_generator** (*Optional*, string): The unique_id generator to use.
+  <EnumOptions
+    options={[
+      { value: "legacy", description: "generates unique_id in format `ESP<component_type><default_object_id>`" },
+      { value: "mac", description: "uses format `<mac_address>-<component_type>-<fnv1_hash(friendly_name)>`" },
+    ]}
+    default="legacy"
+  />
 
-- **discovery_object_id_generator** (*Optional*, string): The object_id generator
-  to use. Can be one of `none` or `device_name`. Defaults to `none` which
-  does not generate object_id. `device_name` generator uses format `<device_name>_<friendly_name>`.
+- **discovery_object_id_generator** (*Optional*, string): The object_id generator to use.
+  <EnumOptions
+    options={[
+      { value: "none", description: "does not generate object_id" },
+      { value: "device_name", description: "uses format `<device_name>_<friendly_name>`" },
+    ]}
+    default="none"
+  />
 
 - **use_abbreviations** (*Optional*, boolean): Whether to use
   [Abbreviations](https://www.home-assistant.io/docs/mqtt/discovery/)

--- a/src/content/docs/components/number/tuya.mdx
+++ b/src/content/docs/components/number/tuya.mdx
@@ -3,6 +3,7 @@ description: "Instructions for setting up a Tuya device integer or enum datapoin
 title: "Tuya Number"
 ---
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 
 The `tuya` number platform allows you to create a number that controls
@@ -91,7 +92,7 @@ Therefore there is also an option to store them on the ESPHome side and they wil
 - **multiply** (*Optional*, float): multiply the new value with this factor before sending the requests.
 - **datapoint_hidden** (*Optional*): Specify information required for hidden datapoints.
 
-  - **datapoint_type** (**Required**, string): The datapoint type, one of *int*, *uint*, *enum*.
+  - **datapoint_type** (**Required**, string): The datapoint type. <EnumOptions inline options={["int", "uint", "enum"]} />
   - **initial_value** (*Optional*, float): The value to be written at initialization. Must be between `min_value` and `max_value`.
   - **restore_value** (*Optional*, boolean): Saves and loads the state to RTC/Flash. Defaults to `false`.
 

--- a/src/content/docs/components/online_image.mdx
+++ b/src/content/docs/components/online_image.mdx
@@ -61,7 +61,7 @@ online_image:
   - `GRAYSCALE`  : Full scale grey. Uses 8 bits per pixel, 1 pixel per byte.
   - `RGB565`  : Lossy RGB color stored. Uses 2 bytes per pixel, 3 with an alpha channel
   - `RGB`  : Full RGB color stored. Uses 3 bytes per pixel, 4 with an alpha channel.
-- **transparency** (*Optional*): If set the alpha channel of the input image will be taken into account. The. See the discussion on transparency in the [image component](/components/image#display-image).
+- **transparency** (*Optional*): If set, the alpha channel of the input image will be taken into account. See the discussion on transparency in the [image component](/components/image#display-image).
   <EnumOptions options={["opaque", "chroma_key", "alpha_channel"]} default="opaque" />
 - **byte_order** (*Optional*, string): For RGB565 images, the pixels are converted to 16 bit values. By default these will be stored in big endian byte order (MSB first),
   but you can override this by setting `byte_order` to `little_endian`. Options are `big_endian` (default) and `little_endian`.

--- a/src/content/docs/components/online_image.mdx
+++ b/src/content/docs/components/online_image.mdx
@@ -3,6 +3,7 @@ description: "Instructions for displaying images downloaded at runtime in ESPHom
 title: "Online Image Component"
 ---
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 
 <span id="online_image"></span>
@@ -60,7 +61,8 @@ online_image:
   - `GRAYSCALE`  : Full scale grey. Uses 8 bits per pixel, 1 pixel per byte.
   - `RGB565`  : Lossy RGB color stored. Uses 2 bytes per pixel, 3 with an alpha channel
   - `RGB`  : Full RGB color stored. Uses 3 bytes per pixel, 4 with an alpha channel.
-- **transparency** (*Optional*): If set the alpha channel of the input image will be taken into account. The possible values are `opaque` (default), `chroma_key` and `alpha_channel`. See the discussion on transparency in the [image component](/components/image#display-image).
+- **transparency** (*Optional*): If set the alpha channel of the input image will be taken into account. The. See the discussion on transparency in the [image component](/components/image#display-image).
+  <EnumOptions options={["opaque", "chroma_key", "alpha_channel"]} default="opaque" />
 - **byte_order** (*Optional*, string): For RGB565 images, the pixels are converted to 16 bit values. By default these will be stored in big endian byte order (MSB first),
   but you can override this by setting `byte_order` to `little_endian`. Options are `big_endian` (default) and `little_endian`.
   Not applicable to other image formats.

--- a/src/content/docs/components/output/template.mdx
+++ b/src/content/docs/components/output/template.mdx
@@ -4,6 +4,7 @@ title: "Template Output"
 ---
 
 import APIClass from '@components/APIClass.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 The `template` output component can be used to create templated binary and float outputs in ESPHome.
 
@@ -30,7 +31,7 @@ output:
 ## Configuration variables
 
 - **id** (**Required**, [ID](/guides/configuration-types#id)): The id to use for this output component.
-- **type** (**Required**, string): The type of output. One of `binary` and `float`.
+- **type** (**Required**, string): The type of output. <EnumOptions inline options={["binary", "float"]} />
 - **write_action** (**Required**, [Automation](/automations)): An automation to perform
   when the state of the output is updated.
 

--- a/src/content/docs/components/pca6416a.mdx
+++ b/src/content/docs/components/pca6416a.mdx
@@ -3,6 +3,7 @@ description: "Instructions for setting up PCA6416A and PCAL6416A, digital port e
 title: "PCA6416A I/O Expander"
 ---
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 
 The PCA6416A component allows you to use **PCA6416A** or **PCAL6416A** I/O expanders in ESPHome.
@@ -89,7 +90,8 @@ switch:
 - **inverted** (*Optional*, boolean): If all read and written values
   should be treated as inverted. Defaults to `false`.
 
-- **mode** (*Optional*, string): A pin mode to set for the pin at. One of `INPUT` or `OUTPUT`.
+- **mode** (*Optional*, string): A pin mode to set for the pin at.
+  <EnumOptions inline options={["INPUT", "OUTPUT"]} />
 
 ## See Also
 

--- a/src/content/docs/components/pca9554.mdx
+++ b/src/content/docs/components/pca9554.mdx
@@ -6,6 +6,7 @@ title: "PCA9554 I/O Expander"
 import { Image } from 'astro:assets';
 import Figure from '@components/Figure.astro';
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 The PCA9554 component allows you to use a variety of Texas Instrument I/O expanders in ESPHome using the
 [I²C Bus](/components/i2c) for communication.
@@ -94,7 +95,8 @@ switch:
 - **inverted** (*Optional*, boolean): If all read and written values
   should be treated as inverted. Defaults to `false`.
 
-- **mode** (*Optional*, string): A pin mode to set for the pin at. One of `INPUT` or `OUTPUT`.
+- **mode** (*Optional*, string): A pin mode to set for the pin at.
+  <EnumOptions inline options={["INPUT", "OUTPUT"]} />
 
 ## See Also
 

--- a/src/content/docs/components/pcf8574.mdx
+++ b/src/content/docs/components/pcf8574.mdx
@@ -7,6 +7,7 @@ import { Image } from 'astro:assets';
 import Figure from '@components/Figure.astro';
 import pcf8574FullImg from './images/pcf8574-full.jpg';
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 The PCF8574 component allows you to use PCF8574 or PCF8575 I/O expanders
 ([datasheet](http://www.ti.com/lit/ds/symlink/pcf8574.pdf),
@@ -72,7 +73,8 @@ switch:
 - **inverted** (*Optional*, boolean): If all read and written values
   should be treated as inverted. Defaults to `false`.
 
-- **mode** (*Optional*, string): A pin mode to set for the pin at. One of `INPUT` or `OUTPUT`.
+- **mode** (*Optional*, string): A pin mode to set for the pin at.
+  <EnumOptions inline options={["INPUT", "OUTPUT"]} />
 
 ## See Also
 

--- a/src/content/docs/components/pi4ioe5v6408.mdx
+++ b/src/content/docs/components/pi4ioe5v6408.mdx
@@ -3,6 +3,7 @@ description: "Instructions for setting up PI4IOE5V6408 8-bit I2C I/O expander in
 title: "PI4IOE5V6408 8-Bit I2C I/O Expander"
 ---
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 
 The PI4IOE5V6408 component allows you to use the Diodes Incorporated PI4IOE5V6408 8-bit I2C I/O
@@ -58,12 +59,15 @@ binary_sensor:
 - **inverted** (*Optional*, boolean): If all read and written values should be treated as inverted.
   Defaults to `false`.
 
-- **mode** (*Optional*, [Pin Mode](/guides/configuration-types#pin-schema)): A pin mode to set for the pin. One of:
-
-  - `INPUT` - Configure the pin as an input.
-  - `OUTPUT` - Configure the pin as an output.
-  - `PULLUP` - Enable internal pull-up resistor (input mode only).
-  - `PULLDOWN` - Enable internal pull-down resistor (input mode only).
+- **mode** (*Optional*, [Pin Mode](/guides/configuration-types#pin-schema)): A pin mode to set for the pin.
+  <EnumOptions
+    options={[
+      { value: "INPUT", description: "Configure the pin as an input." },
+      { value: "OUTPUT", description: "Configure the pin as an output." },
+      { value: "PULLUP", description: "Enable internal pull-up resistor (input mode only)." },
+      { value: "PULLDOWN", description: "Enable internal pull-down resistor (input mode only)." },
+    ]}
+  />
 
 ## Examples
 

--- a/src/content/docs/components/psram.mdx
+++ b/src/content/docs/components/psram.mdx
@@ -2,6 +2,7 @@
 description: "Configuration for the ESP32 PSRAM platform for ESPHome."
 title: "PSRAM"
 ---
+import EnumOptions from '@components/EnumOptions.astro';
 
 This component enables and configures PSRAM if/when available on ESP32 modules/boards.
 Some components require PSRAM, while others may use it for optional features. In any case
@@ -18,10 +19,11 @@ psram:
 
 ## Configuration variables
 
-- **mode** (*Optional*): Defines the operating mode the PSRAM should utilize. One of `quad`, `octal` or `hex`.
-  Defaults to `quad` for ESP32, ESP32-C5, ESP32-C61, ESP32-S2 and `hex` for ESP32-P4. ESP32-S3 has no default and *requires* this option to be set.
-  See notes below.
-- **speed** (*Optional*, int): The speed at which the PSRAM should operate. One of `40MHz` (default), `80MHz` or `120MHz`.
+- **mode** (*Optional*): Defines the operating mode the PSRAM should utilize.
+  Defaults to `quad` for ESP32, ESP32-C5, ESP32-C61, ESP32-S2 and `hex` for ESP32-P4. ESP32-S3 has no default and *requires* this option to be set. See notes below.
+  <EnumOptions options={["quad", "octal", "hex"]} />
+- **speed** (*Optional*, int): The speed at which the PSRAM should operate.
+  <EnumOptions options={["40MHz", "80MHz", "120MHz"]} default="40MHz" />
 - **enable_ecc** (*Optional*, bool): For octal mode, enable ECC (Error Correction Code) for the PSRAM (default is off.)
   ECC is a method of detecting and correcting single-bit errors in memory. It will reduce the available PSRAM size and speed by
   1/16th, but also increases the rated temperature range of some ESP32 modules.

--- a/src/content/docs/components/qr_code.mdx
+++ b/src/content/docs/components/qr_code.mdx
@@ -2,6 +2,7 @@
 description: "Instructions for displaying a QR Code in ESPHome"
 title: "QR Code Component"
 ---
+import EnumOptions from '@components/EnumOptions.astro';
 
 <span id="display-qrcode"></span>
 
@@ -19,13 +20,16 @@ qr_code:
   in your display code.
 
 - **value** (**Required**, string): The string which you want to encode in the QR-code.
-- **ecc** (*Optional*, string): The error correction code level you want to use. Defaults to `LOW`. You can use one of
-  the following values:
-
-  - `LOW`  : The QR Code can tolerate about 7% erroneous codewords
-  - `MEDIUM`  : The QR Code can tolerate about 15% erroneous codewords
-  - `QUARTILE`  : The QR Code can tolerate about 25% erroneous codewords
-  - `HIGH`  : The QR Code can tolerate about 30% erroneous codewords
+- **ecc** (*Optional*, string): The error correction code level you want to use.
+  <EnumOptions
+    options={[
+      { value: "LOW", description: "The QR Code can tolerate about 7% erroneous codewords" },
+      { value: "MEDIUM", description: "The QR Code can tolerate about 15% erroneous codewords" },
+      { value: "QUARTILE", description: "The QR Code can tolerate about 25% erroneous codewords" },
+      { value: "HIGH", description: "The QR Code can tolerate about 30% erroneous codewords" },
+    ]}
+    default="LOW"
+  />
 
 To draw the QR-code, call the `it.qr_code` function from your render lambda:
 

--- a/src/content/docs/components/sensor/apds9306.mdx
+++ b/src/content/docs/components/sensor/apds9306.mdx
@@ -41,25 +41,25 @@ The `apds9306` sensor allows you to use your [Apds9306](/components/sensor/apds9
 
 - **address** (*Optional*, int): The I²C address of the sensor. Should be `0x52` according to datasheet ("Contact factory for other addressing options").
 - **gain** (*Optional*, int): The gain of the ambient light sensor.
-  <EnumOptions inline options={["1", "3", "6", "9", "18"]} default="1" />
+  <EnumOptions inline options={[1, 3, 6, 9, 18]} default={1} />
 - **bit_width** (*Optional*, int): The bit width/resolution of the ambient light sensor.
   <EnumOptions
     options={[
-      { value: "20", description: "takes 400ms" },
-      { value: "19", description: "takes 200ms" },
-      { value: "18", description: "takes 100ms" },
-      { value: "17", description: "takes 50ms" },
-      { value: "16", description: "takes 25ms" },
-      { value: "13", description: "takes 3.125ms" },
+      { value: 20, description: "takes 400ms" },
+      { value: 19, description: "takes 200ms" },
+      { value: 18, description: "takes 100ms" },
+      { value: 17, description: "takes 50ms" },
+      { value: 16, description: "takes 25ms" },
+      { value: 13, description: "takes 3.125ms" },
     ]}
-    default="18"
+    default={18}
   />
 
 - **measurement_rate** (*Optional*, int): The measurement rate of the ambient light sensor in milliseconds.
-  <EnumOptions inline options={["25", "50", "100", "200", "500", "1000"]} default="100" />
+  <EnumOptions inline options={[25, 50, 100, 200, 500, 1000]} default={100} />
 
 - **update_interval** (*Optional*, [Time](/guides/configuration-types#time)): The interval at which the sensor reading will be updated. Defaults to `60s`.
-- All opther options from [Sensor](/components/sensor).
+- All other options from [Sensor](/components/sensor).
 
 ## See Also
 

--- a/src/content/docs/components/sensor/apds9306.mdx
+++ b/src/content/docs/components/sensor/apds9306.mdx
@@ -6,6 +6,7 @@ title: "APDS9306 Sensor"
 import { Image } from 'astro:assets';
 import Figure from '@components/Figure.astro';
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 <span id="apds9306-component"></span>
 
@@ -39,24 +40,23 @@ sensor:
 The `apds9306` sensor allows you to use your [Apds9306](/components/sensor/apds9306/) to perform ambient light measurements.
 
 - **address** (*Optional*, int): The I²C address of the sensor. Should be `0x52` according to datasheet ("Contact factory for other addressing options").
-- **gain** (*Optional*, int): The gain of the ambient light sensor. One of 1, 3, 6, 9, 18. Defaults to `1`.
-- **bit_width** (*Optional*, int): The bit width/resolution of the ambient light sensor. One of:
+- **gain** (*Optional*, int): The gain of the ambient light sensor.
+  <EnumOptions inline options={["1", "3", "6", "9", "18"]} default="1" />
+- **bit_width** (*Optional*, int): The bit width/resolution of the ambient light sensor.
+  <EnumOptions
+    options={[
+      { value: "20", description: "takes 400ms" },
+      { value: "19", description: "takes 200ms" },
+      { value: "18", description: "takes 100ms" },
+      { value: "17", description: "takes 50ms" },
+      { value: "16", description: "takes 25ms" },
+      { value: "13", description: "takes 3.125ms" },
+    ]}
+    default="18"
+  />
 
-  - `20` takes 400ms
-  - `19` takes 200ms
-  - `18` takes 100ms (`default`  )
-  - `17` takes 50ms
-  - `16` takes 25ms
-  - `13` takes 3.125ms
-
-- **measurement_rate** (*Optional*, int): The measurement rate of the ambient light sensor in milliseconds. One of:
-
-  - `25`
-  - `50`
-  - `100` (`default`  );
-  - `200`
-  - `500`
-  - `1000`
+- **measurement_rate** (*Optional*, int): The measurement rate of the ambient light sensor in milliseconds.
+  <EnumOptions inline options={["25", "50", "100", "200", "500", "1000"]} default="100" />
 
 - **update_interval** (*Optional*, [Time](/guides/configuration-types#time)): The interval at which the sensor reading will be updated. Defaults to `60s`.
 - All opther options from [Sensor](/components/sensor).

--- a/src/content/docs/components/sensor/apds9960.mdx
+++ b/src/content/docs/components/sensor/apds9960.mdx
@@ -7,6 +7,7 @@ import { Image } from 'astro:assets';
 import Figure from '@components/Figure.astro';
 import apds9960FullImg from './images/apds9960-full.jpg';
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 <span id="apds9960-component"></span>
 
@@ -54,12 +55,18 @@ Base Configuration:
 - **update_interval** (*Optional*, [Time](/guides/configuration-types#time)): The interval
   to check the sensor. Defaults to `60s`.
 
-- **led_drive** (*Optional*, int): The LED drive level in mA. One of 100mA, 50mA, 25mA, 12.5mA. Defaults to `100mA`.
-- **proximity_gain** (*Optional*, int): The proximity gain level. One of 1x, 2x, 4x, 8x. Defaults to `4x`.
-- **ambient_light_gain** (*Optional*, int): The ambient light gain level. One of 1x, 4x, 16x, 64x. Defaults to `4x`.
-- **gesture_led_drive** (*Optional*, int): The gesture LED drive level in mA. One of 100mA, 50mA, 25mA, 12.5mA. Defaults to `100mA`.
-- **gesture_gain** (*Optional*, int): The proximity gain level. One of 1x, 2x, 4x, 8x. Defaults to `4x`.
-- **gesture_wait_time** (*Optional*, int): The gesture wait time in ms. One of 0ms, 2.8ms, 5.6ms, 8.4ms, 14ms, 22.4ms, 30.8ms, 39.2ms. Defaults to `2.8ms`.
+- **led_drive** (*Optional*, int): The LED drive level in mA.
+  <EnumOptions inline options={["100mA", "50mA", "25mA", "12.5mA"]} default="100mA" />
+- **proximity_gain** (*Optional*, int): The proximity gain level.
+  <EnumOptions inline options={["1x", "2x", "4x", "8x"]} default="4x" />
+- **ambient_light_gain** (*Optional*, int): The ambient light gain level.
+  <EnumOptions inline options={["1x", "4x", "16x", "64x"]} default="4x" />
+- **gesture_led_drive** (*Optional*, int): The gesture LED drive level in mA.
+  <EnumOptions inline options={["100mA", "50mA", "25mA", "12.5mA"]} default="100mA" />
+- **gesture_gain** (*Optional*, int): The proximity gain level.
+  <EnumOptions inline options={["1x", "2x", "4x", "8x"]} default="4x" />
+- **gesture_wait_time** (*Optional*, int): The gesture wait time in ms.
+  <EnumOptions inline options={["0ms", "2.8ms", "5.6ms", "8.4ms", "14ms", "22.4ms", "30.8ms", "39.2ms"]} default="2.8ms" />
 
 ## Sensor
 

--- a/src/content/docs/components/sensor/as7341.mdx
+++ b/src/content/docs/components/sensor/as7341.mdx
@@ -7,6 +7,7 @@ import { Image } from 'astro:assets';
 import Figure from '@components/Figure.astro';
 import as7341FullImg from './images/as7341-full.jpg';
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 The `as7341` sensor platform allows you to use your AS7341 spectral color sensor
 ([datasheet](https://look.ams-osram.com/m/24266a3e584de4db/original/AS7341-DS000504.pdf),
@@ -58,19 +59,8 @@ sensor:
 - **f8** (*Optional*): The reading for the 680nm channel. All options from [Sensor](/components/sensor).
 - **clear** (*Optional*): The reading for the clear channel. All options from [Sensor](/components/sensor).
 - **nir** (*Optional*): The reading for the NIR (near-infrared) channel. All options from [Sensor](/components/sensor).
-- **gain** (*Optional*): The gain used by the device. A higher gain may be more suitable for lower-light environments. Must be one of:
-
-  - `X0.5`
-  - `X1`
-  - `X2`
-  - `X4`
-  - `X8` (*default*)
-  - `X16`
-  - `X32`
-  - `X64`
-  - `X128`
-  - `X256`
-  - `X512`
+- **gain** (*Optional*): The gain used by the device. A higher gain may be more suitable for lower-light environments.
+  <EnumOptions inline options={["X0.5", "X1", "X2", "X4", "X8", "X16", "X32", "X64", "X128", "X256", "X512"]} default="X8" />
 
 - **astep** (*Optional*): The number of integration steps. Default is `599`. Must be between `0` and `65534`.
 - **atime** (*Optional*): The integration time per step in increments of 2.78µs. Default is `29`. Must be between `0` and `255`.

--- a/src/content/docs/components/sensor/atm90e26.mdx
+++ b/src/content/docs/components/sensor/atm90e26.mdx
@@ -3,6 +3,7 @@ description: "Instructions for setting up ATM90E26 energy metering sensors"
 title: "ATM90E26 Power Sensor"
 ---
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 
 The `atm90e26` sensor platform allows you to use your ATM90E26 voltage/current and power sensors
@@ -18,7 +19,8 @@ and additionally provides active, reactive, and apparent power, frequency, power
 ## Configuration variables
 
 - **cs_pin** (**Required**, [Pin Schema](/guides/configuration-types#pin-schema)): The pin CS is connected to. For the 6 channel meter main board, this will always be 5 and 4. For the add-on boards a jumper can be selected for each CS pin, but default to 0 and 16.
-- **line_frequency** (**Required**, string): The AC line frequency of the supply voltage. One of `50Hz`, `60Hz`.
+- **line_frequency** (**Required**, string): The AC line frequency of the supply voltage.
+  <EnumOptions inline options={["50Hz", "60Hz"]} />
 - **meter_constant** (**Required**, float): The number of pulses per kWh. The ATM90E26 internally works based on pulses and
   this value converts a pulse into Wh, which are emitted as `forward_active_energy` etc. Matching it against an existing
   meter is useful in that it allows visual confirmation for some devices that blink an LED for each pulse. Common values are
@@ -61,8 +63,8 @@ and additionally provides active, reactive, and apparent power, frequency, power
 - **gain_ct** (*Optional*, int): CT clamp calibration value.
   Defaults to `31251`.
 
-- **gain_pga** (*Optional*, string): The gain for the CT clamp. Valid values are `1X`, `4X`, `8X`, `16X`, and `24X`.
-  Defaults to `1X`.
+- **gain_pga** (*Optional*, string): The gain for the CT clamp.
+  <EnumOptions inline options={["1X", "4X", "8X", "16X", "24X"]} default="1X" />
 
 - **update_interval** (*Optional*, [Time](/guides/configuration-types#time)): The interval to check the sensor. Defaults to `60s`.
 - **spi_id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID of the [SPI Component](/components/spi) if you want

--- a/src/content/docs/components/sensor/atm90e32.mdx
+++ b/src/content/docs/components/sensor/atm90e32.mdx
@@ -107,7 +107,7 @@ The [CircuitSetup 6-Channel Energy Meter](https://circuitsetup.us/product/expand
 - **chip_temperature** (*Optional*): Use the chip temperature value. All options from
   [Sensor](/components/sensor).
 
-- **gain_pga** (*Optional*, string): Increase this when the output of the CT clamp is too low and `gain_ct` is maxed out. which is suitable for most CT clamps.
+- **gain_pga** (*Optional*, string): Increase this when the output of the CT clamp is too low and `gain_ct` is maxed out. The default is suitable for most CT clamps.
   <EnumOptions inline options={["1X", "2X", "4X"]} default="1X" />
 
 - **current_phases** (*Optional*): The number of phases the meter has, `2` or, `3`

--- a/src/content/docs/components/sensor/atm90e32.mdx
+++ b/src/content/docs/components/sensor/atm90e32.mdx
@@ -8,6 +8,7 @@ import Figure from '@components/Figure.astro';
 import atm90e32Cs2chanFullImg from './images/atm90e32-cs-2chan-full.jpg';
 import atm90e32Cs6chanFullImg from './images/atm90e32-cs-6chan-full.jpg';
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 The `atm90e32` sensor platform allows you to use your ATM90E32 voltage/current and power sensors
 ([datasheet](http://ww1.microchip.com/downloads/en/devicedoc/Atmel-46003-SE-M90E32AS-Datasheet.pdf)) with
@@ -41,7 +42,8 @@ The [CircuitSetup 6-Channel Energy Meter](https://circuitsetup.us/product/expand
 ## Configuration variables
 
 - **cs_pin** (**Required**, [Pin Schema](/guides/configuration-types#pin-schema)): The pin CS is connected to. For the 6 channel meter main board, this will always be 5 and 4. For the add-on boards a jumper can be selected for each CS pin, but default to 0 and 16.
-- **line_frequency** (**Required**, string): The AC line frequency of the supply voltage. One of `50Hz`, `60Hz`.
+- **line_frequency** (**Required**, string): The AC line frequency of the supply voltage.
+  <EnumOptions inline options={["50Hz", "60Hz"]} />
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): Required if using more than one `atm90e32` chip with buttons for calibration, reference voltage/current fields, and phase status fields
 - **phase_a** (*Optional*): The configuration options for the 1st phase.
 
@@ -105,8 +107,8 @@ The [CircuitSetup 6-Channel Energy Meter](https://circuitsetup.us/product/expand
 - **chip_temperature** (*Optional*): Use the chip temperature value. All options from
   [Sensor](/components/sensor).
 
-- **gain_pga** (*Optional*, string): Increase this when the output of the CT clamp is too low and `gain_ct` is maxed out. One of `1X`,
-  `2X`, `4X`. Defaults to `1X`, which is suitable for most CT clamps.
+- **gain_pga** (*Optional*, string): Increase this when the output of the CT clamp is too low and `gain_ct` is maxed out. which is suitable for most CT clamps.
+  <EnumOptions inline options={["1X", "2X", "4X"]} default="1X" />
 
 - **current_phases** (*Optional*): The number of phases the meter has, `2` or, `3`
   The 6 Channel Expandable Energy Meter should be set to `3`, and the Split Single Phase meter should be set to `2`. Defaults to `3`.

--- a/src/content/docs/components/sensor/binary_sensor_map.mdx
+++ b/src/content/docs/components/sensor/binary_sensor_map.mdx
@@ -3,6 +3,7 @@ description: "Instructions for setting up a Binary Sensor Map"
 title: "Binary Sensor Map"
 ---
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 
 The `binary_sensor_map` sensor platform allows you to map multiple [binary sensor](/components/binary_sensor/)
@@ -120,7 +121,9 @@ binary_sensor:
 
 ## Configuration variables
 
-- **type** (**Required**, string): The sensor type. Should be one of: `BAYESIAN`, `GROUP`, or `SUM`.
+- **type** (**Required**, string): The sensor type.
+  <EnumOptions options={["BAYESIAN", "GROUP", "SUM"]} />
+
 - **channels** (**Required for GROUP or SUM types**): A list of channels that are mapped to certain values.
 
   - **binary_sensor** (**Required**): The id of the [binary sensor](/components/binary_sensor/)

--- a/src/content/docs/components/sensor/bl0942.mdx
+++ b/src/content/docs/components/sensor/bl0942.mdx
@@ -3,6 +3,7 @@ description: "Instructions for setting up BL0942 power monitors."
 title: "Belling BL0942 Energy Monitor"
 ---
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 
 The `bl0942` sensor platform allows you to use BL0942 energy monitors sensors with
@@ -49,7 +50,8 @@ sensor:
 - **uart_id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID of the [UART Component](/components/uart) if you want
   to use multiple UART buses.
 
-- **line_frequency** (*Optional*, string): The nominal AC line frequency of the supply voltage. One of `50Hz`, `60Hz`. Defaults to `50Hz`.
+- **line_frequency** (*Optional*, string): The nominal AC line frequency of the supply voltage.
+  <EnumOptions options={["50Hz", "60Hz"]} default="50Hz" />
 - **address** (*Optional*, int): The address of the BL0942 from its strapping pins. Defaults to `0`.
 - **reset** (*Optional*, boolean): Whether to reset the BL0942 chip on startup, resetting all internal counters. Defaults to `true`.
 - **current_reference** (*Optional*, float): The calibration parameter for current readings. Defaults to `251065.6814`.

--- a/src/content/docs/components/sensor/ble_client.mdx
+++ b/src/content/docs/components/sensor/ble_client.mdx
@@ -3,6 +3,7 @@ description: "Fetch numeric values from BLE devices."
 title: "BLE Client Sensor"
 ---
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 
 The `ble_client` component is a sensor platform that can query BLE devices for RSSI or specific
@@ -44,14 +45,14 @@ sensor:
 
 ## Configuration variables
 
-- **type** (**Required**): One of `rssi`, `characteristic`.
+- **type** (**Required**): <EnumOptions inline options={["rssi", "characteristic"]} />
 
-rssi options:
+### RSSI
 
 - **update_interval** (*Optional*, [Time](/guides/configuration-types#time)): The interval to poll the device.
 - All other options from [Sensor](/components/sensor).
 
-characteristic options:
+### Characteristic
 
 - **ble_client_id** (**Required**, [ID](/guides/configuration-types#id)): ID of the associated BLE client.
 - **service_uuid** (**Required**, UUID): UUID of the service on the device.
@@ -67,7 +68,7 @@ characteristic options:
 - **update_interval** (*Optional*, [Time](/guides/configuration-types#time)): The interval to poll the device.
 - All other options from [Sensor](/components/sensor).
 
-Automations:
+### Automations
 
 - **on_notify** (*Optional*, [Automation](/automations)): An automation to
   perform when a notify message is received from the device. See [`on_notify`](#ble_sensor-on_notify).

--- a/src/content/docs/components/sensor/bme280.mdx
+++ b/src/content/docs/components/sensor/bme280.mdx
@@ -7,6 +7,7 @@ import { Image } from 'astro:assets';
 import Figure from '@components/Figure.astro';
 import bme280FullImg from './images/bme280-full.jpg';
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 The `bme280` sensor platform allows you to use your BME280
 ([datasheet](https://cdn-shop.adafruit.com/datasheets/BST-BME280_DS001-10.pdf),
@@ -70,8 +71,8 @@ sensor:
 
   - All other options from [Sensor](/components/sensor).
 
-- **iir_filter** (*Optional*): Set up an Infinite Impulse Response filter to increase accuracy. One of
-  `OFF`, `2x`, `4x`, `16x`. Defaults to `OFF`.
+- **iir_filter** (*Optional*): Set up an Infinite Impulse Response filter to increase accuracy.
+  <EnumOptions options={["OFF", "2x", "4x", "16x"]} default="OFF" />
 
 - **update_interval** (*Optional*, [Time](/guides/configuration-types#time)): The interval to check the
   sensor. Defaults to `60s`.

--- a/src/content/docs/components/sensor/bme680.mdx
+++ b/src/content/docs/components/sensor/bme680.mdx
@@ -8,6 +8,7 @@ import Figure from '@components/Figure.astro';
 import bme680FullImg from './images/bme680-full.jpg';
 import bme680UiImg from './images/bme680-ui.png';
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 The `bme680` sensor platform allows you to use your BME680
 ([datasheet](https://cdn-shop.adafruit.com/product-files/3660/BME680.pdf),
@@ -68,8 +69,8 @@ sensor:
 - **address** (*Optional*, int): Manually specify the I²C address of
   the sensor. Defaults to `0x76`. Another address can be `0x77`.
 
-- **iir_filter** (*Optional*): Set up an Infinite Impulse Response filter to increase accuracy. One of
-  `OFF`, `1x`, `3x`, `7x`, `15x`, `31x`, `63x` and `127x`. Defaults to `OFF`.
+- **iir_filter** (*Optional*): Set up an Infinite Impulse Response filter to increase accuracy.
+  <EnumOptions options={["OFF", "1x", "3x", "7x", "15x", "31x", "63x", "127x"]} default="OFF" />
 
 - **heater** (*Optional*): The settings for the internal heater for the gas sensor. Set this
   to disable the internal heater.

--- a/src/content/docs/components/sensor/bmp280.mdx
+++ b/src/content/docs/components/sensor/bmp280.mdx
@@ -7,6 +7,7 @@ import { Image } from 'astro:assets';
 import Figure from '@components/Figure.astro';
 import bmp280FullImg from './images/bmp280-full.jpg';
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 The `bmp280` sensor platform allows you to use your BMP280
 ([datasheet](https://cdn-shop.adafruit.com/datasheets/BST-BMP280-DS001-11.pdf),
@@ -61,8 +62,8 @@ sensor:
 
   - All other options from [Sensor](/components/sensor).
 
-- **iir_filter** (*Optional*): Set up an Infinite Impulse Response filter to increase accuracy. One of
-  `OFF`, `2x`, `4x`, `16x`. Defaults to `OFF`.
+- **iir_filter** (*Optional*): Set up an Infinite Impulse Response filter to increase accuracy.
+  <EnumOptions options={["OFF", "2x", "4x", "16x"]} default="OFF" />
 
 - **update_interval** (*Optional*, [Time](/guides/configuration-types#time)): The interval to check the
   sensor. Defaults to `60s`.

--- a/src/content/docs/components/sensor/combination.mdx
+++ b/src/content/docs/components/sensor/combination.mdx
@@ -3,6 +3,7 @@ description: "Instructions for setting up a combination sensor"
 title: "Combine the state of several sensors"
 ---
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 
 The `combination` sensor platform allows you to combine the state of several
@@ -70,9 +71,8 @@ sensor:
 
 ## Configuration variables
 
-- **type** (**Required**, enum): Combination statistic type, should be one of
-  `KALMAN`, `LINEAR`, `MAXIMUM`, `MEAN`, `MEDIAN`, `MINIMUM`,
-  `MOST_RECENTLY_UPDATED`, `RANGE`, or `SUM`.
+- **type** (**Required**, enum): Combination statistic type.
+  <EnumOptions options={["KALMAN", "LINEAR", "MAXIMUM", "MEAN", "MEDIAN", "MINIMUM", "MOST_RECENTLY_UPDATED", "RANGE", "SUM"]} />
 
 - **sources** (**Required**, list): A list of sensors to use as source.
 

--- a/src/content/docs/components/sensor/dht.mdx
+++ b/src/content/docs/components/sensor/dht.mdx
@@ -8,6 +8,7 @@ import Figure from '@components/Figure.astro';
 import dhtFullImg from './images/dht-full.jpg';
 import temperatureHumidityImg from './images/temperature-humidity.png';
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 The DHT Temperature+Humidity sensor allows you to use your
 
@@ -57,8 +58,8 @@ sensor:
   - All options from [Sensor](/components/sensor).
 
 - **model** (*Optional*, int): Manually specify the DHT model, can be
-  one of `AUTO_DETECT`, `DHT11`, `DHT22`, `DHT22_TYPE2`, `AM2302`, `RHT03`, `SI7021`, `AM2120`
-  and helps with some connection issues. Defaults to `AUTO_DETECT`. Auto detection doesn't work for the SI7021 chip.
+  and helps with some connection issues. Auto detection doesn't work for the SI7021 chip.
+  <EnumOptions options={["AUTO_DETECT", "DHT11", "DHT22", "DHT22_TYPE2", "AM2302", "RHT03", "SI7021", "AM2120"]} default="AUTO_DETECT" />
 
 - **update_interval** (*Optional*, [Time](/guides/configuration-types#time)): The interval to check the
   sensor. Defaults to `60s`.

--- a/src/content/docs/components/sensor/dht.mdx
+++ b/src/content/docs/components/sensor/dht.mdx
@@ -57,8 +57,7 @@ sensor:
 
   - All options from [Sensor](/components/sensor).
 
-- **model** (*Optional*, int): Manually specify the DHT model, can be
-  and helps with some connection issues. Auto detection doesn't work for the SI7021 chip.
+- **model** (*Optional*, int): Manually specify the DHT model. Helps with some connection issues. Auto detection doesn't work for the SI7021 chip.
   <EnumOptions options={["AUTO_DETECT", "DHT11", "DHT22", "DHT22_TYPE2", "AM2302", "RHT03", "SI7021", "AM2120"]} default="AUTO_DETECT" />
 
 - **update_interval** (*Optional*, [Time](/guides/configuration-types#time)): The interval to check the

--- a/src/content/docs/components/sensor/hlw8012.mdx
+++ b/src/content/docs/components/sensor/hlw8012.mdx
@@ -5,6 +5,7 @@ title: "HLW8012 Power Sensor"
 
 import HLW8012Calculator from '@components/HLW8012Calculator.astro';
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 The `hlw8012` sensor platform allows you to use your HLW8012 voltage/current and power sensors
 ([datasheet](https://github.com/xoseperez/hlw8012/blob/master/docs/HLW8012.pdf)) sensors with
@@ -73,8 +74,8 @@ Advanced Options:
   Defaults to the Sonoff POW's value `2351`.
 
 - **model** (*Optional*, string): The sensor model on the board, to set internal constant factors to convert pulses to measurements.
-  Possible values are `HLW8012`, `CSE7759`, `BL0937`. Defaults to `HLW8012`.
   CSE7759 uses same constants and it also works with default. Must be set for BL0937 to be able to calibrate all three measurements at the same time.
+  <EnumOptions options={["HLW8012", "CSE7759", "BL0937"]} default="HLW8012" />
 
 - **change_mode_every** (*Optional*, int): After how many updates to cycle between the current/voltage measurement mode.
   Note that the first value after switching is discarded because it is often inaccurate. When set to `"never"` the measurement mode will stay at the

--- a/src/content/docs/components/sensor/hm3301.mdx
+++ b/src/content/docs/components/sensor/hm3301.mdx
@@ -3,6 +3,7 @@ description: "Instructions for setting up HM3301 Particulate matter sensor"
 title: "The Grove - Laser PM2.5 Sensor (HM3301)"
 ---
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 
 The `HM3301` sensor platform allows you to use your HM3301 particulate matter sensor
@@ -42,7 +43,8 @@ sensor:
 
   - All options from [Sensor](/components/sensor).
 
-  - **calculation_type** (**Required**): One of: `AQI` or `CAQI`.
+  - **calculation_type** (**Required**): <EnumOptions inline options={["AQI", "CAQI"]} />
+
   - All other options from [Sensor](/components/sensor).
 
 ## Air Quality Index

--- a/src/content/docs/components/sensor/hmc5883l.mdx
+++ b/src/content/docs/components/sensor/hmc5883l.mdx
@@ -6,6 +6,7 @@ title: "HMC5883L Magnetometer"
 import { Image } from 'astro:assets';
 import Figure from '@components/Figure.astro';
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 <span id="hmc5883l"></span>
 
@@ -57,8 +58,8 @@ sensor:
   [Sensor](/components/sensor).
 
 - **update_interval** (*Optional*, [Time](/guides/configuration-types#time)): The interval to check the sensor. Defaults to `60s`.
-- **oversampling** (*Optional*): Number of readings to average over for each sample. One of `1x`, `2x`,
-  `4x`, `8x`. Defaults to `1x`.
+- **oversampling** (*Optional*): Number of readings to average over for each sample.
+  <EnumOptions options={["1x", "2x", "4x", "8x"]} default="1x" />
 
 - **range** (*Optional*): Select a range / gain preset. This does not affect the scale of the values published
   but allows one to avoid overflows at the cost of reading resolution. Supported values are 88µT, 130µT, 190µT,

--- a/src/content/docs/components/sensor/hydreon_rgxx.mdx
+++ b/src/content/docs/components/sensor/hydreon_rgxx.mdx
@@ -6,6 +6,7 @@ title: "Hydreon Rain Sensor"
 import { Image } from 'astro:assets';
 import Figure from '@components/Figure.astro';
 import hydreonRg9FullImg from './images/hydreon_rg9_full.jpg';
+import EnumOptions from '@components/EnumOptions.astro';
 
 The `hydreon_rgxx` sensor platform allows you to use rain sensors by Hydreon. Currently supported are the RG-9 and RG-15 sensors ([model comparison](https://rainsensors.com/products/model-comparison/)).
 
@@ -66,7 +67,8 @@ sensor:
 
 ## Configuration variables
 
-- **model** (**Required**, string): Specify which rain sensor you have connected. Must be either `RG_9` or `RG_15`.
+- **model** (**Required**, string): Specify which rain sensor you have connected.
+  <EnumOptions options={["RG_9", "RG_15"]} />
 
 - **disable_led** (*Optional*): Disables the on-board LED. Defaults to `false`. Only on RG-9 firmware version 1.200-onwards.
 
@@ -81,8 +83,8 @@ sensor:
 
   - All options from [Sensor](/components/sensor).
 
-- **resolution** (*Optional*, string): Specify rain sensor resolution. Must be either `low` or `high`. Default resolution is `high`.
-  Only applies to RG-15.
+- **resolution** (*Optional*, string): Specify rain sensor resolution. Only applies to RG-15.
+  <EnumOptions options={["low", "high"]} default="high" />
 
 - **acc** (*Optional*): Amount of rain since last message (see `update_interval`  ), in `mm`. Only on RG-15.
 

--- a/src/content/docs/components/sensor/ina226.mdx
+++ b/src/content/docs/components/sensor/ina226.mdx
@@ -7,6 +7,7 @@ import { Image } from 'astro:assets';
 import Figure from '@components/Figure.astro';
 import ina226FullImg from './images/ina226-full.jpg';
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 The `ina226` sensor platform allows you to use your INA226 DC Current and Power Sensor
 ([datasheet](http://www.ti.com/lit/ds/symlink/ina226.pdf), [eBay](https://www.ebay.com)) sensors with ESPHome.
@@ -59,15 +60,16 @@ sensor:
 - **max_current** (*Optional*, float): The maximum current you are expecting. ESPHome will use this to
   configure the sensor optimally. Defaults to `3.2A`.
 
-- **adc_time** (*Optional*, [Time](/guides/configuration-types#time) or both of the following nested options): The time in microseconds to perform a single ADC conversion.
-  Defaults to `1100us`. Valid values are `140us`, `204us`, `332us`, `588us`, `1100us`, `2116us`,
-  `4156us`, `8244us`.
+- **adc_time** (*Optional*, [Time](/guides/configuration-types#time) or mapping): The time in microseconds to perform a single ADC conversion. May be specified as a single time applied to all measurements, or as a mapping with separate times per measurement.
+  <EnumOptions options={["140us", "204us", "332us", "588us", "1100us", "2116us", "4156us", "8244us"]} default="1100us" />
 
-  - **voltage** (**Required**, [Time](/guides/configuration-types#time)): ADC conversion time for Bus Voltage
-  - **current** (**Required**, [Time](/guides/configuration-types#time)): ADC conversion time for Shunt Voltage (Current measurement)
+  When provided as a mapping, each sub-key accepts the same values shown above:
 
-- **adc_averaging** (*Optional*, integer): Selects ADC sample averaging count. Defaults to `4`. Valid values are
-  `1`, `4`, `16`, `64`, `128`, `256`, `512`, `1024`.
+  - **voltage** (**Required**, [Time](/guides/configuration-types#time)): ADC conversion time for Bus Voltage.
+  - **current** (**Required**, [Time](/guides/configuration-types#time)): ADC conversion time for Shunt Voltage (Current measurement).
+
+- **adc_averaging** (*Optional*, integer): Selects ADC sample averaging count.
+  <EnumOptions options={["1", "4", "16", "64", "128", "256", "512", "1024"]} default="4" />
 
 - **update_interval** (*Optional*, [Time](/guides/configuration-types#time)): The interval to check the sensor. Defaults to `60s`.
 

--- a/src/content/docs/components/sensor/ina2xx.mdx
+++ b/src/content/docs/components/sensor/ina2xx.mdx
@@ -7,6 +7,7 @@ import { Image } from 'astro:assets';
 import Figure from '@components/Figure.astro';
 import ina228FullImg from './images/ina228-full.jpg';
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 <Figure
   src={ina228FullImg}
@@ -67,12 +68,12 @@ sensor:
 - **adc_range** (*Optional*, `0` or `1`  ): Selects the range for differential input across shunt
   resistor. `0` for ±163.84 mV, `1` for ±40.96 mV range. Defaults to `0`.
 
-- **adc_time** (*Optional*, [Time](/guides/configuration-types#time)): The time in microseconds to perform a single ADC conversion.
-  Defaults to `4120 us`. Valid values are `50 us`, `84 us`, `150 us`, `280 us`, `540 us`,
-  `1052 us`, `2074 us`, `4120 us`.
+- **adc_time** (*Optional*, [Time](/guides/configuration-types#time) or mapping): The time in microseconds to perform a
+  single ADC conversion. May be specified as a single time applied to all measurements, or as a mapping with separate
+  times per measurement.
+  <EnumOptions options={["50 us", "84 us", "150 us", "280 us", "540 us", "1052 us", "2074 us", "4120 us"]} default="4120 us" />
 
-  Instead of one time for all ADC measurements, separate configuration of conversion times for shunt voltage,
-  bus voltage, and temperature measurements possible. Options are the same as for `adc_time`.
+  When provided as a mapping, each sub-key accepts the same values shown above:
 
   - **bus_voltage** (*Optional*, [Time](/guides/configuration-types#time)): Conversion time for bus voltage measurement.
   - **shunt_voltage** (*Optional*, [Time](/guides/configuration-types#time)): Conversion time for shunt voltage measurement.
@@ -122,12 +123,10 @@ sensor:
 - **adc_range** (*Optional*, `0` or `1`  ): Selects the range for differential input across shunt
   resistor. `0` for ±163.84 mV, `1` for ±40.96 mV range. Defaults to `0`.
 
-- **adc_time** (*Optional*, [Time](/guides/configuration-types#time)): The time in microseconds to perform a single ADC conversion.
-  Defaults to `4120 us`. Valid values are `50 us`, `84 us`, `150 us`, `280 us`, `540 us`,
-  `1052 us`, `2074 us`, `4120 us`.
+- **adc_time** (*Optional*, [Time](/guides/configuration-types#time) or mapping): The time in microseconds to perform a single ADC conversion. May be specified as a single time applied to all measurements, or as a mapping with separate times per measurement.
+  <EnumOptions options={["50 us", "84 us", "150 us", "280 us", "540 us", "1052 us", "2074 us", "4120 us"]} default="4120 us" />
 
-  Instead of one time for all ADC measurements, separate configuration of conversion times for shunt voltage,
-  bus voltage, and temperature measurements possible. Options are the same as for `adc_time`.
+  When provided as a mapping, each sub-key accepts the same values shown above:
 
   - **bus_voltage** (*Optional*, [Time](/guides/configuration-types#time)): Conversion time for bus voltage measurement.
   - **shunt_voltage** (*Optional*, [Time](/guides/configuration-types#time)): Conversion time for shunt voltage measurement.
@@ -145,7 +144,7 @@ sensor:
 
 - **reset_on_boot** (*Optional*, boolean): Whether or not to reset the device configuration (including counters) on
   component initialization. Defaults to `true`; set `false` to preserve counters through ESPHome resets.
-  
+
 - All other options from [Sensor](/components/sensor) and [SPI device](/components/spi).
 
 ## Sensors

--- a/src/content/docs/components/sensor/integration.mdx
+++ b/src/content/docs/components/sensor/integration.mdx
@@ -3,6 +3,7 @@ description: "Instructions for setting up sensors that integrate values over tim
 title: "Integration Sensor"
 ---
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 
 The `integration` sensor is a helper sensor that can integrate values from other sensors over
@@ -28,11 +29,11 @@ sensor:
 ## Configuration variables
 
 - **sensor** (**Required**, [ID](/guides/configuration-types#id)): The ID of the sensor to integrate over time.
-- **time_unit** (**Required**, string): The time unit to integrate with, one of
-  `ms`, `s`, `min`, `h` or `d`.
+- **time_unit** (**Required**, string): The time unit to integrate with.
+  <EnumOptions inline options={["ms", "s", "min", "h", "d"]} />
 
-- **integration_method** (*Optional*, string): The integration method to use. One of
-  `trapezoid`, `left` or `right`. Defaults to `trapezoid`.
+- **integration_method** (*Optional*, string): The integration method to use.
+  <EnumOptions options={["trapezoid", "left", "right"]} default="trapezoid" />
 
 - **restore** (*Optional*, boolean): Whether to store the intermediate result on the device so
   that the value can be restored upon power cycle or reboot.

--- a/src/content/docs/components/sensor/lc709203f.mdx
+++ b/src/content/docs/components/sensor/lc709203f.mdx
@@ -10,6 +10,7 @@ import lc709203fUiImg from './images/LC709203f_ui.jpg';
 import lc709203fBatteryMarkingsImg from './images/LC709203f_battery_markings.jpg';
 import lc709203fBatteryProfilesImg from './images/LC709203f_battery_profiles.jpg';
 import lc709203fThermistorConnectionImg from './images/LC709203f_thermistor_connection.jpg';
+import EnumOptions from '@components/EnumOptions.astro';
 
 The `lc709203f` sensor platform allows you to use a LC709203F
 ([datasheet](https://cdn-learn.adafruit.com/assets/assets/000/094/597/original/LC709203F-D.PDF))
@@ -50,10 +51,16 @@ sensor:
 
 - **voltage** (*Optional*): nominal voltage of the battery pack in V.
 
-  - Valid values are `3.7` or `3.8`
-  - Defaults to `3.7`. This is the correct value for the Adafruit batteries.
-  - See [Pack Size and Nominal Voltage](#pack-size-and-voltage) for help if you don't know your pack voltage.
-  - See [Pack Voltage](#pack-voltage) for more information on how this value is used.
+  <EnumOptions
+    options={[
+      { value: "3.7", description: "This is the correct value for the Adafruit batteries." },
+      { value: "3.8" },
+    ]}
+    default="3.7"
+  />
+  > [!NOTE]
+  > - See [Pack Size and Nominal Voltage](#pack-size-and-voltage) for help if you don't know your pack voltage.
+  > - See [Pack Voltage](#pack-voltage) for more information on how this value is used.
 
 - **battery_voltage** (*Optional*): Configuration for the voltage sensor. All options from [sensor](/components/sensor).
 

--- a/src/content/docs/components/sensor/ltr501.mdx
+++ b/src/content/docs/components/sensor/ltr501.mdx
@@ -8,6 +8,7 @@ import Figure from '@components/Figure.astro';
 import ltr501FullImg from './images/ltr501-full.jpg';
 import ltr501UiImg from './images/ltr501-ui.png';
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 <Figure
   src={ltr501FullImg}
@@ -125,16 +126,23 @@ sensor:
 
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID used for code generation.
 - **address** (*Optional*, int): Manually specify the I²C address of the sensor. Default is `0x23`.
-- **type** (*Optional*, string): The type of the sensor. Valid values are `ALS_PS` *(default)* for
-  integrated sensors, `ALS` for ambient light only or `PS` for proximity only devices.
+- **type** (*Optional*, string): The type of the sensor.
+  <EnumOptions
+    options={[
+      { value: "ALS_PS", description: "for integrated sensors" },
+      { value: "ALS", description: "for ambient light only" },
+      { value: "PS", description: "for proximity only devices" },
+    ]}
+    default="ALS_PS"
+  />
 
 - **auto_mode** (*Optional*, boolean): Automatic gain and integration time selection. Defaults to True.
 - **gain** (*Optional*, string): The gain the device will use. Higher values are better in low-light conditions.
-  Valid values are `1X` *(default)*, `150X`.
+  <EnumOptions options={["1X", "150X"]} default="1X" />
 
 - **integration_time** (*Optional*, [Time](/guides/configuration-types#time)):
   The amount of time sensors are exposed. Longer means more accurate values.
-  Valid values are: `50ms`, `100ms` *(default)*, `200ms`, `400ms`.
+  <EnumOptions inline options={["50ms", "100ms", "200ms", "400ms"]} default="100ms" />
 
 - **glass_attenuation_factor** (*Optional*, float): The attenuation factor of glass if it's behind some glass
   or plastic facia. Default is `1.0` means `100%` transmissivity. `2` means `50%` transmissivity etc.
@@ -146,7 +154,7 @@ sensor:
   Helps to avoid multiple calls. Defaults to `5s`.
 
 - **ps_gain** (*Optional*, string): The gain the device will use for proximity sensor. Higher values are better in low-light conditions.
-  Valid values are `1X` *(default)*, `4X`, `8X`, `16X`.
+  <EnumOptions options={["1X", "4X", "8X", "16X"]} default="1X" />
 
 - **ps_high_threshold** (*Optional*, int): The threshold for the proximity sensor to trigger on object getting closer.
   Defaults to `65535`, which implies it will never be triggered.

--- a/src/content/docs/components/sensor/ltr_als_ps.mdx
+++ b/src/content/docs/components/sensor/ltr_als_ps.mdx
@@ -9,6 +9,7 @@ import ltr303FullImg from './images/ltr303-full.jpg';
 import ltr303UiImg from './images/ltr303-ui.png';
 import ltr303SpectralImg from './images/ltr303-spectral.png';
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 <Figure
   src={ltr303FullImg}
@@ -126,16 +127,23 @@ sensor:
 
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID used for code generation.
 - **address** (*Optional*, int): Manually specify the I²C address of the sensor. Default is `0x29`.
-- **type** (*Optional*, string): The type of the sensor. Valid values are `ALS_PS` _(default)_ for
-  integrated sensors, `ALS` for ambient light only or `PS` for proximity only devices.
+- **type** (*Optional*, string): The type of the sensor.
+  <EnumOptions
+    options={[
+      { value: "ALS_PS", description: "for integrated sensors" },
+      { value: "ALS", description: "for ambient light only" },
+      { value: "PS", description: "for proximity only devices" },
+    ]}
+    default="ALS_PS"
+  />
 
 - **auto_mode** (*Optional*, boolean): Automatic gain and integration time selection. Defaults to True.
 - **gain** (*Optional*, string): The gain the device will use. Higher values are better in low-light conditions.
-  Valid values are `1X` _(default)_, `2X`, `4X`, `8X`, `48X`, `96X`.
+  <EnumOptions options={["1X", "2X", "4X", "8X", "48X", "96X"]} default="1X" />
 
 - **integration_time** (*Optional*, [Time](/guides/configuration-types#time)):
   The amount of time sensors are exposed. Longer means more accurate values.
-  Valid values are: `50ms` _(default)_, `100ms`, `150ms`, `200ms`, `250ms`, `300ms`, `350ms`, `400ms`.
+  <EnumOptions inline options={["50ms", "100ms", "150ms", "200ms", "250ms", "300ms", "350ms", "400ms"]} default="50ms" />
 
 - **glass_attenuation_factor** (*Optional*, float): The attenuation factor of glass if it's behind some glass
   or plastic facia. Default is `1.0` means `100%` transmissivity. `2` means `50%` transmissivity etc.
@@ -146,8 +154,8 @@ sensor:
 - **ps_cooldown** (*Optional*, [Time](/guides/configuration-types#time)): The "cooldown" period after the proximity sensor is triggered.
   Helps to avoid multiple calls. Defaults to `5s`.
 
-- **ps_gain** (*Optional*, string): The gain the device will use for proximity sensor. Higher values are better in low-light conditions.
-  Valid values are `16X` _(default)_, `32X`, `64X`. Only for **LTR-659ALS**.
+- **ps_gain** (*Optional*, string): The gain the device will use for proximity sensor. Higher values are better in low-light conditions. Only for **LTR-659ALS**.
+  <EnumOptions options={["16X", "32X", "64X"]} default="16X" />
 
 - **ps_high_threshold** (*Optional*, int): The threshold for the proximity sensor to trigger on object getting closer.
   Defaults to `65535`, which implies it will never be triggered.

--- a/src/content/docs/components/sensor/max44009.mdx
+++ b/src/content/docs/components/sensor/max44009.mdx
@@ -27,7 +27,7 @@ The `max44009` sensor can operate in two modes: `low_power` (default) and `conti
 
 - **address** (*Optional*, int): Manually specify the I²C address of the sensor. Defaults to `0x4A`.
 - **mode** (*Optional*, string): Measurement mode.
-  <EnumOptions options={["auto", "low_power", "continuous"]} />
+  <EnumOptions options={["auto", "low_power", "continuous"]} default="low_power" />
 - **update_interval** (*Optional*, [Time](/guides/configuration-types#time)): The interval to check the
   sensor. Defaults to `60s`.
 

--- a/src/content/docs/components/sensor/max44009.mdx
+++ b/src/content/docs/components/sensor/max44009.mdx
@@ -2,6 +2,7 @@
 description: "Instructions for setting up MAX44009 ambient light sensors in ESPHome."
 title: "MAX44009 Ambient Light Sensor"
 ---
+import EnumOptions from '@components/EnumOptions.astro';
 
 The `max44009` sensor platform allows you to use your MAX44009
 ([datasheet](https://datasheets.maximintegrated.com/en/ds/MAX44009.pdf))
@@ -25,7 +26,8 @@ The `max44009` sensor can operate in two modes: `low_power` (default) and `conti
 ## Configuration variables
 
 - **address** (*Optional*, int): Manually specify the I²C address of the sensor. Defaults to `0x4A`.
-- **mode** (*Optional*, string): Measurement mode. One of `auto`, `low_power`, `continuous`.
+- **mode** (*Optional*, string): Measurement mode.
+  <EnumOptions options={["auto", "low_power", "continuous"]} />
 - **update_interval** (*Optional*, [Time](/guides/configuration-types#time)): The interval to check the
   sensor. Defaults to `60s`.
 

--- a/src/content/docs/components/sensor/mhz19.mdx
+++ b/src/content/docs/components/sensor/mhz19.mdx
@@ -8,6 +8,7 @@ import Figure from '@components/Figure.astro';
 import mhz19FullImg from './images/mhz19-full.jpg';
 import mhz19PinsImg from './images/mhz19-pins.jpg';
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 The `mhz19` sensor platform allows you to use MH-Z19 CO_2 and temperature sensors
 ([Revspace](https://revspace.nl/MHZ19)) with ESPHome.
@@ -60,7 +61,8 @@ sensor:
 
 - **warmup_time** (*Optional*, Time): The sensor has a warmup time and before that, it returns bogus readings (eg: 500ppm, 505ppm...). This setting discards readings until the warmup time happened (`NAN` is returned). The datasheet says preheating takes 1min, but empirical tests have shown it often takes more, so the 75s default should be enough to accommodate for that.
 
-- **detection_range** (*Optional*): The CO_2 sensor can be configured to detect different ranges: 0-2000ppm, 0-5000ppm, or 0-10000ppm. Valid values are `2000ppm`, `5000ppm`, or `10000ppm`. Sensors come from the factory with one of these ranges pre-configured, and this setting persists in the sensor's non-volatile memory. If not specified, the previously configured range is used.
+- **detection_range** (*Optional*): The CO_2 sensor can be configured to detect different ranges: 0-2000ppm, 0-5000ppm, or 0-10000ppm. Sensors come from the factory with one of these ranges pre-configured, and this setting persists in the sensor's non-volatile memory. If not specified, the previously configured range is used.
+  <EnumOptions options={["2000ppm", "5000ppm", "10000ppm"]} />
 
 <Figure
   src={mhz19PinsImg}

--- a/src/content/docs/components/sensor/mlx90393.mdx
+++ b/src/content/docs/components/sensor/mlx90393.mdx
@@ -7,6 +7,7 @@ import { Image } from 'astro:assets';
 import Figure from '@components/Figure.astro';
 import mlx90393FullImg from './images/mlx90393-full.jpg';
 import mlx90393ResolutionImg from './images/mlx90393-resolution.svg';
+import EnumOptions from '@components/EnumOptions.astro';
 
 The `mlx90393` sensor platform allows you to use your MLX90393
 ([datasheet](https://media.melexis.com/-/media/files/documents/datasheets/mlx90393-datasheet-melexis.pdf),
@@ -37,35 +38,20 @@ sensor:
 
 - **x_axis** (*Optional*): The information for the x-axis.
 
-  - **resolution** (*Optional*, int): Specify which part of the full 19-bit value to read. Defaults to `DIV_4`. Must be one of:
-
-    - `DIV_8`
-    - `DIV_4`
-    - `DIV_2`
-    - `DIV_1`
-
+  - **resolution** (*Optional*, int): Specify which part of the full 19-bit value to read.
+    <EnumOptions options={["DIV_8", "DIV_4", "DIV_2", "DIV_1"]} default="DIV_4" />
   - All other options from [Sensor](/components/sensor).
 
 - **y_axis** (*Optional*): The information for the y-axis.
 
-  - **resolution** (*Optional*, int): Specify which part of the full 19-bit value to read. Defaults to `DIV_4`. Must be one of:
-
-    - `DIV_8`
-    - `DIV_4`
-    - `DIV_2`
-    - `DIV_1`
-
+  - **resolution** (*Optional*, int): Specify which part of the full 19-bit value to read.
+    <EnumOptions options={["DIV_8", "DIV_4", "DIV_2", "DIV_1"]} default="DIV_4" />
   - All other options from [Sensor](/components/sensor).
 
 - **z_axis** (*Optional*): The information for the z-axis.
 
-  - **resolution** (*Optional*, int): Specify which part of the full 19-bit value to read. Defaults to `DIV_4`. Must be one of:
-
-    - `DIV_8`
-    - `DIV_4`
-    - `DIV_2`
-    - `DIV_1`
-
+  - **resolution** (*Optional*, int): Specify which part of the full 19-bit value to read.
+    <EnumOptions options={["DIV_8", "DIV_4", "DIV_2", "DIV_1"]} default="DIV_4" />
   - All other options from [Sensor](/components/sensor).
 
 - **temperature** (*Optional*): Built-in temperature sensor.
@@ -75,16 +61,8 @@ sensor:
 
 - **drdy_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): Data-ready pin. Often labelled `INT`. Using this pin might lead to slightly quicker read times.
 
-- **gain** (*Optional*, int): Sets the analog gain. Defaults to `1X`. Must be one of
-
-  - `1X`
-  - `1_25X`
-  - `1_67X`
-  - `2X`
-  - `2_5X`
-  - `3X`
-  - `3_75X`
-  - `5X`
+- **gain** (*Optional*, int): Sets the analog gain.
+  <EnumOptions options={["1X", "1_25X", "1_67X", "2X", "2_5X", "3X", "3_75X", "5X"]} default="1X" />
 
 - **oversampling** (*Optional*, int): On-chip oversampling. Defaults to `2`. Must be between `0` and `3`.
 

--- a/src/content/docs/components/sensor/pulse_counter.mdx
+++ b/src/content/docs/components/sensor/pulse_counter.mdx
@@ -6,6 +6,7 @@ title: "Pulse Counter Sensor"
 import { Image } from 'astro:assets';
 import pulseCounterImg from './images/pulse-counter.png';
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 The pulse counter sensor allows you to count the number of pulses and the frequency of a signal
 on any pin.
@@ -29,11 +30,11 @@ sensor:
 - **count_mode** (*Optional*): Configure how the counter should behave
   on a detected rising edge/falling edge.
 
-  - **rising_edge** (**Required**): What to do when a rising edge is
-    detected. One of `DISABLE`, `INCREMENT` and `DECREMENT`.
+  - **rising_edge** (**Required**): What to do when a rising edge is detected.
+    <EnumOptions options={["DISABLE", "INCREMENT", "DECREMENT"]} />
 
-  - **falling_edge** (**Required**): What to do when a falling edge is
-    detected. One of `DISABLE`, `INCREMENT` and `DECREMENT`.
+  - **falling_edge** (**Required**): What to do when a falling edge is detected.
+    <EnumOptions options={["DISABLE", "INCREMENT", "DECREMENT"]} />
 
 - **use_pcnt** (*Optional*, boolean): Use hardware `PCNT` pulse counter. Only supported on ESP32. Defaults to `true`.
 - **internal_filter** (*Optional*, [Time](/guides/configuration-types#time)): If a pulse shorter than this

--- a/src/content/docs/components/sensor/pulse_meter.mdx
+++ b/src/content/docs/components/sensor/pulse_meter.mdx
@@ -6,6 +6,7 @@ title: "Pulse Meter Sensor"
 import { Image } from 'astro:assets';
 import pulseCounterVsPulseMeterImg from './images/pulse-counter_vs_pulse-meter.png';
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 The pulse meter sensor allows you to count the number and frequency of pulses on any pin. It is intended to be a drop-in replacement
 for the [pulse counter component](/components/sensor/pulse_counter/).
@@ -34,10 +35,13 @@ sensor:
   This acts as a debounce filter to eliminate input noise, so choose a value a little less than your expected minimum pulse width.
 
 - **internal_filter_mode** (*Optional*, string): Determines how the internal filter is applied.
-  One of `EDGE` or `PULSE`. Defaults to `EDGE`.
-
-  - In `EDGE`  mode, subsequent rising edges are compared and if they fall into an interval lesser than the `internal filter` value, the last one is discarded. This is useful if your input signal bounces, but is otherwise clean.
-  - In `PULSE` mode, the rising edge is discarded if any further interrupts are detected before the `internal_filter` time has passed. In other words, a high pulse must be at least `internal_filter` long to be counted. This is useful if you have a noisy input signal that may have bounces before and/or after the main pulse.
+  <EnumOptions
+    options={[
+      { value: "EDGE", description: "subsequent rising edges are compared and if they fall into an interval lesser than the `internal filter` value, the last one is discarded. This is useful if your input signal bounces, but is otherwise clean." },
+      { value: "PULSE", description: "the rising edge is discarded if any further interrupts are detected before the `internal_filter` time has passed. In other words, a high pulse must be at least `internal_filter` long to be counted. This is useful if you have a noisy input signal that may have bounces before and/or after the main pulse." },
+    ]}
+    default="EDGE"
+  />
 
 - **timeout** (*Optional*, [Time](/guides/configuration-types#time)): If we don't see a pulse for this length of time, we assume *0 pulses/s*. Defaults to `5 min`.
 - **total** (*Optional*, [ID](/guides/configuration-types#id)): An additional sensor that outputs the total number of pulses counted.

--- a/src/content/docs/components/sensor/qmp6988.mdx
+++ b/src/content/docs/components/sensor/qmp6988.mdx
@@ -6,6 +6,7 @@ title: "QMP6988 Temperature+Pressure Sensor"
 import { Image } from 'astro:assets';
 import Figure from '@components/Figure.astro';
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 The `qmp6988` sensor platform allows you to use your QMP6988
 ([datasheet](https://m5stack.oss-cn-shenzhen.aliyuncs.com/resource/docs/datasheet/unit/enviii/QMP6988%20Datasheet.pdf),
@@ -55,8 +56,8 @@ sensor:
 - **address** (*Optional*, int): Manually specify the I²C address of
   the sensor. Defaults to `0x70`. `0x56` is also configurable - see datasheet.
 
-- **iir_filter** (*Optional*): Set up an Infinite Impulse Response filter to increase accuracy. One of
-  `OFF`, `2x`, `4x`, `8x`, `16x`, `32x`. Defaults to `OFF`.
+- **iir_filter** (*Optional*): Set up an Infinite Impulse Response filter to increase accuracy.
+  <EnumOptions options={["OFF", "2x", "4x", "8x", "16x", "32x"]} default="OFF" />
 
 - **update_interval** (*Optional*, [Time](/guides/configuration-types#time)): The interval to check the
   sensor. Defaults to `60s`.

--- a/src/content/docs/components/sensor/resistance.mdx
+++ b/src/content/docs/components/sensor/resistance.mdx
@@ -7,6 +7,7 @@ import { Image } from 'astro:assets';
 import Figure from '@components/Figure.astro';
 import resistanceDownstreamImg from './images/resistance-downstream.png';
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 The `resistance` platform is a helper sensor that allows you to convert readings
 from a voltage sensor (such as the [ADC Sensor](/components/sensor/adc/)) into resistance readings
@@ -67,8 +68,8 @@ Some boards like NodeMCUv2 needs to multiply ADC reading by 3.3 to provide accur
 - **sensor** (**Required**, [ID](/guides/configuration-types#id)): The sensor to read the voltage values from
   to convert to resistance readings.
 
-- **configuration** (**Required**, string): The type of circuit, one of `DOWNSTREAM` or
-  `UPSTREAM`.
+- **configuration** (**Required**, string): The type of circuit.
+  <EnumOptions options={["DOWNSTREAM", "UPSTREAM"]} />
 
 - **resistor** (**Required**, float): The value of the resistor with a constant value.
 

--- a/src/content/docs/components/sensor/sht4x.mdx
+++ b/src/content/docs/components/sensor/sht4x.mdx
@@ -6,6 +6,7 @@ title: "SHT4X Temperature and Humidity Sensor"
 import { Image } from 'astro:assets';
 import sht4xFullImg from './images/sht4x-full.jpg';
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 The `sht4x` sensor platform allows you to use your SHT4X temperature and humidity sensor
 ([datasheet](https://sensirion.com/media/documents/33FD6951/661CD142/HT_DS_Datasheet_SHT4x.pdf), [Adafruit](https://www.adafruit.com/product/4885)) with ESPHome.
@@ -33,10 +34,18 @@ sensor:
 
   - All options from [Sensor](/components/sensor).
 
-- **precision** (*Optional*, string): The measurement precision, either `High`, `Med` or `Low`. Default is `High`.
+- **precision** (*Optional*, string): The measurement precision.
+  <EnumOptions options={["High", "Med", "Low"]} default="High" />
 - **heater_max_duty** (*Optional*, float): The maximum duty cycle of the heater (limited to `0.05`  ). Default is `0.0`, i.e. heater off.
-- **heater_power** (*Optional*, string): The heater power, either `High`, `Med` or `Low`. Default is `High`.
-- **heater_time** (*Optional*, string): The length of time to run the heater, either `Long` (1000ms) or `Short` (100ms). Default is `Long`.
+- **heater_power** (*Optional*, string): The heater power.
+  <EnumOptions options={["High", "Med", "Low"]} default="High" />
+- **heater_time** (*Optional*, string): The length of time to run the heater.
+  <EnumOptions default="Long"
+    options={[
+      { value: "Long", description: "1000ms" },
+      { value: "Short", description: "100ms" },
+    ]}
+  />
 - **address** (*Optional*, int): Manually specify the I²C address of the sensor. Default is `0x44`.
 - **update_interval** (*Optional*, [Time](/guides/configuration-types#time)): The interval to check the sensor. Defaults to `60s`.
 

--- a/src/content/docs/components/sensor/sy6970.mdx
+++ b/src/content/docs/components/sensor/sy6970.mdx
@@ -162,7 +162,7 @@ text_sensor:
     ]}
   />
 
-  All other options from [Text Sensor](/components/text_sensor).
+  - All other options from [Text Sensor](/components/text_sensor).
 
 - **ntc_status** (*Optional*): The battery temperature status based on NTC thermistor.
   <EnumOptions
@@ -175,7 +175,7 @@ text_sensor:
     ]}
   />
 
-  All other options from [Text Sensor](/components/text_sensor).
+  - All other options from [Text Sensor](/components/text_sensor).
 
 ## Complete Example
 

--- a/src/content/docs/components/sensor/sy6970.mdx
+++ b/src/content/docs/components/sensor/sy6970.mdx
@@ -2,6 +2,7 @@
 description: "Instructions for setting up SY6970 Battery Management IC"
 title: "SY6970 Battery Management IC"
 ---
+import EnumOptions from '@components/EnumOptions.astro';
 
 The `sy6970` component allows you to use the SY6970 battery management and charging ICs [SY6970 Datasheet](https://github.com/Xinyuan-LilyGO/LilyGo-AMOLED-Series/blob/master/datasheet/SY6970%20Datasheet.pdf) with ESPHome.
 
@@ -137,30 +138,44 @@ text_sensor:
 ## Text Sensor Configuration variables
 
 - **sy6970_id** (*Optional*, [ID](/guides/configuration-types#config-id)): The ID of the SY6970 component. Defaults to the only SY6970 component in your configuration.
-- **bus_status** (*Optional*): The type of power source connected. Possible values are:
-  - `No Input` - No power source connected
-  - `USB SDP` - USB Standard Downstream Port
-  - `USB CDP` - USB Charging Downstream Port
-  - `USB DCP` - USB Dedicated Charging Port
-  - `HVDCP` - High Voltage Dedicated Charging Port
-  - `Adapter` - Dedicated adapter
-  - `Non-Standard Adapter` - Non-standard adapter
-  - `OTG` - OTG mode
+- **bus_status** (*Optional*): The type of power source connected.
+  <EnumOptions
+    options={[
+      { value: "No Input", description: "No power source connected" },
+      { value: "USB SDP", description: "USB Standard Downstream Port" },
+      { value: "USB CDP", description: "USB Charging Downstream Port" },
+      { value: "USB DCP", description: "USB Dedicated Charging Port" },
+      { value: "HVDCP", description: "High Voltage Dedicated Charging Port" },
+      { value: "Adapter", description: "Dedicated adapter" },
+      { value: "Non-Standard Adapter", description: "Non-standard adapter" },
+      { value: "OTG", description: "OTG mode" },
+    ]}
+  />
   - All options from [Text Sensor](/components/text_sensor).
-- **charge_status** (*Optional*): The current charging status. Possible values are:
-  - `Not Charging` - Battery is not charging
-  - `Pre-charge` - Battery is in pre-charge phase
-  - `Fast Charge` - Battery is in fast charge phase
-  - `Charge Done` - Charging is complete
-  - All options from [Text Sensor](/components/text_sensor).
-- **ntc_status** (*Optional*): The battery temperature status based on NTC thermistor. Possible values are:
-  - `Normal` - Temperature is in normal range
-  - `Warm` - Battery is warm
-  - `Cool` - Battery is cool
-  - `Cold` - Battery is cold
-  - `Hot` - Battery is hot
-  - All options from [Text Sensor](/components/text_sensor).
-- All other options from [Text Sensor](/components/text_sensor).
+- **charge_status** (*Optional*): The current charging status.
+  <EnumOptions
+    options={[
+      { value: "Not Charging", description: "Battery is not charging" },
+      { value: "Pre-charge", description: "Battery is in pre-charge phase" },
+      { value: "Fast Charge", description: "Battery is in fast charge phase" },
+      { value: "Charge Done", description: "Charging is complete" },
+    ]}
+  />
+
+  All other options from [Text Sensor](/components/text_sensor).
+
+- **ntc_status** (*Optional*): The battery temperature status based on NTC thermistor.
+  <EnumOptions
+    options={[
+      { value: "Normal", description: "Temperature is in normal range" },
+      { value: "Warm", description: "Battery is warm" },
+      { value: "Cool", description: "Battery is cool" },
+      { value: "Cold", description: "Battery is cold" },
+      { value: "Hot", description: "Battery is hot" },
+    ]}
+  />
+
+  All other options from [Text Sensor](/components/text_sensor).
 
 ## Complete Example
 

--- a/src/content/docs/components/sensor/tcs34725.mdx
+++ b/src/content/docs/components/sensor/tcs34725.mdx
@@ -8,6 +8,7 @@ import Figure from '@components/Figure.astro';
 import tcs34725FullImg from './images/tcs34725-full.jpg';
 import tcs34725UiImg from './images/tcs34725-ui.png';
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 The `tcs34725` sensor platform allows you to use your TCS34725 RGB color sensors
 ([datasheet](https://cdn-shop.adafruit.com/datasheets/TCS34725.pdf),
@@ -70,9 +71,8 @@ sensor:
   values are `1x` (default), `4x`, `16x`, `60x` (highest gain). Will be overwritten if auto integration time
   is used
 
-- **integration_time** (*Optional*): The amount of time the light sensor is exposed. Valid values are
-  `auto` (default), `2.4ms`, `24ms`, `50ms`, `101ms`, `120ms`, `154ms`, `180ms`, `199ms`,
-  `240ms`, `300ms`, `360ms`, `401ms`, `420ms`, `480ms`, `499ms`, `540ms`, `600ms`, `614ms`.
+- **integration_time** (*Optional*): The amount of time the light sensor is exposed.
+  <EnumOptions inline options={["auto", "2.4ms", "24ms", "50ms", "101ms", "120ms", "154ms", "180ms", "199ms", "240ms", "300ms", "360ms", "401ms", "420ms", "480ms", "499ms", "540ms", "600ms", "614ms"]} default="auto" />
 
 - **glass_attenuation_factor** (*Optional*): The attenuation factor of glass if it's behind some glass facia.
   Default is `1.0` means `100%` transmissivity. `2` means `50%` transmissivity etc.

--- a/src/content/docs/components/sensor/tmp1075.mdx
+++ b/src/content/docs/components/sensor/tmp1075.mdx
@@ -5,6 +5,7 @@ title: "TMP1075 Temperature Sensor"
 
 import { Image } from 'astro:assets';
 import Figure from '@components/Figure.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 The TMP1075 Temperature sensor allows you to use your TMP1075
 ([datasheet](https://www.ti.com/lit/gpn/tmp1075))
@@ -55,13 +56,15 @@ sensor:
 - **conversion_rate** (*Optional*): The interval at which the IC performs a
   temperature measurement. This setting also determines how fast the alert pin
   responds to temperature changes, and is thus independent of how often ESPHome
-  checks the sensor. Possible values are `27.5ms`, `55ms`, `110ms`, and
-  `220ms`. Defaults to `27.5ms`.
+  checks the sensor.
+  <EnumOptions options={["27.5ms", "55ms", "110ms", "220ms"]} default="27.5ms" />
 
 - **alert** (*Optional*): Configure the alert pin behaviour.
 
-  - **function** (*Optional*, enum): Function of the alert pin, either `comparator` or `interrupt`. Defaults to `comparator`.
-  - **polarity** (*Optional*, enum): Polarity of the alert pin, either `active_high` or `active_low`. Defaults to `active_high`.
+  - **function** (*Optional*, enum): Function of the alert pin.
+    <EnumOptions options={["comparator", "interrupt"]} default="comparator" />
+  - **polarity** (*Optional*, enum): Polarity of the alert pin.
+    <EnumOptions options={["active_high", "active_low"]} default="active_high" />
   - **limit_low** (*Optional*, int): Lower temperature limit, in °C. Defaults to `-128` (the lowest possible limit value).
   - **limit_high** (*Optional*, int): Higher temperature limit, in °C. Defaults to `127.9375` (the highest possible limit value).
   - **fault_count** (*Optional*, int): Number of measurements. required for the alert pin to act. Must be between `1` and `4`, inclusive. Defaults to `1`.

--- a/src/content/docs/components/sensor/total_daily_energy.mdx
+++ b/src/content/docs/components/sensor/total_daily_energy.mdx
@@ -3,6 +3,7 @@ description: "Instructions for setting up sensors that track the total daily ene
 title: "Total Daily Energy Sensor"
 ---
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 
 The `total_daily_energy` sensor is a helper sensor that can use the power value of
@@ -47,8 +48,8 @@ time:
   that the value can be restored upon power cycle or reboot.
   Defaults to `true`.
 
-- **method** (*Optional*, string): The method to use for calculating the total daily energy. One of
-  `trapezoid`, `left` or `right`. Defaults to `right`.
+- **method** (*Optional*, string): The method to use for calculating the total daily energy.
+  <EnumOptions options={["trapezoid", "left", "right"]} default="right" />
 
 - All other options from [Sensor](/components/sensor).
 

--- a/src/content/docs/components/sensor/tsl2561.mdx
+++ b/src/content/docs/components/sensor/tsl2561.mdx
@@ -8,6 +8,7 @@ import Figure from '@components/Figure.astro';
 import tsl2561FullImg from './images/tsl2561-full.jpg';
 import tsl2561UiImg from './images/tsl2561-ui.png';
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 The `tsl2561` sensor platform allows you to use your TSL2561
 ([datasheet](https://cdn-shop.adafruit.com/datasheets/TSL2561.pdf),
@@ -37,11 +38,11 @@ sensor:
 
 - **address** (*Optional*, int): Manually specify the I²C address of the sensor. Defaults to `0x39`.
 - **integration_time** (*Optional*, [Time](/guides/configuration-types#time)):
-  The time the sensor will take for each measurement. Longer means more accurate values. One of
-  `14ms`, `101ms`, `402ms`. Defaults to `402ms`.
+  The time the sensor will take for each measurement. Longer means more accurate values.
+  <EnumOptions options={["14ms", "101ms", "402ms"]} default="402ms" />
 
 - **gain** (*Optional*, string): The gain of the sensor. Higher values are better in low-light conditions.
-  One of `1x` and `16x`. Defaults to `1x`.
+  <EnumOptions inline options={["1x", "16x"]} default="1x" />
 
 - **is_cs_package** (*Optional*, boolean): The "CS" package of this sensor has a slightly different
   formula for calculating the illuminance in lx. Set this to `true` if you're working with a CS

--- a/src/content/docs/components/sensor/tsl2591.mdx
+++ b/src/content/docs/components/sensor/tsl2591.mdx
@@ -7,6 +7,7 @@ import { Image } from 'astro:assets';
 import Figure from '@components/Figure.astro';
 import tsl2591UiImg from './images/tsl2591-ui.jpg';
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 The `tsl2591` sensor platform allows you to use the AMS TSL2591 ambient light sensor with ESPHome.
 Communication with the device is over [I²C](/components/i2c), which must be present in your configuration.
@@ -123,24 +124,20 @@ For the TSL2591 device:
 
 - **integration_time** (*Optional*, [Time](/guides/configuration-types#time)):
   The time the device will use for each measurement. Longer means more accurate values.
-  You cannot specify an arbitrary amount of time. It must be the equivalent of one of:
-
-  - `100ms`   _(default)_
-  - `200ms`
-  - `300ms`
-  - `400ms`
-  - `500ms`
-  - `600ms`
+  <EnumOptions options={["100ms", "200ms", "300ms", "400ms", "500ms", "600ms"]} default="100ms" />
 
 - **gain** (*Optional*, string): The gain the device will use. Higher values are better in low-light conditions.
-  Multipliers here are approximate. Values below on the same line are aliases.
-  You cannot specify an arbitrary gain multiplier. It must be one of:
-
-  - `low`, `1x`
-  - `medium`, `med`, `25x`
-  - `high`, `400x`
-  - `maximum`, `max`, `9500x`
-  - `auto` _(default)_
+  Multipliers here are approximate.
+  <EnumOptions
+    options={[
+      { value: "low", aliases: ["1x"] },
+      { value: "medium", aliases: ["med", "25x"] },
+      { value: "high", aliases: ["400x"] },
+      { value: "maximum", aliases: ["max", "9500x"] },
+      { value: "auto" },
+    ]}
+    default="auto"
+  />
 
 - **update_interval** (*Optional*, [Time](/guides/configuration-types#time)): The interval for checking the sensors.
   Defaults to `60s`.

--- a/src/content/docs/components/sensor/uptime.mdx
+++ b/src/content/docs/components/sensor/uptime.mdx
@@ -3,6 +3,7 @@ description: "Instructions for setting up a sensor that tracks the uptime of the
 title: "Uptime Sensor"
 ---
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 
 The `uptime` sensor allows you to track the time the ESP has stayed up for in seconds.
@@ -18,10 +19,14 @@ sensor:
 
 ## Configuration variables
 
-- **type** (*Optional*): Either:
-
-  - `seconds` (*default*): A simple counter.
-  - `timestamp`  : presents the time ESPHome last booted up. Requires a [Time](/components/time/).
+- **type** (*Optional*):
+  <EnumOptions
+    options={[
+      { value: "seconds", description: "A simple counter." },
+      { value: "timestamp", description: "presents the time ESPHome last booted up. Requires a [Time](/components/time/)." },
+    ]}
+    default="seconds"
+  />
 
 - **update_interval** (*Optional*, [Time](/guides/configuration-types#time)): The sensor reporting interval. Defaults to `60s`.
   Valid only with `type: seconds`.

--- a/src/content/docs/components/sensor/veml3235.mdx
+++ b/src/content/docs/components/sensor/veml3235.mdx
@@ -6,6 +6,7 @@ title: "VEML3235 Ambient Light Sensor"
 import { Image } from 'astro:assets';
 import Figure from '@components/Figure.astro';
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 The `veml3235` sensor platform allows you to use the Vishay VEML3235 ambient light sensor with ESPHome.
 Communication with the device is over [I²C](/components/i2c), which must be present in your configuration.
@@ -52,26 +53,13 @@ sensor:
 ## Configuration variables
 
 - **gain** (*Optional*, string): The gain the device will use. Higher values are better in low-light conditions.
-  You cannot specify an arbitrary gain multiplier. It must be one of:
+  <EnumOptions options={["1x", "2x", "4x"]} default="1x" />
 
-  - `1x`  *(default)*
-  - `2x`
-  - `4x`
+- **digital_gain** (*Optional*, string): Similar to `gain`; provides an additional multiplier, further increasing range.
+  <EnumOptions options={["1x", "2x"]} default="1x" />
 
-- **digital_gain** (*Optional*, string): Similar to `gain`  ; provides an additional multipler, further increasing
-  range. You cannot specify an arbitrary digital gain multiplier. It must be one of:
-
-  - `1x`  *(default)*
-  - `2x`
-
-- **integration_time** (*Optional*, [Time](/guides/configuration-types#time)): The time the device will use for each measurement. Longer
-  means more accurate values. You cannot specify an arbitrary amount of time. It must be the equivalent of one of:
-
-  - `50ms`   *(default)*
-  - `100ms`
-  - `200ms`
-  - `400ms`
-  - `800ms`
+- **integration_time** (*Optional*, [Time](/guides/configuration-types#time)): The time the device will use for each measurement. Longer means more accurate values.
+  <EnumOptions options={["50ms", "100ms", "200ms", "400ms", "800ms"]} default="50ms" />
 
 - **auto_gain** (*Optional*, boolean): When set to `true` (the default), `gain`, `digital_gain` and
   `integration_time` will be adjusted automatically to avoid saturating the sensor and allow use of the maximum

--- a/src/content/docs/components/sensor/veml7700.mdx
+++ b/src/content/docs/components/sensor/veml7700.mdx
@@ -125,10 +125,10 @@ sensor:
 
 - **auto_mode** (*Optional*, boolean): Automatic gain and integration time selection. Defaults to `True`.
 - **integration_time** (*Optional*, [Time](/guides/configuration-types#time)):
-  The amount of time the sensor is exposed. _(default)_, `200ms`, `400ms`, `800ms`. _In automatic mode it sets starting value_.
+  The amount of time the sensor is exposed. *In automatic mode it sets the starting value*.
   <EnumOptions options={["25ms", "50ms", "100ms", "200ms", "400ms", "800ms"]} default="100ms" />
 
-- **gain** (*Optional*, string): The gain the device will use for the internal ADC. _(default)_, `1/4x`, `1x`, `2x`. Higher values are better in low-light conditions. _In automatic mode it sets starting gain value_.
+- **gain** (*Optional*, string): The gain the device will use for the internal ADC. Higher values are better in low-light conditions. *In automatic mode it sets the starting gain value*.
   <EnumOptions options={["1/8x", "1/4x", "1x", "2x"]} default="1/8x" />
 
 - **lux_compensation** (*Optional*, boolean): Lux compensation formula is used as per manufacturer.

--- a/src/content/docs/components/sensor/veml7700.mdx
+++ b/src/content/docs/components/sensor/veml7700.mdx
@@ -9,6 +9,7 @@ import veml7700FullImg from './images/veml7700-full.jpg';
 import veml7700UiImg from './images/veml7700-ui.png';
 import veml7700SpectralImg from './images/veml7700-spectral.png';
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 The `veml7700` sensor platform allows you to use the Vishay VEML7700 and VEML6030 ambient light sensors with ESPHome.
 Communication with the device is over [I²C](/components/i2c), which must be present in your configuration. VEML7700 and VEML6030
@@ -124,12 +125,11 @@ sensor:
 
 - **auto_mode** (*Optional*, boolean): Automatic gain and integration time selection. Defaults to `True`.
 - **integration_time** (*Optional*, [Time](/guides/configuration-types#time)):
-  The amount of time the sensor is exposed. Valid values are `25ms`, `50ms`, `100ms` _(default)_,
-  `200ms`, `400ms`, `800ms`. _In automatic mode it sets starting value_.
+  The amount of time the sensor is exposed. _(default)_, `200ms`, `400ms`, `800ms`. _In automatic mode it sets starting value_.
+  <EnumOptions options={["25ms", "50ms", "100ms", "200ms", "400ms", "800ms"]} default="100ms" />
 
-- **gain** (*Optional*, string): The gain the device will use for the internal ADC. Valid values are
-  `1/8x` _(default)_, `1/4x`, `1x`, `2x`. Higher values are better in low-light conditions.
-  _In automatic mode it sets starting gain value_.
+- **gain** (*Optional*, string): The gain the device will use for the internal ADC. _(default)_, `1/4x`, `1x`, `2x`. Higher values are better in low-light conditions. _In automatic mode it sets starting gain value_.
+  <EnumOptions options={["1/8x", "1/4x", "1x", "2x"]} default="1/8x" />
 
 - **lux_compensation** (*Optional*, boolean): Lux compensation formula is used as per manufacturer.
   Defaults to `True`.

--- a/src/content/docs/components/sensor/xgzp68xx.mdx
+++ b/src/content/docs/components/sensor/xgzp68xx.mdx
@@ -55,7 +55,7 @@ sensor:
 
 - **temperature** (*Optional*): All options from [Sensor](/components/sensor).
 - **pressure** (*Optional*): All options from [Sensor](/components/sensor).
-  - **oversampling** (*Optional*). It is not possible to disable oversampling. If not specified, this
+  - **oversampling** (*Optional*): It is not possible to disable oversampling.
     <EnumOptions inline options={["256x", "512x", "1024x", "2048x", "4096x", "8192x", "16384x", "32768x"]} default="4096x" />
 - **k_value** (*Optional*, int): The K value comes from the list below. It will default to 4096 if not specified.
 - **update_interval** (*Optional*, [Time](/guides/configuration-types#time)): The interval to check the sensor. Defaults to `60s`.

--- a/src/content/docs/components/sensor/xgzp68xx.mdx
+++ b/src/content/docs/components/sensor/xgzp68xx.mdx
@@ -6,6 +6,7 @@ title: "CFSensor XGZP68xx Non-C Series Differential Pressure Sensor"
 import { Image } from 'astro:assets';
 import Figure from '@components/Figure.astro';
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 CFSensor makes multiple generations of sensors with identical model numbers such as the 6899D or
 6897D, but unfortunately with completely different I²C interfaces. You can identify which from
@@ -54,7 +55,8 @@ sensor:
 
 - **temperature** (*Optional*): All options from [Sensor](/components/sensor).
 - **pressure** (*Optional*): All options from [Sensor](/components/sensor).
-  - **oversampling** (*Optional*): One of `256x`, `512x`, `1024x`, `2048x`, `4096x`, `8192x`, `16384x`, `32768x`. It is not possible to disable oversampling. If not specified, this defaults to `4096x`.
+  - **oversampling** (*Optional*). It is not possible to disable oversampling. If not specified, this
+    <EnumOptions inline options={["256x", "512x", "1024x", "2048x", "4096x", "8192x", "16384x", "32768x"]} default="4096x" />
 - **k_value** (*Optional*, int): The K value comes from the list below. It will default to 4096 if not specified.
 - **update_interval** (*Optional*, [Time](/guides/configuration-types#time)): The interval to check the sensor. Defaults to `60s`.
 

--- a/src/content/docs/components/serial_proxy.mdx
+++ b/src/content/docs/components/serial_proxy.mdx
@@ -3,6 +3,7 @@ description: "Instructions for setting up the Serial Proxy component in ESPHome.
 title: "Serial Proxy"
 ---
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 
 > [!IMPORTANT]
@@ -34,10 +35,13 @@ serial_proxy:
 - **name** (**Required**, string): A human-readable name for this serial port, used to identify it to API clients.
 - **uart_id** (**Required**, [ID](/guides/configuration-types#id)): The ID of the [UART](/components/uart/) component
   this proxy is attached to.
-- **port_type** (**Required**, string): The electrical type of the serial port. One of:
-  - `TTL`: Standard TTL logic-level UART (3.3V or 5V). Typically used for direct connections to most microcontrollers.
-  - `RS232`: RS-232 standard serial port (typically ±12V levels via an appropriate line-driver IC). Typically used for PC-style serial connections, often with a DB9-type connector.
-  - `RS485`: RS-485 differential serial bus. Typically used for industrial/multi-drop serial networks.
+- **port_type** (**Required**, string): The electrical type of the serial port.
+  <EnumOptions options={[
+      { value: "TTL", description: "Standard TTL logic-level UART (3.3V or 5V). Typically used for direct connections to most microcontrollers." },
+      { value: "RS232", description: "RS-232 standard serial port (typically ±12V levels via an appropriate line-driver IC). Typically used for PC-style serial connections, often with a DB9-type connector." },
+      { value: "RS485", description: "RS-485 differential serial bus. Typically used for industrial/multi-drop serial networks." },
+    ]}
+  />
 - **rts_pin** (*Optional*, [Pin](/guides/configuration-types#pin)): GPIO pin to use as the RTS (Request to Send)
   modem control output. The state of this pin may be controlled by the API client at runtime.
 - **dtr_pin** (*Optional*, [Pin](/guides/configuration-types#pin)): GPIO pin to use as the DTR (Data Terminal Ready)

--- a/src/content/docs/components/speaker/i2s_audio.mdx
+++ b/src/content/docs/components/speaker/i2s_audio.mdx
@@ -2,6 +2,7 @@
 description: "Instructions for setting up I²S based speakers in ESPHome."
 title: "I²S Audio Speaker"
 ---
+import EnumOptions from '@components/EnumOptions.astro';
 
 The `i2s_audio` speaker platform allows you to receive audio via the [I2S Audio](/components/i2s_audio/).
 
@@ -25,34 +26,42 @@ speaker:
 ## Configuration variables
 
 - **dac_type** (**Required**, enum):
-
   - `external`  : Use an external DAC, for example the NS4168, or UDA1334A.
   - `internal`  : Use the internal DAC
-
-- **channel** (*Optional*, enum): The channel of the speaker. One of `left`, `right`, `mono`, or `stereo`. If `stereo`, the input data should be twice as big,
-  with each right sample followed by a left sample. `left` and `right` mute the unused channel, while `mono` plays the same samples on both. Defaults to `mono`.
-
+- **channel** (*Optional*, enum): The channel of the speaker. If `stereo`, the input data should be twice as big, with each right sample followed by a left sample. `left` and `right` mute the unused channel, while `mono` plays the same samples on both.
+  <EnumOptions options={["left", "right", "mono", "stereo"]} default="mono" />
 - **sample_rate** (*Optional*, positive integer): I2S sample rate. If in `primary` I²S mode the sample rate of the audio stream is used. Defaults to `16000`.
-- **bits_per_sample** (*Optional*, enum): The bit depth of the audio samples sent to the DAC. One of `8bit`, `16bit`, `24bit`, or `32bit`. Defaults to `16bit`.
+- **bits_per_sample** (*Optional*, enum): The bit depth of the audio samples sent to the DAC.
+  <EnumOptions options={["8bit", "16bit", "24bit", "32bit"]} default="16bit" />
 - **bits_per_channel** (*Optional*, enum): The bit depth of the audio channels. This is what is actually send to the DAC and needs to be equal or larger than `bits_per_sample`.
   See the datasheet of your I2S device for details. Defaults to `bits_per_sample`. Setting is ignored if the legacy driver is not used.
-
-- **mclk_multiple** (*Optional*, enum): The multiple of the MCLK frequency to the sample rate. Must be divisible by 3 if using 24 bits per sample. One of `128`, `256`, `384`, `512`. Defaults to `256`.
+- **mclk_multiple** (*Optional*, enum): The multiple of the MCLK frequency to the sample rate. Must be divisible by 3 if using 24 bits per sample.
+  <EnumOptions options={["128", "256", "384", "512"]} default="256" />
 - **use_apll** (*Optional*, boolean): I2S using APLL as main I2S clock, enable it to get accurate clock. Defaults to `false`.
-- **i2s_mode** (*Optional*, enum): The I²S mode to use. One of `primary` (clock driven by the host) or `secondary` (clock driven by the attached device). Defaults to `primary`.
+- **i2s_mode** (*Optional*, enum): The I²S mode to use.
+  <EnumOptions default="primary"
+    options={[
+      { value: "primary", description: "clock driven by the host" },
+      { value: "secondary", description: "clock driven by the attached device" },
+    ]}
+  />
 - **i2s_audio_id** (*Optional*, [ID](/guides/configuration-types#id)): The ID of the [I²S Audio](/components/i2s_audio#i2s_audio) you wish to use for this speaker.
 - **i2s_comm_fmt** (*Optional*, enum): The I²S communication standard format used by this speaker.
-
-  - `stand_i2s` (Default)
-  - `stand_msb`
-  - `stand_pcm_short`
-  - `stand_pcm_long`
-  - `stand_max` (only with legacy driver)
-  - `i2s_msb`
-  - `i2s_lsb`
-  - `pcm`
-  - `pcm_short`
-  - `pcm_long`
+  <EnumOptions
+    options={[
+      { value: "stand_i2s" },
+      { value: "stand_msb" },
+      { value: "stand_pcm_short" },
+      { value: "stand_pcm_long" },
+      { value: "stand_max", description: "only with legacy driver" },
+      { value: "i2s_msb" },
+      { value: "i2s_lsb" },
+      { value: "pcm" },
+      { value: "pcm_short" },
+      { value: "pcm_long" },
+    ]}
+    default="stand_i2s"
+  />
 - **buffer_duration** (*Optional*, [Time](/guides/configuration-types#time)): The duration of the internal ring buffer. Larger values can reduce stuttering but uses more memory. Defaults to `500ms`.
 - **timeout** (*Optional*, [Time](/guides/configuration-types#time)): How long to wait after finishing playback before releasing the bus. Set to `never` to never stop the speaker due to a timeout. Defaults to `500ms`.
 - All other options from [Speaker Component](/components/speaker#config-speaker).

--- a/src/content/docs/components/speaker/mixer.mdx
+++ b/src/content/docs/components/speaker/mixer.mdx
@@ -2,6 +2,7 @@
 description: "Instructions for setting up mixer speakers in ESPHome."
 title: "Mixer Speaker"
 ---
+import EnumOptions from '@components/EnumOptions.astro';
 
 The `mixer` speaker platform allows you to mix audio sent to different source speakers into one output which is sent to another [speaker component](/components/speaker/). Individual source speakers may be ducked (made quieter) with the [apply ducking action](#mixer_speaker-apply_ducking).
 
@@ -35,7 +36,8 @@ speaker:
   - **timeout** (*Optional*, [Time](/guides/configuration-types#time)): How long to wait after finishing playback before releasing the bus. Set to `never` to never stop the speaker due to a timeout. Defaults to `500ms`.
   - All other options from [Speaker Component](/components/speaker#config-speaker).
 
-- **num_channels** (*Optional*, positive integer): The number of audio channels to send to the output speaker. Either `1` or `2`. Defaults to the output speaker's number of channels.
+- **num_channels** (*Optional*, positive integer): The number of audio channels to send to the output speaker. Defaults to the output speaker's number of channels.
+  <EnumOptions inline options={["1", "2"]} />
 - **queue_mode** (*Optional*, boolean): Enables queue mode. If enabled, audio isn't mixed but instead each source speaker's audio is played successively, starting with the first listed source speaker.
 - **task_stack_in_psram** (*Optional*, boolean): Only with `esp-idf`. Run the audio tasks in external memory. Defaults to `false`.
 

--- a/src/content/docs/components/spi.mdx
+++ b/src/content/docs/components/spi.mdx
@@ -3,6 +3,7 @@ description: "Instructions for setting up SPI components in ESPHome"
 title: "SPI Bus"
 ---
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 
 <span id="spi"></span>
@@ -73,8 +74,7 @@ spi:
 - **clk_pin** (**Required**, [Pin Schema](/guides/configuration-types#pin-schema)): The pin used for the clock line of the SPI bus.
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID for this SPI hub if you need multiple SPI hubs.
 - **interface** (*Optional*): Controls which hardware or software SPI implementation should be used.
-  Value may be one of `any` (default), `software`, `hardware`, `spi`, `spi2` or `spi3`, depending on
-  the type and the particular chip used. See discussion below.
+  <EnumOptions options={["any", "software", "hardware", "spi", "spi2", "spi3"]} default="any" />
 
 For the conventional `single` bit bus at least one of `miso_pin` or `mosi_pin` is required.
 
@@ -145,10 +145,11 @@ spi_device:
 - **data_rate** (*Optional*): Set the data rate of the controller. This may be a numeric value in Hz or a string with
   a unit suffix, e.g. "100kHz" or "20MHz". Must be at least 1000Hz, see below for other constraints.
 
-- **spi_mode** (*Optional*): Set the controller mode - one of `mode0`, `mode1`, `mode2`, `mode3`. The default is `mode3`.
-  See table below for more information
+- **spi_mode** (*Optional*): Set the controller mode. See table below for more information
+  <EnumOptions options={["mode0", "mode1", "mode2", "mode3"]} default="mode3" />
 
-- **bit_order** (*Optional*): Set the bit order - choose one of `msb_first` (default) or `lsb_first`.
+- **bit_order** (*Optional*): Set the bit order.
+  <EnumOptions options={["msb_first", "lsb_first"]} default="msb_first" />
 - **cs_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The CS pin.
 - **release_device** (*Optional*, boolean): For ESP32, release the bus device between transactions. The default is
   `False`. Setting this to `True` will enable more than 6 devices to be connected to hardware SPI buses.

--- a/src/content/docs/components/sx126x.mdx
+++ b/src/content/docs/components/sx126x.mdx
@@ -6,6 +6,7 @@ title: "SX126x Component"
 import { Image } from 'astro:assets';
 import sx126xFullImg from './images/sx126x-full.png';
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 <span id="sx126x"></span>
 
@@ -48,7 +49,7 @@ sx126x:
 - **dio1_pin** (**Required**, [Pin Schema](/guides/configuration-types#pin-schema)): Digital IO pin 1.
 - **rst_pin** (**Required**, [Pin Schema](/guides/configuration-types#pin-schema)): Reset pin.
 - **frequency** (**Required**, frequency): Frequency in Hz of the transceiver.
-- **hw_version** (**Required**, enum): Valid values are `sx1261`, `sx1262`, `sx1268` or `llcc68`.
+- **hw_version** (**Required**, enum): <EnumOptions inline options={["sx1261", "sx1262", "sx1268", "llcc68"]} />
 - **modulation** (**Required**, enum): Modulation can be `FSK` or `LORA`.
 - **pa_power** (**Optional**, int): Transmitter power, range is from -3 to 15 dBm when `hw_version` is
   `sx1261` and from -3 to 22 dBm otherwise.

--- a/src/content/docs/components/sx1509.mdx
+++ b/src/content/docs/components/sx1509.mdx
@@ -8,6 +8,7 @@ import Figure from '@components/Figure.astro';
 import sx1509FullImg from './images/sx1509-full.jpg';
 import sx1509KeypadImg from './images/sx1509-keypad.jpg';
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 ## Component/Hub
 
@@ -181,8 +182,8 @@ light:
 - **inverted** (*Optional*, boolean): If all read and written values
   should be treated as inverted. Defaults to `false`.
 
-- **mode** (*Optional*, string): A pin mode to set for the pin at. One of `INPUT`,
-  `INPUT_PULLUP`, `OUTPUT`, or `OUTPUT_OPEN_DRAIN`.
+- **mode** (*Optional*, string): A pin mode to set for the pin at.
+  <EnumOptions inline options={["INPUT", "INPUT_PULLUP", "OUTPUT", "OUTPUT_OPEN_DRAIN"]} />
 
 ## See Also
 

--- a/src/content/docs/components/tca9555.mdx
+++ b/src/content/docs/components/tca9555.mdx
@@ -3,6 +3,7 @@ description: "Instructions for setting up TCA9555 digital port expanders in ESPH
 title: "TCA9555 I/O Expander"
 ---
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 
 The TCA9555 component allows you to use TCA955 I/O expanders
@@ -51,7 +52,8 @@ switch:
 - **inverted** (*Optional*, boolean): If all read and written values
   should be treated as inverted. Defaults to `false`.
 
-- **mode** (*Optional*, string): A pin mode to set for the pin at. One of `INPUT` or `OUTPUT`.
+- **mode** (*Optional*, string): A pin mode to set for the pin at.
+  <EnumOptions inline options={["INPUT", "OUTPUT"]} />
 
 ## See Also
 

--- a/src/content/docs/components/update/esp32_hosted.mdx
+++ b/src/content/docs/components/update/esp32_hosted.mdx
@@ -3,6 +3,7 @@ description: "Instructions for using the ESP32 Hosted update platform to manage 
 title: "ESP32 Hosted Co-processor Update"
 ---
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 
 This platform allows you to update the firmware of an ESP32 co-processor connected via the
@@ -75,7 +76,8 @@ into ESPHome).
 
 ## Configuration variables
 
-- **type** (**Required**, string): The update mode to use. Must be either `embedded` or `http`.
+- **type** (**Required**, string): The update mode to use.
+  <EnumOptions inline options={["embedded", "http"]} />
 
 ### Embedded mode options
 

--- a/src/content/docs/components/usb_uart.mdx
+++ b/src/content/docs/components/usb_uart.mdx
@@ -3,6 +3,7 @@ description: "Instructions for setting up a USB Host UART interface on an ESP32 
 title: "USB Host UART Interface"
 ---
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 
 This component allows an ESP32-S3 or ESP32-S2 to host USB-serial peripheral devices. It uses the [Usb Host](/components/usb_host/)
@@ -34,7 +35,8 @@ usb_uart:
 ## Configuration variables
 
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): The id to use for this component.
-- **type** (**Required**, string): The type of USB-serial device to connect to. One of `ch34x`, `ch340`, `esp_jtag`, `stm32_vcp`, `cdc_acm`, `cp210x`.
+- **type** (**Required**, string): The type of USB-serial device to connect to.
+  <EnumOptions options={["ch34x", "ch340", "esp_jtag", "stm32_vcp", "cdc_acm", "cp210x"]} />
 - **channels** (**Required**, list): A list of channels to configure.
 - **vid** (*Optional*, int): The vendor ID of the device. Use 0 as a wildcard. Each type has a default VID which will be overridden if this is set.
 - **pid** (*Optional*, int): The product ID of the device. Use 0 as a wildcard. Each type has a default PID which will be overridden if this is set.
@@ -48,7 +50,8 @@ Setting both `vid` and `pid` to 0 will match any device.
 - **buffer_size** (*Optional*, int): The size of the buffer to use for the channel. Defaults to 256 bytes.
 - **stop_bits** (*Optional*, float): The number of stop bits to use. Defaults to 1. Other options are 1.5 and 2.
 - **data_bits** (*Optional*, int): The number of data bits to use in the range 5-8. Defaults to 8.
-- **parity** (*Optional*, string): The parity to use. One of `NONE`, `EVEN`, `ODD`, `MARK` and `SPACE`. Defaults to `NONE`.
+- **parity** (*Optional*, string): The parity to use.
+  <EnumOptions options={["NONE", "EVEN", "ODD", "MARK", "SPACE"]} default="NONE" />
 - **dummy_receiver** (*Optional*, boolean): If set to true, the channel will consume any data received. This is useful for debugging purposes. Defaults to false.
 - **debug** (*Optional*, boolean): If set to true, the channel will log all data sent and received. Defaults to false.
 - **debug_prefix** (*Optional*, string): A string prepended to every debug log line for this channel.

--- a/src/content/docs/components/wifi.mdx
+++ b/src/content/docs/components/wifi.mdx
@@ -111,11 +111,14 @@ wifi:
 
 - **min_auth_mode** (*Optional*, string): Only on `esp32` and `esp8266`. Sets the minimum WiFi authentication mode
   that the device will accept when connecting to access points. This controls the weakest encryption your device will
-  allow. Possible values are:
-
-  - `WPA` - Allows WPA, WPA2, and WPA3 networks (least secure, uses TKIP encryption with known vulnerabilities)
-  - `WPA2` - Allows WPA2 and WPA3 networks (recommended, uses AES encryption)
-  - `WPA3` - Only allows WPA3 networks (most secure, ESP32 only)
+  allow.
+  <EnumOptions
+    options={[
+      { value: "WPA", description: "Allows WPA, WPA2, and WPA3 networks (least secure, uses TKIP encryption with known vulnerabilities)" },
+      { value: "WPA2", description: "Allows WPA2 and WPA3 networks (recommended, uses AES encryption)" },
+      { value: "WPA3", description: "Only allows WPA3 networks (most secure, ESP32 only)" },
+    ]}
+  />
 
   Defaults to `WPA2` on ESP32 and `WPA` on ESP8266 (will change to `WPA2` in 2026.6.0).
 

--- a/src/content/docs/components/wifi.mdx
+++ b/src/content/docs/components/wifi.mdx
@@ -3,6 +3,7 @@ description: "Instructions for setting up the WiFi configuration for your ESP no
 title: "WiFi Component"
 ---
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 
 This core ESPHome component sets up WiFi connections to access points
@@ -129,8 +130,13 @@ wifi:
 - **enable_rrm** (*Optional*, bool): Only on `esp32`. Enable 802.11k Radio Resource Management support.
 
 - **band_mode** (*Optional*, string): Only on `esp32-c5`. Controls which WiFi frequency band the device uses.
-  Possible values are `AUTO` (use both 2.4 GHz and 5 GHz), `2.4GHZ` (2.4 GHz only), and `5GHZ` (5 GHz only).
-  If not specified, it defaults to `AUTO`.
+  <EnumOptions default="AUTO"
+    options={[
+      { value: "AUTO", description: "use both 2.4 GHz and 5 GHz" },
+      { value: "2.4GHZ", description: "2.4 GHz only" },
+      { value: "5GHZ", description: "5 GHz only" },
+    ]}
+  />
 
 - **post_connect_roaming** (*Optional*, bool): Enable basic post-connect
   roaming for stationary devices. After connecting to a non-hidden network,

--- a/src/content/docs/components/xl9535.mdx
+++ b/src/content/docs/components/xl9535.mdx
@@ -3,6 +3,7 @@ description: "Instructions for setting up XL9535 digital port expanders in ESPHo
 title: "XL9535 I/O Expander"
 ---
 import APIRef from '@components/APIRef.astro';
+import EnumOptions from '@components/EnumOptions.astro';
 
 
 The XL9535 component allows you to use **XL9535** I/O expander in ESPHome.
@@ -47,7 +48,8 @@ switch:
 - **inverted** (*Optional*, boolean): If all read and written values
   should be treated as inverted. Defaults to `false`.
 
-- **mode** (*Optional*, string): A pin mode to set for the pin at. One of `INPUT` or `OUTPUT`.
+- **mode** (*Optional*, string): A pin mode to set for the pin at.
+  <EnumOptions inline options={["INPUT", "OUTPUT"]} />
 
 ## See Also
 

--- a/src/content/docs/components/zigbee.mdx
+++ b/src/content/docs/components/zigbee.mdx
@@ -2,6 +2,7 @@
 description: "Zigbee End Device for Zigbee2MQTT and ZHA."
 title: "Zigbee End Device"
 ---
+import EnumOptions from '@components/EnumOptions.astro';
 
 The `zigbee` component allows exposing supported ESPHome components over a Zigbee network to Home Assistant
 via **Zigbee2MQTT** or **ZHA**. Due to the limitations of the Zigbee protocol, only basic properties are exposed.
@@ -43,8 +44,8 @@ binary_sensor:
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): The ID to use for this `zigbee` component.
 
 - **power_source** (*Optional*, enum): Indicates what kind of power the device uses. Affects
-  sleep behavior. One of `UNKNOWN`, `MAINS_SINGLE_PHASE`, `MAINS_THREE_PHASE`, `BATTERY`,
-  `DC_SOURCE`, `EMERGENCY_MAINS_CONST`, or `EMERGENCY_MAINS_TRANSF`. Defaults to `DC_SOURCE`.
+  sleep behavior.
+  <EnumOptions options={["UNKNOWN", "MAINS_SINGLE_PHASE", "MAINS_THREE_PHASE", "BATTERY", "DC_SOURCE", "EMERGENCY_MAINS_CONST", "EMERGENCY_MAINS_TRANSF"]} default="DC_SOURCE" />
 
 - **ieee802154_vendor_oui** (*Optional*, int): Sets the Vendor Organizationally Unique Identifier (OUI).
   This allows replacing Nordic Semiconductor's default company ID with your own.

--- a/src/content/docs/components/zigbee.mdx
+++ b/src/content/docs/components/zigbee.mdx
@@ -32,12 +32,15 @@ binary_sensor:
 
 ## Configuration variables
 
-- **wipe_on_boot** (*Optional*): Erases all non-volatile memory data on boot, including
-  Zigbee network pairing and preferences (e.g., last switch state). One of:
-  - `false` (default): Preserve data across reboots.
-  - `true`: Erase all data on every boot. Use only for recovery from boot loops when
-    you don't have an SWD programmer.
-  - `once`: Erase data only on first boot after flashing new firmware, then preserve.
+- **wipe_on_boot** (*Optional*): Erases all non-volatile memory data on boot, including Zigbee network pairing and preferences (e.g., last switch state).
+  <EnumOptions
+    options={[
+      { value: "false", description: "Preserve data across reboots." },
+      { value: "true", description: "Erase all data on every boot. Use only for recovery from boot loops when you don't have an SWD programmer." },
+      { value: "once", description: "Erase data only on first boot after flashing new firmware, then preserve." },
+    ]}
+    default="false"
+  />
 
 - **on_join** (*Optional*, [Automation](/automations#automation)): Automation to run when the device joins the network.
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Introduces a new `<EnumOptions>` Astro component for documenting the allowed values of enum-type configuration variables, replacing ~165 ad-hoc prose snippets ("One of \`a\`, \`b\`, or \`c\`. Defaults to \`a\`.") across ~110 component pages with a single consistent rendering.

The component renders a bulleted list by default, marks the default value with an italic `(default)`, supports per-value descriptions (rendered as markdown) and per-value aliases (rendered as `value / alias1 / alias2`), and accepts an `inline` prop for compact prose-form rendering. `inline` and per-value descriptions cannot be combined — the component throws at build time if you try.

Migration was limited to bullets under `## Configuration variables` / `## Pin configuration variables` (plus other enums on those same pages, e.g. action parameters). Variant-specific defaults like "Defaults to \`quad\` for ESP32, \`hex\` for ESP32-P4" were intentionally left as prose since they don't fit a single `default=` value. A few cases that looked enum-y but weren't (e.g. heterogeneous shape options on `restore_value`, `packages.files`) were skipped.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.