### PR TITLE
[micro_wake_word] Document task_stack_in_psram option

### DIFF
--- a/src/content/docs/components/micro_wake_word.mdx
+++ b/src/content/docs/components/micro_wake_word.mdx
@@ -26,6 +26,7 @@ micro_wake_word:
 
 - **microphone** (*Optional*, [Microphone Source Configuration](/components/microphone#config-microphone-source)): The [microphone](/components/microphone/) settings to use for audio input.
 - **stop_after_detection** (*Optional*, boolean): Whether to stop the component after detecting a wake word. Defaults to `true`.
+- **task_stack_in_psram** (*Optional*, boolean): Allocate the inference task's stack in external memory (PSRAM). Defaults to `false`.
 - **models** (**Required**, list): The models to use. Only the first model is enabled by default on the first boot. Each model's enabled state is then saved/restored to/from the flash.
 
   - **id** (*Optional*, [ID](/guides/configuration-types#id)): The optional ID used for the model actions below.

--- a/src/content/docs/components/micro_wake_word.mdx
+++ b/src/content/docs/components/micro_wake_word.mdx
@@ -26,7 +26,7 @@ micro_wake_word:
 
 - **microphone** (*Optional*, [Microphone Source Configuration](/components/microphone#config-microphone-source)): The [microphone](/components/microphone/) settings to use for audio input.
 - **stop_after_detection** (*Optional*, boolean): Whether to stop the component after detecting a wake word. Defaults to `true`.
-- **task_stack_in_psram** (*Optional*, boolean): Allocate the inference task's stack in external memory (PSRAM). Defaults to `false`.
+- **task_stack_in_psram** (*Optional*, boolean): If `true`, allocate the inference task stack in PSRAM instead of internal RAM. Requires the [PSRAM](/components/psram/) component. Defaults to `false`.
 - **models** (**Required**, list): The models to use. Only the first model is enabled by default on the first boot. Each model's enabled state is then saved/restored to/from the flash.
 
   - **id** (*Optional*, [ID](/guides/configuration-types#id)): The optional ID used for the model actions below.


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Documents the new `task_stack_in_psram` option.

**Related issue (if applicable):** not applicable

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#16632

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
