### PR TITLE
[docs] Add MDX style checklist to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,17 @@ For repository structure and local development setup, see the [README](README.md
 
 @CONTRIBUTING.md
 
+## Verifying Style Before Submitting
+
+After generating or modifying MDX content, verify against the
+[Before Submitting](CONTRIBUTING.md#before-submitting) checklist in CONTRIBUTING.md. Items easy to overlook:
+
+- Section titles in Title Case
+- Variable names and short code snippets wrapped in backticks
+- Markdown syntax preferred when it produces the same result as raw HTML
+- Repeated HTML or CSS structure may be a candidate for a reusable Astro component — flag in the PR description
+  if you're not sure
+
 ## Guidelines for AI Generated Reviews and PR Summaries
 
 Avoid the use of flowery language and weasel-words that add no useful content. Keep comments concise and technically


### PR DESCRIPTION
## Description

Proposal — adding a short "Verifying Style Before Submitting" section to `AGENTS.md`. Companion to #6695 (CONTRIBUTING.md MDX-style additions).

**Depends on #6695.** This PR links to the `CONTRIBUTING.md#before-submitting` checklist with items added in that PR; merging this before #6695 means the linked items don't exist yet.

In #6692 review @jesserockz pointed out style and pattern issues despite both `CONTRIBUTING.md` and `AGENTS.md` being available to read. The CONTRIBUTING.md additions in #6695 cover the underlying conventions; this PR adds a brief reminder in `AGENTS.md` that points back to the checklist and calls out the items easiest for an agent to overlook.

**Changes:**

- New "Verifying Style Before Submitting" section right after the existing `@CONTRIBUTING.md` pointer
- Four short bullets covering the items most easily overlooked: Title Case headings, backticked variable names, Markdown over HTML, and repeated structure as a component candidate

**This is a proposal, not a finished change.** Happy to fold this into #6695 if maintainers prefer it bundled, or cut it entirely.

**Related issue (if applicable):** n/a

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** n/a

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
