### PR TITLE
[web_server] Remove object ID URL format from Web API docs

### DIFF
--- a/src/content/docs/web-api/index.mdx
+++ b/src/content/docs/web-api/index.mdx
@@ -110,14 +110,6 @@ Examples:
 - `/sensor/Garage/Temperature` - A sensor on a sub-device named "Garage" (GET returns state)
 - `/light/Garage/Main Light/turn_on` - Turn on a light on a sub-device (POST)
 
-> [!WARNING]
-> **Removed: `object_id` URLs**
->
-> The old URL format that matched entities by `object_id` (lowercase with underscores) was
-> removed in ESPHome 2026.7.0; URLs are now matched by entity name only. For example, use
-> `/sensor/Temperature` instead of `/sensor/temperature_sensor`. Update any integrations that
-> still address entities by `object_id`.
-
 By creating a simple GET request for a URL of the form `/<domain>/<entity_name>` you will get a JSON payload
 describing the current state of the component. This payload is equivalent to the ones sent by the
 event source API.

--- a/src/content/docs/web-api/index.mdx
+++ b/src/content/docs/web-api/index.mdx
@@ -110,13 +110,13 @@ Examples:
 - `/sensor/Garage/Temperature` - A sensor on a sub-device named "Garage" (GET returns state)
 - `/light/Garage/Main Light/turn_on` - Turn on a light on a sub-device (POST)
 
-> [!NOTE]
-> **Backward Compatibility**
+> [!WARNING]
+> **Removed: `object_id` URLs**
 >
-> For backward compatibility, the old URL format using `object_id` (lowercase with underscores)
-> is still supported but deprecated and will be removed in ESPHome 2026.7.0. For example,
-> `/sensor/temperature_sensor` will still work but logs a deprecation warning. The new format
-> using the entity name directly is recommended.
+> The old URL format that matched entities by `object_id` (lowercase with underscores) was
+> removed in ESPHome 2026.7.0; URLs are now matched by entity name only. For example, use
+> `/sensor/Temperature` instead of `/sensor/temperature_sensor`. Update any integrations that
+> still address entities by `object_id`.
 
 By creating a simple GET request for a URL of the form `/<domain>/<entity_name>` you will get a JSON payload
 describing the current state of the component. This payload is equivalent to the ones sent by the


### PR DESCRIPTION
## Description

Updates the Web API docs to reflect that the legacy `object_id` URL format was removed in 2026.7.0; URLs are now matched by entity name only.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#17113

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.
