### PR TITLE
2026.6.0b2

### DIFF
--- a/data/version.yaml
+++ b/data/version.yaml
@@ -1,2 +1,2 @@
-release: 2026.6.0b1
+release: 2026.6.0b2
 version: '2026.6'

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "CC-BY-4.0",
       "dependencies": {
         "@astrojs/starlight": "^0.39.3",
-        "astro": "^6.4.4",
+        "astro": "^6.4.6",
         "katex": "^0.17.0",
         "micromark": "^4.0.2",
         "rehype-katex": "^7.0.1",
@@ -2721,9 +2721,9 @@
       }
     },
     "node_modules/astro": {
-      "version": "6.4.4",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-6.4.4.tgz",
-      "integrity": "sha512-hVe8tq3lqt/Dr0UyB//yUmQSlHMTU8scTiF/vQddQVahLE4TTaSdH5H0nb7OvRcwo0UmlAO8DWYar4jNaS7H+A==",
+      "version": "6.4.6",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-6.4.6.tgz",
+      "integrity": "sha512-48OBTBKR9ctbf+DQxpOuxGl8ebfn59zTuNQMBzptmG/Mi/H8IdfMSbJgGuX1I/4U6g9yazG1p4BHlf4+2hWU4Q==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/compiler": "^4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "eslint-plugin-astro": "^1.7.0",
         "globals": "^17.6.0",
         "jsdom": "^29.1.1",
-        "prettier": "^3.8.3",
+        "prettier": "^3.8.4",
         "prettier-plugin-astro": "^0.14.1",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.60.1"
@@ -6787,9 +6787,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
-      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
+      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@astrojs/starlight": "^0.39.3",
-    "astro": "^6.4.4",
+    "astro": "^6.4.6",
     "katex": "^0.17.0",
     "micromark": "^4.0.2",
     "rehype-katex": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "astro build",
     "preview": "astro preview",
     "serve": "astro build && astro preview --host",
-    "lint": "node lint.mjs",
+    "lint": "node script/lint.mjs",
     "lint:js": "eslint .",
     "format": "prettier --write \"**/*.{ts,tsx,js,mjs,cjs,astro,css}\"",
     "format:check": "prettier --check \"**/*.{ts,tsx,js,mjs,cjs,astro,css}\""

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "eslint-plugin-astro": "^1.7.0",
     "globals": "^17.6.0",
     "jsdom": "^29.1.1",
-    "prettier": "^3.8.3",
+    "prettier": "^3.8.4",
     "prettier-plugin-astro": "^0.14.1",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.60.1"

--- a/script/generate_release_notes.py
+++ b/script/generate_release_notes.py
@@ -346,8 +346,11 @@ class ReleaseNotesGenerator:
         """Extract PR numbers from commits between two refs"""
         print(f"Comparing {base_ref}...{head_ref}")
 
-        # Use --paginate with --jq to get all commit messages across all pages
-        # This automatically handles pagination and extracts just what we need
+        # Use --paginate with --jq to get all commit subjects across all pages.
+        # Only the first line of each commit message is used: GitHub appends the
+        # merged PR number as a trailing "(#1234)" on the subject line. Scanning
+        # the body would wrongly pick up issue references (e.g. "Fixes #16420")
+        # and other PR mentions, which are not PRs merged in this range.
         result = subprocess.run(
             [
                 "gh",
@@ -355,23 +358,26 @@ class ReleaseNotesGenerator:
                 f"repos/esphome/esphome/compare/{base_ref}...{head_ref}",
                 "--paginate",
                 "--jq",
-                ".commits[].commit.message",
+                '.commits[].commit.message | split("\\n")[0]',
             ],
             capture_output=True,
             text=True,
             check=True,
         )
 
-        # Each line is a commit message
-        commit_messages = [line for line in result.stdout.strip().split("\n") if line]
+        # One subject line per commit
+        commit_subjects = [line for line in result.stdout.strip().split("\n") if line]
 
-        print(f"Found {len(commit_messages)} commits")
+        print(f"Found {len(commit_subjects)} commits")
 
         pr_numbers = set()
-        for message in commit_messages:
-            # Extract PR numbers from patterns like (#12345)
-            matches = re.findall(r"\(#(\d+)\)", message)
-            pr_numbers.update(int(m) for m in matches)
+        for subject in commit_subjects:
+            # Take the trailing "(#1234)" that GitHub appends on squash merge.
+            # Using the last match also handles reverts like
+            # 'Revert "[x] foo (#123)" (#456)', where #456 is the actual PR.
+            matches = re.findall(r"\(#(\d+)\)", subject)
+            if matches:
+                pr_numbers.add(int(matches[-1]))
 
         return sorted(pr_numbers)
 

--- a/script/lint.mjs
+++ b/script/lint.mjs
@@ -115,13 +115,13 @@ async function checkFileExtension(fname) {
       fname,
       1,
       1,
-      "This file extension is not a registered file type. If this is an error, please update lint.mjs.",
+      "This file extension is not a registered file type. If this is an error, please update script/lint.mjs.",
     );
   }
 }
 
 async function checkExecutableBit(fname, gitMode) {
-  const exclude = ["script/", ".devcontainer/", "lint.py", "lint.mjs"];
+  const exclude = ["script/", ".devcontainer/"];
   if (exclude.some((ex) => fname.startsWith(ex) || fname === ex)) {
     return;
   }
@@ -203,7 +203,7 @@ function checkEsphomeLinks(fname, content) {
 // Build anchor cache for link validation
 async function buildAnchorCache() {
   const cache = new Map();
-  const contentDir = join(__dirname, "src/content/docs");
+  const contentDir = join(__dirname, "..", "src/content/docs");
 
   try {
     await stat(contentDir);

--- a/src/components/LightEffectPreview.astro
+++ b/src/components/LightEffectPreview.astro
@@ -42,6 +42,90 @@ const STRIP_TYPES: ReadonlySet<EffectType> = new Set([
 
 const isStrip = STRIP_TYPES.has(type);
 const PIXEL_COUNT = 20;
+
+// The scan and fireworks previews need motion a single shared keyframe cannot express:
+// the scan's dot lights each pixel at two different phases (out and back), and the
+// fireworks sparks bloom into their neighbours. Rather than animate from client-side JS,
+// we generate per-pixel @keyframes here at build time, so the rendered page stays pure CSS.
+// Each scan/fireworks preview injects its own block; the light page uses a single instance of
+// each, so the keyframes appear once. Repeating the same effect on one page would duplicate them.
+
+type Rgb = [number, number, number];
+
+// Bouncing single-pixel sweep: the dot steps 0 -> last -> 0 at a constant rate (no easing).
+function buildScanCss(pixels: number): string {
+  const steps = 2 * (pixels - 1); // one full out-and-back trip
+  const pct = (step: number): string => ((step / steps) * 100).toFixed(3);
+  const frames: string[] = [];
+  const assignments: string[] = [];
+  for (let i = 0; i < pixels; i++) {
+    // The dot covers pixel i on the way out (step i) and on the way back (step steps - i).
+    const onSteps = Array.from(new Set([i, (steps - i) % steps])).sort((a, b) => a - b);
+    const stops = ["0% { background: #000; }"];
+    for (const s of onSteps) {
+      stops.push(`${pct(s)}% { background: #ffd24a; }`);
+      stops.push(`${pct(s + 1)}% { background: #000; }`);
+    }
+    frames.push(`@keyframes fx-scan-${i} { ${stops.join(" ")} }`);
+    assignments.push(`.fx-scan .fx-pixel:nth-child(${i + 1}) { animation: fx-scan-${i} 3s step-end infinite; }`);
+  }
+  return `${frames.join("\n")}\n@media (prefers-reduced-motion: no-preference) {\n${assignments.join("\n")}\n}`;
+}
+
+// Predetermined fireworks: a fixed list of sparks, each blooming outward and fading.
+const FIREWORKS: { time: number; center: number; color: Rgb }[] = [
+  { time: 0.02, center: 4, color: [255, 56, 96] },
+  { time: 0.16, center: 12, color: [255, 210, 74] },
+  { time: 0.3, center: 7, color: [32, 156, 238] },
+  { time: 0.45, center: 16, color: [35, 209, 96] },
+  { time: 0.6, center: 2, color: [180, 120, 255] },
+  { time: 0.74, center: 10, color: [61, 240, 224] },
+  { time: 0.88, center: 18, color: [255, 74, 210] },
+];
+
+// Deterministic jitter in [0.85, 1.15] so each dot in a bloom fades slightly differently.
+function fireworkJitter(pixel: number, spark: number): number {
+  const v = Math.sin((pixel + 1) * 12.9898 + (spark + 1) * 78.233) * 43758.5453;
+  return 0.85 + 0.3 * (v - Math.floor(v));
+}
+
+function buildFireworksCss(pixels: number): string {
+  const bloomRadius = 2;
+  const drop = 0.5; // brightness falloff per pixel away from the spark centre
+  const cascade = 1.2; // % of loop the bloom takes to reach each successive neighbour
+  const fadeBase = 11; // % of loop for a centre dot to fade to black
+  const rise = 0.4; // % of loop for the near-instant flash on
+  const frames: string[] = [];
+  const assignments: string[] = [];
+  for (let p = 0; p < pixels; p++) {
+    const stops: { at: number; color: string }[] = [{ at: 0, color: "#000" }];
+    FIREWORKS.forEach((spark, index) => {
+      const distance = Math.abs(p - spark.center);
+      if (distance > bloomRadius) return;
+      const level = Math.pow(drop, distance);
+      const [r, g, b] = spark.color;
+      const color = `rgb(${Math.round(r * level)}, ${Math.round(g * level)}, ${Math.round(b * level)})`;
+      const onset = spark.time * 100 + distance * cascade;
+      const fade = fadeBase * (1 + distance * 0.5) * fireworkJitter(p, index);
+      stops.push({ at: Math.max(0, onset - rise), color: "#000" });
+      stops.push({ at: onset, color });
+      stops.push({ at: Math.min(100, onset + fade), color: "#000" });
+    });
+    stops.push({ at: 100, color: "#000" });
+    stops.sort((a, b) => a.at - b.at);
+    const body = stops.map((stop) => `${stop.at.toFixed(2)}% { background: ${stop.color}; }`).join(" ");
+    frames.push(`@keyframes fx-fw-${p} { ${body} }`);
+    assignments.push(`.fx-fireworks .fx-pixel:nth-child(${p + 1}) { animation: fx-fw-${p} 5s linear infinite; }`);
+  }
+  return `${frames.join("\n")}\n@media (prefers-reduced-motion: no-preference) {\n${assignments.join("\n")}\n}`;
+}
+
+let dynamicCss = "";
+if (type === "scan") {
+  dynamicCss = buildScanCss(PIXEL_COUNT);
+} else if (type === "fireworks") {
+  dynamicCss = buildFireworksCss(PIXEL_COUNT);
+}
 ---
 
 <span class:list={["fx-preview", `fx-${type}`]} role="img" aria-label={label}>
@@ -57,6 +141,8 @@ const PIXEL_COUNT = 20;
     )
   }
 </span>
+
+{dynamicCss && <style is:inline set:html={dynamicCss} />}
 
 <style>
   .fx-preview {
@@ -345,29 +431,9 @@ const PIXEL_COUNT = 20;
     }
   }
 
-  .fx-scan .fx-strip {
-    position: relative;
-  }
+  /* Scan: a single lit pixel bounced across the strip (keyframes generated in frontmatter). */
   .fx-scan .fx-pixel {
     background: #000;
-  }
-  .fx-scan .fx-strip::after {
-    content: "";
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 6px;
-    height: 100%;
-    background: #ffd24a;
-    animation: fx-scan 1.6s ease-in-out infinite alternate;
-  }
-  @keyframes fx-scan {
-    from {
-      transform: translateX(0);
-    }
-    to {
-      transform: translateX(133px);
-    }
   }
 
   .fx-twinkle .fx-pixel {
@@ -458,32 +524,9 @@ const PIXEL_COUNT = 20;
     }
   }
 
+  /* Fireworks: blooming/fading sparks (keyframes generated in frontmatter). */
   .fx-fireworks .fx-pixel {
     background: #000;
-    animation: fx-fireworks 2.4s ease-out infinite;
-  }
-  .fx-fireworks .fx-pixel:nth-child(4n) {
-    animation-delay: 0s;
-  }
-  .fx-fireworks .fx-pixel:nth-child(4n + 1) {
-    animation-delay: 0.6s;
-  }
-  .fx-fireworks .fx-pixel:nth-child(4n + 2) {
-    animation-delay: 1.2s;
-  }
-  .fx-fireworks .fx-pixel:nth-child(4n + 3) {
-    animation-delay: 1.8s;
-  }
-  @keyframes fx-fireworks {
-    0% {
-      background: #000;
-    }
-    5% {
-      background: #fff;
-    }
-    100% {
-      background: #000;
-    }
   }
 
   .fx-addr-flicker .fx-pixel {
@@ -597,10 +640,6 @@ const PIXEL_COUNT = 20;
     .fx-color-wipe .fx-pixel:nth-child(-n + 10) {
       background: #209cee;
     }
-    .fx-scan .fx-strip::after {
-      display: none;
-    }
-    .fx-scan .fx-pixel:nth-child(5),
     .fx-scan .fx-pixel:nth-child(6) {
       background: #ffd24a;
     }
@@ -616,8 +655,26 @@ const PIXEL_COUNT = 20;
     .fx-random-twinkle .fx-pixel:nth-child(3n + 2) {
       background: #ffd24a;
     }
-    .fx-fireworks .fx-pixel:nth-child(4n) {
-      background: #fff;
+    .fx-fireworks .fx-pixel:nth-child(5) {
+      background: #ff3860;
+    }
+    .fx-fireworks .fx-pixel:nth-child(4),
+    .fx-fireworks .fx-pixel:nth-child(6) {
+      background: #5e1320;
+    }
+    .fx-fireworks .fx-pixel:nth-child(8) {
+      background: #209cee;
+    }
+    .fx-fireworks .fx-pixel:nth-child(7),
+    .fx-fireworks .fx-pixel:nth-child(9) {
+      background: #0c3a57;
+    }
+    .fx-fireworks .fx-pixel:nth-child(17) {
+      background: #23d160;
+    }
+    .fx-fireworks .fx-pixel:nth-child(16),
+    .fx-fireworks .fx-pixel:nth-child(18) {
+      background: #0d4d24;
     }
     .fx-addr-flicker .fx-pixel {
       opacity: 0.9;

--- a/src/content/docs/changelog/2026.6.0.mdx
+++ b/src/content/docs/changelog/2026.6.0.mdx
@@ -537,6 +537,16 @@ For detailed migration guides and API documentation, see the
 - [dmsr] [breaking] Fix decryption that uses custom auth key. Add CRC to telegram sensor. Automatic hex string detection in equipment_id fields. Support EON Hungary smart meters [esphome#16561](https://github.com/esphome/esphome/pull/16561) by [@PolarGoose](https://github.com/PolarGoose) (breaking-change)
 - [dlms_meter] dlms_parser library [esphome#15458](https://github.com/esphome/esphome/pull/15458) by [@Tomer27cz](https://github.com/Tomer27cz) (new-feature) (breaking-change) (new-platform)
 
+### Beta Changes
+
+- [esp8266] Decode crash handler PC and backtrace in logs [esphome#16911](https://github.com/esphome/esphome/pull/16911) by [@bdraco](https://github.com/bdraco)
+- [spi] Skip logging on begin_transaction() of an auto-releasing write-only SPI device [esphome#16921](https://github.com/esphome/esphome/pull/16921) by [@tjakubo](https://github.com/tjakubo)
+- [lvgl] Fix schema extraction  [esphome#16895](https://github.com/esphome/esphome/pull/16895) by [@clydebarrow](https://github.com/clydebarrow)
+- [mipi_spi] Implement automatic mapping of offsets [esphome#16722](https://github.com/esphome/esphome/pull/16722) by [@clydebarrow](https://github.com/clydebarrow)
+- [esp32] Fix idedata generation failing on unset ESPHOME_ARDUINO [esphome#16925](https://github.com/esphome/esphome/pull/16925) by [@swoboda1337](https://github.com/swoboda1337)
+- [core] Support platformio_options on the native ESP-IDF toolchain [esphome#16917](https://github.com/esphome/esphome/pull/16917) by [@swoboda1337](https://github.com/swoboda1337)
+- [esp32] Add flash_mode and flash_frequency config options [esphome#16920](https://github.com/esphome/esphome/pull/16920) by [@swoboda1337](https://github.com/swoboda1337) (new-feature)
+
 ### All changes
 
 <details>

--- a/src/content/docs/components/display/mipi_spi.mdx
+++ b/src/content/docs/components/display/mipi_spi.mdx
@@ -77,6 +77,7 @@ the pins used to interface to the display to be specified.
 | WAVESHARE-4-TFT                      | Waveshare | [https://www.waveshare.com/4inch-tft-touch-shield.htm](https://www.waveshare.com/4inch-tft-touch-shield.htm) |
 | PICO-RESTOUCH-LCD-3.5                | Waveshare | [https://www.waveshare.com/pico-restouch-lcd-3.5.htm](https://www.waveshare.com/pico-restouch-lcd-3.5.htm) |
 | WAVESHARE-ESP32-C6-LCD-1.47          | Waveshare | [https://www.waveshare.com/wiki/ESP32-C6-LCD-1.47](https://www.waveshare.com/wiki/ESP32-C6-LCD-1.47) |
+| WAVESHARE-ESP32-S3-GEEK              | Waveshare | [https://www.waveshare.com/esp32-s3-geek.htm](https://www.waveshare.com/esp32-s3-geek.htm) |
 | WAVESHARE-ESP32-S3-TOUCH-AMOLED-1.75 | Waveshare | [https://www.waveshare.com/esp32-s3-touch-amoled-1.75.htm](https://www.waveshare.com/esp32-s3-touch-amoled-1.75.htm) |
 | WAVESHARE-ESP32-S3-TOUCH-AMOLED-2.16 | Waveshare | [https://www.waveshare.com/esp32-s3-touch-amoled-2.16.htm](https://www.waveshare.com/esp32-s3-touch-amoled-2.16.htm) |
 | WAVESHARE-ESP32-S3-TOUCH-LCD-3.49    | Waveshare | [https://www.waveshare.com/esp32-s3-touch-lcd-3.49.htm](https://www.waveshare.com/esp32-s3-touch-lcd-3.49.htm) |
@@ -85,6 +86,8 @@ the pins used to interface to the display to be specified.
 | ESP32-2432S028                       | Sunton       | 2.8" CYD. Original micro-USB version with ILI9341 controller.     |
 | ESP32-2432S028-7789                  | Sunton       | Dual-USB version with ST7789V.                                    |
 | ESP32-2432S028-9342                  | Sunton       | Dual-USB version with ILI9342.                                    |
+| GEEKMAGIC-SMALLTV                    | GeekMagic    | [https://geekmagic.com/products/geekmagic-ultra-4](https://geekmagic.com/products/geekmagic-ultra-4) |
+| GEEKMAGIC-SMALLTV-PRO                | GeekMagic    | [https://geekmagic.com/products/geekmagic-ultra](https://geekmagic.com/products/geekmagic-ultra) |
 | JC3248W535                           | Guition | [https://www.aliexpress.com/item/1005007566332450.html](https://www.aliexpress.com/item/1005007566332450.html) |
 | JC3636W518                           | Guition | [https://www.aliexpress.com/item/1005007890666293.html](https://www.aliexpress.com/item/1005007890666293.html) |
 | JC3636W518V2                         | Guition | [https://www.aliexpress.com/item/1005007890666293.html](https://www.aliexpress.com/item/1005007890666293.html) |
@@ -139,6 +142,8 @@ most of the configuration will be set by default, but can be overridden if neede
   - **width** (**Required**, int): Specifies width of display.
   - **offset_width** (*Optional*, int): Specify an offset for the x-direction of the display, typically used when an LCD is smaller than the maximum supported by the driver chip. Default is 0
   - **offset_height** (*Optional*, int): Specify an offset for the y-direction of the display. Default is 0.
+  - **pad_width** (*Optional*, int): Specify additional pixels recognized by the controller after the offset and width. This represents pixels on the right side of the display that are addressable by the driver chip but not visible. Default is 0. Used to calculate native dimensions and support hardware rotation.
+  - **pad_height** (*Optional*, int): Specify additional pixels recognized by the controller after the offset and height. This represents pixels on the bottom of the display that are addressable by the driver chip but not visible. Default is 0. Used to calculate native dimensions and support hardware rotation.
 
 - **invert_colors** (*Optional*, boolean): Specifies whether the display colors should be inverted. Options are `true` or `false`. Defaults to `false`.
 - **rotation** (*Optional*): Rotate the display presentation in software. Choose one of `0°`, `90°`, `180°`, or `270°`. If the driver chip supports hardware rotation for the given orientation this will be translated to the appropriate hardware command. If hardware rotation is not supported, the display will be rotated in software.
@@ -161,7 +166,8 @@ most of the configuration will be set by default, but can be overridden if neede
 - **pixel_mode** (*Optional*): Select the interface mode for the display driver. Options are `16bit` (default) and `18bit`. Most displays require 16 bit mode, and it is preferred unless the display requires 18 bit mode.
 - **spi_16** (*Optional*): Set to `true` on boards where single bit SPI is used but drives the display in parallel via a 16 bit shift register.
 - **data_rate** (*Optional*): The SPI data rate. Defaults to 10MHz but board presets may override this.
-- **spi_mode** (*Optional*): The SPI mode. Options are `MODE0`, `MODE1`, `MODE2`, and `MODE3`. Defaults to `MODE0` for single bit SPI and `MODE3` for octal SPI (parallel bus.)
+- **spi_mode** (*Optional*): The SPI mode. Options are `MODE0`, `MODE1`, `MODE2`, and `MODE3`. Defaults to `MODE3` for
+  octal SPI and single bit SPI with no CS pin, or `MODE0` otherwise.
 - **draw_rounding** (*Optional*): The rounding factor for drawing operations. Defaults to 2. Some chips require a higher value to avoid display artifacts. Must be a power of 2.
 - **use_axis_flips** (*Optional*): If true, the driver will use alternate bits in the MADCTL register to implement x and y mirroring. Defaults to false.
 - **byte_order** (*Optional*): The byte order of the display buffer. Options are `big_endian` (default) and `little_endian`. This affects the byte order for the buffer when

--- a/src/content/docs/components/index.mdx
+++ b/src/content/docs/components/index.mdx
@@ -933,9 +933,9 @@ Used for creating infrared (IR) remote control transmitters and/or receivers.
 ## Motion Components
 
 <ImgTable items={[
-    ["BMI270", "/components/motion/bmi270/", "imu.svg", "Accelerometer & Gyroscope", "dark-invert"],
-    ["LSM6DS", "/components/motion/lsm6ds/", "imu.svg", "Accelerometer & Gyroscope", "dark-invert"],
-    ["Motion (IMU)", "/components/motion/", "imu.svg", "dark-invert"],
+  ["Motion Core", "/components/motion/", "imu.svg", "IMU", "dark-invert"],
+  ["BMI270", "/components/motion/bmi270/", "imu.svg", "Accelerometer & Gyroscope", "dark-invert"],
+  ["LSM6DS", "/components/motion/lsm6ds/", "imu.svg", "Accelerometer & Gyroscope", "dark-invert"],
 ]} />
 
 ## Number Components

--- a/src/content/docs/guides/supporters.mdx
+++ b/src/content/docs/guides/supporters.mdx
@@ -1318,6 +1318,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Christian Glombek (@LorbusChris)](https://github.com/LorbusChris)
 - [Michael Bisbjerg (@LordMike)](https://github.com/LordMike)
 - [lorenzspenger (@lorenzspenger)](https://github.com/lorenzspenger)
+- [Lovlace (@Lovlace777)](https://github.com/Lovlace777)
 - [Leonid Lunin (@lrlunin)](https://github.com/lrlunin)
 - [luar123 (@luar123)](https://github.com/luar123)
 - [LuBeDa (@lubeda)](https://github.com/lubeda)
@@ -2405,4 +2406,4 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Christian Zufferey (@zuzu59)](https://github.com/zuzu59)
 - [Zynth-dev (@Zynth-dev)](https://github.com/Zynth-dev)
 
-*This page was last updated June 11, 2026.*
+*This page was last updated June 15, 2026.*


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- fix: improve PR number extraction in release notes generator [docs#6777](https://github.com/esphome/esphome.io/pull/6777)
- [light] Render scan and fireworks effect previews with pure CSS [docs#6778](https://github.com/esphome/esphome.io/pull/6778)
- [script] Move lint.mjs into script/ folder [docs#6781](https://github.com/esphome/esphome.io/pull/6781)
- Bump astro from 6.4.4 to 6.4.6 [docs#6775](https://github.com/esphome/esphome.io/pull/6775)
- Bump prettier from 3.8.3 to 3.8.4 [docs#6770](https://github.com/esphome/esphome.io/pull/6770)
- [motion] Fix Motion Core component index entry [docs#6780](https://github.com/esphome/esphome.io/pull/6780)
- [mipi_spi] Document padding [docs#6709](https://github.com/esphome/esphome.io/pull/6709)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
