### PR TITLE
[bmi270] document new component

### DIFF
--- a/src/content/docs/components/index.mdx
+++ b/src/content/docs/components/index.mdx
@@ -529,9 +529,9 @@ Sensors are organized into categories; if a given sensor fits into more than one
 ### Motion
 
 <ImgTable items={[
-
   ["APDS9960", "/components/sensor/apds9960/", "apds9960.jpg", "Colour & Gesture"],
   ["BMI160", "/components/sensor/bmi160/", "bmi160.jpg", "Accelerometer & Gyroscope"],
+  ["BMI270", "/components/sensor/bmi270/", "imu.svg", "Accelerometer & Gyroscope", "dark-invert"],
   ["LD2410", "/components/sensor/ld2410/", "ld2410.jpg", "Motion & Presence"],
   ["LD2412", "/components/sensor/ld2412/", "ld2412.jpg", "Motion & Presence"],
   ["LD2420", "/components/sensor/ld2420/", "ld2420.jpg", "Motion & Presence"],
@@ -932,6 +932,7 @@ Used for creating infrared (IR) remote control transmitters and/or receivers.
 
 <ImgTable items={[
     ["Motion (IMU)", "/components/motion/", "imu.svg", "dark-invert"],
+    ["BMI270", "/components/motion/bmi270/", "imu.svg", "Accelerometer & Gyroscope", "dark-invert"],
 ]} />
 
 ## Number Components

--- a/src/content/docs/components/index.mdx
+++ b/src/content/docs/components/index.mdx
@@ -931,8 +931,8 @@ Used for creating infrared (IR) remote control transmitters and/or receivers.
 ## Motion Components
 
 <ImgTable items={[
-    ["Motion (IMU)", "/components/motion/", "imu.svg", "dark-invert"],
     ["BMI270", "/components/motion/bmi270/", "imu.svg", "Accelerometer & Gyroscope", "dark-invert"],
+    ["Motion (IMU)", "/components/motion/", "imu.svg", "dark-invert"],
 ]} />
 
 ## Number Components

--- a/src/content/docs/components/index.mdx
+++ b/src/content/docs/components/index.mdx
@@ -531,7 +531,7 @@ Sensors are organized into categories; if a given sensor fits into more than one
 <ImgTable items={[
   ["APDS9960", "/components/sensor/apds9960/", "apds9960.jpg", "Colour & Gesture"],
   ["BMI160", "/components/sensor/bmi160/", "bmi160.jpg", "Accelerometer & Gyroscope"],
-  ["BMI270", "/components/sensor/bmi270/", "imu.svg", "Accelerometer & Gyroscope", "dark-invert"],
+  ["BMI270", "/components/motion/bmi270/", "imu.svg", "Accelerometer & Gyroscope", "dark-invert"],
   ["LD2410", "/components/sensor/ld2410/", "ld2410.jpg", "Motion & Presence"],
   ["LD2412", "/components/sensor/ld2412/", "ld2412.jpg", "Motion & Presence"],
   ["LD2420", "/components/sensor/ld2420/", "ld2420.jpg", "Motion & Presence"],

--- a/src/content/docs/components/motion/bmi270.mdx
+++ b/src/content/docs/components/motion/bmi270.mdx
@@ -19,7 +19,7 @@ sensor. It requires an internal configuration blob to be uploaded at each power-
 # Example configuration entry
 motion:
   - platform: bmi270
-    acceleration_range: 4G
+    accelerometer_range: 4G
     gyroscope_range: 2000DPS
 
 sensor:

--- a/src/content/docs/components/motion/bmi270.mdx
+++ b/src/content/docs/components/motion/bmi270.mdx
@@ -1,0 +1,55 @@
+---
+description: "Instructions for setting up BMI270 Accelerometer/Gyroscope sensors."
+title: "BMI270 Accelerometer/Gyroscope Sensor"
+---
+
+import APIRef from '@components/APIRef.astro';
+
+The `bmi270` motion platform allows you to use your BMI270 Accelerometer/Gyroscope
+([datasheet](https://www.bosch-sensortec.com/media/boschsensortec/downloads/datasheets/bst-bmi270-ds000.pdf))
+sensors with ESPHome. The [I²C Bus](/components/i2c) is required to be set up in
+your configuration for this sensor to work.
+
+The BMI270 is an ultra-low-power IMU optimized for wearable applications. It includes
+a 16-bit 3-axis accelerometer and a 16-bit 3-axis gyroscope, plus an on-chip temperature
+sensor. It requires an internal configuration blob to be uploaded at each power-on
+(handled automatically by this component).
+
+```yaml
+# Example configuration entry
+motion:
+  - platform: bmi270
+    acceleration_range: 4G
+    gyroscope_range: 2000DPS
+
+sensor:
+  - platform: motion
+    type: acceleration_x
+    name: "BMI270 Accel X"
+  - platform: motion
+    type: gyroscope_x
+    name: "BMI270 Gyro X"
+  - platform: motion
+    type: roll
+    name: "BMI270 Roll"
+```
+
+## Configuration variables
+
+- **address** (*Optional*, int): Manually specify the I²C address of the sensor. Defaults to `0x68`.
+  The BMI270 supports `0x68` (SDO to GND) and `0x69` (SDO to VDDIO).
+- **accelerometer_range** (*Optional*, string): The full-scale range of the accelerometer. One of
+  `2G`, `4G`, `8G`, `16G`. Defaults to `4G`.
+- **accelerometer_odr** (*Optional*, string): The output data rate of the accelerometer. One of
+  `12_5HZ`, `25HZ`, `50HZ`, `100HZ`, `200HZ`, `400HZ`, `800HZ`, `1600HZ`. Defaults to `100HZ`.
+- **gyroscope_range** (*Optional*, string): The full-scale range of the gyroscope. One of
+  `125DPS`, `250DPS`, `500DPS`, `1000DPS`, `2000DPS`. Defaults to `2000DPS`.
+- **gyroscope_odr** (*Optional*, string): The output data rate of the gyroscope. One of
+  `25HZ`, `50HZ`, `100HZ`, `200HZ`, `400HZ`, `800HZ`, `1600HZ`, `3200HZ`. Defaults to `200HZ`.
+
+- All other options from [Motion](/components/motion).
+
+## See Also
+
+- [BMI270 Temperature Sensor](/components/sensor/bmi270/)
+- <APIRef text="bmi270.h" path="bmi270/bmi270.h" />

--- a/src/content/docs/components/motion/index.mdx
+++ b/src/content/docs/components/motion/index.mdx
@@ -193,4 +193,5 @@ entry with the resulting matrix in a format suitable for copy-pasting into your 
 ## See Also
 
 - [Sensor Filters](/components/sensor#sensor-filters)
+- [BMI270 Accelerometer/Gyroscope platform](/components/motion/bmi270/)
 - <APIRef text="motion_component.h" path="motion/motion_component.h" />

--- a/src/content/docs/components/sensor/bmi270.mdx
+++ b/src/content/docs/components/sensor/bmi270.mdx
@@ -1,0 +1,30 @@
+---
+description: "Instructions for setting up BMI270 temperature sensor."
+title: "BMI270 Temperature Sensor"
+---
+
+The `bmi270` sensor platform provides access to the temperature sensor in a BMI270 Accelerometer/Gyroscope
+([datasheet](https://www.bosch-sensortec.com/media/boschsensortec/downloads/datasheets/bst-bmi270-ds000.pdf)) with ESPHome.
+It requires a [`motion`](/components/motion) component to be configured with the `bmi270` platform,
+which handles the accelerometer and gyroscope data processing and configures the device. See that component for more information.
+
+```yaml
+# Example configuration entry
+motion:
+  - platform: bmi270
+
+sensor:
+  - platform: bmi270
+    type: temperature # Optional, temperature is the only supported type for this platform
+    name: "BMI270 Temperature"
+```
+
+## Configuration variables
+
+- **type** (*Optional*, string): Must be set to `temperature`, or simply omitted.
+- All other options from [Sensor](/components/sensor).
+
+## See Also
+
+- [Sensor Filters](/components/sensor#sensor-filters)
+- [BMI270 Accelerometer/Gyroscope platform](/components/motion/bmi270/)


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#16202

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
