### PR TITLE
[climate][water_heater] Document TemperatureUnit C++ API for custom components

### DIFF
--- a/src/content/docs/components/climate/index.mdx
+++ b/src/content/docs/components/climate/index.mdx
@@ -289,30 +289,6 @@ advanced stuff.
     call.perform();
 ```
 
-### Custom C++ Components: Setting Temperature Unit
-
-Custom C++ climate components can set the temperature unit in their traits so the component can work in its native unit without converting values. When set, the unit is communicated to all clients — both the ESPHome web UI and Home Assistant will display temperatures in the declared unit.
-
-```cpp
-climate::ClimateTraits traits() override {
-  traits_.set_temperature_unit(esphome::TemperatureUnit::FAHRENHEIT);
-  // ... other traits_ configuration ...
-  return traits_;
-}
-
-climate::ClimateTraits traits_;
-```
-
-The `TemperatureUnit` enum is defined in `esphome/core/helpers.h`:
-
-- `esphome::TemperatureUnit::CELSIUS` (default)
-- `esphome::TemperatureUnit::FAHRENHEIT`
-- `esphome::TemperatureUnit::KELVIN`
-
-This avoids manual Celsius/Fahrenheit conversion in component code: publish temperatures in the device's native unit and let the clients handle display.
-
-<span id="climate-on_state_trigger"></span>
-
 ### `climate.on_state` Trigger
 
 This trigger is activated each time the state of the climate device is updated
@@ -353,6 +329,30 @@ climate:
               x.set_target_temperature(25.0f);
           }
 ```
+
+## Custom C++ Components: Setting Temperature Unit
+
+Custom C++ climate components can set the temperature unit in their traits so the component can work in its native unit without converting values. When set, the unit is communicated to all clients — both the ESPHome web UI and Home Assistant will display temperatures in the declared unit.
+
+```cpp
+climate::ClimateTraits traits() override {
+  traits_.set_temperature_unit(esphome::TemperatureUnit::FAHRENHEIT);
+  // ... other traits_ configuration ...
+  return traits_;
+}
+
+climate::ClimateTraits traits_;
+```
+
+The `TemperatureUnit` enum is defined in `esphome/core/helpers.h`:
+
+- `esphome::TemperatureUnit::CELSIUS` (default)
+- `esphome::TemperatureUnit::FAHRENHEIT`
+- `esphome::TemperatureUnit::KELVIN`
+
+This avoids manual Celsius/Fahrenheit conversion in component code: publish temperatures in the device's native unit and let the clients handle display.
+
+<span id="climate-on_state_trigger"></span>
 
 ## See Also
 

--- a/src/content/docs/components/climate/index.mdx
+++ b/src/content/docs/components/climate/index.mdx
@@ -289,6 +289,27 @@ advanced stuff.
     call.perform();
 ```
 
+### Custom C++ Components: Setting Temperature Unit
+
+Custom C++ climate components can set the temperature unit reported to Home Assistant by configuring it in the component's traits. This is useful when a device natively operates in Fahrenheit or Kelvin.
+
+```cpp
+void setup() override {
+  // Tell HA this device reports temperatures in Fahrenheit
+  auto traits = make_traits();
+  traits.set_temperature_unit(esphome::TemperatureUnit::FAHRENHEIT);
+  // ...
+}
+```
+
+The `TemperatureUnit` enum is defined in `esphome/core/helpers.h`:
+
+- `esphome::TemperatureUnit::CELSIUS` (default)
+- `esphome::TemperatureUnit::FAHRENHEIT`
+- `esphome::TemperatureUnit::KELVIN`
+
+The temperature unit is conveyed via the ESPHome API to clients such as Home Assistant, which will display temperatures accordingly.
+
 <span id="climate-on_state_trigger"></span>
 
 ### `climate.on_state` Trigger

--- a/src/content/docs/components/climate/index.mdx
+++ b/src/content/docs/components/climate/index.mdx
@@ -289,6 +289,8 @@ advanced stuff.
     call.perform();
 ```
 
+<span id="climate-on_state_trigger"></span>
+
 ### `climate.on_state` Trigger
 
 This trigger is activated each time the state of the climate device is updated

--- a/src/content/docs/components/climate/index.mdx
+++ b/src/content/docs/components/climate/index.mdx
@@ -291,11 +291,10 @@ advanced stuff.
 
 ### Custom C++ Components: Setting Temperature Unit
 
-Custom C++ climate components can set the temperature unit reported to Home Assistant by configuring it in the component's traits. This is useful when a device natively operates in Fahrenheit or Kelvin.
+Custom C++ climate components can set the temperature unit in their traits so the component can work in its native unit without converting values. When set, the unit is communicated to all clients — both the ESPHome web UI and Home Assistant will display temperatures in the declared unit.
 
 ```cpp
 void setup() override {
-  // Tell HA this device reports temperatures in Fahrenheit
   auto traits = make_traits();
   traits.set_temperature_unit(esphome::TemperatureUnit::FAHRENHEIT);
   // ...
@@ -308,7 +307,7 @@ The `TemperatureUnit` enum is defined in `esphome/core/helpers.h`:
 - `esphome::TemperatureUnit::FAHRENHEIT`
 - `esphome::TemperatureUnit::KELVIN`
 
-The temperature unit is conveyed via the ESPHome API to clients such as Home Assistant, which will display temperatures accordingly.
+This avoids manual Celsius/Fahrenheit conversion in component code: publish temperatures in the device's native unit and let the clients handle display.
 
 <span id="climate-on_state_trigger"></span>
 

--- a/src/content/docs/components/climate/index.mdx
+++ b/src/content/docs/components/climate/index.mdx
@@ -294,11 +294,13 @@ advanced stuff.
 Custom C++ climate components can set the temperature unit in their traits so the component can work in its native unit without converting values. When set, the unit is communicated to all clients — both the ESPHome web UI and Home Assistant will display temperatures in the declared unit.
 
 ```cpp
-void setup() override {
-  auto traits = make_traits();
-  traits.set_temperature_unit(esphome::TemperatureUnit::FAHRENHEIT);
-  // ...
+climate::ClimateTraits traits() override {
+  traits_.set_temperature_unit(esphome::TemperatureUnit::FAHRENHEIT);
+  // ... other traits_ configuration ...
+  return traits_;
 }
+
+climate::ClimateTraits traits_;
 ```
 
 The `TemperatureUnit` enum is defined in `esphome/core/helpers.h`:

--- a/src/content/docs/components/water_heater/index.mdx
+++ b/src/content/docs/components/water_heater/index.mdx
@@ -150,12 +150,11 @@ Available C++ enums for modes:
 
 ### Custom C++ Components: Setting Temperature Unit
 
-Custom C++ water heater components can set the temperature unit reported to Home Assistant by configuring it in the component's traits. This is useful when a device natively operates in Fahrenheit or Kelvin.
+Custom C++ water heater components can set the temperature unit in their traits so the component can work in its native unit without converting values. When set, the unit is communicated to all clients — both the ESPHome web UI and Home Assistant will display temperatures in the declared unit.
 
 ```cpp
 WaterHeaterTraits traits() override {
   auto traits = WaterHeaterTraits();
-  // Tell HA this device reports temperatures in Fahrenheit
   traits.set_temperature_unit(esphome::TemperatureUnit::FAHRENHEIT);
   // ...
   return traits;
@@ -168,7 +167,7 @@ The `TemperatureUnit` enum is defined in `esphome/core/helpers.h`:
 - `esphome::TemperatureUnit::FAHRENHEIT`
 - `esphome::TemperatureUnit::KELVIN`
 
-The temperature unit is conveyed via the ESPHome API to clients such as Home Assistant, which will display temperatures accordingly.
+This avoids manual Celsius/Fahrenheit conversion in component code: publish temperatures in the device's native unit and let the clients handle display.
 
 ## See Also
 

--- a/src/content/docs/components/water_heater/index.mdx
+++ b/src/content/docs/components/water_heater/index.mdx
@@ -148,7 +148,7 @@ Available C++ enums for modes:
 - `water_heater::WATER_HEATER_MODE_HEAT_PUMP`
 - `water_heater::WATER_HEATER_MODE_GAS`
 
-### Custom C++ Components: Setting Temperature Unit
+## Custom C++ Components: Setting Temperature Unit
 
 Custom C++ water heater components can set the temperature unit in their traits so the component can work in its native unit without converting values. When set, the unit is communicated to all clients — both the ESPHome web UI and Home Assistant will display temperatures in the declared unit.
 

--- a/src/content/docs/components/water_heater/index.mdx
+++ b/src/content/docs/components/water_heater/index.mdx
@@ -148,6 +148,28 @@ Available C++ enums for modes:
 - `water_heater::WATER_HEATER_MODE_HEAT_PUMP`
 - `water_heater::WATER_HEATER_MODE_GAS`
 
+### Custom C++ Components: Setting Temperature Unit
+
+Custom C++ water heater components can set the temperature unit reported to Home Assistant by configuring it in the component's traits. This is useful when a device natively operates in Fahrenheit or Kelvin.
+
+```cpp
+WaterHeaterTraits traits() override {
+  auto traits = WaterHeaterTraits();
+  // Tell HA this device reports temperatures in Fahrenheit
+  traits.set_temperature_unit(esphome::TemperatureUnit::FAHRENHEIT);
+  // ...
+  return traits;
+}
+```
+
+The `TemperatureUnit` enum is defined in `esphome/core/helpers.h`:
+
+- `esphome::TemperatureUnit::CELSIUS` (default)
+- `esphome::TemperatureUnit::FAHRENHEIT`
+- `esphome::TemperatureUnit::KELVIN`
+
+The temperature unit is conveyed via the ESPHome API to clients such as Home Assistant, which will display temperatures accordingly.
+
 ## See Also
 
 - [Template Water Heater](/components/water_heater/template/)

--- a/src/content/docs/components/water_heater/index.mdx
+++ b/src/content/docs/components/water_heater/index.mdx
@@ -153,12 +153,12 @@ Available C++ enums for modes:
 Custom C++ water heater components can set the temperature unit in their traits so the component can work in its native unit without converting values. When set, the unit is communicated to all clients — both the ESPHome web UI and Home Assistant will display temperatures in the declared unit.
 
 ```cpp
-WaterHeaterTraits traits() override {
+water_heater::WaterHeaterTraits traits() override {
   auto traits = WaterHeaterTraits();
   traits.set_temperature_unit(esphome::TemperatureUnit::FAHRENHEIT);
-  // ...
   return traits;
 }
+
 ```
 
 The `TemperatureUnit` enum is defined in `esphome/core/helpers.h`:


### PR DESCRIPTION
## Description

Documents the new `TemperatureUnit` enum and `set_temperature_unit()` C++ API added to `ClimateTraits` and `WaterHeaterTraits`. This allows custom C++ component authors to declare that their device reports temperatures in Fahrenheit or Kelvin, and have that unit conveyed to Home Assistant via the ESPHome API.

Adds a "Custom C++ Components: Setting Temperature Unit" subsection to both the Climate and Water Heater component docs, showing:
- How to call `traits.set_temperature_unit(esphome::TemperatureUnit::FAHRENHEIT)` in a custom component
- The available `TemperatureUnit` enum values (`CELSIUS`, `FAHRENHEIT`, `KELVIN`)

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#16477

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.