### PR TITLE
[lvgl] Document paused option

### DIFF
--- a/src/content/docs/components/lvgl/index.mdx
+++ b/src/content/docs/components/lvgl/index.mdx
@@ -148,6 +148,8 @@ The following configuration variables apply to the main `lvgl` component, in ord
   to `true` will cause the display to only be updated if the display is idle. During the update LVGL will pause.
   The display `update_interval` should be set to `never` when this is used, as the display will be updated automatically
   by LVGL.
+- **paused** (*Optional*, boolean): When `true`, LVGL will be initially paused and the display will not be updated until `lvgl.resume:` is called. Defaults to `false`.
+  Used to prevent display updates on boot for epaper displays until data is ready, to avoid showing a blank screen or unstyled content.
 - **resume_on_input** (*Optional*, boolean): If LVGL is paused and the user interacts with the screen, resume the activity of LVGL. Defaults to `true`. "Interacts" means to release a touch or button, or rotate an encoder.
 - **color_depth** (*Optional*, string): The color depth at which the contents are generated. Currently only `16` is supported (RGB565, 2 bytes/pixel), which is the default value.
 - **buffer_size** (*Optional*, percentage): The percentage of screen size to allocate buffer memory. If unconfigured, the default is `100%` with runtime fallback to `12%` if a full size buffer allocation fails. For devices without PSRAM, the recommended value is `25%`.

--- a/src/content/docs/components/lvgl/index.mdx
+++ b/src/content/docs/components/lvgl/index.mdx
@@ -148,7 +148,7 @@ The following configuration variables apply to the main `lvgl` component, in ord
   to `true` will cause the display to only be updated if the display is idle. During the update LVGL will pause.
   The display `update_interval` should be set to `never` when this is used, as the display will be updated automatically
   by LVGL.
-- **paused** (*Optional*, boolean): When `true`, LVGL will be initially paused and the display will not be updated until `lvgl.resume:` is called. Defaults to `false`.
+- **paused** (*Optional*, boolean): When `true`, LVGL will be initially paused and the display will not be updated until [`lvgl.resume:`](#lvgl-resume-action) is called. Defaults to `false`.
   Used to prevent display updates on boot for epaper displays until data is ready, to avoid showing a blank screen or unstyled content.
 - **resume_on_input** (*Optional*, boolean): If LVGL is paused and the user interacts with the screen, resume the activity of LVGL. Defaults to `true`. "Interacts" means to release a touch or button, or rotate an encoder.
 - **color_depth** (*Optional*, string): The color depth at which the contents are generated. Currently only `16` is supported (RGB565, 2 bytes/pixel), which is the default value.


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#16973
## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
