### PR TITLE
docs: improve wording in BME280 environment guide

### DIFF
--- a/src/content/docs/cookbook/bme280_environment.mdx
+++ b/src/content/docs/cookbook/bme280_environment.mdx
@@ -64,7 +64,7 @@ After the bme280 sensor, a [Template](/components/sensor/template/) is defined t
 The variable `STANDARD_SEA_LEVEL_PRESSURE` (in hPa), should be filled in for your location.
 The formula derived from [finitespace/BME280](https://github.com/finitespace/BME280/blob/master/src/EnvironmentCalculations.cpp)
 on GitHub,
-converts the currently measured pressure to the altitudes in meters including temperature compensation.
+converts the currently measured pressure to altitude in meters, including temperature compensation.
 
 The second block uses the [Absolute Humidity](/components/sensor/absolute_humidity/) component which
 converts the currently measured temperature and relative humidity to absolute humidity (grams/m^3).


### PR DESCRIPTION
## Description

This pull request improves the wording in the BME280 environment guide.

The phrase "altitudes in meters" was changed to "altitude in meters" for improved readability and grammatical correctness.

## Checklist

- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.