### PR TITLE
Update faq to mention Firefox Webserial support

### DIFF
--- a/src/content/docs/guides/faq.mdx
+++ b/src/content/docs/guides/faq.mdx
@@ -80,7 +80,7 @@ We'll update our recommendations here as support matures for newer microcontroll
 You can use the [ESPHome Device Builder](/guides/getting_started_hassio#installing-esphome-device-builder) directly; after editing your device's
 configuration to your liking, click "INSTALL" and follow the prompts. Note that the first time you install ESPHome onto
 a (new) device, you need to connect it with a (USB) cable; this installation method requires a browser that supports
-WebSerial, like Google Chrome or Microsoft Edge.
+WebSerial, like Firefox, Google Chrome or Microsoft Edge.
 
 If you prefer the more manual way:
 
@@ -104,7 +104,7 @@ If you prefer the more manual way:
 
    - [ESPHome Web](https://web.esphome.io/), our web-based installer. This is the easiest approach but requires a
 
-       browser that supports WebSerial, like Google Chrome or Microsoft Edge.
+       browser that supports WebSerial, like Firefox, Google Chrome or Microsoft Edge.
 
        1. Connect the board to your computer, make sure it's detected as a [serial port](/guides/physical_device_connection#esphome-phy-con-drv) and
           click **Connect**.


### PR DESCRIPTION
Firefox now supports Webserial as of Firefox 151. https://www.firefox.com/en-GB/firefox/151.0/releasenotes/

Updated these FAQs to reflect that.

<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** fixes FAQ

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome# N/A

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.