### PR TITLE
[esp32_hosted] Document use_psram option

### DIFF
--- a/src/content/docs/components/esp32_hosted.mdx
+++ b/src/content/docs/components/esp32_hosted.mdx
@@ -70,6 +70,10 @@ wifi:
 - **sdio_frequency** (*Optional*, frequency): Set the speed of communication between the host and
   the co-processor. If you experience loss of communication, or reboots, then try reducing this value.
   The value can be between 400kHz and 50MHz, with a default of 40MHz.
+- **use_psram** (*Optional*, boolean): Place the transport buffer pool in PSRAM instead of
+  internal RAM. Recommended on host chips with DMA-capable PSRAM (ESP32-P4, ESP32-S3) when the
+  host firmware uses most of internal RAM (for example, a large LVGL UI). Without this, boot can
+  fail with an `sdio_mempool_create` assert. Defaults to `false`.
 
 ## SPI Transport
 
@@ -110,6 +114,10 @@ wifi:
 - **frequency** (*Optional*, frequency): The SPI clock frequency. Maximum depends on variant: 10MHz for ESP32, 40MHz for all other variants. Defaults to the maximum for each variant.
 - **handshake_active_high** (*Optional*, boolean): Polarity of the handshake signal. Defaults to `true`.
 - **data_ready_active_high** (*Optional*, boolean): Polarity of the data ready signal. Defaults to `true`.
+- **use_psram** (*Optional*, boolean): Place the transport buffer pool in PSRAM instead of
+  internal RAM. Recommended on host chips with DMA-capable PSRAM (ESP32-P4, ESP32-S3) when the
+  host firmware uses most of internal RAM (for example, a large LVGL UI). Without this, boot can
+  fail with an `sdio_mempool_create` assert. Defaults to `false`.
 
 ## Updating co-processor firmware
 

--- a/src/content/docs/components/esp32_hosted.mdx
+++ b/src/content/docs/components/esp32_hosted.mdx
@@ -70,10 +70,10 @@ wifi:
 - **sdio_frequency** (*Optional*, frequency): Set the speed of communication between the host and
   the co-processor. If you experience loss of communication, or reboots, then try reducing this value.
   The value can be between 400kHz and 50MHz, with a default of 40MHz.
-- **use_psram** (*Optional*, boolean): Place the transport buffer pool in PSRAM instead of
-  internal RAM. Recommended on host chips with DMA-capable PSRAM (ESP32-P4, ESP32-S3) when the
-  host firmware uses most of internal RAM (for example, a large LVGL UI). Without this, boot can
-  fail with an `sdio_mempool_create` assert. Defaults to `false`.
+- **use_psram** (*Optional*, boolean): Place the SDIO transport buffer pool in PSRAM instead of
+  internal RAM. Requires the host MCU to have DMA-capable PSRAM enabled (ESP32-P4, ESP32-S3).
+  Recommended when the host firmware uses most of internal RAM (for example, a large LVGL UI);
+  without it, boot can fail with an `sdio_mempool_create` assert. Defaults to `false`.
 
 ## SPI Transport
 
@@ -114,10 +114,10 @@ wifi:
 - **frequency** (*Optional*, frequency): The SPI clock frequency. Maximum depends on variant: 10MHz for ESP32, 40MHz for all other variants. Defaults to the maximum for each variant.
 - **handshake_active_high** (*Optional*, boolean): Polarity of the handshake signal. Defaults to `true`.
 - **data_ready_active_high** (*Optional*, boolean): Polarity of the data ready signal. Defaults to `true`.
-- **use_psram** (*Optional*, boolean): Place the transport buffer pool in PSRAM instead of
-  internal RAM. Recommended on host chips with DMA-capable PSRAM (ESP32-P4, ESP32-S3) when the
-  host firmware uses most of internal RAM (for example, a large LVGL UI). Without this, boot can
-  fail with an `sdio_mempool_create` assert. Defaults to `false`.
+- **use_psram** (*Optional*, boolean): Place the SPI transport buffer pool in PSRAM instead of
+  internal RAM. Requires the host MCU to have DMA-capable PSRAM enabled (ESP32-P4, ESP32-S3).
+  Recommended when the host firmware uses most of internal RAM (for example, a large LVGL UI);
+  without it, boot can fail with an `spi_mempool_create` assert. Defaults to `false`.
 
 ## Updating co-processor firmware
 


### PR DESCRIPTION
## Description

Documents the new \`use_psram\` boolean option on the \`esp32_hosted\` component, which places the transport buffer pool in PSRAM instead of internal RAM. Required on memory-tight host configs (e.g. ESP32-P4 with large LVGL UI) where the internal-RAM mempool allocation fails at boot with \`sdio_mempool_create\` assert.

**Related issue (if applicable):** fixes esphome/esphome#16574

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#16627

## Checklist

- [x] I am merging into \`next\` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into \`current\` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in \`/src/content/docs/components/index.mdx\` when creating new documents for new components or cookbook.