### PR TITLE
[safe_mode][wifi][preferences] Document the preference storage options

### DIFF
--- a/src/content/docs/components/esphome.mdx
+++ b/src/content/docs/components/esphome.mdx
@@ -321,6 +321,13 @@ preferences:
   flushed to the flash. This setting helps to prevent rapid changes to a component from being quickly
   written to the flash and wearing it out. Defaults to `1min`. Set to `never` to disable this feature.
 
+- **rtc_storage** (*Optional*, boolean): Only useful on ESP32. Compile RTC-memory-backed preference storage into the
+  firmware even when no other option selects it (options such as `safe_mode`'s and `fast_connect`'s `storage: rtc`
+  enable it automatically). This is intended for external components that request RTC storage through the C++
+  preferences API; without it, such requests fall back to flash (NVS) with a warning in the log. Not available on
+  ESP32 variants without RTC memory (C2 and C61). On ESP8266, RTC storage is integral and always enabled: `true` is
+  accepted (and does nothing), while `false` is rejected since it cannot be disabled.
+
 As all devices have a limited number of flash write cycles, this setting helps to reduce the number of flash writes
 due to quickly changing components. In the past, when components such as `light`, `switch`, `fan` and `globals`
 were changed, the state was immediately committed to flash. The result of this was that the last state of these

--- a/src/content/docs/components/safe_mode.mdx
+++ b/src/content/docs/components/safe_mode.mdx
@@ -34,6 +34,20 @@ safe_mode:
 - **reboot_timeout** (*Optional*, [Time](/guides/configuration-types#time)): The amount of time to wait before rebooting when in safe mode.
    Defaults to `5min`.
 
+- **storage** (*Optional*, string): Where to persist the boot-attempt counter. One of:
+
+  - `flash`: store the counter in flash. It survives power loss but causes a small amount of flash wear on each boot.
+  - `rtc`: store the counter in RTC memory. It survives software reboots (restarts, OTA updates, crashes) and deep
+    sleep but **not** power loss, and avoids flash wear.
+
+  Defaults to `flash` on ESP32 and `rtc` on ESP8266. Only `flash` is available on platforms without RTC-backed storage
+  (the RP2040 and the ESP32-C2 and C61 variants, which have no RTC memory), where `rtc` is rejected.
+
+  Note that on the original ESP32, pressing the hardware reset button (the EN pin) also clears RTC memory, so it
+  counts as power loss rather than as a reboot. On newer variants (S3, C3, C6) RTC memory survives a chip reset
+  triggered over USB. Safe mode itself is unaffected either way: crash loops always consist of software resets, which
+  RTC memory survives on all variants.
+
 - **on_safe_mode** (*Optional*, [Automation](/automations)): An action to be performed once when safe mode is invoked.
 
 > [!WARNING]

--- a/src/content/docs/components/wifi.mdx
+++ b/src/content/docs/components/wifi.mdx
@@ -99,6 +99,28 @@ wifi:
   In case it fails, all networks are then tested one after the other in their declared order, starting with the first
   one in the list.
 
+  Instead of a boolean, this option also accepts a settings block:
+
+  ```yaml
+  wifi:
+    # ...
+    fast_connect:
+      enabled: true
+      storage: rtc
+  ```
+
+  - **enabled** (*Optional*, boolean): Whether fast connect is active. Defaults to `true` when the block form is used.
+  - **storage** (*Optional*, string): Where to persist the connection details (BSSID and channel) that fast connect
+    saves after each successful connection. One of:
+
+    - `flash`: survives power loss but wears flash a little on each save.
+    - `rtc`: stored in RTC memory, which survives software reboots and deep sleep but **not** power loss, and avoids
+      flash wear. A good fit for battery-powered devices that wake from deep sleep frequently.
+
+    Defaults to `rtc` on ESP8266 and `flash` on ESP32, matching each platform's previous behavior. Only `flash` is
+    available on platforms without RTC-backed storage (the RP2040 and the ESP32-C2 and C61 variants, which have no
+    RTC memory), where `rtc` is rejected.
+
   > [!NOTE]
   > While `fast_connect` skips the initial scan, if the connection attempt fails, ESPHome will still perform a scan
   > to find available networks. For hidden networks, use `hidden: true` on the network configuration (see


### PR DESCRIPTION
## Description

Documents the new preference storage options added in esphome/esphome#17073:

- [`safe_mode`](https://esphome.io/components/safe_mode/): the new `storage` option, which selects where the
  boot-attempt counter is persisted: `flash` (durable, minor flash wear) or `rtc` (survives software reboots and
  deep sleep but not power loss, avoids flash wear). Includes per-variant reset behavior notes from hardware
  testing (on the original ESP32 the reset button clears RTC memory; on S3/C3/C6 a USB chip reset does not).
- [`wifi`](https://esphome.io/components/wifi/): the `fast_connect` option now also accepts a settings block with
  `enabled` and `storage` keys, so the saved connection details (BSSID and channel) can be kept in RTC memory
  instead of flash — useful for battery-powered devices that wake from deep sleep frequently.
- [`preferences`](https://esphome.io/components/esphome/#preferences-component): the new `rtc_storage` opt-in, which
  compiles RTC-backed preference storage into ESP32 firmware even when no other option selects it — for external
  components that request RTC storage through the C++ preferences API.

Defaults preserve existing behavior (`flash` on ESP32, `rtc` on ESP8266 for both options); `rtc` is rejected on
platforms without RTC-backed storage.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#17073

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.
