### PR TITLE
[components] Address review findings and drop unused starlight-blog

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,7 +1,6 @@
 import { defineConfig } from "astro/config";
 import starlight from "@astrojs/starlight";
 import sitemap from "@astrojs/sitemap";
-import starlightBlog from "starlight-blog";
 import { fileURLToPath } from "url";
 import path from "path";
 import fs from "fs";
@@ -144,11 +143,7 @@ export default defineConfig({
       titleDelimiter: "-",
       favicon: "/favicon.ico",
       pagination: false,
-      plugins: [
-        //starlightBlog({
-        //  title: 'Blog',
-        //}),
-      ],
+      plugins: [],
       logo: {
         light: "./src/assets/logo-dark.svg",
         dark: "./src/assets/logo-light.svg",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,8 +16,7 @@
         "rehype-katex": "^7.0.1",
         "remark-github-blockquote-alert": "^2.1.0",
         "remark-math": "^6.0.0",
-        "sharp": "^0.34.5",
-        "starlight-blog": "^0.26.1"
+        "sharp": "^0.34.5"
       },
       "devDependencies": {
         "jsdom": "^29.1.1"
@@ -155,17 +154,6 @@
       },
       "engines": {
         "node": ">=22.12.0"
-      }
-    },
-    "node_modules/@astrojs/rss": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@astrojs/rss/-/rss-4.0.18.tgz",
-      "integrity": "sha512-wc5DwKlbTEdgVAWnHy8krFTeQ42t1v/DJqeq5HtulYK3FYHE4krtRGjoyhS3eXXgfdV6Raoz2RU3wrMTFAitRg==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-xml-parser": "^5.5.7",
-        "piccolore": "^0.1.3",
-        "zod": "^4.3.6"
       }
     },
     "node_modules/@astrojs/sitemap": {
@@ -1470,18 +1458,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/@nodable/entities": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
-      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodable"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/@oslojs/encoding": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
@@ -2319,46 +2295,6 @@
         "astro": "^4.0.0-beta || ^5.0.0-beta || ^3.3.0 || ^6.0.0-beta"
       }
     },
-    "node_modules/astro-remote": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/astro-remote/-/astro-remote-0.3.4.tgz",
-      "integrity": "sha512-jL5skNQLA0YBc1R3bVGXyHew3FqGqsT7AgLzWAVeTLzFkwVMUYvs4/lKJSmS7ygcF1GnHnoKG6++8GL9VtWwGQ==",
-      "license": "MIT",
-      "dependencies": {
-        "entities": "^4.5.0",
-        "marked": "^12.0.0",
-        "marked-footnote": "^1.2.2",
-        "marked-smartypants": "^1.1.6",
-        "ultrahtml": "^1.5.3"
-      },
-      "engines": {
-        "node": ">=18.14.1"
-      }
-    },
-    "node_modules/astro-remote/node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/astro-remote/node_modules/marked": {
-      "version": "12.0.2",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-12.0.2.tgz",
-      "integrity": "sha512-qXUm7e/YKFoqFPYPa3Ukg9xlI5cyAtGmyEIzMfW//m6kXwCy2Ps9DYf5ioijFKQ8qyuscrHoY04iJGctu2Kg0Q==",
-      "license": "MIT",
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
     "node_modules/astro/node_modules/@astrojs/internal-helpers": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.10.0.tgz",
@@ -3144,43 +3080,6 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
-    },
-    "node_modules/fast-xml-builder": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
-      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "path-expression-matcher": "^1.5.0",
-        "xml-naming": "^0.1.0"
-      }
-    },
-    "node_modules/fast-xml-parser": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.1.tgz",
-      "integrity": "sha512-8Cc3f8GUGUULg34pBch/KGyPLglS+OFs05deyOlY7fL2MTagYPKrVQNmR1fLF/yJ9PH5ZSTd3YDF6pnmeZU+zA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@nodable/entities": "^2.1.0",
-        "fast-xml-builder": "^1.1.5",
-        "path-expression-matcher": "^1.5.0",
-        "strnum": "^2.2.3"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
-      }
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -4060,48 +3959,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/marked": {
-      "version": "17.0.5",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.5.tgz",
-      "integrity": "sha512-6hLvc0/JEbRjRgzI6wnT2P1XuM1/RrrDEX0kPt0N7jGm1133g6X7DlxFasUIx+72aKAr904GTxhSLDrd5DIlZg==",
-      "license": "MIT",
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/marked-footnote": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/marked-footnote/-/marked-footnote-1.4.0.tgz",
-      "integrity": "sha512-fZTxAhI1TcLEs5UOjCfYfTHpyKGaWQevbxaGTEA68B51l7i87SctPFtHETYqPkEN0ka5opvy4Dy1l/yXVC+hmg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "marked": ">=7.0.0"
-      }
-    },
-    "node_modules/marked-plaintify": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/marked-plaintify/-/marked-plaintify-1.1.1.tgz",
-      "integrity": "sha512-r3kMKArhfo2H3lD4ctFq/OJTzM0uNvXHh7FBTI1hMDpf4Ac1djjtq4g8NfTBWMxWLmaEz3KL1jCkLygik3gExA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "marked": ">=13.0.0"
-      }
-    },
-    "node_modules/marked-smartypants": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/marked-smartypants/-/marked-smartypants-1.1.11.tgz",
-      "integrity": "sha512-Jt0eq/6rf9oXDfEKPzQ0z7UzVWcEAK3L6QBBQzbwV8bT304OvPVLTqpH3yvkSung9foOM4s120TMHEHP76Metg==",
-      "license": "MIT",
-      "dependencies": {
-        "smartypants": "^0.2.2"
-      },
-      "peerDependencies": {
-        "marked": ">=4 <18"
       }
     },
     "node_modules/mdast-util-definitions": {
@@ -5461,21 +5318,6 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
-    "node_modules/path-expression-matcher": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
-      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/piccolore": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/piccolore/-/piccolore-0.1.3.tgz",
@@ -6211,16 +6053,6 @@
         "npm": ">=10.8.2"
       }
     },
-    "node_modules/smartypants": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/smartypants/-/smartypants-0.2.2.tgz",
-      "integrity": "sha512-TzobUYoEft/xBtb2voRPryAUIvYguG0V7Tt3de79I1WfXgCwelqVsGuZSnu3GFGRZhXR90AeEYIM+icuB/S06Q==",
-      "license": "BSD-3-Clause",
-      "bin": {
-        "smartypants": "bin/smartypants.js",
-        "smartypantsu": "bin/smartypantsu.js"
-      }
-    },
     "node_modules/smol-toml": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
@@ -6261,34 +6093,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/starlight-blog": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/starlight-blog/-/starlight-blog-0.26.1.tgz",
-      "integrity": "sha512-c2aLtkVTNFKHDJrh1DwlxBj+VyOrLqJeHmGkKKHwL6oowUoaqUiC/vyOZLXNmZL1kcYI0hgHDw1t4G/lkg8mZg==",
-      "license": "MIT",
-      "dependencies": {
-        "@astrojs/markdown-remark": "^7.0.0",
-        "@astrojs/mdx": "^5.0.0",
-        "@astrojs/rss": "^4.0.17",
-        "astro-remote": "^0.3.4",
-        "github-slugger": "^2.0.0",
-        "hast-util-from-html": "^2.0.3",
-        "hast-util-to-html": "^9.0.5",
-        "hast-util-to-string": "^3.0.1",
-        "marked": "^17.0.4",
-        "marked-plaintify": "^1.1.1",
-        "mdast-util-mdx-expression": "^2.0.1",
-        "unist-util-is": "^6.0.1",
-        "unist-util-remove": "^4.0.0",
-        "unist-util-visit": "^5.1.0"
-      },
-      "engines": {
-        "node": ">=22.12.0"
-      },
-      "peerDependencies": {
-        "@astrojs/starlight": ">=0.38.0"
-      }
-    },
     "node_modules/stream-replace-string": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/stream-replace-string/-/stream-replace-string-2.0.0.tgz",
@@ -6308,18 +6112,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
-    },
-    "node_modules/strnum": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
-      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/style-to-js": {
       "version": "1.1.21",
@@ -6618,21 +6410,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-remove": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-remove/-/unist-util-remove-4.0.0.tgz",
-      "integrity": "sha512-b4gokeGId57UVRX/eVKej5gXqGlc9+trkORhFJpu9raqZkZhU0zm8Doi05+HaiBsMEIJowL+2WtQ5ItjsngPXg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "unist-util-is": "^6.0.0",
-        "unist-util-visit-parents": "^6.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -7020,21 +6797,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/xml-naming": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
-      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.0.0"
       }
     },
     "node_modules/xmlchars": {

--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
     "rehype-katex": "^7.0.1",
     "remark-github-blockquote-alert": "^2.1.0",
     "remark-math": "^6.0.0",
-    "sharp": "^0.34.5",
-    "starlight-blog": "^0.26.1"
+    "sharp": "^0.34.5"
   },
   "repository": {
     "type": "git",

--- a/script/seo_audit.mjs
+++ b/script/seo_audit.mjs
@@ -56,11 +56,15 @@ function extractSEO(html, url) {
   const allLinks = [...doc.querySelectorAll('a[href]')];
   const internalLinks = allLinks.filter(a => {
     const href = a.getAttribute('href');
-    return href?.startsWith('/') || (href ? isEsphomeHost(href) : false);
+    if (!href) return false;
+    if (href.startsWith('//')) return false; // protocol-relative URLs are external
+    return href.startsWith('/') || isEsphomeHost(href);
   }).length;
   const externalLinks = allLinks.filter(a => {
     const href = a.getAttribute('href');
-    return href?.startsWith('http') === true && !isEsphomeHost(href);
+    if (!href) return false;
+    if (href.startsWith('//')) return true; // protocol-relative URLs are external
+    return href.startsWith('http') && !isEsphomeHost(href);
   }).length;
 
   // Images

--- a/script/seo_audit.mjs
+++ b/script/seo_audit.mjs
@@ -18,6 +18,16 @@ const LIVE_SITE = 'https://esphome.io';
 const DIST_DIR = 'dist';
 const SAMPLE_SIZE = 50; // Number of pages to audit
 
+// Resolve an href against the live site and return true if it points at the esphome.io host.
+function isEsphomeHost(href) {
+  try {
+    const { hostname } = new URL(href, LIVE_SITE);
+    return hostname === 'esphome.io' || hostname.endsWith('.esphome.io');
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Extract SEO data from HTML
  */
@@ -46,11 +56,11 @@ function extractSEO(html, url) {
   const allLinks = [...doc.querySelectorAll('a[href]')];
   const internalLinks = allLinks.filter(a => {
     const href = a.getAttribute('href');
-    return href?.startsWith('/') || href?.includes('esphome.io');
+    return href?.startsWith('/') || (href ? isEsphomeHost(href) : false);
   }).length;
   const externalLinks = allLinks.filter(a => {
     const href = a.getAttribute('href');
-    return href?.startsWith('http') && !href?.includes('esphome.io');
+    return href?.startsWith('http') === true && !isEsphomeHost(href);
   }).length;
 
   // Images

--- a/script/seo_audit.mjs
+++ b/script/seo_audit.mjs
@@ -57,14 +57,16 @@ function extractSEO(html, url) {
   const internalLinks = allLinks.filter(a => {
     const href = a.getAttribute('href');
     if (!href) return false;
-    if (href.startsWith('//')) return false; // protocol-relative URLs are external
-    return href.startsWith('/') || isEsphomeHost(href);
+    if (href.startsWith('//')) return isEsphomeHost(href); // protocol-relative: classify by host
+    if (href.startsWith('/')) return true; // root-relative path
+    if (href.startsWith('http')) return isEsphomeHost(href); // absolute URL
+    return false; // anchors, mailto:, bare relative paths
   }).length;
   const externalLinks = allLinks.filter(a => {
     const href = a.getAttribute('href');
     if (!href) return false;
-    if (href.startsWith('//')) return true; // protocol-relative URLs are external
-    return href.startsWith('http') && !isEsphomeHost(href);
+    if (href.startsWith('//') || href.startsWith('http')) return !isEsphomeHost(href);
+    return false;
   }).length;
 
   // Images

--- a/src/components/Figure.astro
+++ b/src/components/Figure.astro
@@ -15,7 +15,8 @@ interface Props {
 
 const { src, alt, caption: rawCaption, layout = 'constrained', style, width, height } = Astro.props;
 
-// Render caption as inline markdown (handles links, escaping, XSS)
+// Render caption as inline markdown (e.g. links). micromark does not sanitize HTML;
+// captions are trusted, maintainer-authored content.
 const caption = rawCaption
   ? micromark(rawCaption).replace(/^<p>|<\/p>\n?$/g, '')
   : undefined;

--- a/src/components/HLW8012Calculator.astro
+++ b/src/components/HLW8012Calculator.astro
@@ -151,9 +151,9 @@
     const sensor_power = parseFloat((document.getElementById("sensor-power") as HTMLInputElement).value.replace(",", "."));
     const sensor_current = parseFloat((document.getElementById("sensor-current") as HTMLInputElement).value.replace(",", "."));
 
-    const calc_voltage = (document.getElementById("real-voltage") as HTMLInputElement).value !== "" && (document.getElementById("sensor-voltage") as HTMLInputElement).value !== "";
-    const calc_power = (document.getElementById("real-power") as HTMLInputElement).value !== "" && (document.getElementById("sensor-power") as HTMLInputElement).value !== "";
-    const calc_current = (document.getElementById("real-current") as HTMLInputElement).value !== "" && (document.getElementById("sensor-current") as HTMLInputElement).value !== "";
+    const calc_voltage = Number.isFinite(real_voltage) && Number.isFinite(sensor_voltage);
+    const calc_power = Number.isFinite(real_power) && Number.isFinite(sensor_power);
+    const calc_current = Number.isFinite(real_current) && Number.isFinite(sensor_current);
 
     let voltage_divider_new = voltage_divider;
     let current_resistor_new = current_resistor;

--- a/src/components/HLW8012Calculator.astro
+++ b/src/components/HLW8012Calculator.astro
@@ -151,9 +151,9 @@
     const sensor_power = parseFloat((document.getElementById("sensor-power") as HTMLInputElement).value.replace(",", "."));
     const sensor_current = parseFloat((document.getElementById("sensor-current") as HTMLInputElement).value.replace(",", "."));
 
-    const calc_voltage = (document.getElementById("real-voltage") as HTMLInputElement).value !== "" || (document.getElementById("sensor-voltage") as HTMLInputElement).value !== "";
-    const calc_power = (document.getElementById("real-power") as HTMLInputElement).value !== "" || (document.getElementById("sensor-power") as HTMLInputElement).value !== "";
-    const calc_current = (document.getElementById("real-current") as HTMLInputElement).value !== "" || (document.getElementById("sensor-current") as HTMLInputElement).value !== "";
+    const calc_voltage = (document.getElementById("real-voltage") as HTMLInputElement).value !== "" && (document.getElementById("sensor-voltage") as HTMLInputElement).value !== "";
+    const calc_power = (document.getElementById("real-power") as HTMLInputElement).value !== "" && (document.getElementById("sensor-power") as HTMLInputElement).value !== "";
+    const calc_current = (document.getElementById("real-current") as HTMLInputElement).value !== "" && (document.getElementById("sensor-current") as HTMLInputElement).value !== "";
 
     let voltage_divider_new = voltage_divider;
     let current_resistor_new = current_resistor;

--- a/src/components/ImgTable.astro
+++ b/src/components/ImgTable.astro
@@ -59,9 +59,9 @@ function addWordBreaks(text: string): string {
           <div class={`component-icon ${cssClass}`}>
             <img src={resolvedImage} alt="" loading="lazy" />
           </div>
-          <div class="component-name" set:html={addWordBreaks(title)} />
+          <div class="component-name">{addWordBreaks(title)}</div>
           {caption && (
-            <div class="component-caption" set:html={addWordBreaks(caption)} />
+            <div class="component-caption">{addWordBreaks(caption)}</div>
           )}
         </a>
       </div>


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Code changes split out of #6751 (which is now formatting/lint only):

- `script/seo_audit.mjs`: parse the href hostname via `new URL()` instead of substring matching (`includes("esphome.io")`), fixing the CodeQL "Incomplete URL substring sanitization" finding.
- `src/components/HLW8012Calculator.astro`: require both the real and sensor inputs (`&&` instead of `||`) before running each paired calculation, so an empty field no longer propagates `NaN`.
- `src/components/ImgTable.astro`: render the `addWordBreaks` output as plain text nodes instead of `set:html` (the helper only inserts zero-width spaces).
- `src/components/Figure.astro`: correct the caption comment — micromark does not sanitize HTML; captions are trusted maintainer-authored content.
- Remove the unused `starlight-blog` dependency (import and commented-out plugin block were already dead).

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.