### PR TITLE
[rp2] Rename rp2040 platform page to rp2 and add redirects

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -122,6 +122,11 @@ status = 301
   status = 301
 
 [[redirects]]
+  from = "/components/rp2040"
+  to = "/components/rp2/"
+  status = 301
+
+[[redirects]]
   from = "/components/sensor/sgp40.html"
   to = "/components/sensor/sgp4x.html"
   status = 301

--- a/netlify.toml
+++ b/netlify.toml
@@ -112,6 +112,16 @@ status = 301
 # Moved components
 
 [[redirects]]
+  from = "/components/rp2040.html"
+  to = "/components/rp2/"
+  status = 301
+
+[[redirects]]
+  from = "/components/rp2040/"
+  to = "/components/rp2/"
+  status = 301
+
+[[redirects]]
   from = "/components/sensor/sgp40.html"
   to = "/components/sensor/sgp4x.html"
   status = 301

--- a/src/content/docs/changelog/2022.11.0.mdx
+++ b/src/content/docs/changelog/2022.11.0.mdx
@@ -8,7 +8,7 @@ slug: "changelog/2022.11.0"
 import ImgTable from "@components/ImgTable.astro";
 
 <ImgTable items={[
-  ["RP2040","/components/rp2040","rp2040.svg"],
+  ["RP2040","/components/rp2","rp2040.svg"],
   ["WL-134 Pet Tag Sensor","/components/text_sensor/wl_134","fingerprint.svg","dark-invert"],
   ["Ethernet Info","/components/text_sensor/ethernet_info","ethernet.svg","dark-invert"],
   ["Atlas Scientific Peristaltic Pump","/components/ezo_pmp","ezo-pmp.jpg"],

--- a/src/content/docs/changelog/2024.6.0.mdx
+++ b/src/content/docs/changelog/2024.6.0.mdx
@@ -147,7 +147,7 @@ sensor:
 ### HTTP(s) Requests
 
 The [http_request](/components/http_request/) platform has been rewritten in this release to
-add support when using ESP-IDF or when using the [rp2040](/components/rp2/) platform. This will
+add support when using ESP-IDF or when using the [rp2](/components/rp2/) platform. This will
 also allow other ESPHome components to make HTTP(s) requests which includes the new `http_request` OTA platform and the
 `update` entities.
 

--- a/src/content/docs/changelog/2024.6.0.mdx
+++ b/src/content/docs/changelog/2024.6.0.mdx
@@ -147,7 +147,7 @@ sensor:
 ### HTTP(s) Requests
 
 The [http_request](/components/http_request/) platform has been rewritten in this release to
-add support when using ESP-IDF or when using the [rp2040](/components/rp2040/) platform. This will
+add support when using ESP-IDF or when using the [rp2040](/components/rp2/) platform. This will
 also allow other ESPHome components to make HTTP(s) requests which includes the new `http_request` OTA platform and the
 `update` entities.
 

--- a/src/content/docs/components/index.mdx
+++ b/src/content/docs/components/index.mdx
@@ -36,7 +36,7 @@ information about ESPHome configuration files.
 <ImgTable items={[
   ["ESP32", "/components/esp32/", "esp32.svg"],
   ["ESP8266", "/components/esp8266/", "esp8266.svg"],
-  ["RP2040", "/components/rp2040/", "rp2040.svg"],
+  ["RP2", "/components/rp2/", "rp2040.svg"],
   ["BK72xx", "/components/libretiny/", "bk72xx.svg"],
   ["RTL87xx", "/components/libretiny/", "rtl87xx.svg"],
   ["LN882x", "/components/libretiny/", "ln882x.svg"],

--- a/src/content/docs/components/rp2.mdx
+++ b/src/content/docs/components/rp2.mdx
@@ -1,9 +1,15 @@
 ---
-description: "Configuration for the RP2040 platform for ESPHome."
-title: "RP2040 Platform"
+description: "Configuration for the RP2 platform (RP2040 and RP2350) for ESPHome."
+title: "RP2 Platform"
 ---
 
-This component contains platform-specific options for the RP2040 platform.
+This component contains platform-specific options for the RP2 platform, which covers both the RP2040 and
+RP2350 chips from the Raspberry Pi RP-series.
+
+> [!NOTE]
+> The platform key was renamed from `rp2040` to `rp2` in ESPHome 2026.7.0 so the family name reflects that
+> the toolchain covers both the RP2040 and RP2350 chips. The legacy `rp2040:` key continues to work as a
+> deprecated alias and will be removed in 2027.7.0.
 
 > [!NOTE]
 > The Raspberry Pi **Pico W** and other RP2040 boards with the Cypress **CYW43439** chip providing wireless
@@ -19,7 +25,7 @@ This component contains platform-specific options for the RP2040 platform.
 
 ```yaml
 # Example configuration entry
-rp2040:
+rp2:
   board: rpipicow
 ```
 
@@ -31,7 +37,7 @@ rp2040:
 
 ```yaml
 # Example configuration entry
-rp2040:
+rp2:
   board: rpipicow
   framework:
     platform_version: https://github.com/maxgerhardt/platform-raspberrypi.git
@@ -56,7 +62,7 @@ automatically reset the device into BOOTSEL mode.
 
 ## Configuration variables
 
-- **variant** (*Optional*, string): The RP2040-series chip to target. One of `rp2040` or `rp2350`.
+- **variant** (*Optional*, string): The RP2-series chip to target. One of `rp2040` or `rp2350`.
   This must match the hardware in use, or it will fail to flash.
 
 - **board** (*Optional*, string): The PlatformIO board identifier. Common boards include `rpipicow`
@@ -110,7 +116,7 @@ resolved to the correct GPIO number for your board:
 ### Onboard LED Example
 
 ```yaml
-rp2040:
+rp2:
   board: rpipicow
 
 output:
@@ -148,7 +154,7 @@ Then connect a USB-to-serial adapter to your board's UART0 pins:
 > [!TIP]
 > The `TX` and `RX` [pin names](#gpio-pin-names) resolve to the default UART0 pins for your board.
 > If your board differs from the Pico W defaults above, search for your board name (e.g. `seeed_xiao_rp2040`)
-> in [boards.py](https://github.com/esphome/esphome/blob/dev/esphome/components/rp2040/boards.py) and look
+> in [boards.py](https://github.com/esphome/esphome/blob/dev/esphome/components/rp2/boards.py) and look
 > for the `TX` and `RX` entries in its pin map. Note that the GPIO numbers may not match the labels
 > silkscreened on your board. For example, on the
 > [Seeed XIAO RP2040](https://wiki.seeedstudio.com/XIAO-RP2040/), TX (GPIO 0) and RX (GPIO 1) are

--- a/src/content/docs/components/rp2040_ble.mdx
+++ b/src/content/docs/components/rp2040_ble.mdx
@@ -34,5 +34,5 @@ rp2040_ble:
 
 ## See Also
 
-- [RP2040 Platform](/components/rp2040/)
+- [RP2 Platform](/components/rp2/)
 - [ESP32 BLE Component](/components/esp32_ble/)


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Documents the platform rename from `rp2040` to `rp2` in esphome/esphome#17145. Moves the platform page to `/components/rp2/`, adds redirects from the old `/components/rp2040/` and legacy `.html` URLs, updates the canonical YAML examples to the `rp2:` key, and repoints internal links to the new page. A note documents that the legacy `rp2040:` key keeps working as a deprecated alias until 2027.7.0.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#17145

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [x] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.