### PR TITLE
fix: re-enable GFM tables in MDX pages

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -128,6 +128,9 @@ export default defineConfig({
     responsiveStyles: true,
   },
   markdown: {
+    // Astro 6 no longer defaults `markdown.gfm` to true, and @astrojs/mdx only applies remark-gfm
+    // to .mdx files when this is explicitly truthy. Without it, GFM tables render as literal text.
+    gfm: true,
     remarkPlugins: [remarkAlert, remarkMath],
     rehypePlugins: [rehypeKatex],
   },


### PR DESCRIPTION
## Description

GFM tables across the site render as literal pipe-delimited text instead of HTML tables (e.g.
[pmsx003](https://esphome.io/components/sensor/pmsx003/), [spi](https://esphome.io/components/spi/)) —
the built HTML contains the cell text inside a `<p>` with no `<table>` element.

<img width="984" height="274" alt="image" src="https://github.com/user-attachments/assets/8295162e-e40e-4764-beb7-b2032db18761" />


**Root cause:** Astro 6 no longer defaults `markdown.gfm` to `true` (the new `unified()` processor
supplies GFM internally, but only for `.md`). `@astrojs/mdx` still gates `remark-gfm` on
`config.markdown.gfm`, which was now `undefined`, so GFM (tables, strikethrough, task lists, autolinks)
was never applied to the `.mdx` pages that make up the entire site.

**Fix:** explicitly set `markdown.gfm: true` in `astro.config.mjs`.

Astro logs a one-line deprecation notice for `markdown.gfm`; it's harmless and remains the practical fix
until `@astrojs/mdx` handles Astro 6's new markdown config model.

I ran dev mode locally to confirm that this works as expected (tables are here again!)
<img width="1163" height="595" alt="image" src="https://github.com/user-attachments/assets/4ca1aa8c-5f9e-4f95-afeb-7cc274a6176c" />

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** N/A

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.