### PR TITLE
[ethernet] Document enable_on_boot, enable/disable actions, and conditions

### DIFF
--- a/src/content/docs/components/ethernet.mdx
+++ b/src/content/docs/components/ethernet.mdx
@@ -157,6 +157,8 @@ If you are using a framework that does not support SPI polling mode,
 
 - **mac_address** (*Optional*, MAC Address): Set the MAC address of the ethernet interface.
 
+- **enable_on_boot** (*Optional*, boolean): If enabled, the Ethernet interface will be enabled on boot. Defaults to `true`.
+
 - **on_connect** (*Optional*, [Automation](/automations)): An action to be performed when a connection is established.
 - **on_disconnect** (*Optional*, [Automation](/automations)): An action to be performed when the connection is dropped.
 
@@ -534,6 +536,74 @@ ethernet:
   on_disconnect:
     - switch.turn_off: switch1
 ```
+
+## Actions
+
+<span id="ethernet-on_disable"></span>
+
+### `ethernet.disable` Action
+
+This action turns off the Ethernet interface on demand.
+
+```yaml
+on_...:
+  then:
+    - ethernet.disable:
+```
+
+> [!NOTE]
+> Be mindful of the reboot timeout set for the [API component](/components/api/) if you disable Ethernet on a device that has no other network interface configured. If Ethernet remains off for longer than that timeout, the device will reboot!
+
+<span id="ethernet-on_enable"></span>
+
+### `ethernet.enable` Action
+
+This action turns on the Ethernet interface on demand.
+
+```yaml
+on_...:
+  then:
+    - ethernet.enable:
+```
+
+> [!NOTE]
+> The configuration option `enable_on_boot` can be set to `false` if you do not want Ethernet to be enabled on boot.
+
+## Conditions
+
+<span id="ethernet-connected_condition"></span>
+
+### `ethernet.connected` Condition
+
+This [Condition](/automations/actions#all-conditions) checks if the device currently has an Ethernet connection.
+
+```yaml
+on_...:
+  if:
+    condition:
+      ethernet.connected:
+    then:
+      - logger.log: Ethernet is connected!
+```
+
+The lambda equivalent for this is `id(ethernet_id).is_connected()`.
+
+<span id="ethernet-enabled_condition"></span>
+
+### `ethernet.enabled` Condition
+
+This [Condition](/automations/actions#all-conditions) checks if the Ethernet interface is currently enabled.
+
+```yaml
+on_...:
+  if:
+    condition:
+      ethernet.enabled:
+    then:
+      - logger.log: Ethernet is enabled!
+```
+
+The lambda equivalent for this is `id(ethernet_id).is_enabled()`.
 
 ## See Also
 


### PR DESCRIPTION
## Description

Documents the new lifecycle surface added in esphome/esphome#16607, mirroring how the same feature is documented on the WiFi component page:

- `enable_on_boot` configuration variable under "Advanced common configuration variables"
- `ethernet.disable` / `ethernet.enable` actions
- `ethernet.connected` / `ethernet.enabled` conditions

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#16607

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)