### PR TITLE
[time] Update timezone docs

### DIFF
--- a/src/content/docs/components/time/homeassistant.mdx
+++ b/src/content/docs/components/time/homeassistant.mdx
@@ -19,9 +19,9 @@ time:
     id: homeassistant_time
 ```
 
-If no `timezone` is configured for this component an initial timezone will be inferred from the build host, but
-at runtime the timezone will be updated from Home Assistant when the time is synced..
-An explicitly configured timezone will prevent the timezone being updated from Home Assistant.
+If no `timezone` is configured for this component, an initial timezone will be inferred from the build host, but
+at runtime the timezone will be updated from Home Assistant when the time is synced.
+An explicitly configured timezone will prevent the timezone from being updated from Home Assistant.
 
 ## Configuration variables
 

--- a/src/content/docs/components/time/homeassistant.mdx
+++ b/src/content/docs/components/time/homeassistant.mdx
@@ -19,6 +19,10 @@ time:
     id: homeassistant_time
 ```
 
+If no `timezone` is configured for this component an initial timezone will be inferred from the build host, but
+at runtime the timezone will be updated from Home Assistant when the time is synced..
+An explicitly configured timezone will prevent the timezone being updated from Home Assistant.
+
 ## Configuration variables
 
 - All options from [Base Time Configuration](/components/time#base_time_config).

--- a/src/content/docs/components/time/index.mdx
+++ b/src/content/docs/components/time/index.mdx
@@ -24,6 +24,8 @@ All time configuration schemas inherit these options.
   or the simpler [TZ database name](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) in the form
   `<Region>/<City>`. ESPHome tries to automatically infer the time zone string based on the time zone of the computer
   that is running ESPHome, but this might not always be accurate. Not available on nRF52 platforms.
+  An empty timezone (the empty string, `""`) will mean no timezone handling will be compiled in, so the device will
+  opearate strictly on UTC.
 
 - **on_time** (*Optional*, [Automation](/automations)): Automation to run at specific intervals using
   a cron-like syntax. See [`on_time` Trigger](#time-on_time).

--- a/src/content/docs/components/time/index.mdx
+++ b/src/content/docs/components/time/index.mdx
@@ -25,7 +25,7 @@ All time configuration schemas inherit these options.
   `<Region>/<City>`. ESPHome tries to automatically infer the time zone string based on the time zone of the computer
   that is running ESPHome, but this might not always be accurate. Not available on nRF52 platforms.
   An empty timezone (the empty string, `""`) will mean no timezone handling will be compiled in, so the device will
-  opearate strictly on UTC.
+  operate strictly on UTC.
 
 - **on_time** (*Optional*, [Automation](/automations)): Automation to run at specific intervals using
   a cron-like syntax. See [`on_time` Trigger](#time-on_time).


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description


**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#16583

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
