### PR TITLE
[made_for_esphome] Update link for renamed devices repository

### DIFF
--- a/src/content/docs/guides/made_for_esphome.mdx
+++ b/src/content/docs/guides/made_for_esphome.mdx
@@ -48,7 +48,7 @@ Note that these are **not** required for projects that only provide a physical/w
 
 ## When your project meets the requirements
 
-- Create a new pull request in our [esphome-devices](https://github.com/esphome/esphome-devices/pulls) repository to
+- Create a new pull request in our [devices.esphome.io](https://github.com/esphome/devices.esphome.io/pulls) repository to
   add your device on the [devices website](https://devices.esphome.io). We will review and merge this PR upon
   confirming that your project meets all of the requirements listed above.
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

The `esphome-devices` repository was renamed to `devices.esphome.io`. This updates the GitHub link (and its link text) in the Made for ESPHome guide to point at the new repository.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.