### PR TITLE
[resampler] Document new passthrough option for bits_per_sample

### DIFF
--- a/src/content/docs/components/speaker/resampler.mdx
+++ b/src/content/docs/components/speaker/resampler.mdx
@@ -28,7 +28,7 @@ speaker:
 
 - **output_speaker** (**Required**, [ID](/guides/configuration-types#id)): The [speaker](/components/speaker/) to output the resampled audio.
 - **buffer_duration** (*Optional*, [Time](/guides/configuration-types#time)): The duration of the internal ring buffer. Larger values may reduce stuttering but use more memory. Defaults to `500ms`.
-- **bits_per_sample** (*Optional*, positive integer or `passthrough`): The audio sample bit depth after resampling. Defaults to the `passthrough` where bit depth matches the input audio.
+- **bits_per_sample** (*Optional*, positive integer or `passthrough`): The audio sample bit depth after resampling. Defaults to `passthrough`, where the bit depth matches the input audio.
 - **sample_rate** (*Optional*, positive integer): Sample rate to convert to. Must be between `8000` and `48000`. Defaults to the output speaker's sample rate.
 - **filters** (*Optional*, positive integer): The number of windowed sinc interpolation filters to use. Must be between `2` and `1024`. Defaults to `16`.
 - **taps** (*Optional*, positive integer): The number of taps per windowed sinc interpolation filter. Must between `16` and `128` and divisible by 4. Defaults to `16`.

--- a/src/content/docs/components/speaker/resampler.mdx
+++ b/src/content/docs/components/speaker/resampler.mdx
@@ -28,7 +28,7 @@ speaker:
 
 - **output_speaker** (**Required**, [ID](/guides/configuration-types#id)): The [speaker](/components/speaker/) to output the resampled audio.
 - **buffer_duration** (*Optional*, [Time](/guides/configuration-types#time)): The duration of the internal ring buffer. Larger values may reduce stuttering but use more memory. Defaults to `500ms`.
-- **bits_per_sample** (*Optional*, positive integer): The audio sample bit depth after resampling. Defaults to the output speaker's bits per sample.
+- **bits_per_sample** (*Optional*, positive integer or `passthrough`): The audio sample bit depth after resampling. Defaults to the `passthrough` where bit depth matches the input bit audio.
 - **sample_rate** (*Optional*, positive integer): Sample rate to convert to. Must be between `8000` and `48000`. Defaults to the output speaker's sample rate.
 - **filters** (*Optional*, positive integer): The number of windowed sinc interpolation filters to use. Must be between `2` and `1024`. Defaults to `16`.
 - **taps** (*Optional*, positive integer): The number of taps per windowed sinc interpolation filter. Must between `16` and `128` and divisible by 4. Defaults to `16`.

--- a/src/content/docs/components/speaker/resampler.mdx
+++ b/src/content/docs/components/speaker/resampler.mdx
@@ -28,7 +28,7 @@ speaker:
 
 - **output_speaker** (**Required**, [ID](/guides/configuration-types#id)): The [speaker](/components/speaker/) to output the resampled audio.
 - **buffer_duration** (*Optional*, [Time](/guides/configuration-types#time)): The duration of the internal ring buffer. Larger values may reduce stuttering but use more memory. Defaults to `500ms`.
-- **bits_per_sample** (*Optional*, positive integer or `passthrough`): The audio sample bit depth after resampling. Defaults to the `passthrough` where bit depth matches the input bit audio.
+- **bits_per_sample** (*Optional*, positive integer or `passthrough`): The audio sample bit depth after resampling. Defaults to the `passthrough` where bit depth matches the input audio.
 - **sample_rate** (*Optional*, positive integer): Sample rate to convert to. Must be between `8000` and `48000`. Defaults to the output speaker's sample rate.
 - **filters** (*Optional*, positive integer): The number of windowed sinc interpolation filters to use. Must be between `2` and `1024`. Defaults to `16`.
 - **taps** (*Optional*, positive integer): The number of taps per windowed sinc interpolation filter. Must between `16` and `128` and divisible by 4. Defaults to `16`.


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Documents the new `passthrough` option for the `bits_per_sample` configuration.

**Related issue (if applicable):** not applicable
**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#16892

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
