### PR TITLE
[i2s_audio] Expose slot_bit_width to speaker YAML configuration

### DIFF
--- a/src/content/docs/components/speaker/i2s_audio.mdx
+++ b/src/content/docs/components/speaker/i2s_audio.mdx
@@ -33,6 +33,7 @@ speaker:
 
 - **sample_rate** (*Optional*, positive integer): I2S sample rate. If in `primary` I²S mode the sample rate of the audio stream is used. Defaults to `16000`.
 - **bits_per_sample** (*Optional*, enum): The bit depth of the audio samples sent to the DAC. One of `8bit`, `16bit`, `24bit`, or `32bit`. Defaults to `16bit`.
+- **slot_bit_width** (*Optional*, enum): The bit width of the I²S slot. Useful for DACs requiring a specific slot size. One of `default`, `8bit`, `16bit`, `24bit`, or `32bit`. Defaults to `default`.
 
 - **mclk_multiple** (*Optional*, enum): The multiple of the MCLK frequency to the sample rate. Must be divisible by 3 if using 24 bits per sample. One of `128`, `256`, `384`, `512`. Defaults to `256`.
 - **use_apll** (*Optional*, boolean): I2S using APLL as main I2S clock, enable it to get accurate clock. Defaults to `false`.


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#16785

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
