### PR TITLE
[motion] Fix Motion Core component index entry

### DIFF
--- a/src/content/docs/components/index.mdx
+++ b/src/content/docs/components/index.mdx
@@ -933,9 +933,9 @@ Used for creating infrared (IR) remote control transmitters and/or receivers.
 ## Motion Components
 
 <ImgTable items={[
-    ["Motion Core", "/components/motion/", "imu.svg", "IMU", "dark-invert"],
-    ["BMI270", "/components/motion/bmi270/", "imu.svg", "Accelerometer & Gyroscope", "dark-invert"],
-    ["LSM6DS", "/components/motion/lsm6ds/", "imu.svg", "Accelerometer & Gyroscope", "dark-invert"],
+  ["Motion Core", "/components/motion/", "imu.svg", "IMU", "dark-invert"],
+  ["BMI270", "/components/motion/bmi270/", "imu.svg", "Accelerometer & Gyroscope", "dark-invert"],
+  ["LSM6DS", "/components/motion/lsm6ds/", "imu.svg", "Accelerometer & Gyroscope", "dark-invert"],
 ]} />
 
 ## Number Components

--- a/src/content/docs/components/index.mdx
+++ b/src/content/docs/components/index.mdx
@@ -933,9 +933,9 @@ Used for creating infrared (IR) remote control transmitters and/or receivers.
 ## Motion Components
 
 <ImgTable items={[
+    ["Motion Core", "/components/motion/", "imu.svg", "IMU", "dark-invert"],
     ["BMI270", "/components/motion/bmi270/", "imu.svg", "Accelerometer & Gyroscope", "dark-invert"],
     ["LSM6DS", "/components/motion/lsm6ds/", "imu.svg", "Accelerometer & Gyroscope", "dark-invert"],
-    ["Motion (IMU)", "/components/motion/", "imu.svg", "dark-invert"],
 ]} />
 
 ## Number Components


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Fix the Motion Core entry in the Motion Components table to be consistent with others.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [x] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.