### PR TITLE
[st7123] Document touchscreen component

### DIFF
--- a/src/content/docs/components/index.mdx
+++ b/src/content/docs/components/index.mdx
@@ -1092,6 +1092,7 @@ Used for creating infrared (IR) remote control transmitters and/or receivers.
   ["FT63X6", "/components/touchscreen/ft63x6/", "wt32-sc01.png"],
   ["GT911", "/components/touchscreen/gt911/", "esp32_s3_box_3.png"],
   ["Lilygo T5 4.7", "/components/touchscreen/lilygo_t5_47/", "lilygo_t5_47_touch.jpg"],
+  ["ST7123", "/components/touchscreen/st7123/", "touch.svg", "dark-invert"],
   ["TT21100", "/components/touchscreen/tt21100/", "esp32-s3-korvo-2-lcd.png"],
   ["XPT2046", "/components/touchscreen/xpt2046/", "xpt2046.jpg"],
 ]} />

--- a/src/content/docs/components/touchscreen/index.mdx
+++ b/src/content/docs/components/touchscreen/index.mdx
@@ -294,5 +294,6 @@ binary_sensor:
 - [XPT2046 Touch Screen Controller (Updated version)](/components/touchscreen/xpt2046/)
 - [TT21100 Touch Screen Controller](/components/touchscreen/tt21100/)
 - [gt911 Touch Screen Controller](/components/touchscreen/gt911/)
+- [ST7123 Touch Screen Controller](/components/touchscreen/st7123/)
 - <APIRef text="touchscreen.h" path="touchscreen/touchscreen.h" />
 - <APIRef text="touchscreen_binary_sensor.h" path="touchscreen/binary_sensor/touchscreen_binary_sensor.h" />

--- a/src/content/docs/components/touchscreen/st7123.mdx
+++ b/src/content/docs/components/touchscreen/st7123.mdx
@@ -1,0 +1,37 @@
+---
+description: "Instructions for setting up st7123 touch screen controller with ESPHome"
+title: "st7123 Touch Screen Controller"
+---
+
+import APIRef from '@components/APIRef.astro';
+
+The `st7123` touchscreen platform allows using the touch screen controllers based on the Sitronix ST7123 chip with ESPHome.
+The [I²C](/components/i2c) is required to be set up in your configuration for this touchscreen to work.
+
+## Base Touchscreen Configuration
+
+```yaml
+# Example configuration entry
+touchscreen:
+  platform: st7123
+  id: my_touchscreen
+  interrupt_pin: GPIOXX
+  reset_pin: GPIOXX
+```
+
+### Configuration variables
+
+- **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually set the ID of this touchscreen.
+- **interrupt_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The touch detection pin. When connected
+  directly to an MCU GPIO, the driver uses it for interrupt-driven operation; otherwise it falls back to polling.
+- **reset_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The chip reset pin.
+- **address** (*Optional*, int): The I²C address of the touchscreen controller. Defaults to `0x55`.
+
+- All other options from [Touchscreen](/components/touchscreen#config-touchscreen).
+
+If no [calibration](/components/touchscreen#config-touchscreen) is supplied, the driver reads the native coordinate
+resolution from the controller and uses it automatically.
+
+## See Also
+
+- <APIRef text="st7123_touchscreen.h" path="st7123/touchscreen/st7123_touchscreen.h" />


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
