### PR TITLE
2026.5.2

### DIFF
--- a/data/version.yaml
+++ b/data/version.yaml
@@ -1,2 +1,2 @@
-release: 2026.5.1
+release: 2026.5.2
 version: '2026.5'

--- a/src/content/docs/changelog/2026.5.0.mdx
+++ b/src/content/docs/changelog/2026.5.0.mdx
@@ -446,6 +446,22 @@ For detailed migration guides and API documentation, see the [ESPHome Developers
 
 </details>
 
+## Release 2026.5.2 - June 2
+
+<details>
+<summary></summary>
+
+- [writer] Mark storage_should_clean as public API for device-builder [esphome#16443](https://github.com/esphome/esphome/pull/16443) by [@bdraco](https://github.com/bdraco)
+- [esp32] Decode crash PCs via IDF toolchain on IDF builds [esphome#16626](https://github.com/esphome/esphome/pull/16626) by [@swoboda1337](https://github.com/swoboda1337)
+- [packages] Resolve git symlinks on Windows when materialized as text [esphome#16657](https://github.com/esphome/esphome/pull/16657) by [@jesserockz](https://github.com/jesserockz)
+- [libretiny] Fix RTL8710B IRAM_ATTR section being dropped from flashed image [esphome#16616](https://github.com/esphome/esphome/pull/16616) by [@bdraco](https://github.com/bdraco)
+- [sx126x] fix a typo in image calibration on 863 - 870 Mhz frequency [esphome#16731](https://github.com/esphome/esphome/pull/16731) by [@Fyleo](https://github.com/Fyleo)
+- [core] Persist esphome.area in StorageJSON [esphome#16710](https://github.com/esphome/esphome/pull/16710) by [@bdraco](https://github.com/bdraco)
+- [core] Clean build when the toolchain changes [esphome#16744](https://github.com/esphome/esphome/pull/16744) by [@swoboda1337](https://github.com/swoboda1337)
+- [api] Fix crash loop on VoiceAssistantConfigurationRequest [esphome#16757](https://github.com/esphome/esphome/pull/16757) by [@bdraco](https://github.com/bdraco)
+
+</details>
+
 ## Full list of changes
 
 ### New Features

--- a/src/content/docs/guides/supporters.mdx
+++ b/src/content/docs/guides/supporters.mdx
@@ -167,6 +167,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Andy Allsopp (@arallsopp)](https://github.com/arallsopp)
 - [arantius (@arantius)](https://github.com/arantius)
 - [Ryan DeShone (@ardichoke)](https://github.com/ardichoke)
+- [Ardumine (@Ardumine)](https://github.com/Ardumine)
 - [Ariff Saad (@arffsaad)](https://github.com/arffsaad)
 - [Ari Mandjelikian (@arim215)](https://github.com/arim215)
 - [ArkanStasarik (@ArkanStasarik)](https://github.com/ArkanStasarik)
@@ -553,6 +554,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [dergib22 (@dergib22)](https://github.com/dergib22)
 - [Mike La Spina (@descipher)](https://github.com/descipher)
 - [Stephan Martin (@designer2k2)](https://github.com/designer2k2)
+- [老王杂谈说 (@Desmond-Dong)](https://github.com/Desmond-Dong)
 - [Destix (@Destix)](https://github.com/Destix)
 - [Deun Lee (@deunlee)](https://github.com/deunlee)
 - [Develo (@devyte)](https://github.com/devyte)
@@ -655,6 +657,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [edk4971 (@edk4971)](https://github.com/edk4971)
 - [Eduardo Pérez (@eduperez)](https://github.com/eduperez)
 - [Edward Firmo (@edwardtfn)](https://github.com/edwardtfn)
+- [Elvin Luff (@Eelviny)](https://github.com/Eelviny)
 - [Eenoo (@Eenoo)](https://github.com/Eenoo)
 - [IDuzTheGamez (@eff3ry)](https://github.com/eff3ry)
 - [Eli Fidler (@efidler)](https://github.com/efidler)
@@ -701,6 +704,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [ervede (@ervede)](https://github.com/ervede)
 - [escoand (@escoand)](https://github.com/escoand)
 - [Eric Severance (@esev)](https://github.com/esev)
+- [ESPHome Bot (@esphbot)](https://github.com/esphbot)
 - [esphome[bot] (@esphome[bot])](https://github.com/esphome[bot])
 - [esphomebot (@esphomebot)](https://github.com/esphomebot)
 - [espressif2022 (@espressif2022)](https://github.com/espressif2022)
@@ -822,6 +826,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Gerard (@gerard33)](https://github.com/gerard33)
 - [German (@ghoeffner)](https://github.com/ghoeffner)
 - [Giampiero Baggiani (@giampiero7)](https://github.com/giampiero7)
+- [Gianluca Giacometti (@gianlucagiacometti)](https://github.com/gianlucagiacometti)
 - [Gideon Kanikevich (@gid204)](https://github.com/gid204)
 - [Giel Janssens (@gieljnssns)](https://github.com/gieljnssns)
 - [GilDev (@GilDev)](https://github.com/GilDev)
@@ -2391,4 +2396,4 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Christian Zufferey (@zuzu59)](https://github.com/zuzu59)
 - [Zynth-dev (@Zynth-dev)](https://github.com/Zynth-dev)
 
-*This page was last updated May 25, 2026.*
+*This page was last updated June 2, 2026.*


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- [docs] Lower RF receiver tolerance from 50% to 25% in setup guide [docs#6686](https://github.com/esphome/esphome.io/pull/6686)
- [docs] Document MDX component reuse and Markdown preferences [docs#6695](https://github.com/esphome/esphome.io/pull/6695)
- [docs] Update repo references after rename to esphome.io [docs#6704](https://github.com/esphome/esphome.io/pull/6704)
- [docs] Use Netlify BRANCH env var to set editLink target branch [docs#6705](https://github.com/esphome/esphome.io/pull/6705)
- [changelog] Update esphome-docs links to point to renamed esphome.io repo [docs#6706](https://github.com/esphome/esphome.io/pull/6706)
- Bump astro from 6.3.6 to 6.3.8 [docs#6701](https://github.com/esphome/esphome.io/pull/6701)
- LEDC: Remove old ESP32 GPIO list of available pins [docs#6635](https://github.com/esphome/esphome.io/pull/6635)
- [lvgl] Add note emphasising display validation [docs#6702](https://github.com/esphome/esphome.io/pull/6702)
- LEDC: Add documentation of valid channels and shared timers [docs#6638](https://github.com/esphome/esphome.io/pull/6638)
- Document 14 bit LEDC restriction for ESP32-S2/S3/C2/C3 [docs#6634](https://github.com/esphome/esphome.io/pull/6634)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
