### PR TITLE
[docs] Update repo references after rename to esphome.io

### DIFF
--- a/.claude/skills/pr-workflow/SKILL.md
+++ b/.claude/skills/pr-workflow/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: pr-workflow
-description: Create pull requests for esphome-docs. Use when creating PRs, submitting changes, or preparing contributions.
+description: Create pull requests for esphome.io. Use when creating PRs, submitting changes, or preparing contributions.
 allowed-tools: Read, Bash, Glob, Grep
 ---
 
 # ESPHome Docs PR Workflow
 
-When creating a pull request for esphome-docs, follow these steps:
+When creating a pull request for esphome.io, follow these steps:
 
 ## 1. Create Branch from Upstream
 
@@ -28,6 +28,7 @@ Before creating a PR, read `.github/PULL_REQUEST_TEMPLATE.md` to understand requ
 Use `gh pr create` with the **full template** filled in. Never skip or abbreviate sections.
 
 Required fields:
+
 - **Description**: What changes are being made
 - **Related issue**: Use `fixes <link>` syntax if applicable
 - **Pull request in esphome**: Link if this documents a new feature
@@ -43,7 +44,7 @@ Required fields:
 
 <describe your changes here>
 
-**Related issue (if applicable):** fixes https://github.com/esphome/esphome-docs/issues/XXX
+**Related issue (if applicable):** fixes https://github.com/esphome/esphome.io/issues/XXX
 
 **Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**
 
@@ -62,7 +63,7 @@ Required fields:
 
 ```bash
 git push -u origin <branch-name>
-gh pr create --repo esphome/esphome-docs --base current --title "[component] Brief description"
+gh pr create --repo esphome/esphome.io --base current --title "[component] Brief description"
 ```
 
 Use `--base next` if documenting a new feature with a matching esphome PR.

--- a/.github/workflows/close-pr-from-fork-default-branch.yml
+++ b/.github/workflows/close-pr-from-fork-default-branch.yml
@@ -32,7 +32,7 @@ jobs:
               ``,
               `It looks like this PR was opened from the \`${headRef}\` branch of your fork (\`${headRepo}\`), which is a protected upstream branch (\`current\` = live docs, \`next\` = docs for the upcoming release). Working directly on \`${headRef}\` in your fork causes a few problems:`,
               ``,
-              `- Your fork's \`${headRef}\` branch will permanently diverge from \`esphome/esphome-docs:${headRef}\`, making it hard to keep your fork in sync.`,
+              `- Your fork's \`${headRef}\` branch will permanently diverge from \`esphome/esphome.io:${headRef}\`, making it hard to keep your fork in sync.`,
               `- Any additional commits you push to \`${headRef}\` will be added to this PR, so you can't easily work on multiple changes at once.`,
               `- Pushing maintainer fixes to your branch is awkward, since it means committing directly to your fork's \`${headRef}\` branch.`,
               `- Local collaboration becomes painful — \`${headRef}\` in a checkout is ambiguous between upstream and your fork, and maintainers end up with naming collisions when fetching the branch.`,

--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,3 @@ my-secrets
 
 # Misc
 _build
-esphome-docs

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ESPHome-Docs
+# ESPHome.io Documentation
 
 [![Netlify Status][netlify-badge]][netlify-link]
 [![Discord Chat][discord-badge]][discord-link]
@@ -25,7 +25,7 @@ This repository contains the source for the documentation site for ESPHome, buil
 The project follows the Astro/Starlight directory structure:
 
 ```text
-esphome-docs/
+esphome.io/
 ├── src/
 │   ├── assets/           # Static assets (logos, etc.)
 │   ├── components/       # Astro components

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -167,7 +167,7 @@ export default defineConfig({
         },
       ],
       editLink: {
-        baseUrl: "https://github.com/esphome/esphome-docs/edit/current/",
+        baseUrl: "https://github.com/esphome/esphome.io/edit/current/",
       },
       routeMiddleware: ["./src/routeData.ts"],
       components: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "esphome-docs",
+  "name": "esphome.io",
   "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "esphome-docs",
+      "name": "esphome.io",
       "version": "2.0.0",
       "license": "CC-BY-4.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "esphome-docs",
+  "name": "esphome.io",
   "version": "2.0.0",
   "description": "ESPHome Documentation",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -23,11 +23,11 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/esphome/esphome-docs.git"
+    "url": "git+https://github.com/esphome/esphome.io.git"
   },
   "license": "CC-BY-4.0",
   "bugs": {
-    "url": "https://github.com/esphome/esphome-docs/issues"
+    "url": "https://github.com/esphome/esphome.io/issues"
   },
   "homepage": "https://esphome.io",
   "devDependencies": {

--- a/src/content/docs/components/index.mdx
+++ b/src/content/docs/components/index.mdx
@@ -11,7 +11,7 @@ function to find the information you're looking for.
 ### Help improve this documentation
 
 If you find any errors in this site, corrections are welcome. You can submit a *Pull Request* (PR) in the
-[GitHub repo](https://github.com/esphome/esphome-docs) with corrections. If you don't know how to create a PR you
+[GitHub repo](https://github.com/esphome/esphome.io) with corrections. If you don't know how to create a PR you
 can just use the "Edit this page on GitHub" link on the page in question which will take you to the source file
 for that page.
 

--- a/src/content/docs/components/web_server.mdx
+++ b/src/content/docs/components/web_server.mdx
@@ -189,16 +189,16 @@ captive_portal:
 
 The following assume copies of the files with local paths - which are config dependent.
 
-Example `web_server` version 1 configuration with CSS and JS included from esphome-docs.
+Example `web_server` version 1 configuration with CSS and JS included from a local folder.
 CSS and JS URL's are set to empty value, so no internet access is needed for this device to show it's web interface.
 
 ```yaml
 web_server:
   port: 80
   version: 1
-  css_include: "../../../esphome-docs/_static/webserver-v1.min.css"
+  css_include: "<some_folder>/webserver-v1.min.css"
   css_url: ""
-  js_include: "../../../esphome-docs/_static/webserver-v1.min.js"
+  js_include: "<some_folder>/webserver-v1.min.js"
   js_url: ""
 ```
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Renames all in-repo references from `esphome/esphome-docs` to `esphome/esphome.io` after the GitHub repo rename. Without these the old name will 404 the moment GitHub's redirect lapses.

Files touched:

- `package.json` — `repository.url` and `bugs.url`.
- `astro.config.mjs` — Starlight `editLink.baseUrl` (drives the per-page "Edit page on GitHub" link).
- `.github/workflows/close-pr-from-fork-default-branch.yml` — hardcoded `esphome/esphome-docs:${headRef}` string posted into PR comments.
- `src/content/docs/components/index.mdx` — "GitHub repo" link in the components index.
- `README.md` — `esphome-docs/` in the project-structure tree.
- `src/content/docs/components/web_server.mdx` — `../../../esphome-docs/_static/...` paths in the local-CSS/JS example were edited to use a generic `<some_folder>/` placeholder (no tooling resolves them; they're prose only). Note: these example paths point at `_static/webserver-v1.min.{css,js}`, which don't exist in this repo — they live at `oi.esphome.io` per the `netlify.toml` redirect. Out of scope for this PR.
- `.gitignore` — stale Hugo-era `esphome-docs` ignore entry (paired with `_build`) — dropped.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist

- [ ] I am merging into \`next\` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into \`current\` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in \`/src/content/docs/components/index.mdx\` when creating new documents for new components or cookbook.