### PR TITLE
[esp32] Document github:// framework source for native ESP-IDF

### DIFF
--- a/src/content/docs/components/esp32.mdx
+++ b/src/content/docs/components/esp32.mdx
@@ -356,17 +356,6 @@ esp32:
   - `github://owner/repo` or `github://owner/repo@branch-or-tag`
   - `https://github.com/owner/repo.git` or `https://github.com/owner/repo.git@branch-or-tag`
 
-  Useful for testing against pre-release ESP-IDF (e.g. chips supported only on `master` before any tagged
-  release ships them):
-
-  ```yaml
-  esp32:
-    framework:
-      type: esp-idf
-      version: 6.1.0
-      source: github://espressif/esp-idf@master
-  ```
-
 - **platform_version** (*Optional*, string): The version of the
   [pioarduino/espressif32](https://github.com/pioarduino/platform-espressif32/releases/) package to use. For known framework versions
   this value will be set automatically.

--- a/src/content/docs/components/esp32.mdx
+++ b/src/content/docs/components/esp32.mdx
@@ -335,16 +335,37 @@ esp32:
   - `latest`  : Use the latest *release*, even if it hasn't been recommended yet.
   - `recommended`  : Use the recommended framework version.
 
-- **source** (*Optional*, string): The PlatformIO package to use for the framework. This variable provides
-  the URL of the git repository or file archive of a custom or patched version of the
+- **source** (*Optional*, string): Override the framework source. The accepted forms depend on the active toolchain.
+
+  When the PlatformIO toolchain is selected, this is a PlatformIO package spec for a custom or patched version of the
   [pioarduino/framework-arduinoespressif32](https://github.com/espressif/arduino-esp32) or
-  [pioarduino/framework-espidf](https://github.com/pioarduino/esp-idf) package for the framework type. Refer to
+  [pioarduino/framework-espidf](https://github.com/pioarduino/esp-idf) package. Refer to
   [PlatformIO package specifications](https://docs.platformio.org/en/latest/core/userguide/pkg/cmd_install.html#package-specifications)
   for the supported URL schemes. Examples:
 
   - `https://github.com/user/arduino-esp32/releases/download/archive.zip`
   - `https://github.com/user/esp-idf.git#branch`
   - `symlink:///path/to/esp-idf`
+
+  When the [native ESP-IDF toolchain](/guides/esp_idf/) is selected, the value must be either an archive URL
+  (tarball or zip) or one of the following GitHub forms, which clone the repository with submodules.
+  Using a GitHub archive URL with the native ESP-IDF toolchain does **not** work because GitHub's
+  generated archives strip git submodules, which ESP-IDF needs for components like `mbedtls`, `openthread`,
+  `esptool`, and `bootloader`.
+
+  - `github://owner/repo` or `github://owner/repo@branch-or-tag`
+  - `https://github.com/owner/repo.git` or `https://github.com/owner/repo.git@branch-or-tag`
+
+  Useful for testing against pre-release ESP-IDF (e.g. chips supported only on `master` before any tagged
+  release ships them):
+
+  ```yaml
+  esp32:
+    framework:
+      type: esp-idf
+      version: 6.1.0
+      source: github://espressif/esp-idf@master
+  ```
 
 - **platform_version** (*Optional*, string): The version of the
   [pioarduino/espressif32](https://github.com/pioarduino/platform-espressif32/releases/) package to use. For known framework versions

--- a/src/content/docs/components/esp32.mdx
+++ b/src/content/docs/components/esp32.mdx
@@ -347,14 +347,22 @@ esp32:
   - `https://github.com/user/esp-idf.git#branch`
   - `symlink:///path/to/esp-idf`
 
-  When the [native ESP-IDF toolchain](/guides/esp_idf/) is selected, the value must be either an archive URL
-  (tarball or zip) or one of the following GitHub forms, which clone the repository with submodules.
-  Using a GitHub archive URL with the native ESP-IDF toolchain does **not** work because GitHub's
-  generated archives strip git submodules, which ESP-IDF needs for components like `mbedtls`, `openthread`,
-  `esptool`, and `bootloader`.
+  When the [native ESP-IDF toolchain](/guides/esp_idf/) is selected, the value must be one of:
 
-  - `github://owner/repo` or `github://owner/repo@branch-or-tag`
-  - `https://github.com/owner/repo.git` or `https://github.com/owner/repo.git@branch-or-tag`
+  - A pre-bundled framework archive URL (`.tar.xz`, `.tar.gz`, or `.zip`) that **includes git submodules**
+    inside the archive — for example a tarball from
+    [esphome-libs/esp-idf releases](https://github.com/esphome-libs/esp-idf/releases) (the same place the
+    default mirrors point to).
+  - One of the following GitHub forms, which clone the repository with submodules:
+
+    - `github://owner/repo` or `github://owner/repo@branch-or-tag`
+    - `https://github.com/owner/repo.git` or `https://github.com/owner/repo.git@branch-or-tag`
+
+  GitHub's auto-generated archive URLs (anything matching
+  `https://github.com/owner/repo/archive/...zip` or `.../archive/refs/heads/...tar.gz`) do **not** work
+  with the native ESP-IDF toolchain: they strip git submodules, and ESP-IDF needs them for components like
+  `mbedtls`, `openthread`, `esptool`, and `bootloader`. Use one of the `github://` / `.git` forms above to
+  clone from such a repository instead.
 
 - **platform_version** (*Optional*, string): The version of the
   [pioarduino/espressif32](https://github.com/pioarduino/platform-espressif32/releases/) package to use. For known framework versions

--- a/src/content/docs/components/esp32.mdx
+++ b/src/content/docs/components/esp32.mdx
@@ -347,22 +347,11 @@ esp32:
   - `https://github.com/user/esp-idf.git#branch`
   - `symlink:///path/to/esp-idf`
 
-  When the [native ESP-IDF toolchain](/guides/esp_idf/) is selected, the value must be one of:
+  When the [native ESP-IDF toolchain](/guides/esp_idf/) is selected, the value may also be one of the
+  following GitHub forms, which clone the repository with submodules:
 
-  - A pre-bundled framework archive URL (`.tar.xz`, `.tar.gz`, or `.zip`) that **includes git submodules**
-    inside the archive — for example a tarball from
-    [esphome-libs/esp-idf releases](https://github.com/esphome-libs/esp-idf/releases) (the same place the
-    default mirrors point to).
-  - One of the following GitHub forms, which clone the repository with submodules:
-
-    - `github://owner/repo` or `github://owner/repo@branch-or-tag`
-    - `https://github.com/owner/repo.git` or `https://github.com/owner/repo.git@branch-or-tag`
-
-  GitHub's auto-generated archive URLs (anything matching
-  `https://github.com/owner/repo/archive/...zip` or `.../archive/refs/heads/...tar.gz`) do **not** work
-  with the native ESP-IDF toolchain: they strip git submodules, and ESP-IDF needs them for components like
-  `mbedtls`, `openthread`, `esptool`, and `bootloader`. Use one of the `github://` / `.git` forms above to
-  clone from such a repository instead.
+  - `github://owner/repo` or `github://owner/repo@branch-or-tag`
+  - `https://github.com/owner/repo.git` or `https://github.com/owner/repo.git@branch-or-tag`
 
 - **platform_version** (*Optional*, string): The version of the
   [pioarduino/espressif32](https://github.com/pioarduino/platform-espressif32/releases/) package to use. For known framework versions

--- a/src/content/docs/components/esp32.mdx
+++ b/src/content/docs/components/esp32.mdx
@@ -348,13 +348,11 @@ esp32:
   - `symlink:///path/to/esp-idf`
 
   When the [native ESP-IDF toolchain](/guides/esp_idf/) is selected, the value may be either:
-
-  - A pre-bundled framework archive URL (`.tar.xz`, `.tar.gz`, or `.zip`) — e.g.
-    `https://github.com/esphome-libs/esp-idf/releases/download/v5.2.7/esp-idf-v5.2.7.tar.gz`.
-  - One of the following GitHub forms, which clone the repository with submodules:
-
-    - `github://owner/repo` or `github://owner/repo@branch-or-tag`
-    - `https://github.com/owner/repo.git` or `https://github.com/owner/repo.git@branch-or-tag`
+  - A pre-bundled framework archive URL (`.tar.xz`, `.tar.gz`, or `.zip`), for example
+    `https://github.com/esphome-libs/esp-idf/releases/download/v5.2.7/esp-idf-v5.2.7.tar.gz`
+  - A GitHub repository, cloned with submodules at the optional branch or tag:
+    - `github://owner/repo[@branch-or-tag]`
+    - `https://github.com/owner/repo.git[@branch-or-tag]`
 
 - **platform_version** (*Optional*, string): The version of the
   [pioarduino/espressif32](https://github.com/pioarduino/platform-espressif32/releases/) package to use. For known framework versions

--- a/src/content/docs/components/esp32.mdx
+++ b/src/content/docs/components/esp32.mdx
@@ -347,11 +347,14 @@ esp32:
   - `https://github.com/user/esp-idf.git#branch`
   - `symlink:///path/to/esp-idf`
 
-  When the [native ESP-IDF toolchain](/guides/esp_idf/) is selected, the value may also be one of the
-  following GitHub forms, which clone the repository with submodules:
+  When the [native ESP-IDF toolchain](/guides/esp_idf/) is selected, the value may be either:
 
-  - `github://owner/repo` or `github://owner/repo@branch-or-tag`
-  - `https://github.com/owner/repo.git` or `https://github.com/owner/repo.git@branch-or-tag`
+  - A pre-bundled framework archive URL (`.tar.xz`, `.tar.gz`, or `.zip`) — e.g.
+    `https://github.com/esphome-libs/esp-idf/releases/download/v5.2.7/esp-idf-v5.2.7.tar.gz`.
+  - One of the following GitHub forms, which clone the repository with submodules:
+
+    - `github://owner/repo` or `github://owner/repo@branch-or-tag`
+    - `https://github.com/owner/repo.git` or `https://github.com/owner/repo.git@branch-or-tag`
 
 - **platform_version** (*Optional*, string): The version of the
   [pioarduino/espressif32](https://github.com/pioarduino/platform-espressif32/releases/) package to use. For known framework versions


### PR DESCRIPTION
## Description

Documents the new `framework.source` forms accepted by the native ESP-IDF toolchain:

- `github://owner/repo[@ref]`
- `https://github.com/owner/repo.git[@ref]`

These trigger a `git clone --recurse-submodules` instead of an archive download. Required when using a custom IDF (e.g. \`master\` for chips not yet in a tagged release) because GitHub's archive URLs strip submodules and the build fails.

The existing PlatformIO source examples are kept for the PlatformIO toolchain path.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#16639

## Checklist

- [x] I am merging into \`next\` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into \`current\` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in \`/src/content/docs/components/index.mdx\` when creating new documents for new components or cookbook.