### PR TITLE
[neopixelbus] Note ESP32 deprecation

### DIFF
--- a/src/content/docs/components/light/neopixelbus.mdx
+++ b/src/content/docs/components/light/neopixelbus.mdx
@@ -6,11 +6,16 @@ import APIRef from '@components/APIRef.astro';
 
 
 > [!CAUTION]
-> **Deprecated on ESP32 in 2026.6.** The upstream [NeoPixelBus](https://github.com/Makuna/NeoPixelBus/) library
-> is no longer actively maintained. Removal is targeted for 2027.1 and may happen sooner once ESPHome moves to
-> ESP-IDF 6. Migrate ESP32 configurations to [Esp32 Rmt Led Strip](/components/light/esp32_rmt_led_strip/).
+> **ESP32 support deprecated in 2026.6.** The upstream
+> [NeoPixelBus](https://github.com/Makuna/NeoPixelBus/) library is no longer actively maintained, and it does
+> not build on top of ESP-IDF 6. ESP32 support will be removed no later than 2027.1, and may happen sooner once
+> ESPHome moves to ESP-IDF 6. ESP8266 is not affected.
 >
-> NeoPixelBus does **not** work with ESP-IDF.
+> Migration paths for ESP32:
+> - Clockless lights (WS2811, WS2812, SK6812, etc.) → [Esp32 Rmt Led Strip](/components/light/esp32_rmt_led_strip/).
+> - 2-wire SPI lights (DotStar, WS2801, LPD8806, P9813) → [Spi Led Strip](/components/light/spi_led_strip/).
+>
+> NeoPixelBus does **not** work with ESP-IDF (use the migration paths above).
 
 The `neopixelbus` light platform allows you to create RGB lights
 in ESPHome for individually addressable lights like NeoPixel or WS2812.

--- a/src/content/docs/components/light/neopixelbus.mdx
+++ b/src/content/docs/components/light/neopixelbus.mdx
@@ -5,10 +5,12 @@ title: "NeoPixelBus Light"
 import APIRef from '@components/APIRef.astro';
 
 
-> [!WARNING]
-> NeoPixelBus does **not** work with ESP-IDF.
+> [!CAUTION]
+> **Deprecated on ESP32 in 2026.6.** The upstream [NeoPixelBus](https://github.com/Makuna/NeoPixelBus/) library
+> is no longer actively maintained. Removal is targeted for 2027.1 and may happen sooner once ESPHome moves to
+> ESP-IDF 6. Migrate ESP32 configurations to [Esp32 Rmt Led Strip](/components/light/esp32_rmt_led_strip/).
 >
-> For clockless lights, you can use [Esp32 Rmt Led Strip](/components/light/esp32_rmt_led_strip/), and for SPI LEDs see [Spi Led Strip](/components/light/spi_led_strip/).
+> NeoPixelBus does **not** work with ESP-IDF.
 
 The `neopixelbus` light platform allows you to create RGB lights
 in ESPHome for individually addressable lights like NeoPixel or WS2812.


### PR DESCRIPTION
## Description

Replace the existing IDF-incompatibility warning with a deprecation callout pointing ESP32 users to
[`esp32_rmt_led_strip`](/components/light/esp32_rmt_led_strip/). The upstream
[NeoPixelBus](https://github.com/Makuna/NeoPixelBus/) library is no longer actively maintained, and it fails
to build on top of ESP-IDF 6.

ESP8266 still uses the library and is not deprecated.

**Related issue (if applicable):** n/a

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#16676

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.