### PR TITLE
[cli] Document --no-defaults and --show-secrets for esphome config

### DIFF
--- a/src/content/docs/guides/cli.mdx
+++ b/src/content/docs/guides/cli.mdx
@@ -137,6 +137,18 @@ basis, or set with this option at the time of uploading.
 
 The `esphome config <CONFIG>` validates the configuration and displays the validation result.
 
+#### Options
+
+**`--show-secrets`**
+: Show secret values in the output instead of redacting them.
+
+
+**`--no-defaults`**
+: Only output the configuration the user wrote, without the values that schema validation fills in from defaults.
+Useful for sharing a minimal reproduction or diffing two configurations without hundreds of defaulted keys in the way.
+Substitutions, packages, and `!extend` / `!remove` are resolved in the output.
+
+
 ### `config-hash` Command
 
 The `esphome config-hash <CONFIG>` loads the configuration and calculates the hash that you can compare


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Documents the new `--no-defaults` flag on `esphome config` (added in esphome/esphome#16718) and, while at it, the previously-undocumented `--show-secrets` flag. Both are listed under a new `#### Options` section in `guides/cli.mdx`.

`--no-defaults` makes `esphome config` emit only the keys the user wrote in YAML, skipping the values that schema validation fills in from defaults. Substitutions, packages, and `!extend` / `!remove` are still resolved so the output remains a faithful "user YAML" view.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#16718

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.