### PR TITLE
[docs] Rename "add-on" to "app" in getting started guide

### DIFF
--- a/src/content/docs/components/font.mdx
+++ b/src/content/docs/components/font.mdx
@@ -233,7 +233,7 @@ it.horizontal_line(0, height, it.get_width());
 
 > [!NOTE]
 > To use fonts you will need to have the python `pillow` package installed, as ESPHome uses that package
-> to translate the OpenType/TrueType and bitmap font files into an internal format. If you're running this as a Home Assistant add-on or with the official ESPHome docker image, it should already be installed. Otherwise you need
+> to translate the OpenType/TrueType and bitmap font files into an internal format. If you're running this as a Home Assistant app or with the official ESPHome docker image, it should already be installed. Otherwise you need
 > to install it using `pip install "pillow==10.4.0"`.
 
 ## See Also

--- a/src/content/docs/components/mdns.mdx
+++ b/src/content/docs/components/mdns.mdx
@@ -7,7 +7,7 @@ The `mdns` component makes the node announce itself on the local network using t
 
 Both Home Assistant and the ESPHome dashboard use mDNS to identify the IP address of all ESPHome nodes on the network.
 If mDNS is disabled, they will no longer be able to automatically find your devices. It may be necessary to use a static
-IP for all nodes and to enable the ping option in the Home Assistant add-on.
+IP for all nodes and to enable the ping option in the Home Assistant app.
 
 It is recommended to leave mDNS enabled.
 

--- a/src/content/docs/components/ota/http_request.mdx
+++ b/src/content/docs/components/ota/http_request.mdx
@@ -63,7 +63,7 @@ on_...:
 > [!NOTE]
 > - You can obtain the `firmware.ota.bin` file from either:
 >
->   - **ESPHome dashboard** (HA add-on): download in *"OTA format"* (formerly "legacy format")
+>   - **ESPHome dashboard** (HA app): download in *"OTA format"* (formerly "legacy format")
 >   - **ESPHome CLI**: the directory `.esphome/build/project/.pioenvs/project/firmware.ota.bin`
 >
 >     ...where *"project"* is the name of your ESPHome device/project.

--- a/src/content/docs/guides/faq.mdx
+++ b/src/content/docs/guides/faq.mdx
@@ -297,7 +297,7 @@ You can find our issue tracker [on GitHub](https://github.com/esphome/esphome/is
 
 ## How do I update to the latest version?
 
-In Home Assistant, an update notification will appear when there's an update available (as with all add-ons).
+In Home Assistant, an update notification will appear when there's an update available (as with all apps).
 
 If you're running the Docker container independently of Home Assistant, run:
 
@@ -314,7 +314,7 @@ docker pull ghcr.io/esphome/esphome:stable
 ESPHome has a beta release cycle so that new releases can easily be tested before the changes are deployed to the
 stable channel. You can help test ESPHome (and use new features) by installing the beta:
 
-- For Home Assistant supervised installs, search for "ESPHome" in the Add-on Store. Note that the add-ons are named
+- For Home Assistant supervised installs, search for "ESPHome" in the App Store. Note that the apps are named
   accordingly; for the beta version, you'll want "ESPHome Device Builder (beta)".
 
 - If you're running the container in Docker independently of Home Assistant:
@@ -337,7 +337,7 @@ only developers use.
 
 That aside, if you want to install the `dev` version of ESPHome:
 
-- For Home Assistant supervised installs, search for "ESPHome" in the Add-on Store. Note that the add-ons are named
+- For Home Assistant supervised installs, search for "ESPHome" in the App Store. Note that the apps are named
   accordingly; for the dev version, you'll want "ESPHome Device Builder (dev)".
 
 - From `pip`  :

--- a/src/content/docs/guides/getting_started_command_line.mdx
+++ b/src/content/docs/guides/getting_started_command_line.mdx
@@ -215,7 +215,7 @@ want new features, please either create a new issue on the
 ## Bonus: ESPHome Device Builder
 
 The ESPHome Device Builder allows you to easily manage your nodes from a nice web interface. It was primarily designed
-as a [Home Assistant add-on](/guides/getting_started_hassio/), but can run in docker independently from
+as a [Home Assistant app](/guides/getting_started_hassio/), but can run in docker independently from
 Home Assistant.
 
 To start the ESPHome Device Builder, simply start ESPHome with the following command (with `config/` pointing to a

--- a/src/content/docs/guides/getting_started_hassio.mdx
+++ b/src/content/docs/guides/getting_started_hassio.mdx
@@ -1,5 +1,5 @@
 ---
-description: "Getting Started guide for installing ESPHome Device Builder as a Home Assistant add-on and creating a basic configuration."
+description: "Getting Started guide for installing ESPHome Device Builder as a Home Assistant app and creating a basic configuration."
 title: "Getting Started with ESPHome and Home Assistant"
 ---
 
@@ -9,7 +9,7 @@ import dashboardEmptyImg from './images/dashboard_empty.png';
 import dashboardStatesImg from './images/dashboard_states.png';
 
 In this guide, we'll walk you through how to install ESPHome onto a device/microcontroller using the ESPHome Device
-Builder, installed as a Home Assistant add-on.
+Builder, installed as a Home Assistant app.
 
 This is generally the easiest way to get started with ESPHome.
 
@@ -37,19 +37,19 @@ device configurations onto your devices.
 
 To install the ESPHome Device Builder in Home Assistant, click the following button:
 
-[![Open your Home Assistant instance and show the dashboard of an add-on.][my-badge]][my-url]
+[![Open your Home Assistant instance and show the dashboard of an app.][my-badge]][my-url]
 
 [my-badge]: https://my.home-assistant.io/badges/supervisor_addon.svg
 [my-url]: https://my.home-assistant.io/redirect/supervisor_addon/?addon=5c53de3b_esphome&repository_url=https%3A%2F%2Fgithub.com%2Fesphome%2Fhome-assistant-addon
 
-This should open the ESPHome add-on page; once you're there, just click the INSTALL button:
+This should open the ESPHome app page; once you're there, just click the INSTALL button:
 
 <Image src={addonImg} layout="constrained" alt="" />
 
-Installation of the add-on may take a moment or two. Once done, click "Start" and then click "Open Web UI".
+Installation of the app may take a moment or two. Once done, click "Start" and then click "Open Web UI".
 
 > [!NOTE]
-> If you're running Home Assistant in a way that does not provide access to add-ons, you may
+> If you're running Home Assistant in a way that does not provide access to apps, you may
 > [run the ESPHome Device Builder independently in Docker](/guides/getting_started_command_line#esphome-device-builder-docker).
 
 The web UI will present a wizard which will walk you through creating your first configuration:
@@ -90,7 +90,7 @@ The main page displays a list of all configuration files for nodes you've create
 actions you can perform:
 
 - **UPDATE**: This button appears when the device is running an ESPHome version which is older than that available in
-  the ESPHome Device Builder add-on.
+  the ESPHome Device Builder app.
 
 - **EDIT**: This will open the configuration editor.
 - **LOGS**: This allows you to view logs emitted by the device. If a device is connected via USB, you can choose to use
@@ -111,9 +111,9 @@ The configuration files for ESPHome are stored in the `<HOME_ASSISTANT_CONFIG>/e
 configuration for the "Bedroom Light" node in the picture above can be found in `/config/esphome/bedroom-light.yaml`.
 
 > [!NOTE]
-> Home Assistant add-ons run as individual containers; this can make accessing your configuration files/logs a bit
+> Home Assistant apps run as individual containers; this can make accessing your configuration files/logs a bit
 > challenging. If you wish to do so, you'll need to install Home Assistant's
-> [SSH add-on](https://www.home-assistant.io/common-tasks/os/#installing-and-using-the-ssh-add-on), configure it
+> [SSH app](https://www.home-assistant.io/common-tasks/os/#installing-and-using-the-ssh-add-on), configure it
 > with a username and password and also disable "Protection Mode" (please assess the risks associated with doing so).
 >
 > Finally, to access the logs from a device through an SSH client, you can log in and use a command like

--- a/src/content/docs/guides/migrate_espeasy.mdx
+++ b/src/content/docs/guides/migrate_espeasy.mdx
@@ -15,7 +15,7 @@ ESPHome create a binary for you and then upload that in the ESPEasy web interfac
 First follow the guides for the [different supported devices](/components#devices) and create a configuration
 file. Then, generate and download the binary:
 
-- **Using the Home Assistant add-on/dashboard**: Just click the `COMPILE` button,
+- **Using the Home Assistant app/dashboard**: Just click the `COMPILE` button,
   wait for the compilation to end and press the `DOWNLOAD BINARY` button.
 
 <Image src={downloadBinaryImg} layout="constrained" alt="" />

--- a/src/content/docs/guides/migrate_espurna.mdx
+++ b/src/content/docs/guides/migrate_espurna.mdx
@@ -16,7 +16,7 @@ ESPHome create a binary for you and then upload that in the ESPurna web interfac
 First follow the guides for the [different supported devices](/components#devices) and create a configuration
 file. Then, generate and download the binary:
 
-- **Using the Home Assistant add-on/dashboard**: Just click the `COMPILE`
+- **Using the Home Assistant app/dashboard**: Just click the `COMPILE`
   button, wait for the compilation to end and press the `DOWNLOAD BINARY`
   button.
 

--- a/src/content/docs/guides/migrate_sonoff_tasmota.mdx
+++ b/src/content/docs/guides/migrate_sonoff_tasmota.mdx
@@ -53,7 +53,7 @@ ota:
 
 Generate and download the firmware image:
 
-### Using the Home Assistant add-on/dashboard
+### Using the Home Assistant app/dashboard
 
 From the card of your device: open **the three dots menu** and select **Install** option.
 

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -63,7 +63,7 @@ hero:
 <div class="getting-started-grid not-content">
   <div class="feature-card">
     <div class="getting-started-heading">From Home Assistant</div>
-    <p>The easiest way to get started with ESPHome is through the Home Assistant add-on.</p>
+    <p>The easiest way to get started with ESPHome is through the Home Assistant app.</p>
     <a href="/guides/getting_started_hassio/" class="btn btn-primary">Home Assistant Guide</a>
   </div>
   <div class="feature-card">


### PR DESCRIPTION
## Description

Home Assistant 2026.2 [renamed "add-ons" to "apps"](https://www.home-assistant.io/blog/2026/02/04/release-20262/#add-ons-are-now-called-apps). This PR updates user-facing text in the getting started with Home Assistant guide to reflect the new terminology.

Changes in `src/content/docs/guides/getting_started_hassio.mdx`:
- Frontmatter description
- Intro paragraph
- Badge alt text
- Install instructions (2 occurrences)
- Note about access to apps
- SSH app reference

Technical identifiers (variable names, external URLs, Docker container names) are left unchanged.

---

> [!NOTE]
> The following files also contain "add-on" references that may need similar updates. Should these be included in this PR or handled separately?
>
> - `src/content/docs/index.mdx`
> - `src/content/docs/components/mdns.mdx`
> - `src/content/docs/components/font.mdx`
> - `src/content/docs/components/ota/http_request.mdx`
> - `src/content/docs/guides/getting_started_command_line.mdx`
> - `src/content/docs/guides/faq.mdx`
> - `src/content/docs/guides/migrate_espurna.mdx`
> - `src/content/docs/guides/migrate_sonoff_tasmota.mdx`
> - `src/content/docs/guides/migrate_espeasy.mdx`
>
> Note: `atm90e26.mdx` and `atm90e32.mdx` use "add-on" to refer to hardware expansion boards, not Home Assistant add-ons — these should remain as-is.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- N/A

## Checklist

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.