### PR TITLE
[docs] Use Netlify BRANCH env var to set editLink target branch

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -167,7 +167,9 @@ export default defineConfig({
         },
       ],
       editLink: {
-        baseUrl: "https://github.com/esphome/esphome.io/edit/current/",
+        baseUrl: `https://github.com/esphome/esphome.io/edit/${
+          ["next", "beta"].includes(process.env.BRANCH) ? "next" : "current"
+        }/`,
       },
       routeMiddleware: ["./src/routeData.ts"],
       components: {
@@ -254,14 +256,14 @@ export default defineConfig({
               document.querySelector('button[data-open-modal]')?.click();
               return;
             }
-          
+
             // 2. New 'Enter' shortcut for first search result
             if (e.key === 'Enter' && e.target.classList.contains('pagefind-ui__search-input')) {
               const firstResult = document.querySelector('.pagefind-ui__result-link');
-              
+
               if (firstResult) {
                 // Prevent the default form submission or modal close behavior
-                e.preventDefault(); 
+                e.preventDefault();
                 e.stopImmediatePropagation();
                 firstResult.click();
               }


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Updates `editLink.baseUrl` in `astro.config.mjs` to derive the target branch from Netlify's `BRANCH` environment variable: `next` when building from `next` or `beta`, otherwise `current`. This makes the GitHub edit link on each page open the same branch that produced the build.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.