### PR TITLE
[lvgl] Document `rounded` property for meter arcs

### DIFF
--- a/src/content/docs/components/lvgl/widgets.mdx
+++ b/src/content/docs/components/lvgl/widgets.mdx
@@ -1282,6 +1282,8 @@ The meter widget can visualize data in very flexible ways. It can use arcs, need
       - **start_value**: The value in the scale range to start drawing the arc from.
       - **end_value**: The value in the scale range to end drawing the arc to.
       - **width**: Arc width in pixels. Defaults to `4`.
+      - **rounded**: Controls
+      - **rounded** (*Optional*, boolean): If `true` the ends of the arc will be rounded. Defaults to `false`.
       - **padding**: Adjust the position of the arc from the scale radius with this amount (can be negative). Defaults to `0`. (The deprecated name `r_mod` is also accepted.)
       - **opa**: Opacity of the arc.
     - **image** (*Optional*): Add a rotating needle image to the scale:

--- a/src/content/docs/components/lvgl/widgets.mdx
+++ b/src/content/docs/components/lvgl/widgets.mdx
@@ -1282,7 +1282,6 @@ The meter widget can visualize data in very flexible ways. It can use arcs, need
       - **start_value**: The value in the scale range to start drawing the arc from.
       - **end_value**: The value in the scale range to end drawing the arc to.
       - **width**: Arc width in pixels. Defaults to `4`.
-      - **rounded**: Controls
       - **rounded** (*Optional*, boolean): If `true` the ends of the arc will be rounded. Defaults to `false`.
       - **padding**: Adjust the position of the arc from the scale radius with this amount (can be negative). Defaults to `0`. (The deprecated name `r_mod` is also accepted.)
       - **opa**: Opacity of the arc.


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#16669

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
