### PR TITLE
[ld2420] Remove third-party vendor email address

### DIFF
--- a/src/content/docs/components/sensor/ld2420.mdx
+++ b/src/content/docs/components/sensor/ld2420.mdx
@@ -363,5 +363,4 @@ At this time only firmware version v1.5.6 and up can be upgraded.
 
 ## See Also
 
-- Official Datasheet/Manuals are still in development; for info email `sales@hlktech.com`.
 - Official web site `https://www.hlktech.net/`


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Removes the `sales@hlktech.com` third-party vendor email address from the LD2420 sensor documentation.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.