### PR TITLE
[lock] Migrate to esphome/workflows reusable lock workflow

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -1,27 +1,16 @@
-name: Lock
+name: Lock closed issues and PRs
 
 on:
   schedule:
-    - cron: '30 0 * * *'
+    - cron: "30 0 * * *"  # Run daily at 00:30 UTC
   workflow_dispatch:
 
-permissions:
-  issues: write
-  pull-requests: write
-
-concurrency:
-  group: lock
+# Deny by default; the lock job opts in to exactly what the reusable workflow needs.
+permissions: {}
 
 jobs:
   lock:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: dessant/lock-threads@7266a7ce5c1df01b1c6db85bf8cd86c737dadbe7 # v4
-        with:
-          pr-inactive-days: "1"
-          pr-lock-reason: ""
-          exclude-any-pr-labels: keep-open
-
-          issue-inactive-days: "7"
-          issue-lock-reason: ""
-          exclude-any-issue-labels: keep-open
+    permissions:
+      issues: write         # issues.lock on closed issues
+      pull-requests: write  # issues.lock on closed pull requests
+    uses: esphome/workflows/.github/workflows/lock.yml@025a1e6255610c498ed590403b7e510b69e474df  # 2026.4.1


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Replaces the inline `dessant/lock-threads` job with a call to the shared `esphome/workflows/.github/workflows/lock.yml` reusable workflow, pinned to `2026.4.1` — matching how the main esphome repo locks closed issues and PRs.

The reusable workflow's defaults (PR close: 1 day, issue close: 7 days, exclude label: `keep-open`, empty lock reason) match the previous configuration. Permissions now follow deny-by-default with the `issues: write` / `pull-requests: write` opt-in scoped to the lock job.

Note: the shared workflow keys off the closed date rather than last-activity date, and scans items closed within the last 30 days, which is a slight semantic change from `dessant/lock-threads`.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.