### PR TITLE
Render loose lists as tight visually

### DIFF
--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -163,6 +163,16 @@ dialog::backdrop {
   visibility: hidden;
 }
 
+/* Tighten loose lists: blank lines between list items in source produce
+   <li><p>...</p></li> output. Strip the leading/trailing paragraph margins so
+   single-paragraph items sit flush against each other while items with multiple
+   paragraphs still get spacing between their internal paragraphs. The class is
+   repeated to win specificity against Starlight's own li > :last-child rule. */
+.sl-markdown-content.sl-markdown-content li > p:first-child { margin-block-start: 0; }
+.sl-markdown-content.sl-markdown-content li > p:last-child { margin-block-end: 0; }
+.sl-markdown-content.sl-markdown-content li > ul,
+.sl-markdown-content.sl-markdown-content li > ol { margin-block-start: 0; }
+
 /* GitHub Alerts - Custom ESPHome Colors (matching Hugo theme style) */
 .markdown-alert {
   padding: 0.75rem 1rem;


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Configuration variables lists rendered with extra vertical whitespace because blank lines between bullets in source produced loose-list HTML (`<li><p>...</p></li>` with margins). Fix this purely in CSS by stripping the leading/trailing `<p>` margins inside `<li>` and the top margin on nested sub-lists, without rewriting any content.

HTML semantics stay intact — paragraphs and sub-lists are still rendered as separate blocks; only their outer margins are zeroed so they sit flush against each other. Items with multiple paragraphs (e.g. wireguard's `address` with its follow-up paragraph) keep their internal paragraph break because the rule only targets first/last `<p>` children.

The class selector is doubled (`.sl-markdown-content.sl-markdown-content`) to win specificity against Starlight's own `li > :is(:last-child:not(...))` rule which was adding the 1.25rem bottom margin.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.