### PR TITLE
[component-image] Allow mixed-case component names in generate command

### DIFF
--- a/.github/workflows/component-image.yml
+++ b/.github/workflows/component-image.yml
@@ -34,12 +34,15 @@ jobs:
           # Extract component name using bash parameter expansion (no external commands)
           component="${COMMENT_BODY#@esphomebot generate image }"
 
-          # Validate component name: only lowercase alphanumeric and underscores
-          if [[ "$component" =~ ^[a-z0-9_]+$ ]]; then
+          # Validate component name: letters (any case), numbers, and underscores.
+          # A few component paths use mixed case (e.g. /components/mcp23Sxx/), so the
+          # requested name must be allowed to carry uppercase letters. The filename is
+          # always lowercased separately below (name_lower).
+          if [[ "$component" =~ ^[A-Za-z0-9_]+$ ]]; then
             echo "name=$component" >> $GITHUB_OUTPUT
             echo "name_lower=${component,,}" >> $GITHUB_OUTPUT
           else
-            echo "::error::Invalid component name. Must contain only lowercase letters, numbers, and underscores."
+            echo "::error::Invalid component name. Must contain only letters, numbers, and underscores."
             exit 1
           fi
 
@@ -55,7 +58,7 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `@${context.actor} Invalid component name. Use lowercase letters, numbers, ` +
+              body: `@${context.actor} Invalid component name. Use letters, numbers, ` +
                 'and underscores only (e.g. `bme280`, `sht3x`, `dallas_temp`).'
             })
 
@@ -172,9 +175,9 @@ jobs:
             const path = 'src/content/docs/components/index.mdx';
             const name = process.env.COMPONENT;
             const img = process.env.IMG;
-            // Component name is validated to [a-z0-9_]+, so it is safe in a regex.
+            // Component name is validated to [A-Za-z0-9_]+, so it is safe in a regex.
             // Match case-insensitively: a few index paths use mixed case (e.g.
-            // /components/mcp23Sxx/) while the requested name is always lowercase.
+            // /components/mcp23Sxx/) and the requested name may also carry mixed case.
             const re = new RegExp('("/components/' + name + '/",\\s*")[^"]*(")', 'gi');
             let count = 0;
             const updated = fs.readFileSync(path, 'utf8')


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

The component-image generator validated the requested component name with `^[a-z0-9_]+$`, which rejected any uppercase letter. That made `@esphomebot generate image mcp23Sxx` fail even though `/components/mcp23Sxx/` is a real mixed-case path in the index. The regex now allows `^[A-Za-z0-9_]+$`; the generated `.svg` filename is still lowercased separately via `name_lower`, and the case-insensitive index-update match is unchanged. Uppercase letters aren't regex metacharacters, so the injection-safety guarantee on the interpolated `new RegExp(...)` still holds. Error messages and code comments were updated to match.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- N/A

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.