### PR TITLE
[microphone] Remove deprecated legacy i2s options

### DIFF
--- a/src/content/docs/components/i2s_audio.mdx
+++ b/src/content/docs/components/i2s_audio.mdx
@@ -21,7 +21,6 @@ i2s_audio:
 - **i2s_bclk_pin** (*Optional*, [Pin](/guides/configuration-types#pin)): The GPIO pin to use for the I²S `BCLK` *(Bit Clock)* signal, also referred to as `SCK` *(Serial Clock)*.
 - **i2s_mclk_pin** (*Optional*, [Pin](/guides/configuration-types#pin)): The GPIO pin to use for the I²S `MCLK` *(Master Clock)* signal.
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID for this I²S bus if you need multiple.
-- **use_legacy** (*Optional, boolean*): Use the legacy I²S driver when using esp-idf framework version 5.x.x. Not valid for Arduino framework or esp-idf version < 5. All `i2s_audio` components need to use the same setting. Defaults to `false`.
 
 ## See Also
 

--- a/src/content/docs/components/microphone/i2s_audio.mdx
+++ b/src/content/docs/components/microphone/i2s_audio.mdx
@@ -28,7 +28,7 @@ microphone:
 - **adc_type** (**Required**, enum):
 
   - `external`  : Use an external ADC connected to the I²S bus.
-  - `internal`  : Internal ADC is no longer supported. Use an external I2S microphone instead.
+  - `internal`  : Internal ADC is no longer supported. Use an external I²S microphone instead.
 
 - **channel** (*Optional*, enum): The channel of the microphone. One of `left`, `right`, or `stereo`. If `stereo`, the output data will
   be twice as big, with each right sample followed by a left sample. Defaults to `right`.

--- a/src/content/docs/components/microphone/i2s_audio.mdx
+++ b/src/content/docs/components/microphone/i2s_audio.mdx
@@ -21,11 +21,6 @@ microphone:
     id: external_mic
     adc_type: external
     i2s_din_pin: GPIOXX
-
-  - platform: i2s_audio
-    id: adc_mic
-    adc_type: internal
-    adc_pin: GPIOXX
 ```
 
 ## Configuration variables
@@ -33,14 +28,13 @@ microphone:
 - **adc_type** (**Required**, enum):
 
   - `external`  : Use an external ADC connected to the I²S bus.
-  - `internal`  : Use the internal ADC of the ESP32. Only supported on ESP32, no variant support.
+  - `internal`  : Internal ADC is no longer supported. Use an external I2S microphone instead.
 
 - **channel** (*Optional*, enum): The channel of the microphone. One of `left`, `right`, or `stereo`. If `stereo`, the output data will
   be twice as big, with each right sample followed by a left sample. Defaults to `right`.
 
 - **sample_rate** (*Optional*, positive integer): I2S sample rate. Defaults to `16000`.
 - **bits_per_sample** (*Optional*, enum): The bit depth of audio samples representing real data received from the microphone. One of `8bit`, `16bit`, `24bit`, or `32bit`. Defaults to `32bit`.
-- **bits_per_channel** (*Optional*, enum): The bit depth of audio samples actually read from the microphone. One of `8bit`, `16bit`, `24bit`, or `32bit`. Defaults to `32bit`. Setting is ignored if the legacy driver is not used.
 - **mclk_multiple** (*Optional*, enum): The multiple of the MCLK frequency to the sample rate. Must be divisible by 3 if using 24 bits per sample. One of `128`, `256`, `384`, `512`. Defaults to `256`.
 - **use_apll** (*Optional*, boolean): I2S using APLL as main I2S clock, enable it to get accurate clock. Defaults to `false`.
 - **i2s_mode** (*Optional*, enum): The I²S mode to use. One of `primary` (clock driven by the host) or `secondary` (clock driven by the attached device). Defaults to `primary`.
@@ -55,13 +49,6 @@ microphone:
 
 > [!NOTE]
 > PDM microphones are only supported on ESP32 and ESP32-S3.
-
-## Internal ADC
-
-> [!NOTE]
-> Internal ADC microphones are only supported by the legacy I²S driver on a regular ESP32, not the variants.
-
-- **adc_pin** (**Required**, [Pin Schema](/guides/configuration-types#pin-schema)): The GPIO pin to use for the ADC input.
 
 ## Known Devices
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

This commit removes a few configuration variables from the microphone components that are no longer present after
https://github.com/esphome/esphome/pull/14932, including:

  * `use_legacy`
  * Anything related to `adc_type: internal`
  * `bits_per_channel`

The `adc_type: internal` variable description is instead replaced with the same error message that would be raised at compile time if you tried to use it, as an explanation for anyone that would be wondering why that option exists or why it's not valid.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#14932

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

## Testing

On the latest esphome release (`Version: 2026.5.3`), `bits_per_channel` on a `microphone: [{"platform": "i2s_audio"}]` component (which from memory, did previously work) now returns `[bits_per_channel] is an invalid option for [microphone.i2s_audio]. Did you mean [bits_per_sample], [channel]?`. I did a double check with `rg -i bits_per_channel` in the main codebase, and to my surprise it _is_ still present in https://github.com/esphome/esphome/blob/cbd3aaa1e001e889eac042d22558406ef4c09bb0/esphome/components/i2s_audio/__init__.py#L118-L124 (and as a string const). I'm not sure if this should be removed.

There are still a few references to `adc_type: internal` in the main codebase, but my understanding is that with https://github.com/esphome/esphome/blob/cbd3aaa1e001e889eac042d22558406ef4c09bb0/esphome/components/i2s_audio/microphone/__init__.py#L128-L131, any lingering code flows will never be reachable anyway. The wording implies that this will never be supported again, which seems like a bit of a shame - but if so, maybe this needs to be cleaned up too?

`use_legacy` is completely absent from the main codebase.