### PR TITLE
Revise report option details for Zigbee component

### DIFF
--- a/src/content/docs/components/zigbee.mdx
+++ b/src/content/docs/components/zigbee.mdx
@@ -126,13 +126,13 @@ Zigbee can have some overrides for specific options.
 
 Only on `ESP32`:
 
-- **report** (*Optional*, enum): Report the state. One of `coordinator`, `enable`, `force`. `coordinator` uses the configuration from
-  the coordinator, `enable` activates reporting with default settings and uses the configuration from the coordinator if possible.
-  `force` ignores the coordinator configuration and reports every change. On `nRF52` the coordinator configuration is always used.
-  Defaults to `coordinator`.
+- **report** (*Optional*, enum): How the state is reported. One of `default` or `force`. `default` activates reporting with default settings
+  and uses the configuration from the coordinator if possible. `force` sends manual reports for every change to the coordinator.
+  On `nRF52` the coordinator configuration is always used.
+  Defaults to `default`.
 
 > [!NOTE]
-> ZHA sets the minimum reporting interval to 30 seconds for most sensor devices. If you need faster responses set `report` to `force`.
+> ZHA sets the minimum reporting interval to 30 seconds for some sensor devices. If a faster response is needed set `report` to `force`.
 
 
 ## Supported Components


### PR DESCRIPTION
Updated the 'report' option description for Zigbee on ESP32 to clarify its functionality and default settings.

<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#16869

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.