### PR TITLE
[docs] Document MDX component reuse and Markdown preferences

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -338,6 +338,27 @@ import Figure from '@components/Figure.astro';
 
 - `caption`: For captions with markdown/links (use `<Fragment slot="caption">` with markdown content)
 
+### Reusable Components for Repeated Patterns
+
+If your content needs the same HTML or CSS structure repeated many times — for example, every row in a table calling
+the same widget — that pattern is a candidate for a reusable Astro component under `src/components/`.
+`LightEffectPreview` is an example: it renders a small animated preview that the light effects table calls once per
+row.
+
+When you're not sure whether a new component is the right call, flag it in your PR description and let maintainers
+decide. Avoid duplicating large blocks of inline `<style>` or HTML directly in MDX content.
+
+### Prefer Markdown over Raw HTML
+
+When Markdown syntax produces the same rendered result, use it instead of raw HTML:
+
+- Markdown tables (`| col1 | col2 |`) over `<table>` blocks
+- Markdown links (`[text](url)`) over `<a href>`
+- Markdown emphasis (`*italic*`, `**bold**`) over `<i>`, `<b>`, `<em>`, `<strong>`
+
+Raw HTML and JSX should appear only when Markdown cannot express what you need: invoking custom components like
+`LightEffectPreview` or `Figure`, complex layouts, or specific accessibility attributes.
+
 ## Git Workflow
 
 ### Branch Strategy
@@ -345,6 +366,8 @@ import Figure from '@components/Figure.astro';
 - **Bug fixes and documentation corrections**: Target the `current` branch
 - **New features and new component docs**: Target the `next` branch
 - **Create separate branches** for each pull request (one PR per feature/fix)
+- **Prefer small, focused pull requests**: If a change spans multiple unrelated topics or files, split into
+  separate PRs for easier review
 - **Always branch from the target branch**: Use `git checkout -b <branch-name> current` or `git checkout -b <branch-name> next` to ensure you're branching from the correct base
 
 ### Commit Messages
@@ -394,6 +417,10 @@ npm run build
 - [ ] Verify no H1 headings in content (title comes from frontmatter)
 - [ ] Verify images are imported correctly (single-use) or in /public/images/ (multi-use)
 - [ ] Check that ImgTable images are in /public/images/
+- [ ] Section headings use Title Case (e.g., "Configuration Variables")
+- [ ] Variable names, parameter names, and short code snippets are wrapped in single backticks
+- [ ] Markdown syntax used when it produces the same result as raw HTML
+- [ ] No large inline `<style>` blocks in MDX (raise with maintainers if you think one is needed)
 
 ## Common Patterns
 


### PR DESCRIPTION
## Description

Proposal — adding three MDX-style sections and four "Before Submitting" checklist items to `CONTRIBUTING.md`, triggered by feedback on #6692.

In #6692 I wrote about 300 lines of inline `<style>` and duplicated HTML tables in MDX rather than extracting an Astro component, and used `<table>` HTML where native Markdown tables would have rendered the same. @jesserockz refactored both in a follow-up commit on the PR. The patterns aren't covered in `CONTRIBUTING.md` today, so this PR proposes language to capture them.

**Changes:**

- New "Reusable Components for Repeated Patterns" subsection that cites `LightEffectPreview` as the example, defers new-component decisions to maintainers, and discourages large inline `<style>` blocks
- New "Prefer Markdown over Raw HTML" subsection covering tables, links, and emphasis
- New "Prefer small, focused pull requests" bullet under Branch Strategy
- Four new "Before Submitting" checklist items: Title Case headings, backticked variable names, Markdown over HTML, no large inline `<style>` blocks

**This is a proposal, not a finished change.** Open to wording changes, scope cuts, or rephrasing — if maintainers prefer to leave new-component decisions implicit (and just refactor in review like #6692 went), that subsection can be cut. Submitting per the "prefer small, focused PRs" guidance this PR adds, so `AGENTS.md` is in a separate PR.

**Related issue (if applicable):** n/a

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** n/a

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
