### PR TITLE
[usb_uart] Add pl2303 support in usb-uart-docs

### DIFF
--- a/src/content/docs/components/usb_uart.mdx
+++ b/src/content/docs/components/usb_uart.mdx
@@ -22,6 +22,13 @@ Currently supported devices are listed in the table below:
 | FT232     | 0x0403 | 0x6001 | FTDI USB to serial adapter single port |
 | FT2232     | 0x0403 | 0x6010 | FTDI USB to serial adapter dual port |
 | FT4232     | 0x0403 | 0x6011 | FTDI USB to serial adapter dual port |
+| PL2303     | 0x067B | 0x2303 | Prolific USB to serial adapter |
+| PL2303GC   | 0x067B | 0x23A3 | Prolific PL2303 G-series (GC) |
+| PL2303GB   | 0x067B | 0x23B3 | Prolific PL2303 G-series (GB) |
+| PL2303GT   | 0x067B | 0x23C3 | Prolific PL2303 G-series (GT) |
+| PL2303GL   | 0x067B | 0x23D3 | Prolific PL2303 G-series (GL) |
+| PL2303GE   | 0x067B | 0x23E3 | Prolific PL2303 G-series (GE) |
+| PL2303GS   | 0x067B | 0x23F3 | Prolific PL2303 G-series (GS) |
 | STM32_VCP | 0x0483 | 0x5740 | STM32 Virtual COM Port |
 
 
@@ -41,7 +48,7 @@ usb_uart:
 ## Configuration variables
 
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): The id to use for this component.
-- **type** (**Required**, string): The type of USB-serial device to connect to. One of `ft23xx`, `ch34x`, `ch340`, `esp_jtag`, `stm32_vcp`, `cdc_acm`, `cp210x`.
+- **type** (**Required**, string): The type of USB-serial device to connect to. One of `ft23xx`, `ch34x`, `ch340`, `esp_jtag`, `stm32_vcp`, `cdc_acm`, `cp210x`, `pl2303`, `pl2303gc`, `pl2303gb`, `pl2303gt`, `pl2303gl`, `pl2303ge`, `pl2303gs`.
 - **channels** (**Required**, list): A list of channels to configure.
 - **vid** (*Optional*, int): The vendor ID of the device. Use 0 as a wildcard. Each type has a default VID which will be overridden if this is set.
 - **pid** (*Optional*, int): The product ID of the device. Use 0 as a wildcard. Each type has a default PID which will be overridden if this is set.


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description
Small additions related to adding pl2303 support
**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#16885

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
