### PR TITLE
Use Correct Username/Password Environment Variables For Example Docker Config

### DIFF
--- a/src/content/docs/guides/getting_started_command_line.mdx
+++ b/src/content/docs/guides/getting_started_command_line.mdx
@@ -39,8 +39,8 @@ services:
     privileged: true
     network_mode: host
     environment:
-      - USERNAME=test
-      - PASSWORD=ChangeMe
+      ESPHOME_USERNAME: 'test'
+      ESPHOME_PASSWORD: 'Change Me!'
 ```
 
 > [!NOTE]


### PR DESCRIPTION
Documented at https://github.com/esphome/device-builder#standalone-pypi-1

The legacy `USERNAME`/`PASSWORD` have been replaced with `ESPHOME_USERNAME`/`ESPHOME_PASSWORD` since `USERNAME` clashes with a standard OS environment variable.

<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** N/A

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.
