### PR TITLE
[mipi_spi] Document padding

### DIFF
--- a/src/content/docs/components/display/mipi_spi.mdx
+++ b/src/content/docs/components/display/mipi_spi.mdx
@@ -77,6 +77,7 @@ the pins used to interface to the display to be specified.
 | WAVESHARE-4-TFT                      | Waveshare | [https://www.waveshare.com/4inch-tft-touch-shield.htm](https://www.waveshare.com/4inch-tft-touch-shield.htm) |
 | PICO-RESTOUCH-LCD-3.5                | Waveshare | [https://www.waveshare.com/pico-restouch-lcd-3.5.htm](https://www.waveshare.com/pico-restouch-lcd-3.5.htm) |
 | WAVESHARE-ESP32-C6-LCD-1.47          | Waveshare | [https://www.waveshare.com/wiki/ESP32-C6-LCD-1.47](https://www.waveshare.com/wiki/ESP32-C6-LCD-1.47) |
+| WAVESHARE-ESP32-S3-GEEK              | Waveshare | [https://www.waveshare.com/esp32-s3-geek.htm](https://www.waveshare.com/esp32-s3-geek.htm) |
 | WAVESHARE-ESP32-S3-TOUCH-AMOLED-1.75 | Waveshare | [https://www.waveshare.com/esp32-s3-touch-amoled-1.75.htm](https://www.waveshare.com/esp32-s3-touch-amoled-1.75.htm) |
 | WAVESHARE-ESP32-S3-TOUCH-LCD-3.49    | Waveshare | [https://www.waveshare.com/esp32-s3-touch-lcd-3.49.htm](https://www.waveshare.com/esp32-s3-touch-lcd-3.49.htm) |
 | WT32-SC01-PLUS                       | Wireless-Tag | [https://www.wireless-tag.com/portfolio/wt32-sc01-plus/](https://www.wireless-tag.com/portfolio/wt32-sc01-plus/) |
@@ -84,7 +85,8 @@ the pins used to interface to the display to be specified.
 | ESP32-2432S028                       | Sunton       | 2.8" CYD. Original micro-USB version with ILI9341 controller.     |
 | ESP32-2432S028-7789                  | Sunton       | Dual-USB version with ST7789V.                                    |
 | ESP32-2432S028-9342                  | Sunton       | Dual-USB version with ILI9342.                                    |
-| GEEKMAGIC-SMALLTV                    | GeekMagic    | 1.28" ST7789V display with 240x240 resolution.                    |
+| GEEKMAGIC-SMALLTV                    | GeekMagic    | [https://geekmagic.com/products/geekmagic-ultra-4](https://geekmagic.com/products/geekmagic-ultra-4) |
+| GEEKMAGIC-SMALLTV-PRO                | GeekMagic    | [https://geekmagic.com/products/geekmagic-ultra](https://geekmagic.com/products/geekmagic-ultra) |
 | JC3248W535                           | Guition | [https://www.aliexpress.com/item/1005007566332450.html](https://www.aliexpress.com/item/1005007566332450.html) |
 | JC3636W518                           | Guition | [https://www.aliexpress.com/item/1005007890666293.html](https://www.aliexpress.com/item/1005007890666293.html) |
 | JC3636W518V2                         | Guition | [https://www.aliexpress.com/item/1005007890666293.html](https://www.aliexpress.com/item/1005007890666293.html) |

--- a/src/content/docs/components/display/mipi_spi.mdx
+++ b/src/content/docs/components/display/mipi_spi.mdx
@@ -84,6 +84,7 @@ the pins used to interface to the display to be specified.
 | ESP32-2432S028                       | Sunton       | 2.8" CYD. Original micro-USB version with ILI9341 controller.     |
 | ESP32-2432S028-7789                  | Sunton       | Dual-USB version with ST7789V.                                    |
 | ESP32-2432S028-9342                  | Sunton       | Dual-USB version with ILI9342.                                    |
+| GEEKMAGIC-SMALLTV                    | GeekMagic    | 1.28" ST7789V display with 240x240 resolution.                    |
 | JC3248W535                           | Guition | [https://www.aliexpress.com/item/1005007566332450.html](https://www.aliexpress.com/item/1005007566332450.html) |
 | JC3636W518                           | Guition | [https://www.aliexpress.com/item/1005007890666293.html](https://www.aliexpress.com/item/1005007890666293.html) |
 | JC3636W518V2                         | Guition | [https://www.aliexpress.com/item/1005007890666293.html](https://www.aliexpress.com/item/1005007890666293.html) |
@@ -138,6 +139,8 @@ most of the configuration will be set by default, but can be overridden if neede
   - **width** (**Required**, int): Specifies width of display.
   - **offset_width** (*Optional*, int): Specify an offset for the x-direction of the display, typically used when an LCD is smaller than the maximum supported by the driver chip. Default is 0
   - **offset_height** (*Optional*, int): Specify an offset for the y-direction of the display. Default is 0.
+  - **pad_width** (*Optional*, int): Specify additional pixels recognized by the controller after the offset and width. This represents pixels on the right side of the display that are addressable by the driver chip but not visible. Default is 0. Used to calculate native dimensions and support hardware rotation.
+  - **pad_height** (*Optional*, int): Specify additional pixels recognized by the controller after the offset and height. This represents pixels on the bottom of the display that are addressable by the driver chip but not visible. Default is 0. Used to calculate native dimensions and support hardware rotation.
 
 - **invert_colors** (*Optional*, boolean): Specifies whether the display colors should be inverted. Options are `true` or `false`. Defaults to `false`.
 - **rotation** (*Optional*): Rotate the display presentation in software. Choose one of `0°`, `90°`, `180°`, or `270°`. If the driver chip supports hardware rotation for the given orientation this will be translated to the appropriate hardware command. If hardware rotation is not supported, the display will be rotated in software.

--- a/src/content/docs/components/display/mipi_spi.mdx
+++ b/src/content/docs/components/display/mipi_spi.mdx
@@ -163,7 +163,8 @@ most of the configuration will be set by default, but can be overridden if neede
 - **pixel_mode** (*Optional*): Select the interface mode for the display driver. Options are `16bit` (default) and `18bit`. Most displays require 16 bit mode, and it is preferred unless the display requires 18 bit mode.
 - **spi_16** (*Optional*): Set to `true` on boards where single bit SPI is used but drives the display in parallel via a 16 bit shift register.
 - **data_rate** (*Optional*): The SPI data rate. Defaults to 10MHz but board presets may override this.
-- **spi_mode** (*Optional*): The SPI mode. Options are `MODE0`, `MODE1`, `MODE2`, and `MODE3`. Defaults to `MODE0` for single bit SPI and `MODE3` for octal SPI (parallel bus.)
+- **spi_mode** (*Optional*): The SPI mode. Options are `MODE0`, `MODE1`, `MODE2`, and `MODE3`. Defaults to `MODE3` for
+  octal SPI and single bit SPI with no CS pin, or `MODE0` otherwise.
 - **draw_rounding** (*Optional*): The rounding factor for drawing operations. Defaults to 2. Some chips require a higher value to avoid display artifacts. Must be a power of 2.
 - **use_axis_flips** (*Optional*): If true, the driver will use alternate bits in the MADCTL register to implement x and y mirroring. Defaults to false.
 - **byte_order** (*Optional*): The byte order of the display buffer. Options are `big_endian` (default) and `little_endian`. This affects the byte order for the buffer when


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Also add GeekMagic SmallTV docs

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#16722

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
