### PR TITLE
[epaper_spi] Add Seeed Sticky

### DIFF
--- a/src/content/docs/components/display/epaper_spi.mdx
+++ b/src/content/docs/components/display/epaper_spi.mdx
@@ -80,6 +80,10 @@ but can be overridden if needed.
 
 - **reset_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The RESET pin, if used.
   Make sure you pull this pin high (by connecting it to 3.3V with a resistor) if not connected to a GPIO pin.
+- **enable_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): An optional pin to enable the
+  display, if required. A list of pins can be provided for displays that require multiple enable pins.
+  A full pin configuration may be provided to set the pin mode and inverted property if required.
+  The pin or pins will be driven high (low if inverted) prior to display initialisation.
 - **dimensions** (**Required**, dict): Dimensions of the screen, specified either as *width* **x** *height* (e.g `320x240`  )
   or with separate config keys. For integrated boards with full pre-defined configuration this is optional and will be preset by
   the model selected. The dimensions are specified in pixels, and the width and height must be greater than 0.

--- a/src/content/docs/components/display/epaper_spi.mdx
+++ b/src/content/docs/components/display/epaper_spi.mdx
@@ -58,10 +58,11 @@ the pins used to interface to the display to be specified.
 These models correspond to displays integrated with a microcontroller, and have a full configuration predefined, so at
 a minimum only the model name need be configured. Other options can be overridden in the configuration if needed.
 
-| Model name             | Manufacturer | Product Description                                                                                                          |
-| ---------------------- |--------------| ---------------------------------------------------------------------------------------------------------------------------- |
-| Seeed-reTerminal-E1002 | Seeed Studio | [https://www.seeedstudio.com/reTerminal-E1002-p-6533.html](https://www.seeedstudio.com/reTerminal-E1002-p-6533.html)                                                                   |
-| Seeed-ee04-mono-4.26   | Seeed Studio | Seeed EE04 board with Waveshare 4.26" mono epaper. [https://www.seeedstudio.com/XIAO-ePaper-Display-Board-EE04-p-6560.html](https://www.seeedstudio.com/XIAO-ePaper-Display-Board-EE04-p-6560.html)  |
+| Model name              | Manufacturer | Product Description                                                                                                          |
+| ----------------------  |--------------| ---------------------------------------------------------------------------------------------------------------------------- |
+| Seeed-ee04-mono-4.26    | Seeed Studio | Seeed EE04 board with Waveshare 4.26" mono epaper. [https://www.seeedstudio.com/XIAO-ePaper-Display-Board-EE04-p-6560.html](https://www.seeedstudio.com/XIAO-ePaper-Display-Board-EE04-p-6560.html)  |
+| Seeed-reTerminal-E1002  | Seeed Studio | [https://www.seeedstudio.com/reTerminal-E1002-p-6533.html](https://www.seeedstudio.com/reTerminal-E1002-p-6533.html)                                                                   |
+| Seeed-reTerminal-Sticky | Seeed Studio | [https://www.seeedstudio.com/](https://www.seeedstudio.com/)                                                                  |
 
 ## Configuration variables
 

--- a/src/content/docs/components/display/epaper_spi.mdx
+++ b/src/content/docs/components/display/epaper_spi.mdx
@@ -59,10 +59,10 @@ These models correspond to displays integrated with a microcontroller, and have 
 a minimum only the model name need be configured. Other options can be overridden in the configuration if needed.
 
 | Model name              | Manufacturer | Product Description                                                                                                          |
-| ----------------------  |--------------| ---------------------------------------------------------------------------------------------------------------------------- |
+|-------------------------|--------------|------------------------------------------------------------------------------------------------------------------------------|
 | Seeed-ee04-mono-4.26    | Seeed Studio | Seeed EE04 board with Waveshare 4.26" mono epaper. [https://www.seeedstudio.com/XIAO-ePaper-Display-Board-EE04-p-6560.html](https://www.seeedstudio.com/XIAO-ePaper-Display-Board-EE04-p-6560.html)  |
-| Seeed-reTerminal-E1002  | Seeed Studio | [https://www.seeedstudio.com/reTerminal-E1002-p-6533.html](https://www.seeedstudio.com/reTerminal-E1002-p-6533.html)                                                                   |
-| Seeed-reTerminal-Sticky | Seeed Studio | [https://www.seeedstudio.com/](https://www.seeedstudio.com/)                                                                  |
+| Seeed-reTerminal-E1002  | Seeed Studio | [https://www.seeedstudio.com/reTerminal-E1002-p-6533.html](https://www.seeedstudio.com/reTerminal-E1002-p-6533.html)         |
+| Seeed-reTerminal-Sticky | Seeed Studio | [https://www.seeedstudio.com/](https://www.seeedstudio.com/)                                                                 |
 
 ## Configuration variables
 

--- a/src/content/docs/components/display/epaper_spi.mdx
+++ b/src/content/docs/components/display/epaper_spi.mdx
@@ -62,7 +62,7 @@ a minimum only the model name need be configured. Other options can be overridde
 |-------------------------|--------------|------------------------------------------------------------------------------------------------------------------------------|
 | Seeed-ee04-mono-4.26    | Seeed Studio | Seeed EE04 board with Waveshare 4.26" mono epaper. [https://www.seeedstudio.com/XIAO-ePaper-Display-Board-EE04-p-6560.html](https://www.seeedstudio.com/XIAO-ePaper-Display-Board-EE04-p-6560.html)  |
 | Seeed-reTerminal-E1002  | Seeed Studio | [https://www.seeedstudio.com/reTerminal-E1002-p-6533.html](https://www.seeedstudio.com/reTerminal-E1002-p-6533.html)         |
-| Seeed-reTerminal-Sticky | Seeed Studio | [https://www.seeedstudio.com/](https://www.seeedstudio.com/)                                                                 |
+| Seeed-reTerminal-Sticky | Seeed Studio | [https://www.seeedstudio.com/sticky/](https://www.seeedstudio.com/sticky/)                                                                 |
 
 ## Configuration variables
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#16950

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
