### PR TITLE
[light] Document `it` reference in lambda light effect

### DIFF
--- a/src/content/docs/components/light/index.mdx
+++ b/src/content/docs/components/light/index.mdx
@@ -680,8 +680,10 @@ light:
 
 This effect allows you to write completely custom light effects yourself using [lambdas](/automations/templates#config-lambda).
 
-Available variable in the lambda:
+Available variables in the lambda:
 
+- **it** - <APIClass text="LightState" path="light::LightState" /> instance for the light running this effect, allowing
+  you to reference the light directly without needing its `id` (see API reference for more info).
 - **initial_run** - A bool which is true on the first execution of the lambda. Useful to reset static variables when
   restarting an effect.
 
@@ -695,7 +697,7 @@ light:
           update_interval: 1s
           lambda: |-
             static int state = 0;
-            auto call = id(my_light).turn_on();
+            auto call = it.turn_on();
             // Transition of 1000ms = 1s
             call.set_transition_length(1000);
             if (state == 0) {


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Documents the new `it` variable available in the regular `lambda` light effect. The effect now exposes its `LightState` as `it`, mirroring the addressable lambda effect, so users can reference the light directly without needing an `id`. Updates the example to use `it.turn_on()`.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#16815

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.