### PR TITLE
[lvgl] Document rotation and layout changes

### DIFF
--- a/src/content/docs/components/lvgl/index.mdx
+++ b/src/content/docs/components/lvgl/index.mdx
@@ -862,7 +862,7 @@ lvgl:
 
 <span id="lvgl-on-landscape-trigger"></span>
 
-### `on_landscape` / `on_portrait` trigger
+### `on_landscape` / `on_portrait` triggers
 
 These [triggers](/components/lvgl/widgets#lvgl-automation-triggers) fire when the display orientation changes, as
 determined by the effective width/height ratio of the display: `on_landscape` fires when the display becomes wider than

--- a/src/content/docs/components/lvgl/index.mdx
+++ b/src/content/docs/components/lvgl/index.mdx
@@ -662,13 +662,16 @@ on_...:
 
 This [action](/automations/actions#actions-action) rotates the LVGL display.
 
-- **rotation** (**Required**, int): The angle to rotate the display to. Valid values are `0`, `90`, `180` and `270`. Note
-  that the angle is absolute, not relative, so the current rotation of the display does not affect the result.
+- **rotation** (**Required**, [templatable](/automations/templates), int): The angle in degrees to rotate the display to.
+  Valid values are `0`, `90`, `180` and `270`. Note that the angle is absolute, not relative, so the current rotation of
+  the display does not affect the result. When a lambda is used, it must return the angle in degrees.
 - **lvgl_id** (*Optional*): The ID of the LVGL instance to rotate.
 
 ```yaml
 on_...:
   - lvgl.display.set_rotation: 90
+  # or with a lambda returning the angle in degrees:
+  - lvgl.display.set_rotation: !lambda "return id(my_rotation_number).state;"
 ```
 
 ### `lvgl.update` Action

--- a/src/content/docs/components/lvgl/index.mdx
+++ b/src/content/docs/components/lvgl/index.mdx
@@ -674,9 +674,14 @@ on_...:
   - lvgl.display.set_rotation: !lambda "return id(my_rotation_number).state;"
 ```
 
+<span id="lvgl-update-action"></span>
+
 ### `lvgl.update` Action
 
-This [action](/automations/actions#actions-action) allows changing/updating the background styling of the LVGL display layers at runtime. You can style the `top_layer` and/or `bottom_layer` using any [style properties](#lvgl-styling).
+This [action](/automations/actions#actions-action) allows changing/updating the styling and layout of the active screen and the LVGL display layers at runtime. Top-level [style properties](#lvgl-styling) and a `layout:` apply to the currently active screen; you can also style and lay out the `top_layer` and/or `bottom_layer`.
+
+- **layout** (*Optional*): Update the [layout](/components/lvgl/layouts#lvgl-layouts-update) options of the active screen. Only the layout options may be changed, not the layout type.
+- **top_layer** / **bottom_layer** (*Optional*): Update the [style properties](#lvgl-styling) and `layout:` of the respective display layer.
 
 ```yaml
 # Examples:
@@ -688,6 +693,9 @@ on_...:
   - lvgl.update:
       top_layer:
         opa: 0.5
+  - lvgl.update:
+      layout:
+        flex_flow: column
 ```
 
 <span id="lvgl-page-next-previous-action"></span>
@@ -850,6 +858,24 @@ to be sent to the display for it to be updated.
 lvgl:
   on_draw_end:
     - component.update: my_display_id
+```
+
+<span id="lvgl-on-landscape-trigger"></span>
+
+### `on_landscape` / `on_portrait` trigger
+
+These [triggers](/components/lvgl/widgets#lvgl-automation-triggers) fire when the display orientation changes, as
+determined by the effective width/height ratio of the display: `on_landscape` fires when the display becomes wider than
+it is tall (a square display is treated as landscape), and `on_portrait` fires when it becomes taller than it is wide.
+The matching trigger also fires once at boot to establish the initial orientation. A subsequent change typically results
+from the [`lvgl.display.set_rotation`](#lvgl-display-set-rotation-action) action.
+
+```yaml
+lvgl:
+  on_landscape:
+    - logger.log: Display is now landscape
+  on_portrait:
+    - logger.log: Display is now portrait
 ```
 
 ### Display event triggers

--- a/src/content/docs/components/lvgl/layouts.mdx
+++ b/src/content/docs/components/lvgl/layouts.mdx
@@ -295,3 +295,45 @@ Values for use with `grid_column_align`, `grid_row_align`, `grid_cell_x_align`, 
 
 > [!TIP]
 > To visualize real, calculated sizes of transparent widgets you can temporarily set `outline_width: 1` on them.
+
+<span id="lvgl-layouts-update"></span>
+
+### Updating a layout at runtime
+
+A `layout:` option may be supplied to the [`lvgl.update`](/components/lvgl#lvgl-update-action) and
+[`lvgl.widget.update`](/components/lvgl/widgets#lvgl-automation-actions) actions to change the layout options of a
+container while the device is running. This is useful, for example, to re-flow a screen when the display orientation
+changes.
+
+Only the layout *options* may be changed this way. The layout **type** (`FLEX`/`GRID`) and the grid structure
+(`grid_rows`/`grid_columns`) are fixed when the widget is created, because they determine which options are available to
+the child widgets and which grid cells those children occupy. Attempting to set them in an update is a configuration
+error. The options that may be updated are:
+
+- For flex layouts: `flex_flow`, `flex_align_main`, `flex_align_cross`, `flex_align_track`
+- For grid layouts: `grid_column_align`, `grid_row_align`
+- For either layout: `pad_row`, `pad_column`
+
+Only the options actually specified are changed; any option left out keeps its current value.
+
+When applied to the `lvgl.update` action, a top-level `layout:` updates the currently active screen, while a `layout:`
+under `top_layer:` or `bottom_layer:` updates that display layer.
+
+```yaml
+# Re-flow widgets when the display orientation changes
+lvgl:
+  on_landscape:
+    - lvgl.widget.update:
+        id: my_container
+        layout:
+          flex_flow: row
+  on_portrait:
+    - lvgl.widget.update:
+        id: my_container
+        layout:
+          flex_flow: column
+    # Update the layout of the active screen itself
+    - lvgl.update:
+        layout:
+          pad_row: 8px
+```

--- a/src/content/docs/components/lvgl/widgets.mdx
+++ b/src/content/docs/components/lvgl/widgets.mdx
@@ -2086,6 +2086,7 @@ This powerful [action](/automations/actions#actions-action) allows changing/upda
 
 - **id** (**Required**): The ID or a list of IDs of widgets configured in LVGL to be updated.
 - The widget's common [style property](/components/lvgl#lvgl-styling), state (templatable) or [flag](#lvgl-widget-flags).
+- **layout** (*Optional*): Update the [layout](/components/lvgl/layouts#lvgl-layouts-update) options of the widget. Only the layout options may be changed; the layout type and grid structure are fixed when the widget is created.
 
 ```yaml
 # Example for updating styles (in states):
@@ -2101,6 +2102,13 @@ on_...:
   - lvgl.widget.update:
       id: my_label_id
       hidden: true
+
+# Example for updating layout options:
+on_...:
+  - lvgl.widget.update:
+      id: my_container_id
+      layout:
+        flex_flow: column
 ```
 
 Check out in the Cookbook [Remote light button](/cookbook/lvgl#lvgl-cookbook-binent) for an example which demonstrates how to use a template to update the state.


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Document new features allowing dynamic rotation and layout updates.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#16773
## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
