### PR TITLE
[combination] Amend constants to match code.

### DIFF
--- a/src/content/docs/components/sensor/combination.mdx
+++ b/src/content/docs/components/sensor/combination.mdx
@@ -71,7 +71,7 @@ sensor:
 ## Configuration variables
 
 - **type** (**Required**, enum): Combination statistic type, should be one of
-  `KALMAN`, `LINEAR`, `MAXIMUM`, `MEAN`, `MEDIAN`, `MINIMUM`,
+  `KALMAN`, `LINEAR`, `MAX`, `MEAN`, `MEDIAN`, `MIN`,
   `MOST_RECENTLY_UPDATED`, `RANGE`, or `SUM`.
 
 - **sources** (**Required**, list): A list of sensors to use as source.

--- a/src/content/docs/components/sensor/combination.mdx
+++ b/src/content/docs/components/sensor/combination.mdx
@@ -52,7 +52,7 @@ sensor:
         coefficient: -1.0
 ```
 
-- `MAXIMUM`, `MEAN`, `MEDIAN`, `MINIMUM`, `MOST_RECENTLY_UPDATED`,
+- `MAX`, `MEAN`, `MEDIAN`, `MIN`, `MOST_RECENTLY_UPDATED`,
   `RANGE`, `SUM` combinations: These types compute the specified combination among
   all source sensor states.
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

The codebase permits combination types `max` and `min`, not `maximum` and `minimum` as currently documented.

Changing the codebase would be a breaking change, so best to simply make the docs reflect what is implemented.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
