### PR TITLE
[i2s_audio] Remove restrictions on bits per sample in SPDIF mode

### DIFF
--- a/src/content/docs/components/speaker/i2s_audio.mdx
+++ b/src/content/docs/components/speaker/i2s_audio.mdx
@@ -72,8 +72,8 @@ The transmitter is connected to the `i2s_dout_pin` (the same pin used for standa
 
 When `spdif_mode` is enabled, the following settings are required:
 
-- **Sample Rate**: Only `44100` Hz (CD quality) or `48000` Hz (DVD/DAT quality) are supported
-- **Channels**: Must be set to `stereo` (2 channels)
+- **sample_rate**: Only `44100` Hz (CD quality) or `48000` Hz (DVD/DAT quality) are supported
+- **channel**: Must be set to `stereo` (2 channels)
 - **use_apll**: Must be set to `true` for accurate clock generation
 - **i2s_mode**: Must be set to `primary`
 - **i2s_comm_fmt**: Must be set to `stand_i2s`

--- a/src/content/docs/components/speaker/i2s_audio.mdx
+++ b/src/content/docs/components/speaker/i2s_audio.mdx
@@ -74,7 +74,6 @@ When `spdif_mode` is enabled, the following settings are required:
 
 - **Sample Rate**: Only `44100` Hz (CD quality) or `48000` Hz (DVD/DAT quality) are supported
 - **Channels**: Must be set to `stereo` (2 channels)
-- **bits_per_sample**: Must be set to `16bit`
 - **use_apll**: Must be set to `true` for accurate clock generation
 - **i2s_mode**: Must be set to `primary`
 - **i2s_comm_fmt**: Must be set to `stand_i2s`
@@ -96,7 +95,6 @@ speaker:
     spdif_mode: true
     use_apll: true
     sample_rate: 48000
-    bits_per_sample: 16bit
     channel: stereo
     timeout: never
 ```


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

With the new SPDIF enhancements, the bits per sample field doesn't matter, so this PR updates the docs accordingly

**Related issue (if applicable):** not applicable

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#16504

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
