### PR TITLE
[web_server] Document viewing logs over the web_server stream

### DIFF
--- a/src/content/docs/components/web_server.mdx
+++ b/src/content/docs/components/web_server.mdx
@@ -80,7 +80,9 @@ web_server:
   [Private Network Access Permission Prompt](https://wicg.github.io/private-network-access/#permission-prompt).
   Defaults to `true`.
 
-- **log** (*Optional*, boolean): Turn on or off the log feature inside webserver. Defaults to `true`.
+- **log** (*Optional*, boolean): Turn on or off the log feature inside the web server. When enabled, the device also
+  streams logs over the `/events` endpoint, so [`esphome logs`](/guides/cli/#logs-command) can view logs over the
+  network on devices that have no [native API](/components/api/) configured. Defaults to `true`.
 - **ota** (*Optional*, boolean): Explicitly disable OTA updates through the web server interface. Only accepts `false`.
   This option is typically used when you have both `web_server` and `captive_portal` configured, and you want
   OTA updates to be available only through the captive portal. Since `captive_portal` automatically loads the
@@ -318,5 +320,6 @@ By clicking on any sensor it will expand a graph with the historical values for 
 
 - [Event Source API](/web-api#api-event-source)
 - [REST API](/web-api#api-rest)
+- [`esphome logs` Command](/guides/cli/#logs-command)
 - [Prometheus Component](/components/prometheus/)
 - <APIRef text="web_server.h" path="web_server/web_server.h" />

--- a/src/content/docs/guides/cli.mdx
+++ b/src/content/docs/guides/cli.mdx
@@ -341,6 +341,10 @@ esphome bundle my-device.yaml
 
 The `esphome logs <CONFIG>` command validates the configuration and shows all logs.
 
+For network logging, ESPHome uses the [native API](/components/api/) if configured, then MQTT, then the
+[`web_server`](/components/web_server/) `/events` stream. The web_server stream is used for devices that have a
+`web_server` but no native API, and reconnects automatically if the connection drops.
+
 #### Options
 
 **`--topic TOPIC`**


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Documents that `esphome logs` can stream device logs over the `web_server` `/events` SSE endpoint, for devices that have `web_server:` configured but no native API. Updates the `web_server` `log` option and adds a transport note to the CLI `logs` command.

**Related issue (if applicable):** fixes N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#17110

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
