### PR TITLE
[esp32] Document flash_mode and flash_frequency options

### DIFF
--- a/src/content/docs/components/esp32.mdx
+++ b/src/content/docs/components/esp32.mdx
@@ -35,6 +35,11 @@ esp32:
   `4MB`, `8MB`, `16MB` or `32MB`. Defaults to `4MB`. **Warning: specifying a size larger than that available
   on your board will cause the ESP32 to fail to boot.**
 
+- **flash_mode** (*Optional*, string): The SPI mode used to access the flash chip. One of `qio`, `qout`, `dio`,
+  `dout` or `opi` (octal flash chips only). When not set, the board definition (PlatformIO) or the ESP-IDF
+  default decides. **Warning: specifying a mode your flash chip does not support will cause the ESP32 to fail
+  to boot.**
+
 - **cpu_frequency** (*Optional*, string): The CPU frequency to use. Defaults to the maximum supported
   frequency for the variant. The allowed values depend on the variant:
 

--- a/src/content/docs/components/esp32.mdx
+++ b/src/content/docs/components/esp32.mdx
@@ -40,6 +40,11 @@ esp32:
   default decides. **Warning: specifying a mode your flash chip does not support will cause the ESP32 to fail
   to boot.**
 
+- **flash_frequency** (*Optional*, string): The SPI frequency used to access the flash chip, for example `80MHz`
+  or `40MHz`. The supported values depend on the variant and are checked at build time. When not set, the board
+  definition (PlatformIO) or the ESP-IDF default decides. **Warning: specifying a frequency your flash chip does
+  not support will cause the ESP32 to fail to boot.**
+
 - **cpu_frequency** (*Optional*, string): The CPU frequency to use. Defaults to the maximum supported
   frequency for the variant. The allowed values depend on the variant:
 


### PR DESCRIPTION
## Description:

Documents the new `esp32.flash_mode` and `esp32.flash_frequency` options, which select the SPI flash access mode (`qio`/`qout`/`dio`/`dout`/`opi`) and frequency (e.g. `80MHz`) and work on both the PlatformIO and native ESP-IDF backends.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#16920

## Checklist:

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.