### PR TITLE
[esp32] Document ESP-IDF as the default toolchain

### DIFF
--- a/src/content/docs/components/esp32.mdx
+++ b/src/content/docs/components/esp32.mdx
@@ -271,14 +271,14 @@ Currently supported toolchains include:
 - `esp-idf` (default)
 - `platformio`
 
+By default, ESPHome uses its native ESP-IDF integration, including automatic framework installation and environment management as described in this [documentation](/guides/esp_idf/).
+
 **Example for using the PlatformIO toolchain:**
 
 ```yaml
 esp32:
   toolchain: platformio
 ```
-
-When `esp-idf` is selected, ESPHome uses its native ESP-IDF integration, including automatic framework installation and environment management as described in this [documentation](/guides/esp_idf/).
 
 You can also select the toolchain via the [CLI](/guides/cli#cli-toolchain):
 

--- a/src/content/docs/components/esp32.mdx
+++ b/src/content/docs/components/esp32.mdx
@@ -268,14 +268,14 @@ ESPHome supports multiple toolchains for building firmware. The toolchain determ
 
 Currently supported toolchains include:
 
-- `platformio` (default)
-- `esp-idf`
+- `esp-idf` (default)
+- `platformio`
 
-**Example for using ESP-IDF toolchain:**
+**Example for using the PlatformIO toolchain:**
 
 ```yaml
 esp32:
-  toolchain: esp-idf
+  toolchain: platformio
 ```
 
 When `esp-idf` is selected, ESPHome uses its native ESP-IDF integration, including automatic framework installation and environment management as described in this [documentation](/guides/esp_idf/).
@@ -283,10 +283,10 @@ When `esp-idf` is selected, ESPHome uses its native ESP-IDF integration, includi
 You can also select the toolchain via the [CLI](/guides/cli#cli-toolchain):
 
 ```bash
-esphome --toolchain esp-idf compile my_device.yaml
+esphome --toolchain platformio compile my_device.yaml
 ```
 
-If not specified, `platformio` is used by default.
+If not specified, `esp-idf` is used by default.
 If both `esp32.toolchain` and the `--toolchain` CLI option are set, the CLI option takes precedence.
 
 <span id="esp32-framework"></span>

--- a/src/content/docs/guides/cli.mdx
+++ b/src/content/docs/guides/cli.mdx
@@ -60,11 +60,11 @@ Please see [command line substitutions](/components/substitutions#command-line-s
 **`--toolchain TOOLCHAIN`**
 : Selects which toolchain to use for compiling the project. Supported values are:
 
-* `esp-idf` (default)
+* `esp-idf` (ESP32 only)
 * `platformio`
 
 The toolchain can be configured using `esp32.toolchain` (see the [ESP32 toolchain configuration](/components/esp32#esp32-toolchain)).
-If not specified, `esp-idf` is used by default.
+If not specified, ESP32 devices default to `esp-idf`; all other platforms use `platformio`.
 If both `esp32.toolchain` and the `--toolchain` CLI option are set, the CLI option takes precedence.
 
 Please see [ESP-IDF toolchain documentation](/guides/esp_idf/) for details on using the ESP-IDF integration.

--- a/src/content/docs/guides/cli.mdx
+++ b/src/content/docs/guides/cli.mdx
@@ -60,11 +60,11 @@ Please see [command line substitutions](/components/substitutions#command-line-s
 **`--toolchain TOOLCHAIN`**
 : Selects which toolchain to use for compiling the project. Supported values are:
 
-* `platformio` (default)
-* `esp-idf`
+* `esp-idf` (default)
+* `platformio`
 
 The toolchain can be configured using `esp32.toolchain` (see the [ESP32 toolchain configuration](/components/esp32#esp32-toolchain)).
-If not specified, `platformio` is used by default.
+If not specified, `esp-idf` is used by default.
 If both `esp32.toolchain` and the `--toolchain` CLI option are set, the CLI option takes precedence.
 
 Please see [ESP-IDF toolchain documentation](/guides/esp_idf/) for details on using the ESP-IDF integration.


### PR DESCRIPTION
## Description:

Updates the toolchain docs for the default flip from `platformio` to `esp-idf` (esphome/esphome#16910):

- `components/esp32.mdx`: toolchain list now marks `esp-idf` as the default; the explicit-selection example shows `toolchain: platformio` instead (selecting the default explicitly is no longer interesting); "If not specified" sentence updated.
- `guides/cli.mdx`: same default/list update for the `--toolchain` option.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#16910

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.