### PR TITLE
[rp2040] Document variant config option

### DIFF
--- a/src/content/docs/components/rp2040.mdx
+++ b/src/content/docs/components/rp2040.mdx
@@ -20,7 +20,7 @@ This component contains platform-specific options for the RP2040 platform.
 ```yaml
 # Example configuration entry
 rp2040:
-  variant: rp2040
+  board: rpipicow
 ```
 
 > [!NOTE]
@@ -32,7 +32,7 @@ rp2040:
 ```yaml
 # Example configuration entry
 rp2040:
-  variant: rp2040
+  board: rpipicow
   framework:
     platform_version: https://github.com/maxgerhardt/platform-raspberrypi.git
 ```

--- a/src/content/docs/components/rp2040.mdx
+++ b/src/content/docs/components/rp2040.mdx
@@ -20,7 +20,7 @@ This component contains platform-specific options for the RP2040 platform.
 ```yaml
 # Example configuration entry
 rp2040:
-  board: rpipicow
+  variant: rp2040
 ```
 
 > [!NOTE]
@@ -32,7 +32,7 @@ rp2040:
 ```yaml
 # Example configuration entry
 rp2040:
-  board: rpipicow
+  variant: rp2040
   framework:
     platform_version: https://github.com/maxgerhardt/platform-raspberrypi.git
 ```
@@ -56,11 +56,22 @@ automatically reset the device into BOOTSEL mode.
 
 ## Configuration variables
 
-- **board** (**Required**, string): The PlatformIO board identifier. Common boards include `rpipicow`
+- **variant** (*Optional*, string): The RP2040-series chip to target. One of `rp2040` or `rp2350`.
+  This must match the hardware in use, or it will fail to flash.
+
+- **board** (*Optional*, string): The PlatformIO board identifier. Common boards include `rpipicow`
   (Raspberry Pi Pico W), `rpipico` (Raspberry Pi Pico), `rpipico2w` (Raspberry Pi Pico 2 W), and
   `rpipico2` (Raspberry Pi Pico 2). Over 140 boards from the
   [arduino-pico](https://github.com/earlephilhower/arduino-pico) framework are supported. Any board
   supported by the framework can be used here.
+
+> [!NOTE]
+> At least one of `board` or `variant` must be specified. If `variant` alone is specified, the board
+> configuration will be automatically filled using the canonical Raspberry Pi Foundation reference board
+> for that variant: `rpipicow` (Pico W) for `rp2040` and `rpipico2w` (Pico 2 W) for `rp2350`. Both may
+> be specified, but they must define the same variant. If the board is not recognised by ESPHome,
+> `variant` must be specified explicitly.
+
 - **watchdog_timeout** (*Optional*, [Time](/guides/configuration-types#time)): The timeout to apply to the RP2040 watchdog.
   When the device hangs for that period of time, it will reboot. Defaults to `8388ms` (maximum). Set to `0s` to
   disable the watchdog entirely.

--- a/src/content/docs/components/rp2040.mdx
+++ b/src/content/docs/components/rp2040.mdx
@@ -72,6 +72,12 @@ automatically reset the device into BOOTSEL mode.
 > be specified, but they must define the same variant. If the board is not recognised by ESPHome,
 > `variant` must be specified explicitly.
 
+> [!WARNING]
+> Some components are restricted to specific boards rather than the whole variant. The [WiFi](/components/wifi/)
+> component, for example, requires a board with the Cypress CYW43439 wireless chip (such as `rpipicow` or
+> `rpipico2w`); selecting a board without it (such as `rpipico` or `rpipico2`) will fail validation even though
+> the variant is otherwise capable.
+
 - **watchdog_timeout** (*Optional*, [Time](/guides/configuration-types#time)): The timeout to apply to the RP2040 watchdog.
   When the device hangs for that period of time, it will reboot. Defaults to `8388ms` (maximum). Set to `0s` to
   disable the watchdog entirely.


### PR DESCRIPTION
## Description

Documents the new `variant` config option for the `rp2040` platform component. Variant can be `rp2040` or `rp2350`. The variant is auto-derived from the configured board, or — when specified alone — picks the canonical Raspberry Pi Foundation reference board (`rpipicow` for `rp2040`, `rpipico2w` for `rp2350`). When both are given they must match. Unknown boards must specify the variant explicitly.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#16602

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.