### PR TITLE
[wifi] Document WPA2 as the ESP8266 default

### DIFF
--- a/src/content/docs/components/wifi.mdx
+++ b/src/content/docs/components/wifi.mdx
@@ -116,7 +116,7 @@ wifi:
   - `WPA2` - Allows WPA2 and WPA3 networks (recommended, uses AES encryption)
   - `WPA3` - Only allows WPA3 networks (most secure, ESP32 only)
 
-  Defaults to `WPA2` on ESP32 and `WPA` on ESP8266 (will change to `WPA2` in 2026.6.0).
+  Defaults to `WPA2` on ESP32 and ESP8266.
 
   **Security Warning:** Setting `min_auth_mode: WPA` allows connection to networks using deprecated WPA/TKIP encryption,
   which has known security vulnerabilities. Only use this setting for legacy routers that cannot be upgraded to WPA2 or WPA3.

--- a/src/content/docs/guides/security_best_practices.mdx
+++ b/src/content/docs/guides/security_best_practices.mdx
@@ -160,7 +160,7 @@ wifi:
   password: !secret wifi_password
 
   # Set minimum WiFi security - reject connections to networks with weaker security
-  # Default is WPA2 on ESP32, WPA on ESP8266 (will change to WPA2 in 2026.6.0)
+  # Default is WPA2 on ESP32 and ESP8266
   min_auth_mode: WPA2  # Or WPA3 for ESP32 if all your networks support it
 
   # Optional: Fallback AP with password (only if needed)

--- a/src/content/docs/guides/security_best_practices.mdx
+++ b/src/content/docs/guides/security_best_practices.mdx
@@ -172,8 +172,7 @@ wifi:
 
 **Best practices:**
 
-- **ESP32 users:** The default `min_auth_mode: WPA2` is secure and allows WPA2 and WPA3 networks - only set `min_auth_mode: WPA3` if you want to restrict to WPA3-only networks
-- **ESP8266 users:** Explicitly set `min_auth_mode: WPA2` to avoid the insecure WPA default
+- The default `min_auth_mode: WPA2` is secure on both ESP32 and ESP8266 and allows WPA2 and WPA3 networks - on ESP32 you can set `min_auth_mode: WPA3` to restrict to WPA3-only networks
 - **WPA (TKIP) has known vulnerabilities** - only use if you have a legacy router that can't be upgraded
 - Never use open or WEP-encrypted networks
 - Use WPA2 (minimum) or WPA3 (recommended) on your router


### PR DESCRIPTION
## Description

Companion to esphome/esphome#16682. The ESP8266 `min_auth_mode` default flips from `WPA` to `WPA2` in 2026.6,
matching ESP32; update the wifi component reference and the security best-practices snippet.

**Related issue (if applicable):** n/a

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#16682

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.