### PR TITLE
[web_server] Document version 1 deprecation

### DIFF
--- a/src/content/docs/components/web_server.mdx
+++ b/src/content/docs/components/web_server.mdx
@@ -97,7 +97,8 @@ web_server:
   is recommended for maximum compatibility. Defaults to `gzip`.
 
 - **version** (*Optional*, string): `1`, `2` or `3`. Version 1 displays as a table. Version 2 uses web components
-  and has more functionality. Version 3 uses HA-Styling. Defaults to `2`.
+  and has more functionality. Version 3 uses HA-Styling. Defaults to `2`. Version 1 is deprecated and will be removed
+  in 2027.1.0; please migrate to version 2 (the default) or version 3.
 
 - **sorting_groups** (*Optional*, list): Available only on `version: 3`. A list of group ID's and names to group the
   entities. See [Webserver Entity Grouping](#config-webserver-grouping).
@@ -156,6 +157,9 @@ web_server:
 > Always enable authentication when using the web server. See the [Security Best Practices](/guides/security_best_practices#2-web-server-authentication) guide for recommendations.
 
 Use version 1 user interface:
+
+> [!WARNING]
+> Version 1 is deprecated and will be removed in 2027.1.0; please migrate to version 2 (the default) or version 3.
 
 ```yaml
 # Example configuration entry


### PR DESCRIPTION
## Description

Documents the deprecation of `web_server` version 1; it notes on the `version` option and the version 1 example that v1 will be removed in 2027.1.0 and points users to version 2 (the default) or version 3.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#17109

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
