### PR TITLE
[component-image] Grant pull-requests: write for PR comments

### DIFF
--- a/.github/workflows/component-image.yml
+++ b/.github/workflows/component-image.yml
@@ -12,6 +12,7 @@ jobs:
     name: Prepare
     permissions:
       issues: write
+      pull-requests: write
     if: >-
       github.event.issue.pull_request &&
       startsWith(github.event.comment.body, '@esphomebot generate image') &&
@@ -77,7 +78,7 @@ jobs:
     name: Generate
     permissions:
       issues: write
-      pull-requests: read
+      pull-requests: write
       contents: read
     if: >-
       github.event.issue.pull_request &&


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

The `component-image` workflow posts and updates comments on PRs via the issues-comments endpoint (`github.rest.issues.createComment` / `updateComment`). When the target is a pull request, GitHub requires both `issues=write` and `pull-requests=write` (the 403 response's `x-accepted-github-permissions` header lists both as a single required set). The `prepare` job only had `issues: write` and the `generate` job had `pull-requests: read`, so commenting failed with `403 Resource not accessible by integration`.

This grants `pull-requests: write` to both jobs.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.