### PR TITLE
[docs] Lower RF receiver tolerance from 50% to 25% in setup guide

### DIFF
--- a/src/content/docs/guides/setting_up_rmt_devices.mdx
+++ b/src/content/docs/guides/setting_up_rmt_devices.mdx
@@ -97,11 +97,16 @@ remote_receiver:
   pin: GPIOXX
   dump: all
   # Settings to optimize recognition of RF devices
-  tolerance: 50%
+  tolerance: 25%
   filter: 250us
   idle: 4ms
   buffer_size: 2kb # only for ESP8266
 ```
+
+The `tolerance` setting defaults to `25%`. If a known protocol fails to decode, raise
+it in small steps. Avoid values close to `50%` — wide windows for adjacent timing slots
+within a protocol start to overlap, and the decoder can match the wrong symbol and emit
+garbage data.
 
 Compile and upload the code. While viewing the log output from the ESP,
 press a button on an RF remote you want to capture (one at a time).


### PR DESCRIPTION
## Description

The RF receiver setup guide recommends \`tolerance: 50%\`. The default in \`remote_receiver\` is \`25%\`; doubling it widens each timing slot's window enough that adjacent slots within the same protocol overlap. Users following the guide get worse decoding than the default — wrong protocol matches and garbage data — and there's no signal in the existing prose that this is a risky knob.

Set the example to \`25%\` (the safe default) and add a short note explaining when to raise it and why values near \`50%\` cause overlap.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** None — docs-only.

## Checklist

- [ ] I am merging into \`next\` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into \`current\` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in \`/src/content/docs/components/index.mdx\` when creating new documents for new components or cookbook.