### PR TITLE
Refine grove_tb6612fng documentation

### DIFF
--- a/src/content/docs/components/grove_tb6612fng.mdx
+++ b/src/content/docs/components/grove_tb6612fng.mdx
@@ -43,7 +43,7 @@ on_...:
 - **id** (**Required**, [ID](/guides/configuration-types#id)): The id to use for this TB6612FNG component.
 - **channel** (*Required*, int): 1 for channel A, 2 for Channel B.
 - **direction** (*Optional*, string):   "FORWARD" or "BACKWARD". Defaults to FORWARD.
-- **speed** (Required, int): in range from 0 to 255
+- **speed** (**Required**, int): in range from 0 to 255
 
 
 

--- a/src/content/docs/components/grove_tb6612fng.mdx
+++ b/src/content/docs/components/grove_tb6612fng.mdx
@@ -49,7 +49,7 @@ on_...:
 
 ### `grove_tb6612fng.stop` Action
 
-Stop providing power to run the motor.  This does not stop the motor spinning, but lets the motor run free.  If you want to stop the motor spinning use the grove_tb6612fng.break Action. 
+Stop providing power to the motor. This does not stop the motor from spinning, but allows the motor to spin freely. If you want to stop the motor from spinning, use the `grove_tb6612fng.break` action.
 
 ```yaml
 on_...:

--- a/src/content/docs/components/grove_tb6612fng.mdx
+++ b/src/content/docs/components/grove_tb6612fng.mdx
@@ -23,11 +23,10 @@ grove_tb6612fng:
 - **address** (*Optional*, int): The I²C address of the driver.
   Defaults to `0x14`.
 
-.. grove_tb6612fng.run:
 
 ### `grove_tb6612fng.run` Action
 
-Set the motor to spin by defining the direction and speed of the rotation, speed is a range from 0 to 255
+Set the motor to spin by defining the direction and speed of the rotation.
 
 ```yaml
 on_...:
@@ -39,11 +38,18 @@ on_...:
         id: test_motor
 ```
 
-.. grove_tb6612fng.stop:
+## Configuration variables
+
+- **id** (**Required**, [ID](/guides/configuration-types#id)): The id to use for this TB6612FNG component.
+- **channel** (*Required*, int): 1 for channel A, 2 for Channel B.
+- **direction** (*Optional*, string):   "FORWARD" or "BACKWARD". Defaults to FORWARD.
+- **speed** (Required, int): in range from 0 to 255
+
+
 
 ### `grove_tb6612fng.stop` Action
 
-Set the motor to stop motion but wont stop to spin in case there is a force pulling down, you would want to use break action if this is your case
+Stop providing power to run the motor.  This does not stop the motor spinning, but lets the motor run free.  If you want to stop the motor spinning use the grove_tb6612fng.break Action. 
 
 ```yaml
 on_...:
@@ -52,7 +58,7 @@ on_...:
         channel: 1
 ```
 
-.. grove_tb6612fng.break:
+
 
 ### `grove_tb6612fng.break` Action
 
@@ -66,7 +72,7 @@ on_...:
         id: test_motor
 ```
 
-.. grove_tb6612fng.standby:
+
 
 ### `grove_tb6612fng.standby` Action
 
@@ -79,7 +85,7 @@ on_...:
         id: test_motor
 ```
 
-.. grove_tb6612fng.no_standby:
+
 
 ### `grove_tb6612fng.no_standby` Action
 
@@ -92,7 +98,7 @@ on_...:
         id: test_motor
 ```
 
-.. grove_tb6612fng.change_address:
+
 
 ### `grove_tb6612fng.change_address` Action
 

--- a/src/content/docs/components/grove_tb6612fng.mdx
+++ b/src/content/docs/components/grove_tb6612fng.mdx
@@ -38,7 +38,7 @@ on_...:
         id: test_motor
 ```
 
-## Configuration variables
+### Action Parameters
 
 - **id** (**Required**, [ID](/guides/configuration-types#id)): The id to use for this TB6612FNG component.
 - **channel** (*Required*, int): 1 for channel A, 2 for Channel B.


### PR DESCRIPTION
Updated descriptions for grove_tb6612fng actions and configuration variables.

<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
