### PR TITLE
time-based manual tracking

### DIFF
--- a/src/content/docs/components/cover/time_based.mdx
+++ b/src/content/docs/components/cover/time_based.mdx
@@ -91,6 +91,88 @@ stop_action:
       }
 ```
 
+## External Sensing & Manual Override
+
+If your cover (like a standing desk or motorized blind) has its own physical buttons that operate the motor directly, ESPHome can track the cover's position when it's moved manually.
+
+You can update the internal state of the `time_based` cover from a lambda using the `update_external_state(bool up_active, bool down_active)` method.
+When either of these states is true, the cover enters an "external override" mode, which actively ignores commands from Home Assistant to prevent conflicting movements.
+Once both are false, it resumes normal operation.
+
+**C++ Method:**
+
+```cpp
+// up_active: True if the cover is currently being manually opened/raised.
+// down_active: True if the cover is currently being manually closed/lowered.
+id(my_cover).update_external_state(up_active, down_active);
+```
+
+### Example Configuration:
+
+This example assumes you are using GPIO pins to monitor the voltage of physical "Up" and "Down" buttons.
+
+```yaml
+cover:
+  - platform: time_based
+    name: "Desk"
+    id: desk_cover
+    open_duration: 17s
+    close_duration: 16s
+    open_action:
+      - switch.turn_on: button_up
+    close_action:
+      - switch.turn_on: button_down
+    stop_action:
+      - switch.turn_off: button_up
+      - switch.turn_off: button_down
+
+script:
+  - id: process_desk_buttons
+    mode: restart
+    then:
+      - lambda: |-
+          // Check if the physical button is pressed but the relay (switch) is off.
+          // This indicates a human is pressing the button, not ESPHome.
+          bool human_up = id(desk_button_up).state && !id(button_up).state;
+          bool human_down = id(desk_button_down).state && !id(button_down).state;
+
+          // Ignore manual tracking if ESPHome is currently driving the motor
+          if (id(button_up).state && !human_down) return;
+          if (id(button_down).state && !human_up) return;
+
+          // Update the cover's internal state
+          id(desk_cover).update_external_state(human_up, human_down);
+
+binary_sensor:
+  - platform: gpio
+    id: desk_button_up
+    pin:
+      number: 18
+      mode: INPUT_OUTPUT_OPEN_DRAIN
+      allow_other_uses: true
+      inverted: true
+    filters:
+      - delayed_on: 50ms
+      - delayed_off: 50ms
+    on_state:
+      then:
+        - script.execute: process_desk_buttons
+
+  - platform: gpio
+    id: desk_button_down
+    pin:
+      number: 16
+      mode: INPUT_OUTPUT_OPEN_DRAIN
+      allow_other_uses: true
+      inverted: true
+    filters:
+      - delayed_on: 50ms
+      - delayed_off: 50ms
+    on_state:
+      then:
+        - script.execute: process_desk_buttons
+```
+
 ## See Also
 
 - [Cover Component](/components/cover/)


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** fixes <link to issue>
N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<16474>

## Checklist

- [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
