### PR TITLE
[cli] Document --states and env setting

### DIFF
--- a/src/content/docs/guides/cli.mdx
+++ b/src/content/docs/guides/cli.mdx
@@ -133,6 +133,11 @@ basis, or set with this option at the time of uploading.
 `ESPHOME_SERIAL_LOGGING_RESET=true`.
 
 
+**`--no-states`** / **`--states`**
+: Control whether entity state changes are shown in log output. See the [`logs` command](#logs-command)
+for details. The default can be set with the environment variable `ESPHOME_LOG_STATES`.
+
+
 ### `config` Command
 
 The `esphome config <CONFIG>` validates the configuration and displays the validation result.
@@ -362,10 +367,14 @@ esphome logs my-device.yaml --device 192.168.1.100 --device 2001:db8::1
 : If set, reset the device before starting the logs. May also be configured with the environment variable
 `ESPHOME_SERIAL_LOGGING_RESET=true`.
 
-**`--no-states`**
-: Do not show entity state changes in log output. By default, when using the native API for logging,
-state changes are shown as `[S]` lines (e.g., `[S][sensor]: 'Temperature' >> 22.5 °C`). Use this flag
-to suppress them and only see firmware log messages.
+**`--no-states`** / **`--states`**
+: Control whether entity state changes are shown in log output. By default, when using the native API
+for logging, state changes are shown as `[S]` lines (e.g., `[S][sensor]: 'Temperature' >> 22.5 °C`).
+Pass `--no-states` to suppress them and only see firmware log messages, or `--states` to show them.
+
+The default can be set with the environment variable `ESPHOME_LOG_STATES`: set it to `false` to suppress
+state changes by default, or `true` to show them. The `--states` and `--no-states` flags always take
+precedence over the environment variable.
 
 
 ### `update-all` Command


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#16746

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
