### PR TITLE
[script] Move lint.mjs into script/ folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "astro build",
     "preview": "astro preview",
     "serve": "astro build && astro preview --host",
-    "lint": "node lint.mjs",
+    "lint": "node script/lint.mjs",
     "lint:js": "eslint .",
     "format": "prettier --write \"**/*.{ts,tsx,js,mjs,cjs,astro,css}\"",
     "format:check": "prettier --check \"**/*.{ts,tsx,js,mjs,cjs,astro,css}\""

--- a/script/lint.mjs
+++ b/script/lint.mjs
@@ -115,13 +115,13 @@ async function checkFileExtension(fname) {
       fname,
       1,
       1,
-      "This file extension is not a registered file type. If this is an error, please update lint.mjs.",
+      "This file extension is not a registered file type. If this is an error, please update script/lint.mjs.",
     );
   }
 }
 
 async function checkExecutableBit(fname, gitMode) {
-  const exclude = ["script/", ".devcontainer/", "lint.py", "lint.mjs"];
+  const exclude = ["script/", ".devcontainer/", "lint.py"];
   if (exclude.some((ex) => fname.startsWith(ex) || fname === ex)) {
     return;
   }
@@ -203,7 +203,7 @@ function checkEsphomeLinks(fname, content) {
 // Build anchor cache for link validation
 async function buildAnchorCache() {
   const cache = new Map();
-  const contentDir = join(__dirname, "src/content/docs");
+  const contentDir = join(__dirname, "..", "src/content/docs");
 
   try {
     await stat(contentDir);

--- a/script/lint.mjs
+++ b/script/lint.mjs
@@ -121,7 +121,7 @@ async function checkFileExtension(fname) {
 }
 
 async function checkExecutableBit(fname, gitMode) {
-  const exclude = ["script/", ".devcontainer/", "lint.py"];
+  const exclude = ["script/", ".devcontainer/"];
   if (exclude.some((ex) => fname.startsWith(ex) || fname === ex)) {
     return;
   }


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Move the documentation linter `lint.mjs` from the repo root into the `script/` folder alongside the other repo scripts (`check_urls.mjs`, `seo_audit.mjs`, etc.). Adjusted the content-dir resolution to account for the new directory depth, updated the `npm run lint` script path in `package.json`, and dropped the now-redundant `lint.mjs`/`lint.py` entries from the executable-bit exclude list (the `script/` prefix already covers the relocated file, and `lint.py` no longer exists).

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** N/A

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.