### PR TITLE
[cst9220] Document new touchscreen component

### DIFF
--- a/src/content/docs/components/index.mdx
+++ b/src/content/docs/components/index.mdx
@@ -1075,6 +1075,7 @@ Used for creating infrared (IR) remote control transmitters and/or receivers.
   ["CHSC6X", "/components/touchscreen/chsc6x/", "chsc6x.png"],
   ["CST226", "/components/touchscreen/cst226/", "t4-s3.jpg"],
   ["CST816", "/components/touchscreen/cst816/", "cst816.jpg"],
+  ["CST9220", "/components/touchscreen/cst9220/", "touch.svg"],
   ["EKTF2232", "/components/touchscreen/ektf2232/", "ektf2232.svg", "Inkplate 6 Plus"],
   ["FT63X6", "/components/touchscreen/ft63x6/", "wt32-sc01.png"],
   ["GT911", "/components/touchscreen/gt911/", "esp32_s3_box_3.png"],

--- a/src/content/docs/components/touchscreen/cst9220.mdx
+++ b/src/content/docs/components/touchscreen/cst9220.mdx
@@ -1,0 +1,36 @@
+---
+description: "Instructions for setting up cst9220 touch screen controller with ESPHome"
+title: "cst9220 Touch Screen Controller"
+---
+
+import APIRef from '@components/APIRef.astro';
+
+The `cst9220` touchscreen platform allows using touch screen controllers based on the Hynitron CST92xx series of
+chips with ESPHome. The component supports the CST9220 (multi-touch) and CST9217 (single-touch) controllers, which
+are found on a number of Waveshare ESP32-S3 Touch AMOLED displays.
+The [I²C](/components/i2c) is required to be set up in your configuration for this touchscreen to work.
+
+## Base Touchscreen Configuration
+
+```yaml
+# Example configuration entry
+touchscreen:
+  platform: cst9220
+  id: my_touchscreen
+  interrupt_pin: GPIOXX
+  reset_pin: GPIOXX
+```
+
+### Configuration variables
+
+- **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually set the ID of this touchscreen.
+- **interrupt_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The touch detection pin.
+- **reset_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The chip reset pin.
+
+- All other options from [Touchscreen](/components/touchscreen#config-touchscreen).
+
+The display resolution is read from the controller automatically; calibration is therefore not normally required.
+
+## See Also
+
+- <APIRef text="cst9220_touchscreen.h" path="cst9220/touchscreen/cst9220_touchscreen.h" />


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#16888
## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
