### PR TITLE
[component-image] Commit generated image directly to the PR branch

### DIFF
--- a/.github/workflows/component-image.yml
+++ b/.github/workflows/component-image.yml
@@ -5,13 +5,13 @@ on:
     types: [created]
 
 permissions:
-  pull-requests: write
-  issues: write
   contents: read
 
 jobs:
   prepare:
     name: Prepare
+    permissions:
+      issues: write
     if: >-
       github.event.issue.pull_request &&
       startsWith(github.event.comment.body, '@esphomebot generate image') &&
@@ -75,6 +75,10 @@ jobs:
 
   generate:
     name: Generate
+    permissions:
+      issues: write
+      pull-requests: read
+      contents: read
     if: >-
       github.event.issue.pull_request &&
       startsWith(github.event.comment.body, '@esphomebot generate image') &&
@@ -136,12 +140,16 @@ jobs:
             });
             core.setOutput('head_repo', pr.head.repo.full_name);
             core.setOutput('head_ref', pr.head.ref);
+            core.setOutput('head_sha', pr.head.sha);
 
+      # Check out the immutable head SHA rather than the branch ref: the ref can
+      # be moved between the authorization check and this checkout, so pinning to
+      # the SHA prevents a swapped-in commit (untrusted-checkout TOCTOU).
       - name: Checkout PR branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ${{ steps.pr.outputs.head_repo }}
-          ref: ${{ steps.pr.outputs.head_ref }}
+          ref: ${{ steps.pr.outputs.head_sha }}
           token: ${{ steps.app-token.outputs.token }}
           persist-credentials: true
 
@@ -232,8 +240,8 @@ jobs:
                 artifactLine;
             } else {
               body = `@${actor} Couldn't commit the image to this PR branch automatically ` +
-                `(this happens for pull requests from forks — the bot can only push to ` +
-                `branches in this repository). Download it here:${url ? ` ${url}` : ' check the workflow logs.'}`;
+                `(the bot doesn't have write access to this fork). ` +
+                `Download the generated image here:${url ? ` ${url}` : ' check the workflow logs.'}`;
             }
             await github.rest.issues.updateComment({
               owner: context.repo.owner,

--- a/.github/workflows/component-image.yml
+++ b/.github/workflows/component-image.yml
@@ -172,7 +172,9 @@ jobs:
             const name = process.env.COMPONENT;
             const img = process.env.IMG;
             // Component name is validated to [a-z0-9_]+, so it is safe in a regex.
-            const re = new RegExp('("/components/' + name + '/",\\s*")[^"]*(")', 'g');
+            // Match case-insensitively: a few index paths use mixed case (e.g.
+            // /components/mcp23Sxx/) while the requested name is always lowercase.
+            const re = new RegExp('("/components/' + name + '/",\\s*")[^"]*(")', 'gi');
             let count = 0;
             const updated = fs.readFileSync(path, 'utf8')
               .replace(re, (_m, p1, p2) => { count++; return p1 + img + p2; });
@@ -240,7 +242,8 @@ jobs:
                 artifactLine;
             } else {
               body = `@${actor} Couldn't commit the image to this PR branch automatically ` +
-                `(the bot doesn't have write access to this fork). ` +
+                `(usually the bot lacks write access to a fork; the push can also fail ` +
+                `for other reasons — see the workflow logs). ` +
                 `Download the generated image here:${url ? ` ${url}` : ' check the workflow logs.'}`;
             }
             await github.rest.issues.updateComment({

--- a/.github/workflows/component-image.yml
+++ b/.github/workflows/component-image.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   pull-requests: write
+  contents: read
 
 jobs:
   prepare:
@@ -58,20 +59,140 @@ jobs:
         with:
           component: ${{ needs.prepare.outputs.name }}
 
+      # Always publish the raw SVG as an unarchived artifact (downloads as a bare
+      # .svg, not a zip) so there is a fallback when the image cannot be pushed
+      # to the PR branch (e.g. organization-owned forks).
       - name: Upload
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         id: upload-artifact
         with:
-          name: ${{ needs.prepare.outputs.name }}
           path: ${{ needs.prepare.outputs.name_lower }}.svg
+          archive: false
 
-      - name: Update Comment
+      # Move the generated image out of the workspace before checkout wipes it.
+      - name: Stash generated image
+        run: |
+          mkdir -p "${{ runner.temp }}/component-image"
+          mv "${{ needs.prepare.outputs.name_lower }}.svg" "${{ runner.temp }}/component-image/"
+
+      - name: Generate a token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.ESPHOME_GITHUB_APP_CLIENT_ID }}
+          private-key: ${{ secrets.ESPHOME_GITHUB_APP_PRIVATE_KEY }}
+
+      - name: Get app user id
+        id: app-user
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          user_id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)
+          echo "user-id=$user_id" >> "$GITHUB_OUTPUT"
+
+      - name: Get PR head info
+        id: pr
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+            core.setOutput('head_repo', pr.head.repo.full_name);
+            core.setOutput('head_ref', pr.head.ref);
+
+      - name: Checkout PR branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ${{ steps.pr.outputs.head_repo }}
+          ref: ${{ steps.pr.outputs.head_ref }}
+          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: true
+
+      - name: Place image
+        run: |
+          mv -f "${{ runner.temp }}/component-image/${{ needs.prepare.outputs.name_lower }}.svg" \
+            "public/images/${{ needs.prepare.outputs.name_lower }}.svg"
+
+      - name: Update component index
+        id: index
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          COMPONENT: ${{ needs.prepare.outputs.name }}
+          IMG: ${{ needs.prepare.outputs.name_lower }}.svg
+        with:
+          script: |
+            const fs = require('fs');
+            const path = 'src/content/docs/components/index.mdx';
+            const name = process.env.COMPONENT;
+            const img = process.env.IMG;
+            // Component name is validated to [a-z0-9_]+, so it is safe in a regex.
+            const re = new RegExp('("/components/' + name + '/",\\s*")[^"]*(")', 'g');
+            let count = 0;
+            const updated = fs.readFileSync(path, 'utf8')
+              .replace(re, (_m, p1, p2) => { count++; return p1 + img + p2; });
+            if (count > 0) fs.writeFileSync(path, updated);
+            core.setOutput('updated', count > 0 ? 'true' : 'false');
+
+      - name: Commit and push
+        id: push
+        continue-on-error: true
+        env:
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+          USER_ID: ${{ steps.app-user.outputs.user-id }}
+          IMG: ${{ needs.prepare.outputs.name_lower }}.svg
+          COMPONENT: ${{ needs.prepare.outputs.name }}
+          HEAD_REF: ${{ steps.pr.outputs.head_ref }}
+        run: |
+          git config user.name "${APP_SLUG}[bot]"
+          git config user.email "${USER_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
+          git add "public/images/${IMG}" src/content/docs/components/index.mdx
+          if git diff --cached --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No changes to commit."
+            exit 0
+          fi
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+          git commit -m "[${COMPONENT}] Add generated component image"
+          git push origin "HEAD:${HEAD_REF}"
+
+      - name: Update Comment
+        if: always()
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          PUSH_OUTCOME: ${{ steps.push.outcome }}
+          CHANGED: ${{ steps.push.outputs.changed }}
+          INDEX_UPDATED: ${{ steps.index.outputs.updated }}
+          ARTIFACT_URL: ${{ steps.upload-artifact.outputs.artifact-url }}
+          IMG: ${{ needs.prepare.outputs.name_lower }}.svg
+        with:
+          script: |
+            const outcome = process.env.PUSH_OUTCOME;
+            const changed = process.env.CHANGED;
+            const indexUpdated = process.env.INDEX_UPDATED === 'true';
+            const url = process.env.ARTIFACT_URL;
+            const img = process.env.IMG;
+            const actor = context.actor;
+            let body;
+            if (outcome === 'success' && changed === 'true') {
+              body = `@${actor} Committed \`public/images/${img}\` to this PR` +
+                (indexUpdated
+                  ? ' and updated the component index.'
+                  : ' (no matching index entry found — update it manually).') +
+                `\n\nArtifact: ${url}`;
+            } else if (outcome === 'success' && changed === 'false') {
+              body = `@${actor} No changes needed — \`public/images/${img}\` is already up to date.` +
+                `\n\nArtifact: ${url}`;
+            } else {
+              body = `@${actor} Couldn't push the image to this PR branch automatically ` +
+                `(organization-owned fork, or "Allow edits by maintainers" is disabled). ` +
+                `Download it here: ${url}`;
+            }
             await github.rest.issues.updateComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               comment_id: ${{ needs.prepare.outputs.comment_id }},
-              body: `@${context.actor} Here is the image for the component ${{ steps.upload-artifact.outputs.artifact-url }}`
-            })
+              body,
+            });

--- a/.github/workflows/component-image.yml
+++ b/.github/workflows/component-image.yml
@@ -6,31 +6,25 @@ on:
 
 permissions:
   pull-requests: write
+  issues: write
   contents: read
 
 jobs:
   prepare:
     name: Prepare
-    if: github.event.issue.pull_request && startsWith(github.event.comment.body, '@esphomebot generate image')
+    if: >-
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '@esphomebot generate image') &&
+      (
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) ||
+        github.event.comment.user.login == github.event.issue.user.login
+      )
     runs-on: ubuntu-latest
     outputs:
       name: ${{ steps.get_component.outputs.name }}
       name_lower: ${{ steps.get_component.outputs.name_lower }}
       comment_id: ${{ steps.create-comment.outputs.result }}
     steps:
-      - name: Comment
-        id: create-comment
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        with:
-          script: |
-            const result = await github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `@${context.actor} Generating image...`
-            })
-            return result.data.id
-
       - name: Get Component name
         id: get_component
         env:
@@ -48,13 +42,51 @@ jobs:
             exit 1
           fi
 
+      # Tell the commenter why nothing happened when the name fails validation.
+      # The raw name is never interpolated into the script (code-injection risk);
+      # the message is intentionally generic.
+      - name: Comment on invalid name
+        if: failure() && steps.get_component.outcome == 'failure'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `@${context.actor} Invalid component name. Use lowercase letters, numbers, ` +
+                'and underscores only (e.g. `bme280`, `sht3x`, `dallas_temp`).'
+            })
+
+      # Posted only after the component name validates, so an invalid name never
+      # leaves a dangling "Generating image..." comment on the PR.
+      - name: Comment
+        id: create-comment
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const result = await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `@${context.actor} Generating image...`
+            })
+            return result.data.id
+
   generate:
     name: Generate
-    if: github.event.issue.pull_request && startsWith(github.event.comment.body, '@esphomebot generate image')
+    if: >-
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '@esphomebot generate image') &&
+      (
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) ||
+        github.event.comment.user.login == github.event.issue.user.login
+      )
     runs-on: ubuntu-latest
     needs: prepare
     steps:
       - name: Generate
+        id: generate
         uses: esphome/component-image-generator@d0d2a195b500e8c37c17f299ff6b90933f2197cf # v1.0.0
         with:
           component: ${{ needs.prepare.outputs.name }}
@@ -71,9 +103,11 @@ jobs:
 
       # Move the generated image out of the workspace before checkout wipes it.
       - name: Stash generated image
+        env:
+          IMG: ${{ needs.prepare.outputs.name_lower }}.svg
         run: |
           mkdir -p "${{ runner.temp }}/component-image"
-          mv "${{ needs.prepare.outputs.name_lower }}.svg" "${{ runner.temp }}/component-image/"
+          mv "$IMG" "${{ runner.temp }}/component-image/"
 
       - name: Generate a token
         id: app-token
@@ -112,9 +146,10 @@ jobs:
           persist-credentials: true
 
       - name: Place image
+        env:
+          IMG: ${{ needs.prepare.outputs.name_lower }}.svg
         run: |
-          mv -f "${{ runner.temp }}/component-image/${{ needs.prepare.outputs.name_lower }}.svg" \
-            "public/images/${{ needs.prepare.outputs.name_lower }}.svg"
+          mv -f "${{ runner.temp }}/component-image/$IMG" "public/images/$IMG"
 
       - name: Update component index
         id: index
@@ -162,6 +197,8 @@ jobs:
         if: always()
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
+          GENERATE_OUTCOME: ${{ steps.generate.outcome }}
+          UPLOAD_OUTCOME: ${{ steps.upload-artifact.outcome }}
           PUSH_OUTCOME: ${{ steps.push.outcome }}
           CHANGED: ${{ steps.push.outputs.changed }}
           INDEX_UPDATED: ${{ steps.index.outputs.updated }}
@@ -169,26 +206,34 @@ jobs:
           IMG: ${{ needs.prepare.outputs.name_lower }}.svg
         with:
           script: |
-            const outcome = process.env.PUSH_OUTCOME;
+            const generateOutcome = process.env.GENERATE_OUTCOME;
+            const uploadOutcome = process.env.UPLOAD_OUTCOME;
+            const pushOutcome = process.env.PUSH_OUTCOME;
             const changed = process.env.CHANGED;
             const indexUpdated = process.env.INDEX_UPDATED === 'true';
             const url = process.env.ARTIFACT_URL;
             const img = process.env.IMG;
             const actor = context.actor;
+            const artifactLine = url ? `\n\nArtifact: ${url}` : '';
             let body;
-            if (outcome === 'success' && changed === 'true') {
+            if (generateOutcome !== 'success') {
+              body = `@${actor} Image generation failed. Check the workflow logs for details.`;
+            } else if (uploadOutcome !== 'success') {
+              body = `@${actor} The image was generated but could not be uploaded. ` +
+                `Check the workflow logs for details.`;
+            } else if (pushOutcome === 'success' && changed === 'true') {
               body = `@${actor} Committed \`public/images/${img}\` to this PR` +
                 (indexUpdated
                   ? ' and updated the component index.'
                   : ' (no matching index entry found — update it manually).') +
-                `\n\nArtifact: ${url}`;
-            } else if (outcome === 'success' && changed === 'false') {
+                artifactLine;
+            } else if (pushOutcome === 'success' && changed === 'false') {
               body = `@${actor} No changes needed — \`public/images/${img}\` is already up to date.` +
-                `\n\nArtifact: ${url}`;
+                artifactLine;
             } else {
-              body = `@${actor} Couldn't push the image to this PR branch automatically ` +
-                `(organization-owned fork, or "Allow edits by maintainers" is disabled). ` +
-                `Download it here: ${url}`;
+              body = `@${actor} Couldn't commit the image to this PR branch automatically ` +
+                `(this happens for pull requests from forks — the bot can only push to ` +
+                `branches in this repository). Download it here:${url ? ` ${url}` : ' check the workflow logs.'}`;
             }
             await github.rest.issues.updateComment({
               owner: context.repo.owner,


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Reworks the component image generator workflow so the generated SVG is committed directly to the pull request instead of only being offered as a downloadable artifact.

- Uploads the generated SVG as an unarchived artifact (`archive: false`), so it downloads as a bare `.svg` rather than a zip.
- Mints an `esphome[bot]` token and commits the image into `public/images/` and updates the matching `/components/<name>/` row in `src/content/docs/components/index.mdx` on the PR branch. This works for in-repo branches and user-owned forks with "Allow edits by maintainers" enabled.
- Falls back to the artifact download link when the branch cannot be pushed to (organization-owned forks, or maintainer edits disabled).

Note: the "New Component Images" instructions in this PR template still describe the old zip-download-and-place-manually flow and should be updated separately to reflect the bot now committing the image directly.

**Related issue (if applicable):**

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.