### PR TITLE
Rename ESPHome Builder references to ESPHome Device Builder

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,9 +6,9 @@ contact_links:
   - name: Report an issue with the ESPHome web server
     url: https://github.com/esphome/esphome-webserver/issues/new/choose
     about: Report an issue with the ESPHome web server.
-  - name: Report an issue with the ESPHome Builder / Dashboard
+  - name: Report an issue with the ESPHome Device Builder / Dashboard
     url: https://github.com/esphome/dashboard/issues/new/choose
-    about: Report an issue with the ESPHome Builder / Dashboard.
+    about: Report an issue with the ESPHome Device Builder / Dashboard.
   - name: Report an issue with the ESPHome API client
     url: https://github.com/esphome/aioesphomeapi/issues/new/choose
     about: Report an issue with the ESPHome API client.

--- a/src/content/docs/guides/troubleshooting.mdx
+++ b/src/content/docs/guides/troubleshooting.mdx
@@ -17,7 +17,7 @@ instructions for capturing and understanding crash data.
 
 ESPHome automatically captures crash backtraces and stores them across software resets (warm reboots) on
 **ESP32**, **ESP8266**, and **RP2040**. After a crash, the backtrace is logged at boot and
-when `esphome logs` connects via the API. The ESPHome CLI and ESPHome Builder automatically decode the addresses
+when `esphome logs` connects via the API. The ESPHome CLI and ESPHome Device Builder automatically decode the addresses
 using the debug symbols from your last local compile.
 
 > [!NOTE]
@@ -26,8 +26,8 @@ using the debug symbols from your last local compile.
 
 > [!WARNING]
 > To get decoded stack traces, you must view the logs using the **ESPHome CLI** (`esphome logs`) or the
-> **ESPHome Builder**. Viewing logs through other tools (such as a generic serial monitor or the Home Assistant
-> log viewer) will show raw addresses without decoding them. The ESPHome CLI and ESPHome Builder use the debug
+> **ESPHome Device Builder**. Viewing logs through other tools (such as a generic serial monitor or the Home Assistant
+> log viewer) will show raw addresses without decoding them. The ESPHome CLI and ESPHome Device Builder use the debug
 > symbols from your last local compile to decode the crash addresses into function names, file paths, and line
 > numbers.
 
@@ -40,7 +40,7 @@ To see the decoded crash data:
    esphome upload your-device.yaml
    ```
 
-1. **View logs using the ESPHome CLI or ESPHome Builder** after the crash (no USB needed):
+1. **View logs using the ESPHome CLI or ESPHome Device Builder** after the crash (no USB needed):
 
    ```shell
    esphome logs your-device.yaml
@@ -157,7 +157,7 @@ crash output via serial console. This requires:
 If you already have a stack trace but need to decode it, you can use the
 [ESP Stack Trace Decoder](https://esphome.github.io/esp-stacktrace-decoder/) web tool:
 
-1. **Download the .elf file**: From ESPHome Builder, click the overflow menu (three dots) on your device card
+1. **Download the .elf file**: From ESPHome Device Builder, click the overflow menu (three dots) on your device card
    and select "Download .elf file"
 
    > [!NOTE]


### PR DESCRIPTION
## Description

The desktop wrapper has been renamed to **ESPHome Device Builder** to match the underlying Python package (see esphome/esphome-desktop#103). Updates the user-facing references in the troubleshooting guide and the docs-repo issue template.

The historical changelog entry under `src/content/docs/changelog/2025.9.0.mdx` is intentionally left as-is since that entry describes the product as it was named at that release.

**Related issue (if applicable):** n/a

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- n/a

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.