### PR TITLE
[docs] Remove namespace-prefixed anchor spans, repoint links to headings

### DIFF
--- a/src/content/docs/automations/templates.mdx
+++ b/src/content/docs/automations/templates.mdx
@@ -94,14 +94,14 @@ using the lambda syntax as described/shown above.
 
 ## All Lambda Calls
 
-- [Sensor](/components/sensor#sensor-lambda_calls)
-- [Binary Sensor](/components/binary_sensor#binary_sensor-lambda_calls)
-- [Switch](/components/switch#switch-lambda_calls)
+- [Sensor](/components/sensor#lambda-calls)
+- [Binary Sensor](/components/binary_sensor#lambda-calls)
+- [Switch](/components/switch#lambda-calls)
 - [Display](/components/display#display-engine)
 - [Cover](/components/cover#lambdas)
-- [Text Sensor](/components/text_sensor#text_sensor-lambda_calls)
-- [Stepper](/components/stepper#stepper-lambda_calls)
-- [Number](/components/number#number-lambda_calls)
+- [Text Sensor](/components/text_sensor#lambda-calls)
+- [Stepper](/components/stepper#lambda-calls)
+- [Number](/components/number#lambda-calls)
 
 ## See Also
 

--- a/src/content/docs/changelog/2024.10.0.mdx
+++ b/src/content/docs/changelog/2024.10.0.mdx
@@ -33,7 +33,7 @@ Please see [Entity sorting](/components/web_server#config-webserver-sorting) for
 ESPHome now supports reading a custom MAC address from the ESP32 eFuse blocks and will read and use it by default if
 there is data burned into the eFuses. If you would like to disable this, or the eFuse has data burned that is not a
 MAC address into those eFuses, then you can add `ignore_efuse_custom_mac: true` to your ESP32 `advanced`
-configuration. See [ESP32 Advanced Configuration](/components/esp32#esp32-advanced_configuration) for more details.
+configuration. See [ESP32 Advanced Configuration](/components/esp32#advanced-configuration) for more details.
 
 ## CSE7766 Breaking Changes
 

--- a/src/content/docs/changelog/2026.4.0.mdx
+++ b/src/content/docs/changelog/2026.4.0.mdx
@@ -60,7 +60,7 @@ Users on battery power or with thermal constraints can override with `cpu_freque
 
 **ESP32 crash handler improvements**: The existing crash handler now captures backtraces from **both cores** on dual-core ESP32 variants ([#15559](https://github.com/esphome/esphome/pull/15559)) and preserves crash data across OTA rollback reboots ([#15578](https://github.com/esphome/esphome/pull/15578)).
 
-**40KB extra IRAM on original ESP32** ([#14874](https://github.com/esphome/esphome/pull/14874)): A new option reclaims 40KB of previously reserved SRAM1 as IRAM, expanding the flash cache window and reducing cache misses for WiFi, BLE, and API operations, at no cost to heap. ESPHome will automatically detect your bootloader version at boot and suggest enabling this option only when it is safe to do so. **Do not enable this option without the bootloader check confirming it is safe**; enabling it with a pre-v5.1 bootloader will brick the device (requiring USB reflash to recover). See the [ESP32 documentation](/components/esp32#esp32-advanced_configuration) for details.
+**40KB extra IRAM on original ESP32** ([#14874](https://github.com/esphome/esphome/pull/14874)): A new option reclaims 40KB of previously reserved SRAM1 as IRAM, expanding the flash cache window and reducing cache misses for WiFi, BLE, and API operations, at no cost to heap. ESPHome will automatically detect your bootloader version at boot and suggest enabling this option only when it is safe to do so. **Do not enable this option without the bootloader check confirming it is safe**; enabling it with a pre-v5.1 bootloader will brick the device (requiring USB reflash to recover). See the [ESP32 documentation](/components/esp32#advanced-configuration) for details.
 
 **Signed OTA verification** ([#15357](https://github.com/esphome/esphome/pull/15357)): New `signed_ota_verification` option enables firmware signature verification during OTA updates without requiring hardware Secure Boot (eFuse burning). Two workflows are supported:
 
@@ -77,7 +77,7 @@ esp32:
         signing_scheme: rsa3072
 ```
 
-**Custom partition tables** ([#7682](https://github.com/esphome/esphome/pull/7682)): Components and YAML configs can now define custom data/app partitions that are appended to the flash layout. The partition table generation has been unified across Arduino and IDF, and NVS has been moved to the end of flash with increased size (20KB to 384KB on Arduino). See the [ESP32 documentation](/components/esp32#esp32-partitions) for details.
+**Custom partition tables** ([#7682](https://github.com/esphome/esphome/pull/7682)): Components and YAML configs can now define custom data/app partitions that are appended to the flash layout. The partition table generation has been unified across Arduino and IDF, and NVS has been moved to the end of flash with increased size (20KB to 384KB on Arduino). See the [ESP32 documentation](/components/esp32#partitions) for details.
 
 **ESP-IDF 5.5.4 and Arduino 3.3.8** ([#15666](https://github.com/esphome/esphome/pull/15666), [#15705](https://github.com/esphome/esphome/pull/15705)): Platform bumped to pioarduino 55.03.38-1 with ESP-IDF 5.5.4 and Arduino 3.3.8. PlatformIO is now run in a subprocess to isolate its virtualenv from ESPHome, preventing import errors after build.
 

--- a/src/content/docs/changelog/v1.14.0.mdx
+++ b/src/content/docs/changelog/v1.14.0.mdx
@@ -268,7 +268,7 @@ be possible!
   See the updated custom component guide.
 
 - [Sensors](/components/sensor) have a new `force_update` option ([esphome#783](https://github.com/esphome/esphome/pull/783)).
-- Add GPIO Switch [interlock_wait_time](/components/switch/gpio#switch-gpio-interlocking) ([esphome#777](https://github.com/esphome/esphome/pull/777)).
+- Add GPIO Switch [interlock_wait_time](/components/switch/gpio#interlocking) ([esphome#777](https://github.com/esphome/esphome/pull/777)).
 - Add a configurable priority for WiFi network selection ([esphome#658](https://github.com/esphome/esphome/pull/658), [docs](/components/wifi/)).
 - Add [script.wait](/components/script#script-wait-action) action ([esphome#778](https://github.com/esphome/esphome/pull/778)).
 - Dashboard Interface: Add an interface for editing `secrets.yaml` ([esphome#672](https://github.com/esphome/esphome/pull/672) by [@Anonym-tsk](https://github.com/Anonym-tsk)).

--- a/src/content/docs/components/alarm_control_panel/index.mdx
+++ b/src/content/docs/components/alarm_control_panel/index.mdx
@@ -23,7 +23,7 @@ Configuration variables:
 - **name** (*Optional*, string): The name of the alarm control panel. At least one of **id** and **name** must be specified.
 
 > [!NOTE]
-> If you have a [friendly_name](/components/esphome#esphome-configuration_variables) set for your device and
+> If you have a [friendly_name](/components/esphome#configuration-variables) set for your device and
 > you want the switch to use that name, you can set `name: None`.
 
 - **on_state** (*Optional*, [Action](/automations/actions#all-actions)): An automation to perform
@@ -301,8 +301,6 @@ on_...:
     condition:
       alarm_control_panel.is_armed: acp1
 ```
-
-<span id="alarm_control_panel_lambda_calls"></span>
 
 ### lambda calls
 

--- a/src/content/docs/components/alarm_control_panel/template.mdx
+++ b/src/content/docs/components/alarm_control_panel/template.mdx
@@ -58,8 +58,6 @@ alarm_control_panel:
 > If `binary_sensors` is omitted then you're expected to trigger the alarm using
 > [`pending` Action](/components/alarm_control_panel#alarm_control_panel-pending-action) or [`triggered` Action](/components/alarm_control_panel#alarm_control_panel-triggered-action).
 
-<span id="template_alarm_control_panel-trigger_modes"></span>
-
 ## Trigger Modes
 
 Each binary sensor "zone" supports 4 trigger modes. The modes are:
@@ -96,8 +94,6 @@ or door. If there is a PIR guarding the main hallway, it will cause an instant t
 entered the premises in an unusual manner. Likewise, if someone enters the premises through a door set to the `delayed`
 trigger mode, and then triggers the PIR, the alarm will stay in the `pending` state until either they disarm the alarm,
 or the pending timer expires.
-
-<span id="template_alarm_control_panel-state_flow"></span>
 
 ## State Flow
 

--- a/src/content/docs/components/api.mdx
+++ b/src/content/docs/components/api.mdx
@@ -123,8 +123,6 @@ api:
 - **on_client_disconnected** (*Optional*, [Action](/automations/actions#all-actions)): An automation to perform when a client
   disconnects from the API. See [`on_client_disconnected` Trigger](#api-on_client_disconnected_trigger).
 
-<span id="api-actions"></span>
-
 ## Actions
 
 Before using any of the actions below, you'll need to tell Home Assistant to allow your device to
@@ -148,12 +146,10 @@ Then:
 
 1. Then click "submit"
 
-<span id="api-homeassistant_event_action"></span>
-
 ### `homeassistant.event` Action
 
 > [!NOTE]
-> Be sure to [follow the instructions above](#api-actions) to tell Home Assistant to allow
+> Be sure to [follow the instructions above](#actions) to tell Home Assistant to allow
 > your device to perform actions.
 
 When using the native API with Home Assistant, you can create events in the Home Assistant event bus
@@ -179,12 +175,10 @@ on_...:
 - **variables** (*Optional*, mapping): Optional variables that can be used in the `data_template`.
   Values are [lambdas](/automations/templates#config-lambda) and will be evaluated before sending the request.
 
-<span id="api-homeassistant_action-action"></span>
-
 ### `homeassistant.action` Action
 
 > [!NOTE]
-> Be sure to [follow the instructions above](#api-actions) to tell Home Assistant to allow
+> Be sure to [follow the instructions above](#actions) to tell Home Assistant to allow
 > your device to perform actions.
 
 When using the native API with Home Assistant, you can perform Home Assistant actions straight from ESPHome [Automations](/automations).
@@ -341,7 +335,7 @@ When `response_template` is used, the processed result is available in `response
 ### `homeassistant.tag_scanned` Action
 
 > [!NOTE]
-> Be sure to [follow the instructions above](#api-actions) to tell Home Assistant to allow
+> Be sure to [follow the instructions above](#actions) to tell Home Assistant to allow
 > your device to make action calls.
 
 When using the native API with Home Assistant, you can push tag_scanned to Home Assistant

--- a/src/content/docs/components/at581x.mdx
+++ b/src/content/docs/components/at581x.mdx
@@ -81,8 +81,6 @@ binary_sensor:
 
 - Refer to other options from [Binary Sensor](/components/binary_sensor#config-binary_sensor) and [GPIO Binary Sensor](/components/binary_sensor/gpio/).
 
-<span id="at581x-switch"></span>
-
 ## Switch
 
 [Switch components](/components/switch#config-switch) are used to enable/disable radio frequency hardware.
@@ -100,8 +98,6 @@ switch:
   Required when multiple instances of the `at581x` component are defined.
 
 - All other options from [Switch](/components/switch#config-switch).
-
-<span id="at581x-actions"></span>
 
 ## Actions
 

--- a/src/content/docs/components/binary_sensor/ble_presence.mdx
+++ b/src/content/docs/components/binary_sensor/ble_presence.mdx
@@ -78,8 +78,6 @@ binary_sensor:
 
 - All other options from [Binary Sensor](/components/binary_sensor#config-binary_sensor).
 
-<span id="esp32_ble_tracker-setting_up_devices"></span>
-
 ## Setting Up Devices
 
 To set up binary sensors for specific BLE beacons you first have to know which MAC address

--- a/src/content/docs/components/binary_sensor/esp32_touch.mdx
+++ b/src/content/docs/components/binary_sensor/esp32_touch.mdx
@@ -12,15 +12,15 @@ Capacitive touch detection is possible on ESP32, ESP32-S2, ESP32-S3 and ESP32-P4
 In ESPHome, it is configured in two parts:
 
 - [Component/Hub](#esp32-touch-component)
-- [Binary Sensor](#esp32-touch-binary-sensor)
+- [Binary Sensor](#binary-sensor)
 
 <span id="esp32-touch-component"></span>
 
 ## Component/Hub
 
 The `esp32_touch` component creates a global hub enabling (capacitive) touch detection on GPIO pins
-[supported by ESP32, ESP32-S2, ESP32-S3 and ESP32-P4 processors](#esp32-touch-pad-pins). With this enabled,
-[binary sensors](#esp32-touch-binary-sensor) may then be configured to permit touch detection.
+[supported by ESP32, ESP32-S2, ESP32-S3 and ESP32-P4 processors](#touch-pad-pins). With this enabled,
+[binary sensors](#binary-sensor) may then be configured to permit touch detection.
 
 ```yaml
 # Example configuration entry
@@ -32,7 +32,7 @@ esp32_touch:
 
 - **setup_mode** (*Optional*, boolean): Whether debug messages with the touch pad value should
    be displayed in the logs. Useful for finding out suitable thresholds for the binary sensors, but
-   will spam the logs. See [setting up touch pads](#esp32-touch-binary-sensor)
+   will spam the logs. See [setting up touch pads](#binary-sensor)
    for more information. Defaults to `false`.
 
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID for code generation.
@@ -119,8 +119,6 @@ Waterproof configuration:
 For a more detailed explanation of the waterproof configuration, please see the
 [ESP-IDF documentation.](https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/api-reference/peripherals/touch_pad.html#_CPPv420touch_pad_waterproof)
 
-<span id="esp32-touch-binary-sensor"></span>
-
 ## Binary Sensor
 
 The `esp32_touch` binary sensor platform lets you use the touch peripheral of the
@@ -150,10 +148,10 @@ binary_sensor:
    events on.
 
 - **threshold** (**Required**, `int`  ): The threshold to use to detect touch events. See
-   [Finding Thresholds](#esp32-finding-thresholds) below for help determining this value.
+   [Finding Thresholds](#finding-thresholds) below for help determining this value.
 
 - **wakeup_threshold** (*Optional*, `int`  ): The threshold to use to detect touch events to wake-up from deep sleep.
-   See [Finding Thresholds](#esp32-finding-thresholds) below for help determining this value. Touch pad sensors that should trigger a
+   See [Finding Thresholds](#finding-thresholds) below for help determining this value. Touch pad sensors that should trigger a
    wake-up from deep sleep must specify this value. The [Deep Sleep Component](/components/deep_sleep#deep_sleep-component) must also be configured to enable
    wake-up from a touch event. Note that no filter(s) is/are active during deep sleep.
 
@@ -186,8 +184,6 @@ One example of use is a wide area pressure sensor that integrates a number of sm
 of aluminium foil that sandwich paper, and connect one wire to a touch pin and the other to ground. Set up several sensors
 under a flexible object like a plastic mat, add the raw values, and apply a threshold.
 
-<span id="esp32-touch-pad-pins"></span>
-
 ## Touch Pad Pins
 
 Various pins on the ESP32, ESP32-S2, ESP32-S3 and ESP32-P4 can be used to detect touches. They are as follows (using the default
@@ -196,8 +192,6 @@ Various pins on the ESP32, ESP32-S2, ESP32-S3 and ESP32-P4 can be used to detect
 | ESP32                                                                       | ESP32-S2       | ESP32-S3       | ESP32-P4       |
 | --------------------------------------------------------------------------- | -------------- | -------------- | -------------- |
 | GPIO4, GPIO0, GPIO2, GPIO15, GPIO13, GPIO12, GPIO14, GPIO27, GPIO33, GPIO32 | GPIO1 - GPIO14 | GPIO1 - GPIO14 | GPIO2 - GPIO15 |
-
-<span id="esp32-finding-thresholds"></span>
 
 ## Finding Thresholds
 

--- a/src/content/docs/components/binary_sensor/index.mdx
+++ b/src/content/docs/components/binary_sensor/index.mdx
@@ -31,7 +31,7 @@ Configuration variables:
 - **name** (*Optional*, string): The name for the binary sensor. At least one of **id** and **name** must be specified.
 
 > [!NOTE]
-> If you have a [friendly_name](/components/esphome#esphome-configuration_variables) set for your device and
+> If you have a [friendly_name](/components/esphome#configuration-variables) set for your device and
 > you want the binary sensor to use that name, you can set `name: None`.
 
 - **device_class** (*Optional*, string): The device class for the
@@ -463,7 +463,7 @@ Configuration variables:
 
 > [!NOTE]
 > Getting the timing right for your use-case can sometimes be a bit difficult. If you set the
-> [global log level](/components/logger#logger-log_levels) to `VERBOSE`, the multi click trigger shows logs
+> [global log level](/components/logger#log-levels) to `VERBOSE`, the multi click trigger shows logs
 > about what stopped the trigger from happening.
 
 You can use an `OFF` timing at the end of the timing sequence to differentiate between different
@@ -540,8 +540,6 @@ on_...:
       # Same syntax for is_off
       binary_sensor.is_on: my_binary_sensor
 ```
-
-<span id="binary_sensor-lambda_calls"></span>
 
 ### lambda calls
 

--- a/src/content/docs/components/binary_sensor/lvgl.mdx
+++ b/src/content/docs/components/binary_sensor/lvgl.mdx
@@ -6,7 +6,7 @@ title: "LVGL Binary Sensor"
 The `lvgl` binary sensor platform creates a binary sensor from an LVGL widget
 and requires [LVGL](/components/lvgl/) to be configured.
 
-Any widget that supports the `pressed` or `checked` [state](/components/lvgl/widgets#lvgl-widgetproperty-state) can be used; in particular, [`button`](/components/lvgl/widgets#lvgl-widget-button), [`buttonmatrix`](/components/lvgl/widgets#lvgl-widget-buttonmatrix), [`checkbox`](/components/lvgl/widgets#lvgl-widget-checkbox) and [`switch`](/components/lvgl/widgets#lvgl-widget-switch). A single binary sensor supports only a single widget; in other words, it's not possible to have multiple widgets associated with a single ESPHome binary sensor component.
+Any widget that supports the `pressed` or `checked` [state](/components/lvgl/widgets#lvgl-widgetproperty-state) can be used; in particular, [`button`](/components/lvgl/widgets#button), [`buttonmatrix`](/components/lvgl/widgets#buttonmatrix), [`checkbox`](/components/lvgl/widgets#checkbox) and [`switch`](/components/lvgl/widgets#switch). A single binary sensor supports only a single widget; in other words, it's not possible to have multiple widgets associated with a single ESPHome binary sensor component.
 
 ## Configuration variables
 
@@ -37,7 +37,7 @@ binary_sensor:
 ## See Also
 
 - [LVGL Main component](/components/lvgl/)
-- [Button widget](/components/lvgl/widgets#lvgl-widget-button)
+- [Button widget](/components/lvgl/widgets#button)
 - [LVGL Sensor](/components/sensor/lvgl/)
 - [LVGL Number](/components/number/lvgl/)
 - [LVGL Switch](/components/switch/lvgl/)

--- a/src/content/docs/components/binary_sensor/nextion.mdx
+++ b/src/content/docs/components/binary_sensor/nextion.mdx
@@ -44,8 +44,8 @@ binary_sensor:
 - **page_id** (*Optional*, string): The ID of the page the component is on. Use `0`   for the default page.
 - **component_id** (*Optional*, string): The ID (the number, not name!) of the component to track.
 - **update_interval** (*Optional*, [Time](/guides/configuration-types#time)): The duration to update the sensor. If using a [Nextion Custom Binary Sensor Protocol](#nextion-custom-binary-sensor-protocol) this should not be used
-- **background_color** (*Optional*, [Color](/components/display#config-color)): The background color
-- **foreground_color** (*Optional*, [Color](/components/display#config-color)): The foreground color
+- **background_color** (*Optional*, [Color](/components/display#color)): The background color
+- **foreground_color** (*Optional*, [Color](/components/display#color)): The foreground color
 - **visible** (*Optional*, boolean): Visible or not
 - All other options from [Binary Sensor](/components/binary_sensor#config-binary_sensor).
 
@@ -70,7 +70,7 @@ Example:
       id(nextion1).update_components_by_page_prefix("page"+x+".");
 ```
 
-See [How things Update](#nextion_binary_sensor_how_things_update) for additional information
+See [How things Update](#how-things-update) for additional information
 
 ### Globals
 
@@ -119,9 +119,7 @@ on_...:
   display which will update component. Default is true.
 
 > [!NOTE]
-> This action can also be written in lambdas. See [Lambda Calls](#nextion_binary_sensor_lambda_calls)
-
-<span id="nextion_binary_sensor_lambda_calls"></span>
+> This action can also be written in lambdas. See [Lambda Calls](#lambda-calls)
 
 ## Lambda Calls
 
@@ -144,8 +142,6 @@ more advanced functions (see the full <APIRef text="nextion_binarysensor.h" path
 - `set_foreground_pressed_color(Color color)`  : Sets the background color to **Color**
 - `set_visible(bool visible)`   : Sets visible or not. If set to false, no updates will be sent to the component
 
-<span id="nextion_binary_sensor_how_things_update"></span>
-
 ## How things Update
 
 A Nextion component with an integer value (.val) or Nextion variable will be automatically polled if **update_interval** is set.
@@ -165,7 +161,7 @@ Using the above yaml example:
 - "Radio 0 Binary Sensor" will poll the Nextion for the `r0.val`   value and set the state accordingly.
 - "Is Darkmode Set" will NOT poll the Nextion. Either the Nextion will need to use the [Nextion Custom Binary Sensor Protocol](#nextion-custom-binary-sensor-protocol) or use a lambda:
 
-- [Lambda Calls](#nextion_binary_sensor_lambda_calls).
+- [Lambda Calls](#lambda-calls).
 
 > [!NOTE]
 > No updates will be sent to the Nextion if it is sleeping. Once it wakes the components will be updated. If a component is invisible, `visible(false)`, then it won't update until it is set to be visible.

--- a/src/content/docs/components/binary_sensor/nfc.mdx
+++ b/src/content/docs/components/binary_sensor/nfc.mdx
@@ -45,8 +45,6 @@ binary_sensor:
 
 - All other options from [Binary Sensor](/components/binary_sensor#config-binary_sensor).
 
-<span id="nfc-setting_up_tags"></span>
-
 ## Setting Up Tags
 
 To set up a binary sensor for a given NFC tag, you must first know either its unique ID (`uid`  ), tag ID (if it was

--- a/src/content/docs/components/binary_sensor/pn532.mdx
+++ b/src/content/docs/components/binary_sensor/pn532.mdx
@@ -21,7 +21,7 @@ create individual binary sensors that track if an NFC/RFID tag is currently dete
 
 <Image src={pn532FullImg} layout="constrained" alt="" />
 
-See [Setting Up Tags](#pn532-setting_up_tags) for information on how to setup individual binary sensors for this component.
+See [Setting Up Tags](#setting-up-tags) for information on how to setup individual binary sensors for this component.
 
 The PN532 can be configured to use either the SPI **or** I²C protocol for data communication.
 You will need to switch the dip switches located on the module according to the table printed on the board.
@@ -116,7 +116,7 @@ if the tag is changed or goes away for one cycle of `update_interval`.
 The parameter `x` this trigger provides is of type `std::string` and is the tag UID in the format
 `74-10-37-94`. The configuration below will for example publish the tag ID on the MQTT topic `pn532/tag`.
 
-See [NDEF reading](#pn532-ndef_reading) below for how to use the second `tag` parameter that is provided to this trigger.
+See [NDEF reading](#ndef-reading) below for how to use the second `tag` parameter that is provided to this trigger.
 
 ```yaml
 pn532_...:
@@ -208,8 +208,6 @@ binary_sensor:
 
 - All other options from [Binary Sensor](/components/binary_sensor#config-binary_sensor).
 
-<span id="pn532-setting_up_tags"></span>
-
 ## Setting Up Tags
 
 To set up binary sensors for specific NFC tags you first have to know their unique IDs. To obtain this
@@ -224,13 +222,9 @@ Found new tag '74-10-37-94'
 Then copy this id and create a `binary_sensor` entry as in the configuration example. Repeat this process for
 each tag.
 
-<span id="pn532-ndef"></span>
-
 ## NDEF
 
 The PN532 supports reading and writing NDEF formatted data into the cards.
-
-<span id="pn532-ndef_reading"></span>
 
 ### NDEF reading
 
@@ -258,8 +252,6 @@ pn532_...:
           }
           return x;
 ```
-
-<span id="pn532-ndef_writing"></span>
 
 ### NDEF Writing
 

--- a/src/content/docs/components/binary_sensor/rc522.mdx
+++ b/src/content/docs/components/binary_sensor/rc522.mdx
@@ -15,7 +15,7 @@ The `rc522` component allows you to use RC522 NFC/RFID controllers
 ([datasheet](https://www.nxp.com/docs/en/data-sheet/MFRC522.pdf), [Ali Express](https://www.aliexpress.com/item/1260729519.html))
 with ESPHome. ESPHome can read the UID from the tag. Every NFC/RFID tag has a unique "UID" value assigned at the time
 of manufacture. Tags can be associated with binary sensors, making it easy to determine when a specific tag is present.
-You can also use the tag information directly within ESPHome automations/lambdas. See [Setting Up Tags](#rc522-setting_up_tags) for
+You can also use the tag information directly within ESPHome automations/lambdas. See [Setting Up Tags](#setting-up-tags) for
 information on how to setup individual binary sensors using this component.
 
 The RC522 IC supports SPI, I²C and UART communication protocols; ESPHome can use either SPI or I²C.
@@ -185,8 +185,6 @@ binary_sensor:
   of hexadecimal values. For example `74-10-37-94`.
 
 - All other options from [Binary Sensor](/components/binary_sensor#config-binary_sensor).
-
-<span id="rc522-setting_up_tags"></span>
 
 ## Setting Up Tags
 

--- a/src/content/docs/components/binary_sensor/rdm6300.mdx
+++ b/src/content/docs/components/binary_sensor/rdm6300.mdx
@@ -20,7 +20,7 @@ create individual binary sensors that track if an NFC/RFID tag is currently dete
 
 <Image src={rdm6300FullImg} layout="constrained" alt="" />
 
-See [Setting Up Tags](#rdm6300-setting_up_tags) for information on how to setup individual binary sensors for this component.
+See [Setting Up Tags](#setting-up-tags) for information on how to setup individual binary sensors for this component.
 
 As the communication with the RDM6300 is done using UART, you need
 to have an [UART bus](/components/uart) in your configuration with the `rx_pin` connected to the data pin of the RDM6300 and
@@ -105,8 +105,6 @@ binary_sensor:
 
 - **uid** (**Required**, int): The unique ID of the NFC/RFID tag.
 - All other options from [Binary Sensor](/components/binary_sensor#config-binary_sensor).
-
-<span id="rdm6300-setting_up_tags"></span>
 
 ## Setting Up Tags
 

--- a/src/content/docs/components/ble_nus.mdx
+++ b/src/content/docs/components/ble_nus.mdx
@@ -19,7 +19,7 @@ ble_nus:
 - **rx_buffer_size** (*Optional*, int): Size of the receive buffer in bytes. Range: 160-8192. Defaults to `512`.
   Valid only for mode `uart`.
 - **tx_buffer_size** (*Optional*, int): Size of the transmit buffer in bytes. Range: 160-8192. Defaults to `512`.
-- **debug** (*Optional*, mapping): Options for debugging communication on the UART hub, see [Debugging](/components/uart#uart-debugging).
+- **debug** (*Optional*, mapping): Options for debugging communication on the UART hub, see [Debugging](/components/uart#debugging).
 
 ## Usage
 

--- a/src/content/docs/components/button/index.mdx
+++ b/src/content/docs/components/button/index.mdx
@@ -43,7 +43,7 @@ Configuration variables:
 - **name** (*Optional*, string): The name for the button. At least one of **id** and **name** must be specified.
 
 > [!NOTE]
-> If you have a [friendly_name](/components/esphome#esphome-configuration_variables) set for your device and
+> If you have a [friendly_name](/components/esphome#configuration-variables) set for your device and
 > you want the button to use that name, you can set `name: None`.
 
 - **icon** (*Optional*, icon): Manually set the icon to use for the button in the frontend.
@@ -108,9 +108,7 @@ Configuration variables:
 > Buttons are designed to trigger an action on a device from Home Assistant, and have an unidirectional flow from
 > Home Assistant to ESPHome. If you press a button using this action, no button press event will be triggered in Home
 > Assistant. If you want to trigger an automation in Home Assistant, you should use a
-> [Home Assistant event](/components/api#api-homeassistant_event_action) instead.
-
-<span id="button-lambda_calls"></span>
+> [Home Assistant event](/components/api#homeassistant-event-action) instead.
 
 ### lambda calls
 

--- a/src/content/docs/components/climate/index.mdx
+++ b/src/content/docs/components/climate/index.mdx
@@ -54,7 +54,7 @@ Configuration variables:
 - **name** (*Optional*, string): The name of the climate device. At least one of **id** and **name** must be specified.
 
 > [!NOTE]
-> If you have a [friendly_name](/components/esphome#esphome-configuration_variables) set for your device and
+> If you have a [friendly_name](/components/esphome#configuration-variables) set for your device and
 > you want the climate to use that name, you can set `name: None`.
 
 - **icon** (*Optional*, icon): Manually set the icon to use for the climate device in the frontend.
@@ -213,8 +213,6 @@ Configuration variables:
 
 - **swing_mode** (*Optional*, string, [templatable](/automations/templates)): Set the swing mode
   of the climate device. One of `OFF`, `BOTH`, `VERTICAL`, `HORIZONTAL`.
-
-<span id="climate-lambda_calls"></span>
 
 ### lambda calls
 

--- a/src/content/docs/components/cover/am43.mdx
+++ b/src/content/docs/components/cover/am43.mdx
@@ -42,7 +42,7 @@ etc are programmed in (this component does not yet support setting these).
 
 Once setup, configure the yaml per the above example, using the MAC
 address of your device.
-See [Setting up devices](/components/binary_sensor/ble_presence#esp32_ble_tracker-setting_up_devices) for
+See [Setting up devices](/components/binary_sensor/ble_presence#setting-up-devices) for
 how to discover the MAC address.
 
 To make use of the battery and light level sensors, see the

--- a/src/content/docs/components/cover/index.mdx
+++ b/src/content/docs/components/cover/index.mdx
@@ -34,7 +34,7 @@ Configuration variables:
 - **name** (*Optional*, string): The name for the cover. At least one of **id** and **name** must be specified.
 
 > [!NOTE]
-> If you have a [friendly_name](/components/esphome#esphome-configuration_variables) set for your device and
+> If you have a [friendly_name](/components/esphome#configuration-variables) set for your device and
 > you want the cover to use that name, you can set `name: None`.
 
 - **device_class** (*Optional*, string): The device class for the

--- a/src/content/docs/components/datetime/index.mdx
+++ b/src/content/docs/components/datetime/index.mdx
@@ -35,7 +35,7 @@ Configuration variables:
 - **name** (*Optional*, string): The name for the datetime. At least one of **id** and **name** must be specified.
 
 > [!NOTE]
-> If you have a [friendly_name](/components/esphome#esphome-configuration_variables) set for your device and
+> If you have a [friendly_name](/components/esphome#configuration-variables) set for your device and
 > you want the datetime to use that name, you can set `name: None`.
 
 - **icon** (*Optional*, icon): Manually set the icon to use for the datetime in the frontend.
@@ -128,8 +128,6 @@ Configuration variables:
 - **date** (**Required**, string, date parts, [templatable](/automations/templates)):
   The value to set the datetime to.
 
-<span id="datetime-lambda_calls"></span>
-
 ### lambda calls
 
 From [lambdas](/automations/templates#config-lambda), you can call several methods on all datetimes to do some
@@ -191,8 +189,6 @@ Configuration variables:
 - **id** (**Required**, [ID](/guides/configuration-types#id)): The ID of the datetime to set.
 - **time** (**Required**, string, time parts, [templatable](/automations/templates)):
   The value to set the datetime to.
-
-<span id="datetime-time-lambda_calls"></span>
 
 ### lambda calls
 
@@ -258,8 +254,6 @@ Configuration variables:
 - **id** (**Required**, [ID](/guides/configuration-types#id)): The ID of the datetime to set.
 - **datetime** (**Required**, string, datetime parts, [templatable](/automations/templates)):
   The value to set the datetime to.
-
-<span id="datetime-datetime-lambda_calls"></span>
 
 ### Lambda calls
 

--- a/src/content/docs/components/deep_sleep.mdx
+++ b/src/content/docs/components/deep_sleep.mdx
@@ -47,7 +47,7 @@ deep_sleep:
 
 - **sleep_duration** (*Optional*, [Time](/guides/configuration-types#time)): The time duration to stay in deep sleep mode. On BK72xx, the maximum is 36 hours. On Zephyr, the maximum is 49 days.
 - **touch_wakeup** (*Optional*, boolean): Only on ESP32. Use a touch event to wakeup from deep sleep. To be able
-  to wakeup from a touch event, [Binary Sensor](/components/binary_sensor/esp32_touch#esp32-touch-binary-sensor) must be configured properly.
+  to wakeup from a touch event, [Binary Sensor](/components/binary_sensor/esp32_touch#binary-sensor) must be configured properly.
 
 - **wakeup_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema) / list): Only on ESP32/BK72xx. A single pin to wake up to once
   in deep sleep mode. Use the inverted property to wake up to LOW signals.

--- a/src/content/docs/components/dfrobot_sen0395.mdx
+++ b/src/content/docs/components/dfrobot_sen0395.mdx
@@ -74,11 +74,7 @@ dfrobot_sen0395:
 - **uart_id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID of the [Uart](/components/uart/) if you want
   to use multiple UART buses.
 
-<span id="dfrobot_sen0395-binary_sensor"></span>
-
 ## Binary Sensor
-
-<span id="dfrobot_sen0395-via_gpio"></span>
 
 ### Via GPIO
 
@@ -99,13 +95,11 @@ binary_sensor:
       mode: INPUT_PULLDOWN
 ```
 
-<span id="dfrobot_sen0395-via_uart"></span>
-
 ### Via UART
 
 Connecting the sensor via the serial connection (UART) allows both changing its settings as well as reading its state.
 Note, however, that the UART peripheral cannot wake the processor; if you plan on sleeping the processor, you'll likely
-still need to use the [GPIO pin](#dfrobot_sen0395-via_gpio) approach described above (in addition to the UART).
+still need to use the [GPIO pin](#via-gpio) approach described above (in addition to the UART).
 
 First, setup a [Uart](/components/uart/) and [Hub Component](#dfrobot_sen0395-component) and then use its binary sensor platform
 to create individual binary sensors for each presence sensor.
@@ -122,8 +116,6 @@ binary_sensor:
   Required when multiple instances of the `dfrobot_sen0395` component are defined.
 
 - All other options from [Binary Sensor](/components/binary_sensor#config-binary_sensor).
-
-<span id="dfrobot_sen0395-switch"></span>
 
 ## Switch
 
@@ -155,8 +147,6 @@ switch:
     remain off.
 
 - All other options from [Switch](/components/switch#config-switch).
-
-<span id="dfrobot_sen0395-actions"></span>
 
 ## Actions
 

--- a/src/content/docs/components/display/ili9xxx.mdx
+++ b/src/content/docs/components/display/ili9xxx.mdx
@@ -169,7 +169,7 @@ dimensions:
 ```
 
 To utilize the color capabilities of this display module, you'll likely want to add a `color:` section to your
-YAML configuration; please see [color](/components/display#config-color) for more detail on this configuration section.
+YAML configuration; please see [color](/components/display#color) for more detail on this configuration section.
 
 To use colors in your lambda:
 

--- a/src/content/docs/components/display/index.mdx
+++ b/src/content/docs/components/display/index.mdx
@@ -437,8 +437,6 @@ class Rect {
 
 With `is_clipping();` tells you if clipping is activated.
 
-<span id="config-color"></span>
-
 ### Color
 
 When using RGB-capable displays in ESPHome you may wish to use custom colors.

--- a/src/content/docs/components/display/nextion.mdx
+++ b/src/content/docs/components/display/nextion.mdx
@@ -32,10 +32,10 @@ bkcmd=0       // Tells the Nextion to not send responses on commands. This is th
 ```
 
 This permits faster communication with the Nextion display and it is highly recommended when using
-[Hardware UARTs](/components/uart#uart-hardware_uarts).
+[Hardware UARTs](/components/uart#hardware-uarts).
 
 > [!WARNING]
-> **We highly recommend using only** [Hardware UARTs](/components/uart#uart-hardware_uarts) **with Nextion displays.**
+> **We highly recommend using only** [Hardware UARTs](/components/uart#hardware-uarts) **with Nextion displays.**
 >
 > *Use of software UARTs is known to result in unpredictable/inconsistent behavior.*
 >
@@ -402,7 +402,7 @@ logging or other [automations](/automations/) will occur. This process uses the 
 > update process failing.*
 >
 > If you experience problems with the update process and are using a software UART (for example, on the ESP8266), you
-> should switch to an ESP32 or supported variant which has more available [Hardware UARTs](/components/uart#uart-hardware_uarts).
+> should switch to an ESP32 or supported variant which has more available [Hardware UARTs](/components/uart#hardware-uarts).
 
 You can use Home Assistant itself or any other web server to host the TFT file. When using HTTPS (generally
 recommended), you may notice reduced upload speeds as the encryption consumes more resources on the microcontroller.

--- a/src/content/docs/components/display/ssd1325.mdx
+++ b/src/content/docs/components/display/ssd1325.mdx
@@ -71,7 +71,7 @@ display:
 ### Configuration examples
 
 To utilize the grayscale capabilities of this display module, add a `color:` section to your YAML configuration;
-please see [color](/components/display#config-color) for more details. As this is a grayscale display, it only uses the white color
+please see [color](/components/display#color) for more details. As this is a grayscale display, it only uses the white color
 element as shown below.
 
 To use grayscale in your lambda:

--- a/src/content/docs/components/display/ssd1327.mdx
+++ b/src/content/docs/components/display/ssd1327.mdx
@@ -129,7 +129,7 @@ display:
 ### Configuration examples
 
 To utilize the grayscale capabilities of this display module, add a `color:` section to your YAML configuration;
-please see [color](/components/display#config-color) for more details. As this is a grayscale display, it only uses the white color
+please see [color](/components/display#color) for more details. As this is a grayscale display, it only uses the white color
 element as shown below.
 
 To use grayscale in your lambda:

--- a/src/content/docs/components/display/ssd1331.mdx
+++ b/src/content/docs/components/display/ssd1331.mdx
@@ -59,7 +59,7 @@ display:
 ### Configuration examples
 
 You may wish to add a `color:` section to your YAML configuration to make using colors easier; please see
-[color](/components/display#config-color) for more detail on this optional configuration section.
+[color](/components/display#color) for more detail on this optional configuration section.
 
 ```yaml
 color:

--- a/src/content/docs/components/display/ssd1351.mdx
+++ b/src/content/docs/components/display/ssd1351.mdx
@@ -65,7 +65,7 @@ display:
 
 ### Configuration examples
 
-Add a `color:` section to your YAML configuration; please see [color](/components/display#config-color) for more detail on this configuration section.
+Add a `color:` section to your YAML configuration; please see [color](/components/display#color) for more detail on this configuration section.
 
 ```yaml
 color:

--- a/src/content/docs/components/display_menu/graphical_display_menu.mdx
+++ b/src/content/docs/components/display_menu/graphical_display_menu.mdx
@@ -43,10 +43,10 @@ Configuration variables:
   [Drawing Modes](#drawing-modes) for more details
 
 - **font** (**Required**, [Font](/components/font#display-fonts)): Specifies the font to use
-- **foreground_color** (*Optional*, [Color](/components/display#config-color)): Specifies the foreground color to use.
+- **foreground_color** (*Optional*, [Color](/components/display#color)): Specifies the foreground color to use.
   Defaults to COLOR_ON
 
-- **background_color** (*Optional*, [Color](/components/display#config-color)): Specifies the background color to use.
+- **background_color** (*Optional*, [Color](/components/display#color)): Specifies the background color to use.
   Defaults to COLOR_OFF
 
 Automations:

--- a/src/content/docs/components/esp32.mdx
+++ b/src/content/docs/components/esp32.mdx
@@ -62,9 +62,9 @@ esp32:
   lower) to work around this.
 
 - **partitions** (*Optional*, filename or list): A partition table CSV file or a list of custom partitions to add.
-  See [Partitions](#esp32-partitions).
+  See [Partitions](#partitions).
 
-- **framework** (*Optional*): Options for the underlying framework used by ESPHome. See [Framework](#esp32-framework).
+- **framework** (*Optional*): Options for the underlying framework used by ESPHome. See [Framework](#framework).
 
 - **watchdog_timeout** (*Optional*, [Time](/guides/configuration-types#time)): The timeout applied to the
   ESP-IDF task watchdog. If a subscribed task fails to feed the watchdog within this period, the device
@@ -299,8 +299,6 @@ esphome --toolchain esp-idf compile my_device.yaml
 If not specified, `platformio` is used by default.
 If both `esp32.toolchain` and the `--toolchain` CLI option are set, the CLI option takes precedence.
 
-<span id="esp32-framework"></span>
-
 ## Framework
 
 ESPHome supports two framework options for ESP32 chips:
@@ -375,10 +373,8 @@ esp32:
 - **log_level** (*Optional*, string): Log level of the framework, one of `ERROR` (default), `NONE`, `WARN`, `INFO`,
   `DEBUG` or `VERBOSE`.
 
-- **advanced** (*Optional*, mapping): See [Advanced Configuration](#esp32-advanced_configuration) below.
-- **components** (*Optional*, list of components): See [IDF Components](#esp32-idf_components) below.
-
-<span id="esp32-advanced_configuration"></span>
+- **advanced** (*Optional*, mapping): See [Advanced Configuration](#advanced-configuration) below.
+- **components** (*Optional*, list of components): See [IDF Components](#idf-components) below.
 
 ## Advanced Configuration
 
@@ -762,8 +758,6 @@ esp32:
 > [!NOTE]
 > If you were already adding libraries via `libraries` config or calling `cg.add_library()`, no action is needed. If you were previously using Arduino library APIs directly in lambdas (e.g. `Preferences`, `Wire`, `SPI`) without adding them to the `libraries` config, you will need to explicitly add them.
 
-<span id="esp32-idf_components"></span>
-
 ## IDF Components
 
 The `components` option allows you to include IDF components. These components will then be compiled into the resulting
@@ -805,8 +799,6 @@ esp32:
   custom or patched version of the component.
 - **path** (*Optional*, string): The path of the component in the git repository or a local path to the
   component if `source` is not set.
-
-<span id="esp32-partitions"></span>
 
 ## Partitions
 

--- a/src/content/docs/components/esp32_ble_server.mdx
+++ b/src/content/docs/components/esp32_ble_server.mdx
@@ -32,7 +32,7 @@ esp32_ble_server:
 ## Configuration variables
 
 - **manufacturer** (*Optional*, [Value Configuration](#esp32_ble_server-value)): The name of the manufacturer/firmware creator. Defaults to `ESPHome`.
-- **model** (*Optional*, [Value Configuration](#esp32_ble_server-value)): The model name of the device. Defaults to the project's name defined in the [core configuration](/components/esphome#esphome-creators_project) if present, otherwise to the friendly name of the `board` chosen in the [core configuration](/components/esphome#esphome-configuration_variables).
+- **model** (*Optional*, [Value Configuration](#esp32_ble_server-value)): The model name of the device. Defaults to the project's name defined in the [core configuration](/components/esphome#esphome-creators_project) if present, otherwise to the friendly name of the `board` chosen in the [core configuration](/components/esphome#configuration-variables).
 - **appearance** (*Optional*, int): Sets the [appearance](https://bitbucket.org/bluetooth-SIG/public/src/main/assigned_numbers/core/appearance_values.yaml) of the device (included in advertising data.) Defaults to `0`.
 - **firmware_version** (*Optional*, [Value Configuration](#esp32_ble_server-value)): The firmware version of the device. Defaults to the project's version defined in the [core configuration](/components/esphome#esphome-creators_project) if present, otherwise to the ESPHome version.
 - **manufacturer_data** (*Optional*, list of bytes): The manufacturer-specific data to include in the advertising

--- a/src/content/docs/components/esp32_ble_tracker.mdx
+++ b/src/content/docs/components/esp32_ble_tracker.mdx
@@ -9,7 +9,7 @@ import APIRef from '@components/APIRef.astro';
 The `esp32_ble_tracker` component creates a global hub so that you can track bluetooth low energy devices
 using your ESP32 node.
 
-See [Setting up devices](/components/binary_sensor/ble_presence#esp32_ble_tracker-setting_up_devices) for information on how you can determine
+See [Setting up devices](/components/binary_sensor/ble_presence#setting-up-devices) for information on how you can determine
 the MAC address of a device and track it using ESPHome.
 
 > [!WARNING]

--- a/src/content/docs/components/esphome.mdx
+++ b/src/content/docs/components/esphome.mdx
@@ -15,8 +15,6 @@ esphome:
     area: Living Room
 ```
 
-<span id="esphome-configuration_variables"></span>
-
 ## Configuration variables
 
 - **name** (**Required**, string): This is the name of the node. It
@@ -56,13 +54,13 @@ Advanced options:
 
 - **includes** (*Optional*, list of files): A list of C/C++ files to include in the (auto-generated) `main` file.
   The paths in this list are relative to the directory where the YAML configuration file is located or `<...>` includes.
-  See [`includes`](#esphome-includes).
+  See [`includes`](#includes).
 
 - **includes_c** (*Optional*, list of files): The same as `includes` but for files that require C linkage. All includes
-  will be wrapped in `extern "C" {}`. See [`includes`](#esphome-includes).
+  will be wrapped in `extern "C" {}`. See [`includes`](#includes).
 
 - **libraries** (*Optional*, list of libraries): A list of libraries to include in the project. See
-  [`libraries`](#esphome-libraries).
+  [`libraries`](#libraries).
 
 - **comment** (*Optional*, string): Additional text information about this node. Only for display in UI.
 - **name_add_mac_suffix** (*Optional*, boolean): Appends the last 3 bytes of the mac address of the device to
@@ -238,8 +236,6 @@ esphome:
 > Environment variables set here are only available during the build process. They do not affect
 > the runtime behavior of your device.
 
-<span id="esphome-includes"></span>
-
 ## `includes`
 
 With `includes` you can include source files in the generated PlatformIO project.
@@ -272,8 +268,6 @@ This option behaves differently depending on what the included file is pointing 
 - If the include string points to a regular source file (.c, .cpp), it is copied in the src/ folder
    AND compiled into the binary. This way implementation of classes and functions in header files can
    be provided.
-
-<span id="esphome-libraries"></span>
 
 ## `libraries`
 

--- a/src/content/docs/components/espnow.mdx
+++ b/src/content/docs/components/espnow.mdx
@@ -20,10 +20,10 @@ espnow:
 - **channel** (*Optional*, int): The Wi-Fi channel that the ESP-NOW communication will use to send/receive data packets.
   Cannot be set when [Wi-Fi](/components/wifi/) is used, as ESP-NOW will use the same channel as the Wi-Fi network.
 - **auto_add_peer** (*Optional*, boolean): When set to `true`, the ESP-NOW component will automatically add any new incoming
-  device as a peer. See [Peers](#espnow-peers) below. Defaults to `false`.
+  device as a peer. See [Peers](#peers) below. Defaults to `false`.
 - **enable_on_boot** (*Optional*, boolean): Enable the ESP-NOW component on boot. Defaults to `true`.
 - **peers** (*Optional*, list of MAC Address): The list of MAC addresses of the devices that this device is allowed to
-  communicate with. See [Peers](#espnow-peers) below.
+  communicate with. See [Peers](#peers) below.
 
 Automations:
 - **on_receive** (*Optional*, [Automation](/automations)): An automation to perform when a directed (non-broadcast) packet is
@@ -182,7 +182,7 @@ Automations:
 ### `espnow.broadcast` Action
 This is an [Action](/automations/actions#all-actions) for sending a data packet over the ESP-NOW protocol to every
 device on the same Wi-Fi channel that is listening for ESP-NOW broadcasts. It is equivalent to using `espnow.send`
-with the address `FF:FF:FF:FF:FF:FF`. See [Broadcasting](#espnow-broadcasting) below for a discussion of when
+with the address `FF:FF:FF:FF:FF:FF`. See [Broadcasting](#broadcasting) below for a discussion of when
 broadcasts are appropriate.
 
 ```yaml
@@ -251,7 +251,6 @@ on_...:
   or consult the [Espressif ESP-NOW documentation](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/network/esp_now.html).
   Both peers must be on the same channel for ESP-NOW packets to be exchanged.
 
-<span id="espnow-peers"></span>
 ## Peers
 A peer is a device that this device is allowed to send to. Broadcast and unencrypted unicast data can be received from
 any device without explicitly adding it as a peer; however, only packets whose source address is in the registered peer
@@ -264,7 +263,6 @@ will be an error when trying to send data to a non-broadcast address.
 Setting `auto_add_peer` to `true` will allow the component to automatically add any incoming device as a peer, and
 will automatically add any peer that data is sent to.
 
-<span id="espnow-broadcasting"></span>
 ## Broadcasting
 The ESP-NOW protocol supports both directed (unicast) frames addressed to a specific peer and broadcast frames sent to
 the special address `FF:FF:FF:FF:FF:FF`. Each style has different trade-offs:

--- a/src/content/docs/components/event/index.mdx
+++ b/src/content/docs/components/event/index.mdx
@@ -16,7 +16,7 @@ triggered in Home Assistant via automations.
 > [!NOTE]
 > Events in ESPHome are designed to trigger an action in Home Assistant, and have a unidirectional flow from ESPHome to Home Assistant.
 > Home Assistant event entities are different from events on event bus. If you just want to trigger an event on the
-> Home Assistant event bus, you should use a [Home Assistant event](/components/api#api-homeassistant_event_action) instead.
+> Home Assistant event bus, you should use a [Home Assistant event](/components/api#homeassistant-event-action) instead.
 
 > [!NOTE]
 > Home Assistant Core 2024.5 or higher is required for ESPHome event entities to work.
@@ -50,7 +50,7 @@ One of `id` or `name` is required.
 - **name** (*Optional*, string): The name for the event. At least one of **id** and **name** must be specified.
 
 > [!NOTE]
-> If you have a [friendly_name](/components/esphome#esphome-configuration_variables) set for your device and
+> If you have a [friendly_name](/components/esphome#configuration-variables) set for your device and
 > you want the event to use that name, you can set `name: None`.
 
 - **icon** (*Optional*, icon): Manually set the icon to use for the event in the frontend.
@@ -120,8 +120,6 @@ Configuration variables:
 
 - **id** (**Required**, [ID](/guides/configuration-types#id)): The ID of the event.
 - **event_type** (**Required**, string, [templatable](/automations/templates)): The type of event to trigger.
-
-<span id="event-lambda_calls"></span>
 
 ### lambda Calls
 

--- a/src/content/docs/components/external_components.mdx
+++ b/src/content/docs/components/external_components.mdx
@@ -41,14 +41,14 @@ external_components:
 
 ## Configuration variables
 
-- **source**: The location of the components you want to retrieve. See [Local](#external-components_local)
-  and [external-components_git](#external-components_git).
+- **source**: The location of the components you want to retrieve. See [Local](#local)
+  and [external-components_git](#git).
 
   - **type** (**Required**): Repository type. One of `local`, `git`.
 
   git options:
 
-  - **url** (**Required**, url): Git repository url. See [external-components_git](#external-components_git).
+  - **url** (**Required**, url): Git repository url. See [external-components_git](#git).
   - **ref** (*Optional*, string): Git ref (branch or tag). If not specified the default branch is used.
   - **username** (*Optional*, string): Username for the Git server, if one is required
   - **password** (*Optional*, string): Password for the Git server, if one is required
@@ -56,15 +56,13 @@ external_components:
 
   local options:
 
-  - **path** (**Required**): Path to use when using local components. See [Local](#external-components_local).
+  - **path** (**Required**): Path to use when using local components. See [Local](#local).
 
 - **components** (*Optional*, list): The list of components to use from the external source.
   By default, all available components are used.
 
 - **refresh** (*Optional*, [Time](/guides/configuration-types#time)): The interval the source will be checked. Has no
-  effect on `local`. See [Refresh](#external-components_refresh). for more info. Defaults to `1day`.
-
-<span id="external-components_local"></span>
+  effect on `local`. See [Refresh](#refresh). for more info. Defaults to `1day`.
 
 ## Local
 
@@ -105,8 +103,6 @@ Given the above example of `my_components`, the folder structure must look like:
         ├── component2.h
         └── switch.py
 ```
-
-<span id="external-components_git"></span>
 
 ## Git
 
@@ -196,8 +192,6 @@ server using the `username` and `password` fields. This is most useful when comb
 `!secret`  feature, to load the values in from a `secrets.yaml` file. This is not a comprehensive
 security measure; your username and password will necessarily be stored in clear text within the
 `.esphome` directory.
-
-<span id="external-components_refresh"></span>
 
 ### Refresh
 

--- a/src/content/docs/components/ezo_pmp.mdx
+++ b/src/content/docs/components/ezo_pmp.mdx
@@ -497,8 +497,6 @@ button:
                   return id(duration).state;
 ```
 
-<span id="ezo_pmp-lambda_calls"></span>
-
 ## lambda calls
 
 From [lambdas](/automations/templates#config-lambda), you can also access the actions on the peristaltic pump to do some

--- a/src/content/docs/components/fan/index.mdx
+++ b/src/content/docs/components/fan/index.mdx
@@ -33,7 +33,7 @@ Configuration variables:
 - **name** (*Optional*, string): The name of the fan. At least one of **id** and **name** must be specified.
 
 > [!NOTE]
-> If you have a [friendly_name](/components/esphome#esphome-configuration_variables) set for your device and
+> If you have a [friendly_name](/components/esphome#configuration-variables) set for your device and
 > you want the fan to use that name, you can set `name: None`.
 
 - **icon** (*Optional*, icon): Manually set the icon to use for the fan in the frontend.

--- a/src/content/docs/components/fingerprint_grow.mdx
+++ b/src/content/docs/components/fingerprint_grow.mdx
@@ -71,7 +71,7 @@ Base Configuration:
 - **sensor_power_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): Output pin responsible for toogling the sensor power on and off.
 - **password** (*Optional*, int): Password to use for authentication. Defaults to `0x00`.
 - **new_password** (*Optional*, int): Sets a new password to use for authentication. See [Setting a New Password](#fingerprint_grow-set_new_password) for more information.
-- **idle_period_to_sleep** (*Optional*, [Time](/guides/configuration-types#time)): The sensor idle period to wait before powering it off (sleep). Defaults to `5s`. See [Sleep Mode](#fingerprint_grow-sleep_mode) for more information.
+- **idle_period_to_sleep** (*Optional*, [Time](/guides/configuration-types#time)): The sensor idle period to wait before powering it off (sleep). Defaults to `5s`. See [Sleep Mode](#sleep-mode) for more information.
 - **on_finger_scan_start** (*Optional*, [Automation](/automations)): An action to be performed when the finger touches the sensor. See [`on_finger_scan_start` Trigger](#fingerprint_grow-on_finger_scan_start).
 - **on_finger_scan_matched** (*Optional*, [Automation](/automations)): An action to be performed when an enrolled fingerprint is scanned. See [`on_finger_scan_matched` Trigger](#fingerprint_grow-on_finger_scan_matched).
 - **on_finger_scan_unmatched** (*Optional*, [Automation](/automations)): An action to be performed when an unknown fingerprint is scanned. See [`on_finger_scan_unmatched` Trigger](#fingerprint_grow-on_finger_scan_unmatched).
@@ -108,8 +108,6 @@ Base Configuration:
 
 - **security_level**: The integer representation of the currently configured security level of the reader. Higher security levels reduce the false acceptance rate (FAR) at the expense of increasing the false rejection rate (FRR). Range is 1 (lowest) to 5 (highest).
   All options from [Sensor](/components/sensor).
-
-<span id="fingerprint_grow-sleep_mode"></span>
 
 ## Sleep Mode
 

--- a/src/content/docs/components/http_request.mdx
+++ b/src/content/docs/components/http_request.mdx
@@ -12,8 +12,6 @@ The `http_request` component lets you make HTTP/HTTPS requests. To do so, you ne
 http_request:
 ```
 
-<span id="http_request-configuration_variables"></span>
-
 ## Configuration variables
 
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID used for code generation.
@@ -144,7 +142,7 @@ on_...:
 
 - **body** (*Optional*, string, [templatable](/automations/templates)): A HTTP body string to send with request.
 - **json** (*Optional*, mapping): A HTTP body in JSON format. Values are [templatable](/automations/templates).
-  See [Examples](#http_request-examples).
+  See [Examples](#examples).
 
 - All other options from [`http_request.get` Action](#http_request-get-action).
 
@@ -215,8 +213,6 @@ This automation will be triggered when the HTTP request fails to complete. This 
 or the server is not reachable. This will *not* be triggered if the request
 completes, even if the response code is not 200. No information on the type of error is available and no variables
 are available for use in [lambdas](/automations/templates#config-lambda). See example usage above.
-
-<span id="http_request-examples"></span>
 
 ## Examples
 

--- a/src/content/docs/components/infrared/index.mdx
+++ b/src/content/docs/components/infrared/index.mdx
@@ -43,7 +43,7 @@ Configuration variables:
 - **name** (*Optional*, string): The name for the infrared entity. At least one of **id** and **name** must be specified.
 
 > [!NOTE]
-> If you have a [friendly_name](/components/esphome#esphome-configuration_variables) set for your device and
+> If you have a [friendly_name](/components/esphome#configuration-variables) set for your device and
 > you want the infrared entity to use that name, you can set `name: None`.
 
 - **icon** (*Optional*, icon): Manually set the icon to use for the infrared entity in the frontend.

--- a/src/content/docs/components/key_collector.mdx
+++ b/src/content/docs/components/key_collector.mdx
@@ -8,7 +8,7 @@ import APIRef from '@components/APIRef.astro';
 
 The `key_collector` component collects key presses from components
 like [Matrix keypad](/components/matrix_keypad#matrix_keypad), [Wiegand keypad](/components/wiegand/)
-or LVGL [Button Matrix](/components/lvgl/widgets#lvgl-widget-buttonmatrix), [Keyboard](/components/lvgl/widgets#lvgl-widget-keyboard)
+or LVGL [Button Matrix](/components/lvgl/widgets#buttonmatrix), [Keyboard](/components/lvgl/widgets#keyboard)
 widgets. It allows you to process key sequences and treat them as one, for
 example to allow inputting of a PIN code or a passkey. The component outputs
 the result of the keypress sequence as a variable usable in automations, and
@@ -129,6 +129,6 @@ that publishes the collected key sequence when a successful result occurs.
 - [Key Collector Text Sensor](/components/text_sensor/key_collector/)
 - [Matrix keypad](/components/matrix_keypad/)
 - [Wiegand keypad and tag reader](/components/wiegand/)
-- [LVGL Button Matrix widget](/components/lvgl/widgets#lvgl-widget-buttonmatrix)
-- [LVGL Keyboard widget](/components/lvgl/widgets#lvgl-widget-keyboard)
+- [LVGL Button Matrix widget](/components/lvgl/widgets#buttonmatrix)
+- [LVGL Keyboard widget](/components/lvgl/widgets#keyboard)
 - <APIRef text="key_collector.h" path="key_collector/key_collector.h" />

--- a/src/content/docs/components/light/cwww.mdx
+++ b/src/content/docs/components/light/cwww.mdx
@@ -21,8 +21,6 @@ light:
     constant_brightness: true
 ```
 
-<span id="cwww_mixing"></span>
-
 ## Mixing
 
 The two channels of this light can be controlled individually by using the `cold_white` and `warm_white` options of

--- a/src/content/docs/components/light/esp32_rmt_led_strip.mdx
+++ b/src/content/docs/components/light/esp32_rmt_led_strip.mdx
@@ -25,7 +25,7 @@ light:
 - **pin** (**Required**, [Pin Schema](/guides/configuration-types#pin-schema)): The pin for the data line of the light.
 - **num_leds** (**Required**, int): The number of LEDs in the strip.
 - **chipset** (*Optional*, enum): The name of the chipset used; determines signal timing. Not required if
-  [specifying the timings manually](#esp32-rmt-led-strip-manual_timings).
+  [specifying the timings manually](#manual-timings).
 
   - `WS2811`
   - `WS2812`
@@ -71,8 +71,6 @@ light:
   the DMA buffer size and can be set to a large value.
 
 - All other options from [Light](/components/light#config-light).
-
-<span id="esp32-rmt-led-strip-manual_timings"></span>
 
 ### Manual Timings
 

--- a/src/content/docs/components/light/fastled.mdx
+++ b/src/content/docs/components/light/fastled.mdx
@@ -27,15 +27,13 @@ import APIRef from '@components/APIRef.astro';
 >
 > For addressable lights, you can use [Esp32 Rmt Led Strip](/components/light/esp32_rmt_led_strip/) or for SPI LEDs see [Spi Led Strip](/components/light/spi_led_strip/)..
 
-<span id="fastled-clockless"></span>
-
 ## Clockless
 
 The `fastled_clockless` light platform allows you to create RGB lights
 in ESPHome for a [number of supported chipsets](#fastled_clockless-chipsets).
 
 Clockless FastLED lights differ from the
-[SPI](#fastled-spi) in that they only have a single data wire to connect, and not separate data and clock wires.
+[SPI](#spi) in that they only have a single data wire to connect, and not separate data and clock wires.
 
 <Image src={fastledClocklessUiImg} layout="constrained" alt="" />
 
@@ -98,8 +96,6 @@ light:
 - `UCS2903`
 - `SM16703`
 
-<span id="fastled-spi"></span>
-
 ## SPI
 
 The `fastled_spi` light platform allows you to create RGB lights
@@ -108,7 +104,7 @@ in ESPHome for a [number of supported chipsets](#fastled_spi-chipsets).
 See [Spi Led Strip](/components/light/spi_led_strip/) for an alternative component that works on ESP-IDF (and Arduino.)
 
 SPI FastLED lights differ from the
-[Clockless](#fastled-clockless) in that they require two pins to be connected, one for a data and one for a clock signal
+[Clockless](#clockless) in that they require two pins to be connected, one for a data and one for a clock signal
 whereas the clockless lights only need a single pin.
 
 <Image src={fastledSpiUiImg} layout="constrained" alt="" />

--- a/src/content/docs/components/light/index.mdx
+++ b/src/content/docs/components/light/index.mdx
@@ -35,7 +35,7 @@ light:
 - **name** (*Optional*, string): The name of the light. At least one of **id** and **name** must be specified.
 
 > [!NOTE]
-> If you have a [friendly_name](/components/esphome#esphome-configuration_variables) set for your device and you want the light
+> If you have a [friendly_name](/components/esphome#configuration-variables) set for your device and you want the light
 > to use that name, you can set `name: None`.
 
 - **icon** (*Optional*, icon): Manually set the icon to use for the light in the frontend.

--- a/src/content/docs/components/light/lvgl.mdx
+++ b/src/content/docs/components/light/lvgl.mdx
@@ -6,7 +6,7 @@ title: "LVGL Light"
 The `lvgl` light platform creates a light from an LVGL widget
 and requires [LVGL](/components/lvgl/) to be configured.
 
-Supported widget is [`led`](/components/lvgl/widgets#lvgl-widget-led). A single light supports only a single widget; in other words, it's not possible to have multiple widgets associated with a single ESPHome light component.
+Supported widget is [`led`](/components/lvgl/widgets#led). A single light supports only a single widget; in other words, it's not possible to have multiple widgets associated with a single ESPHome light component.
 
 ## Configuration variables
 
@@ -28,7 +28,7 @@ light:
 ## See Also
 
 - [LVGL Main component](/components/lvgl/)
-- [LED widget](/components/lvgl/widgets#lvgl-widget-led)
+- [LED widget](/components/lvgl/widgets#led)
 - [LVGL Binary Sensor](/components/binary_sensor/lvgl/)
 - [LVGL Sensor](/components/sensor/lvgl/)
 - [LVGL Number](/components/number/lvgl/)

--- a/src/content/docs/components/light/neopixelbus.mdx
+++ b/src/content/docs/components/light/neopixelbus.mdx
@@ -76,7 +76,7 @@ light:
   - `P9813`
 
 - **method** (*Optional*, string): The method used to transmit the data. By default, ESPHome will try to use the best method
-  available for this chipset, ESP platform, and the given pin. See [methods](#neopixelbus-methods) for more information.
+  available for this chipset, ESP platform, and the given pin. See [methods](#methods) for more information.
 
 - **invert** (*Optional*, boolean): Invert data output, for use with n-type transistors. Defaults to `no`.
 
@@ -94,8 +94,6 @@ If you have one line, only specify `pin`, otherwise specify both `clock_pin` and
 > [!WARNING]
 > On ESP8266 it's highly recommended to connect the light strip to pin
 > GPIO3 to reduce flickering.
-
-<span id="neopixelbus-methods"></span>
 
 ## Methods
 

--- a/src/content/docs/components/light/rgbct.mdx
+++ b/src/content/docs/components/light/rgbct.mdx
@@ -42,7 +42,7 @@ light:
   expressed in Kelvin.
 
 - **color_interlock** (*Optional*, boolean): When enabled, this will prevent white leds being on at the same
-  time as RGB leds. See [Color Interlock](/components/light/rgbw#rgbw_color_interlock) for more information. Defaults to `false`.
+  time as RGB leds. See [Color Interlock](/components/light/rgbw#color-interlock) for more information. Defaults to `false`.
 
 - All other options from [Light](/components/light#config-light).
 

--- a/src/content/docs/components/light/rgbw.mdx
+++ b/src/content/docs/components/light/rgbw.mdx
@@ -44,8 +44,6 @@ output:
 > [!NOTE]
 > Remember that `gamma_correct` is enabled by default (`γ=2.8`  ), and you may want take it into account for the calibration. For instance if you command a light to *50%* brightness and want it to be the new maximum: `max_PWM_power = max_light_power^2.8 = 0.5^2.8 = 0.144`, then you would set `max_power` to *14.4%*.
 
-<span id="rgbw_color_interlock"></span>
-
 ## Color Interlock
 
 With some LED bulbs, it is not possible to enable the RGB leds at the same time as the white leds, or setting
@@ -65,7 +63,7 @@ the `color_mode` option of the [light control actions](/components/light#light-t
 - **blue** (**Required**, [ID](/guides/configuration-types#id)): The id of the float [Output Component](/components/output/) to use for the blue channel.
 - **white** (**Required**, [ID](/guides/configuration-types#id)): The id of the float [Output Component](/components/output/) to use for the white channel.
 - **color_interlock** (*Optional*, boolean): When enabled, this will prevent white leds being on at the same
-  time as RGB leds. See [Color Interlock](#rgbw_color_interlock) for more information. Defaults to `false`.
+  time as RGB leds. See [Color Interlock](#color-interlock) for more information. Defaults to `false`.
 
 - All other options from [Light](/components/light#config-light).
 

--- a/src/content/docs/components/light/rgbww.mdx
+++ b/src/content/docs/components/light/rgbww.mdx
@@ -7,7 +7,7 @@ import APIRef from '@components/APIRef.astro';
 
 The `rgbww` light platform creates an RGBWW (cold white + warm white)
 light from 5 [float output components](/components/output/) (one for each channel). The cold and warm
-white channels can be controlled individually or together, see [Mixing](/components/light/cwww#cwww_mixing) for more information.
+white channels can be controlled individually or together, see [Mixing](/components/light/cwww#mixing) for more information.
 
 ```yaml
 # Example configuration entry
@@ -86,7 +86,7 @@ the `color_mode` option of the [light control actions](/components/light#light-t
   both channels at full brightness at once. Defaults to `false`.
 
 - **color_interlock** (*Optional*, boolean): When enabled, this will prevent white leds being on at the same
-  time as RGB leds. See [Color Interlock](/components/light/rgbw#rgbw_color_interlock) for more information. Defaults to `false`.
+  time as RGB leds. See [Color Interlock](/components/light/rgbw#color-interlock) for more information. Defaults to `false`.
 
 - All other options from [Light](/components/light#config-light).
 

--- a/src/content/docs/components/lock/index.mdx
+++ b/src/content/docs/components/lock/index.mdx
@@ -26,7 +26,7 @@ Configuration variables:
 - **name** (*Optional*, string): The name of the lock. At least one of **id** and **name** must be specified.
 
 > [!NOTE]
-> If you have a [friendly_name](/components/esphome#esphome-configuration_variables) set for your device and
+> If you have a [friendly_name](/components/esphome#configuration-variables) set for your device and
 > you want the lock to use that name, you can set `name: None`.
 
 - **icon** (*Optional*, icon): Manually set the icon to use for the
@@ -98,8 +98,6 @@ on_...:
       # Same syntax for is_unlocked
       lock.is_locked: my_lock
 ```
-
-<span id="lock-lambda_calls"></span>
 
 ### lambda calls
 

--- a/src/content/docs/components/logger.mdx
+++ b/src/content/docs/components/logger.mdx
@@ -13,7 +13,7 @@ configuration). By default, all logs with a severity `DEBUG` or higher will be s
 Increasing the log level severity (to e.g `INFO` or `WARN`  ) can help with the performance of the application and memory size.
 
 > [!NOTE]
-> The "severity" of a log message represents the importance of the message, i.e. how critical it is. The severity levels are defined in the [log levels](#logger-log_levels) section.
+> The "severity" of a log message represents the importance of the message, i.e. how critical it is. The severity levels are defined in the [log levels](#log-levels) section.
 
 ```yaml
 # Example configuration entry
@@ -50,7 +50,7 @@ Advanced settings:
    Set to `0` to disable the log buffer. Defaults to `768B`.
 
 - **hardware_uart** (*Optional*, string): The Hardware UART to use for logging. The default varies depending on
-   the specific processor/chip and framework you are using. See the [table below](#logger-default_hardware_interfaces).
+   the specific processor/chip and framework you are using. See the [table below](#default-hardware-interfaces).
 
 - **esp8266_store_log_strings_in_flash** (*Optional*, boolean): **ESP8266 only.** Compile-time
    setting for where log format strings live. When `true` (default), they stay in flash via
@@ -77,8 +77,6 @@ Advanced settings:
 
 - **early_message** (*Optional*, boolean): Displays early debug information, such as the boot reason.
    Only on nRF52.
-
-<span id="logger-hardware_uarts"></span>
 
 ## Hardware UARTs
 
@@ -107,8 +105,6 @@ so if you use any other configuration you will not get log messages over the on-
 
 *Undefined* means that the logger component cannot use this hardware UART at this time.
 
-<span id="logger-default_hardware_interfaces"></span>
-
 ## Default Hardware Interfaces
 
 Because of the wide variety of boards and processors/chips available, we've selected varying default
@@ -129,8 +125,6 @@ the original ESP32 or ESP8266) continue to use USB-to-serial bridge ICs for comm
 | ESP32-S3  | `USB_SERIAL_JTAG` |
 | RP2040    | `USB_CDC`         |
 | NRF52     | `USB_CDC`         |
-
-<span id="logger-log_levels"></span>
 
 ## Log Levels
 
@@ -230,7 +224,7 @@ Configuration options:
 - **args** (*Optional*, list of [lambda](/automations/templates#config-lambda)): The optional arguments for the
    format message.
 
-- **level** (*Optional*, string): The [log level](#logger-log_levels) to print the message
+- **level** (*Optional*, string): The [log level](#log-levels) to print the message
    with. Defaults to `DEBUG`.
 
 - **tag** (*Optional*, string): The tag (seen in front of the message in the logs) to print the message

--- a/src/content/docs/components/lvgl/index.mdx
+++ b/src/content/docs/components/lvgl/index.mdx
@@ -100,8 +100,8 @@ The following configuration variables apply to the main `lvgl` component, in ord
 - **displays** (*Optional*, list, [ID](/guides/configuration-types#id)): A list of display IDs where LVGL should perform rendering based on its configuration. This may be omitted if there is a single display configured, which will be used automatically.
 - **touchscreens** (*Optional*, list): A list of touchscreens interacting with the LVGL widgets on the display. If you configure a single touchscreen it will be used automatically, and this config entry will not be required.
   - **touchscreen_id** (**Required**, [ID](/guides/configuration-types#id)): ID of a touchscreen configuration related to a display.
-  - **long_press_time** (*Optional*, [Time](/guides/configuration-types#time)): For the touchscreen, delay after which the `on_long_pressed` [interaction trigger](/components/lvgl/widgets#lvgl-automation-triggers) will be called. Defaults to `400ms`.
-  - **long_press_repeat_time** (*Optional*, [Time](/guides/configuration-types#time)): For the touchscreen, repeated interval after `long_press_time`, when `on_long_pressed_repeat` [interaction trigger](/components/lvgl/widgets#lvgl-automation-triggers) will be called. Defaults to `100ms`.
+  - **long_press_time** (*Optional*, [Time](/guides/configuration-types#time)): For the touchscreen, delay after which the `on_long_pressed` [interaction trigger](/components/lvgl/widgets#triggers) will be called. Defaults to `400ms`.
+  - **long_press_repeat_time** (*Optional*, [Time](/guides/configuration-types#time)): For the touchscreen, repeated interval after `long_press_time`, when `on_long_pressed_repeat` [interaction trigger](/components/lvgl/widgets#triggers) will be called. Defaults to `100ms`.
 - **encoders** (*Optional*, list): A list of rotary encoders interacting with the LVGL widgets on the display.
   - **group** (*Optional*, string): A name for a group of widgets which will interact with the input device. See the [common properties](/components/lvgl/widgets/) of the widgets for more information on groups.
   - **initial_focus** (*Optional*, [ID](/guides/configuration-types#id)): An optional ID for a widget to be given focus on startup (especially useful if there is only one focusable widget.)
@@ -109,8 +109,8 @@ The following configuration variables apply to the main `lvgl` component, in ord
   - **sensor** (*Optional*, [ID](/guides/configuration-types#id)): The ID of a [Rotary Encoder](/components/sensor/rotary_encoder/); or a list with buttons for left/right interaction with the widgets:
     - **left_button** (*Optional*, [ID](/guides/configuration-types#id)): The ID of a [Binary Sensor](/components/binary_sensor/), to be used as `LEFT` key.
     - **right_button** (*Optional*, [ID](/guides/configuration-types#id)): The ID of a [Binary Sensor](/components/binary_sensor/), to be used as `RIGHT` key.
-  - **long_press_time** (*Optional*, [Time](/guides/configuration-types#time)): For the rotary encoder, delay after which the `on_long_pressed` [interaction trigger](/components/lvgl/widgets#lvgl-automation-triggers) will be called. Defaults to `400ms`. Can be disabled with `never`.
-  - **long_press_repeat_time** (*Optional*, [Time](/guides/configuration-types#time)): For the rotary encoder, repeated interval after `long_press_time`, when `on_long_pressed_repeat` [interaction trigger](/components/lvgl/widgets#lvgl-automation-triggers) will be called. Defaults to `100ms`. Can be disabled with `never`.
+  - **long_press_time** (*Optional*, [Time](/guides/configuration-types#time)): For the rotary encoder, delay after which the `on_long_pressed` [interaction trigger](/components/lvgl/widgets#triggers) will be called. Defaults to `400ms`. Can be disabled with `never`.
+  - **long_press_repeat_time** (*Optional*, [Time](/guides/configuration-types#time)): For the rotary encoder, repeated interval after `long_press_time`, when `on_long_pressed_repeat` [interaction trigger](/components/lvgl/widgets#triggers) will be called. Defaults to `100ms`. Can be disabled with `never`.
 - **rotary_sensitivity** (*Optional*, int16): Adjust sensitivity for rotary encoders in 1/256 unit. For example with 128 slow down the rotary to half, 512 speeds up to double, 256 no change.
 - **keypads** (*Optional*, list): A list of keypads interacting with the LVGL widgets on the display.
   - **group** (*Optional*, string): A name for a group of widgets which will interact with the input device. See the [common properties](/components/lvgl/widgets/) of the widgets for more information on groups.
@@ -126,11 +126,11 @@ The following configuration variables apply to the main `lvgl` component, in ord
   - **prev** (*Optional*, [ID](/guides/configuration-types#id)): The ID of a [Binary Sensor](/components/binary_sensor/), to be used as `PREV` key.
   - **home** (*Optional*, [ID](/guides/configuration-types#id)): The ID of a [Binary Sensor](/components/binary_sensor/), to be used as `HOME` key.
   - **end** (*Optional*, [ID](/guides/configuration-types#id)): The ID of a [Binary Sensor](/components/binary_sensor/), to be used as `END` key.
-  - **long_press_time** (*Optional*, [Time](/guides/configuration-types#time)): For the keypad, delay after which the `on_long_pressed` [interaction trigger](/components/lvgl/widgets#lvgl-automation-triggers) will be called. Defaults to `400ms`. Can be disabled with `never`.
-  - **long_press_repeat_time** (*Optional*, [Time](/guides/configuration-types#time)): For the keypad, repeated interval after `long_press_time`, when `on_long_pressed_repeat` [interaction trigger](/components/lvgl/widgets#lvgl-automation-triggers) will be called. Defaults to `100ms`. Can be disabled with `never`.
+  - **long_press_time** (*Optional*, [Time](/guides/configuration-types#time)): For the keypad, delay after which the `on_long_pressed` [interaction trigger](/components/lvgl/widgets#triggers) will be called. Defaults to `400ms`. Can be disabled with `never`.
+  - **long_press_repeat_time** (*Optional*, [Time](/guides/configuration-types#time)): For the keypad, repeated interval after `long_press_time`, when `on_long_pressed_repeat` [interaction trigger](/components/lvgl/widgets#triggers) will be called. Defaults to `100ms`. Can be disabled with `never`.
 
 > [!TIP]
-> When using binary sensors (from physical keys) to interact with LVGL, if there are only three keys available, they are best used when configured as a rotary encoder, where `LEFT` and `RIGHT` act like the rotary wheel, and `ENTER` generates an `on_press` [trigger](/components/lvgl/widgets#lvgl-automation-triggers). With four or more keys, a keypad configuration is generally more appropriate. For example, a keypad consisting of five keys might use `PREV`, `NEXT`, `UP`, `DOWN` and `ENTER`  ; `PREV`  /`NEXT` are used to select a widget within the group, `UP`  /`DOWN` changes the selected value and `ENTER` generates an `on_press` [trigger](/components/lvgl/widgets#lvgl-automation-triggers).
+> When using binary sensors (from physical keys) to interact with LVGL, if there are only three keys available, they are best used when configured as a rotary encoder, where `LEFT` and `RIGHT` act like the rotary wheel, and `ENTER` generates an `on_press` [trigger](/components/lvgl/widgets#triggers). With four or more keys, a keypad configuration is generally more appropriate. For example, a keypad consisting of five keys might use `PREV`, `NEXT`, `UP`, `DOWN` and `ENTER`  ; `PREV`  /`NEXT` are used to select a widget within the group, `UP`  /`DOWN` changes the selected value and `ENTER` generates an `on_press` [trigger](/components/lvgl/widgets#triggers).
 >
 > The `long_press_time` and `long_press_repeat_time` can be fine-tuned also by setting them to `never` and using the `autorepeat` filter on each binary sensor separately.
 
@@ -154,9 +154,9 @@ The following configuration variables apply to the main `lvgl` component, in ord
 - **draw_rounding** (*Optional*, int): An optional value to use for rounding draw areas to a specified boundary. Defaults to 2. Useful for displays that require draw windows to be on specified boundaries (usually powers of 2.)
 - **log_level** (*Optional*, string): Set the logger level specifically for the messages of the LVGL library: `VERBOSE`, `DEBUG`, `INFO`, `WARN`, `ERROR`, `NONE`. Defaults to `WARN`.
 - **byte_order** (*Optional*, string): The byte order of the data LVGL outputs; either `big_endian` or `little_endian`. Will try to auto-configure based on the display metadata. Defaults to `big_endian` if the display driver does not supply the information.
-- **default_font** (*Optional*, ID): The ID of the [font](#lvgl-fonts) used by default to render the text or symbols. Defaults to LVGL's internal `montserrat_14` if not specified.
+- **default_font** (*Optional*, ID): The ID of the [font](#fonts) used by default to render the text or symbols. Defaults to LVGL's internal `montserrat_14` if not specified.
 - **style_definitions** (*Optional*, list): A batch of style definitions to use in LVGL widget's `styles` configuration. See [below](#lvgl-theme) for more details.
-- **gradients** (*Optional*, list): A list of gradient definitions to use in *bg_grad* styles. See [below](#lvgl-gradients) for more details.
+- **gradients** (*Optional*, list): A list of gradient definitions to use in *bg_grad* styles. See [below](#gradients) for more details.
 - **theme** (*Optional*, dict): Theme configuration. Supports `dark_mode` and per-widget style defaults. See [below](#lvgl-theme) for more details.
 - **widgets** (*Optional*, list): A list of [Widgets](/components/lvgl/widgets/) to be drawn on the root display. May not be used if `pages` (below) is configured.
 - **pages** (*Optional*, list): A list of page IDs. Each page acts as a parent for widgets placed on it. May not be used with `widgets` (above). Options for each page:
@@ -265,29 +265,29 @@ You can adjust the appearance of widgets by changing their foreground, backgroun
 
 These style properties may be applied to any widget, though not all widgets use all of them.
 
-- **opa** (*Optional*, [opacity](#lvgl-opacity)): Opacity of the entire widget. Inherited from parent. Defaults to `COVER`.
-- **opa_layered** (*Optional*, [opacity](#lvgl-opacity)): Opacity of the entire layer the widget is on. Inherited from parent. Defaults to `COVER`.
+- **opa** (*Optional*, [opacity](#opacity)): Opacity of the entire widget. Inherited from parent. Defaults to `COVER`.
+- **opa_layered** (*Optional*, [opacity](#opacity)): Opacity of the entire layer the widget is on. Inherited from parent. Defaults to `COVER`.
 - **base_dir** (*Optional*): Set base direction of widget. One of `LTR` `RTL` `AUTO` (default).
 - **bg_color** (*Optional*, [color](#lvgl-color)): Color for the background of the widget. Defaults to `0xFFFFFF` (white).
-- **bg_opa** (*Optional*, [opacity](#lvgl-opacity)): Opacity of the widget background.
-- **bg_grad** (*Optional*, [gradient](#lvgl-gradients)): A gradient to apply to the background.
+- **bg_opa** (*Optional*, [opacity](#opacity)): Opacity of the widget background.
+- **bg_grad** (*Optional*, [gradient](#gradients)): A gradient to apply to the background.
 - **bg_grad_color** (*Optional*, [color](#lvgl-color)): Color to make the background gradually fade to. Defaults to `0` (black).
 - **bg_grad_dir** (*Optional*, dict): Choose the direction of the background gradient: `NONE`, `HOR`, `VER`. Defaults to `NONE`.
 - **bg_main_stop** (*Optional*, 0-255): Specify where the gradient should start: `0` = upper left, `128` = in the center, `255` = lower right. Defaults to `0`.
 - **bg_grad_stop** (*Optional*, 0-255): Specify where the gradient should stop: `0` = upper left, `128` = in the center, `255` = lower right. Defaults to `255`.
-- **bg_main_opa** (*Optional*, [opacity](#lvgl-opacity)): Set opacity of the first gradient color. Defaults to `COVER`.
-- **bg_grad_opa** (*Optional*, [opacity](#lvgl-opacity)): Set opacity of the second gradient color. Defaults to `COVER`.
+- **bg_main_opa** (*Optional*, [opacity](#opacity)): Set opacity of the first gradient color. Defaults to `COVER`.
+- **bg_grad_opa** (*Optional*, [opacity](#opacity)): Set opacity of the second gradient color. Defaults to `COVER`.
 - **bg_image_src** (*Optional*, [image](/components/image#display-image)): The ID of an existing image configuration, to show as the background of the widget.
-- **bg_image_opa** (*Optional*, [opacity](#lvgl-opacity)): Opacity of the background image of the widget.
+- **bg_image_opa** (*Optional*, [opacity](#opacity)): Opacity of the background image of the widget.
 - **bg_image_recolor** (*Optional*, [color](#lvgl-color)): Color to mix with every pixel of the background image of the widget.
-- **bg_image_recolor_opa** (*Optional*, [opacity](#lvgl-opacity)): Opacity of the recoloring of the background image of the widget.
+- **bg_image_recolor_opa** (*Optional*, [opacity](#opacity)): Opacity of the recoloring of the background image of the widget.
 - **blend_mode** (*Optional*): Describes how to blend the colors to the background. One of `NORMAL` (default), `ADDITIVE`, `SUBTRACTIVE`, `MULTIPLY`, `DIFFERENCE`.
 - **blur_radius** (*Optional*, int16): Sets the intensity of blurring. Applied on each widget part separately before the children are rendered. Defaults to `0`.
 - **blur_backdrop** (*Optional*, boolean): If `true` the background of the widget will be blurred. The part should have opacity smaller to make it visible. If `false` the given part will be blurred when it's rendered but before drawing the children. Defaults to `false`.
 - **blur_quality** (*Optional*): One of `AUTO`, `SPEED`, `PRECISION`. Setting to `SPEED` the blurring algorithm will prefer speed over quality. `PRECISION` will force using higher quality but slower blur. With `AUTO` the quality will be selected automatically (default).
 - **border_width** (*Optional*, int16): Set the width of the border in pixels. Defaults to `0`.
 - **border_color** (*Optional*, [color](#lvgl-color)): Color to draw borders of the widget. Defaults to `0` (black).
-- **border_opa** (*Optional*, [opacity](#lvgl-opacity)): Opacity of the borders of the widget. Defaults to `COVER`.
+- **border_opa** (*Optional*, [opacity](#opacity)): Opacity of the borders of the widget. Defaults to `COVER`.
 - **border_post** (*Optional*, boolean): If `true` the border will be drawn after all children of the widget have been drawn. Defaults to `false`.
 - **border_side** (*Optional*, list): Select which borders of the widgets to show (multiple can be specified as a YAML list, defaults to `NONE`):
   - `NONE`
@@ -298,16 +298,16 @@ These style properties may be applied to any widget, though not all widgets use 
   - `INTERNAL`
 - **radius** (*Optional*, uint16): The radius to be used to form the widget's rounded corners. 0 = no radius (square corners); 65535 (max) = pill shaped widget (true circle if it has same width and height, radius then should be set to half the width/height).
 - **clip_corner** (*Optional*, boolean): If set to `true`, overflowing content will be clipped off by the widget's rounded corners (`radius` > `0`).
-- **color_filter_opa** (*Optional*, [opacity](#lvgl-opacity)): Opacity of the color filter. Currently color filters are applied only by the default LVGL theme, this option allows the effect of those to be disabled by setting to `TRANSP`.
+- **color_filter_opa** (*Optional*, [opacity](#opacity)): Opacity of the color filter. Currently color filters are applied only by the default LVGL theme, this option allows the effect of those to be disabled by setting to `TRANSP`.
 - **anim_duration** (*Optional*, int16): Animation duration in milliseconds. Its meaning is widget specific. E.g. blink time of the cursor on the Text Area or scroll time of a roller. See [Widgets](/components/lvgl/widgets/) documentation to learn more where this applies.
-- **image_opa** (*Optional*, [opacity](#lvgl-opacity)): Set opacity of an image.
+- **image_opa** (*Optional*, [opacity](#opacity)): Set opacity of an image.
 - **image_recolor** (*Optional*, [color](#lvgl-color)): Color to mix with every pixel of an image. Note that `image_recolor_opa` defaults to `TRANSP`, so it must also be set.
-- **image_recolor_opa** (*Optional*, [opacity](#lvgl-opacity)): Opacity of the image recoloring.
+- **image_recolor_opa** (*Optional*, [opacity](#opacity)): Opacity of the image recoloring.
 - **recolor** (*Optional*, [color](#lvgl-color)): Color to mix with the widget. Defaults to `0` (black). Note that `recolor_opa` defaults to `TRANSP`, so it must also be set.
-- **recolor_opa** (*Optional*, [opacity](#lvgl-opacity)): Sets the intensity of color mixing. Intermediate values result in semi-transparency.
+- **recolor_opa** (*Optional*, [opacity](#opacity)): Sets the intensity of color mixing. Intermediate values result in semi-transparency.
 - **outline_width** (*Optional*, int16): Set the width of the outline in pixels. It's like a border but drawn outside of the rectangles. Defaults to `0`.
 - **outline_color** (*Optional*, [color](#lvgl-color)): Color used to draw the outline around the widget. Defaults to `0` (black).
-- **outline_opa** (*Optional*, [opacity](#lvgl-opacity)): Opacity of the outline of the widget. Defaults to `COVER`.
+- **outline_opa** (*Optional*, [opacity](#opacity)): Opacity of the outline of the widget. Defaults to `COVER`.
 - **outline_pad** (*Optional*, int16): Distance between the outline and the widget itself. Defaults to `0`.
 - **pad_all** (*Optional*, int16): Set the padding in all directions, in pixels. It makes the content area smaller in all directions.
 - **pad_top** (*Optional*, int16): Set the padding on the top, in pixels. It makes the content area smaller in this direction.
@@ -324,10 +324,10 @@ These style properties may be applied to any widget, though not all widgets use 
 - **shadow_color** (*Optional*, [color](#lvgl-color)): Color used to create a shadow under the widget rectangle. Defaults to `0` (black).
 - **shadow_offset_x** (*Optional*, int16): Horizontal offset of the shadow, in pixels. Defaults to `0`.
 - **shadow_offset_y** (*Optional*, int16): Vertical offset of the shadow, in pixels. Defaults to `0`.
-- **shadow_opa** (*Optional*, [opacity](#lvgl-opacity)): Opacity of the shadow. Defaults to `COVER`.
+- **shadow_opa** (*Optional*, [opacity](#opacity)): Opacity of the shadow. Defaults to `COVER`.
 - **shadow_spread** (*Optional*, int16): Spread of the shadow, in pixels. Defaults to `0`.
 - **shadow_width** (*Optional*, int16): Width of the shadow, in pixels. Defaults to `0`.
-- **drop_shadow_opa** (*Optional*, [opacity](#lvgl-opacity)): Take a snapshot of a part of a widget and blur it. Set the opacity of the shadow. Defaults to `0`.
+- **drop_shadow_opa** (*Optional*, [opacity](#opacity)): Take a snapshot of a part of a widget and blur it. Set the opacity of the shadow. Defaults to `0`.
 - **drop_shadow_radius** (*Optional*, int16): Sets the intensity of blurring. Applied on each widget part separately before the children are rendered. Defaults to `0`.
 - **drop_shadow_offset_x** (*Optional*, int16): Set an offset on the shadow in pixels in X direction. Defaults to `0`.
 - **drop_shadow_offset_y** (*Optional*, int16): Set an offset on the shadow in pixels in Y direction. Defaults to `0`.
@@ -350,8 +350,6 @@ These style properties may be applied to any widget, though not all widgets use 
 > [!NOTE]
 > The property names `transform_angle`, `transform_zoom`, `shadow_ofs_x` and `shadow_ofs_y` are deprecated. Use `transform_rotation`, `transform_scale`, `shadow_offset_x` and `shadow_offset_y` respectively.
 
-<span id="lvgl-opacity"></span>
-
 ### Opacity
 
 Various parts of the widgets (like background, borders etc.) support opacity. It can be specified in one of several ways:
@@ -367,12 +365,12 @@ Default values depend on widget specifics.
 
 ### Colors
 
-Colors can be specified anywhere in the LVGL configuration either by referencing a preconfigured [ESPHome color](/components/display#config-color) ID or by representing the color in the common hexadecimal notation. For example, `0xFF0000` would be red.
+Colors can be specified anywhere in the LVGL configuration either by referencing a preconfigured [ESPHome color](/components/display#color) ID or by representing the color in the common hexadecimal notation. For example, `0xFF0000` would be red.
 
 You may also use any of the [standard CSS color names](https://developer.mozilla.org/en-US/docs/Web/CSS/named-color), e.g. `springgreen`.
 
 When using a lambda to provide a color you can use the `lv_color_hex` function to convert a hex value, or
-return a [Color](/components/display#config-color) ID - this is useful when using the [Mapping](/components/mapping/). Examples:
+return a [Color](/components/display#color) ID - this is useful when using the [Mapping](/components/mapping/). Examples:
 
 ```yaml
 # Example to set the color directly via Lambda
@@ -381,8 +379,6 @@ return a [Color](/components/display#config-color) ID - this is useful when usin
       text: 'Hello World!'
       text_color: !lambda return lv_color_hex(0xFF0000);
 ```
-
-<span id="lvgl-gradients"></span>
 
 ### Gradients
 
@@ -393,7 +389,7 @@ A gradient is a sequence of colors which can be applied to an object using the `
 - **direction** (**Required**, string): The direction of the gradient: `hor` (or `horizontal`) or `ver` (or `vertical`).
 - **stops** (**Required**, list): A list of at least 2 color stop points. Each stop point has the following options:
   - **color** (**Required**, [Color](#lvgl-color)): The color of the stop point.
-  - **opa** (*Optional*, [opacity](#lvgl-opacity)): The opacity at this stop point. Defaults to `COVER` (fully opaque).
+  - **opa** (*Optional*, [opacity](#opacity)): The opacity at this stop point. Defaults to `COVER` (fully opaque).
   - **position** (**Required**, float): The position of the stop point. Must be a float between 0.0 and 1.0, a percentage between 0% and 100%, or an integer between 0 and 255.
 
 ```yaml
@@ -419,8 +415,6 @@ lvgl:
         - color: 0xFF0000
           position: 255
 ```
-
-<span id="lvgl-fonts"></span>
 
 ### Fonts
 
@@ -717,8 +711,6 @@ on_...:
   - lvgl.page.show: secret_page  # shorthand version
 ```
 
-<span id="lvgl-conditions"></span>
-
 ## Conditions
 
 ### `lvgl.is_idle` Condition
@@ -774,7 +766,7 @@ on_...:
 
 ## Triggers
 
-Widget level [interaction triggers](/components/lvgl/widgets#lvgl-automation-triggers) are available, plus a few for the LVGL component itself:
+Widget level [interaction triggers](/components/lvgl/widgets#triggers) are available, plus a few for the LVGL component itself:
 
 <span id="lvgl-on-idle-trigger"></span>
 
@@ -805,27 +797,27 @@ See [Turn off screen when idle](/cookbook/lvgl#lvgl-cookbook-idlescreen) for an 
 
 ### `on_pause` trigger
 
-This [trigger](/components/lvgl/widgets#lvgl-automation-triggers) is triggered when LVGL is paused. This can be used to perform any desired actions when the screen is locked, such as turning off the display backlight.
+This [trigger](/components/lvgl/widgets#triggers) is triggered when LVGL is paused. This can be used to perform any desired actions when the screen is locked, such as turning off the display backlight.
 
 <span id="lvgl_on_resume_trigger"></span>
 
 ### `on_resume` trigger
 
-This [trigger](/components/lvgl/widgets#lvgl-automation-triggers) is triggered when LVGL is resumed. This can be used to perform any desired actions when the screen is unlocked, such as turning on the display backlight.
+This [trigger](/components/lvgl/widgets#triggers) is triggered when LVGL is resumed. This can be used to perform any desired actions when the screen is unlocked, such as turning on the display backlight.
 
 ### `on_boot` trigger
 
-This [trigger](/components/lvgl/widgets#lvgl-automation-triggers) is triggered after LVGL has been setup. It is available on the `lvgl` component and any widget and can be used to perform any LVGL related setup that is not possible with static configuration. When used on a widget, it does not act specifically on that widget but can be used to keep actions related to that widget together with its configuration.
+This [trigger](/components/lvgl/widgets#triggers) is triggered after LVGL has been setup. It is available on the `lvgl` component and any widget and can be used to perform any LVGL related setup that is not possible with static configuration. When used on a widget, it does not act specifically on that widget but can be used to keep actions related to that widget together with its configuration.
 
 ### `on_draw_start` trigger
 
-This [trigger](/components/lvgl/widgets#lvgl-automation-triggers) is executed before each LVGL drawing operation.
+This [trigger](/components/lvgl/widgets#triggers) is executed before each LVGL drawing operation.
 
 <span id="lvgl-on-draw-end-trigger"></span>
 
 ### `on_draw_end` trigger
 
-This [trigger](/components/lvgl/widgets#lvgl-automation-triggers) is executed after LVGL has completed drawing all updated screen elements. It
+This [trigger](/components/lvgl/widgets#triggers) is executed after LVGL has completed drawing all updated screen elements. It
 may be used for example to trigger an update of a display component like an e-paper screen that requires the buffer
 to be sent to the display for it to be updated.
 

--- a/src/content/docs/components/lvgl/widgets.mdx
+++ b/src/content/docs/components/lvgl/widgets.mdx
@@ -34,8 +34,6 @@ Widgets can have children, which can be any other widgets. Think of this as a ne
 
 By default, LVGL draws new widgets on top of old widgets, including their children. When widgets have children, property inheritance takes place. Some properties (typically those related to text and opacity) can be inherited from the parent widgets's styles. When the property is inheritable, the parent will be searched for an object which specifies a value for the property. The parents will use their own [state](#lvgl-widgetproperty-state) to determine the value. For example, if a button is pressed and the text color is defined by the "pressed" state, this "pressed" text color will be used.
 
-<span id="lvgl-widget-parts"></span>
-
 ## Widget parts
 
 Widgets can be composed of multiple parts, each of which can be styled independently. For example, a checkbox has a *main* part that styles the background and text label, and an *indicator* part that styles the tick box. All widgets have a *main* part, the available parts for other widgets are specified in the widget description.
@@ -244,11 +242,9 @@ on_...:
         if_nan: "N/A"
 ```
 
-For styling text, see the properties of the [`label`](#lvgl-widget-label) widget.
+For styling text, see the properties of the [`label`](#label) widget.
 
 ## Widgets
-
-<span id="lvgl-widget-animimg"></span>
 
 ### `animimg`
 
@@ -282,7 +278,7 @@ The animation image is similar to the normal `image` widget. The main difference
 
 **Triggers:**
 
-- [interaction](#lvgl-automation-triggers) LVGL event triggers.
+- [interaction](#triggers) LVGL event triggers.
 
 **Example:**
 
@@ -304,8 +300,6 @@ on_...:
 
 See [Battery charging animation](/cookbook/lvgl#lvgl-cookbook-animbatt) in the Cookbook for a more detailed example.
 
-<span id="lvgl-widget-arc"></span>
-
 ### `arc`
 
 The arc consists of a background and a foreground arc. The indicator foreground can be touch-adjusted with a knob.
@@ -316,7 +310,7 @@ The arc consists of a background and a foreground arc. The indicator foreground 
 
 - **adjustable** (*Optional*, boolean): Add a knob that the user can move to change the value. Defaults to `false`.
 - **arc_color** (*Optional*, [color](/components/lvgl#lvgl-color)): Color used to draw the arc.
-- **arc_opa** (*Optional*, [opacity](/components/lvgl#lvgl-opacity)): Opacity of the arc.
+- **arc_opa** (*Optional*, [opacity](/components/lvgl#opacity)): Opacity of the arc.
 - **arc_rounded** (*Optional*, boolean): Make the end points of the arcs rounded. `true` rounded, `false` perpendicular line ending.
 - **arc_width** (*Optional*, int16): Set the width of the arcs in pixels.
 - **change_rate** (*Optional*, uint16): Limits the speed at which the arc value changes when touched or dragged. The change rate is defined in degree/second. Defaults to `720`.
@@ -355,7 +349,7 @@ By default the whole area of the widget is interactive. If the `adv_hittest` [fl
 - `on_value` [trigger](/automations/actions#actions-trigger) is activated when the arc value changes, either by user interaction or programmatically. The new value is returned in the variable `x`.
 - `on_change` [trigger](/automations/actions#actions-trigger) is activated when the arc value is changed by user interaction. The new value is returned in the variable `x`.
 - `on_update` [trigger](/automations/actions#actions-trigger) is activated when the arc value is changed programmatically (e.g. via `lvgl.arc.update`). The new value is returned in the variable `x`.
-- [interaction](#lvgl-automation-triggers) LVGL event triggers which also return the value in `x`.
+- [interaction](#triggers) LVGL event triggers which also return the value in `x`.
 
 **Example:**
 
@@ -387,13 +381,11 @@ on_...:
 ```
 
 > [!NOTE]
-> The `on_value` and `on_change` triggers are sent as the arc knob is dragged or changed with keys. The event is sent *continuously* while the arc knob is being dragged; this generally has a negative effect on performance. To mitigate this, consider using a [universal interaction trigger](#lvgl-automation-triggers) like `on_release`, to get the `x` variable once after the interaction has completed.
+> The `on_value` and `on_change` triggers are sent as the arc knob is dragged or changed with keys. The event is sent *continuously* while the arc knob is being dragged; this generally has a negative effect on performance. To mitigate this, consider using a [universal interaction trigger](#triggers) like `on_release`, to get the `x` variable once after the interaction has completed.
 
 The `arc` can be also integrated as a [Number](/components/number/lvgl/) or [Sensor](/components/sensor/lvgl/) component.
 
 See [Light brightness slider](/cookbook/lvgl#lvgl-cookbook-bright) and [Media player volume slider](/cookbook/lvgl#lvgl-cookbook-volume) for examples which demonstrate how to use a slider (or an arc) to control entities in Home Assistant.
-
-<span id="lvgl-widget-bar"></span>
 
 ### `bar`
 
@@ -428,7 +420,7 @@ Not only the end, but also the start value of the bar can be set, which changes 
 
 **Triggers:**
 
-- [interaction](#lvgl-automation-triggers) LVGL event triggers.
+- [interaction](#triggers) LVGL event triggers.
 
 **Example:**
 
@@ -449,8 +441,6 @@ on_...:
 ```
 
 The `bar` can be also integrated as [Number](/components/number/lvgl/) or [Sensor](/components/sensor/lvgl/) component.
-
-<span id="lvgl-widget-button"></span>
 
 ### `button`
 
@@ -478,7 +468,7 @@ A notable state is `checked` (boolean) which can have different styles applied.
 - `on_change` [trigger](/automations/actions#actions-trigger) is activated after clicking. If `checkable` is `true`, the boolean variable `x`, representing the checked state, may be used by lambdas within this trigger.
 - `on_value` [trigger](/automations/actions#actions-trigger) is activated when the checked value changes, either by user interaction or programmatically. The new value is returned in the variable `x`.
 - `on_update` [trigger](/automations/actions#actions-trigger) is activated when the checked value is changed programmatically (e.g. via `lvgl.widget.update`). The new value is returned in the variable `x`.
-- [interaction](#lvgl-automation-triggers) LVGL event triggers.
+- [interaction](#triggers) LVGL event triggers.
 
 **Example:**
 
@@ -489,7 +479,7 @@ A notable state is `checked` (boolean) which can have different styles applied.
     text: "Click me!"
 ```
 
-To create an image button, add a child [`image`](#lvgl-widget-image) widget to it:
+To create an image button, add a child [`image`](#image) widget to it:
 
 ```yaml
 # Example toggle button with image:
@@ -538,8 +528,6 @@ See [Remote light button](/cookbook/lvgl#lvgl-cookbook-binent) for an example wh
         text: "Clicked"
 ```
 
-<span id="lvgl-widget-buttonmatrix"></span>
-
 ### `buttonmatrix`
 
 The button matrix widget is a lightweight way to display multiple buttons in rows and columns. It's lightweight because the buttons are not actually created but instead simply drawn on the fly. This reduces the memory footprint of each button from approximately 200 bytes (for both the button and its label widget) down to only eight bytes.
@@ -558,7 +546,7 @@ The button matrix widget is a lightweight way to display multiple buttons in row
     - **control** (*Optional*): Binary flags to control behavior of the buttons (all `false` by default):
       - **checkable** (*Optional*, boolean): Enable toggling of a button, `checked` state will be added/removed as the button is clicked.
       - **checked** (*Optional*, boolean): Make the button checked. Apply `checked` styles to the button.
-      - **click_trig** (*Optional*, boolean): Control how to [trigger](#lvgl-automation-triggers) `on_value` : if `true` on *click*, if `false` on *press*.
+      - **click_trig** (*Optional*, boolean): Control how to [trigger](#triggers) `on_value` : if `true` on *click*, if `false` on *press*.
       - **custom_1** and **custom_2** (*Optional*, boolean): Custom, free to use flags.
       - **disabled** (*Optional*, boolean): Apply `disabled` styles to the button.
       - **hidden** (*Optional*, boolean): Make a button hidden (hidden buttons still take up space in the layout, they are just not visible or clickable).
@@ -582,8 +570,8 @@ The button matrix widget is a lightweight way to display multiple buttons in row
 
 **Triggers:**
 
-- `on_value` and [interaction](#lvgl-automation-triggers) triggers can be configured for each button, is activated after clicking. If `checkable` is `true`, the boolean variable `x`, representing the checked state, may be used by lambdas within this trigger.
-- The [interaction](#lvgl-automation-triggers) LVGL event triggers can be configured for the main widget, they pass the ID of the pressed button (or null if nothing pressed) as variable `x` (a pointer to a `uint16_t` which holds the index number of the button).
+- `on_value` and [interaction](#triggers) triggers can be configured for each button, is activated after clicking. If `checkable` is `true`, the boolean variable `x`, representing the checked state, may be used by lambdas within this trigger.
+- The [interaction](#triggers) LVGL event triggers can be configured for the main widget, they pass the ID of the pressed button (or null if nothing pressed) as variable `x` (a pointer to a `uint16_t` which holds the index number of the button).
 
 **Example:**
 
@@ -684,12 +672,12 @@ Where a list of points is required, this can be provided in the form of a list o
 - `lvgl.canvas.fill` fills the entire canvas with a color:
   - **id** (**Required**): The ID of the canvas widget.
   - **color** (**Required**, [color](/components/lvgl#lvgl-color)): Fill color.
-  - **opa** (*Optional*, [opacity](/components/lvgl#lvgl-opacity)): Opacity of the fill. Defaults to `COVER`.
+  - **opa** (*Optional*, [opacity](/components/lvgl#opacity)): Opacity of the fill. Defaults to `COVER`.
 
 - `lvgl.canvas.set_pixels` sets individual pixels:
   - **id** (**Required**): The ID of the canvas widget.
   - **color** (**Required**, [color](/components/lvgl#lvgl-color)): Pixel color.
-  - **opa** (*Optional*, [opacity](/components/lvgl#lvgl-opacity)): Opacity of the pixels. Defaults to `COVER`.
+  - **opa** (*Optional*, [opacity](/components/lvgl#opacity)): Opacity of the pixels. Defaults to `COVER`.
   - **points** (**Required**, list): List of points to set, each with:
     - **x** (**Required**, int): X coordinate.
     - **y** (**Required**, int): Y coordinate.
@@ -702,17 +690,17 @@ Where a list of points is required, this can be provided in the form of a list o
   - **height** (**Required**, int): Height in pixels
   - **radius** (*Optional*, int): Corner radius.
   - **bg_color** (*Optional*, [color](/components/lvgl#lvgl-color)): Background color.
-  - **bg_opa** (*Optional*, [opacity](/components/lvgl#lvgl-opacity)): Background opacity. Defaults to `COVER`.
+  - **bg_opa** (*Optional*, [opacity](/components/lvgl#opacity)): Background opacity. Defaults to `COVER`.
   - **border_color** (*Optional*, [color](/components/lvgl#lvgl-color)): Border color.
   - **border_width** (*Optional*, int): Border width.
-  - **border_opa** (*Optional*, [opacity](/components/lvgl#lvgl-opacity)): Border opacity. Defaults to `COVER`.
+  - **border_opa** (*Optional*, [opacity](/components/lvgl#opacity)): Border opacity. Defaults to `COVER`.
   - **outline_color** (*Optional*, [color](/components/lvgl#lvgl-color)): Outline color.
   - **outline_width** (*Optional*, int): Outline width.
-  - **outline_opa** (*Optional*, [opacity](/components/lvgl#lvgl-opacity)): Opacity of the outline. Defaults to `COVER`.
+  - **outline_opa** (*Optional*, [opacity](/components/lvgl#opacity)): Opacity of the outline. Defaults to `COVER`.
   - **outline_pad** (*Optional*, int): Padding of the outline. Defaults to `0`.
   - **shadow_color** (*Optional*, [color](/components/lvgl#lvgl-color)): Shadow color.
   - **shadow_width** (*Optional*, int): Shadow width.
-  - **shadow_opa** (*Optional*, [opacity](/components/lvgl#lvgl-opacity)): Opacity of the shadow. Defaults to `COVER`.
+  - **shadow_opa** (*Optional*, [opacity](/components/lvgl#opacity)): Opacity of the shadow. Defaults to `COVER`.
   - **shadow_offset_x** (*Optional*, int): Shadow offset X.
   - **shadow_offset_y** (*Optional*, int): Shadow offset Y.
   - **shadow_spread** (*Optional*, int): Shadow spread.
@@ -730,7 +718,7 @@ Where a list of points is required, this can be provided in the form of a list o
   - **max_width** (**Required**, int): Max width in pixels.
   - **align** (*Optional*, enum): Alignment of the text relative to `x` and `max_width`. One of `LEFT`, `CENTER`, `RIGHT`, `AUTO`.
   - **color** (*Optional*, [color](/components/lvgl#lvgl-color)): Text color.
-  - **opa** (*Optional*, [opacity](/components/lvgl#lvgl-opacity)): Text opacity. Defaults to `COVER`.
+  - **opa** (*Optional*, [opacity](/components/lvgl#opacity)): Text opacity. Defaults to `COVER`.
   - **font** (*Optional*, string): Font to use.
   - **decor** (*Optional*, list): Choose decorations for the text: `NONE`, `UNDERLINE`, `STRIKETHROUGH` (multiple can be specified as YAML list). Defaults to `NONE`.
   - **letter_space** (*Optional*, int16): Extra character spacing of the text. Defaults to `0`.
@@ -743,7 +731,7 @@ Where a list of points is required, this can be provided in the form of a list o
     - **y** (**Required**, int): Y coordinate.
   - **color** (*Optional*, [color](/components/lvgl#lvgl-color)): Line color.
   - **width** (*Optional*, int): Line width.
-  - **opa** (*Optional*, [opacity](/components/lvgl#lvgl-opacity)): Line opacity. Defaults to `COVER`.
+  - **opa** (*Optional*, [opacity](/components/lvgl#opacity)): Line opacity. Defaults to `COVER`.
   - **round_start** (*Optional*, boolean): Round the start of the line. Defaults to `false`.
   - **round_end** (*Optional*, boolean): Round the end of the line. Defaults to `false`.
 
@@ -756,7 +744,7 @@ Where a list of points is required, this can be provided in the form of a list o
   - **end_angle** (**Required**, 0-360): End angle.
   - **color** (*Optional*, [color](/components/lvgl#lvgl-color)): Arc color.
   - **width** (*Optional*, int): Arc line width.
-  - **opa** (*Optional*, [opacity](/components/lvgl#lvgl-opacity)): Arc opacity. Defaults to `COVER`.
+  - **opa** (*Optional*, [opacity](/components/lvgl#opacity)): Arc opacity. Defaults to `COVER`.
   - **rounded** (*Optional*, boolean): Round the start/end of the arc.
 
 - `lvgl.canvas.draw_image` draws an image:
@@ -805,8 +793,6 @@ on_...:
       color: red
 ```
 
-<span id="lvgl-widget-checkbox"></span>
-
 ### `checkbox`
 
 The checkbox widget is made internally from a *tick box* and a label. When the checkbox is clicked the tick box's `checked` state will be toggled.
@@ -830,7 +816,7 @@ The checkbox widget is made internally from a *tick box* and a label. When the c
 - `on_change` [trigger](/automations/actions#actions-trigger) is activated when interactively toggling the checkbox. The boolean variable `x`, representing the checkbox's state, may be used by lambdas within this trigger.
 - `on_value` [trigger](/automations/actions#actions-trigger) is activated when the checkbox is toggled, either by user interaction or programmatically. The new value is returned in the variable `x`.
 - `on_update` [trigger](/automations/actions#actions-trigger) is activated when the checkbox is toggled programmatically (e.g. via `lvgl.checkbox.update`). The new value is returned in the variable `x`.
-- [interaction](#lvgl-automation-triggers) LVGL event triggers which also return the value in `x`.
+- [interaction](#triggers) LVGL event triggers which also return the value in `x`.
 
 **Example:**
 
@@ -863,8 +849,6 @@ on_...:
 
 The `checkbox` can be also integrated as a [Switch](/components/switch/lvgl/) component.
 
-<span id="lvgl-widget-container"></span>
-
 ### `container`
 
 A `container` is an unstyled widget that is, as the name suggests, intended to act as a container for other widgets.
@@ -877,7 +861,7 @@ it is invisible. It has a default width and height of 100%.
 
 **Triggers:**
 
-- [interaction](#lvgl-automation-triggers) LVGL event triggers.
+- [interaction](#triggers) LVGL event triggers.
 
 **Example:**
 
@@ -891,8 +875,6 @@ it is invisible. It has a default width and height of 100%.
     widgets:
       - ...
 ```
-
-<span id="lvgl-widget-dropdown"></span>
 
 ### `dropdown`
 
@@ -912,8 +894,8 @@ The Dropdown widget is built internally from a *button* part and a *list* part (
 - **options** (**Required**, list): The list of available options in the drop-down.
 - **selected_index** (*Optional*, int8): The index of the item you wish to be selected.
 - **selected_text** (*Optional*, string): The text of the item you wish to be selected.
-- **symbol** (*Optional*, dict): A symbol (typically an chevron) is shown in dropdown list. If `dir` of the drop-down list is `LEFT` the symbol will be shown on the left, otherwise on the right. Choose a different [symbol](/components/lvgl#lvgl-fonts) from those built-in or from your own customized font.
-- Style options from [Style properties](/components/lvgl#lvgl-styling) for the background of the button. Uses the typical background properties and [`label`](#lvgl-widget-label) text properties for the text on it. `text_font` can be used to set the font of the button part, including the symbol.
+- **symbol** (*Optional*, dict): A symbol (typically an chevron) is shown in dropdown list. If `dir` of the drop-down list is `LEFT` the symbol will be shown on the left, otherwise on the right. Choose a different [symbol](/components/lvgl#fonts) from those built-in or from your own customized font.
+- Style options from [Style properties](/components/lvgl#lvgl-styling) for the background of the button. Uses the typical background properties and [`label`](#label) text properties for the text on it. `text_font` can be used to set the font of the button part, including the symbol.
 
 **Actions:**
 
@@ -925,11 +907,11 @@ The Dropdown widget is built internally from a *button* part and a *list* part (
 
 **Triggers:**
 
-- `on_change` [trigger](/automations/actions#actions-trigger) is activated only when the user selects an item from the list. The new selected index is returned in the variable `x`. The [interaction](#lvgl-automation-triggers) LVGL event triggers also apply, and they also return the selected index in `x`.
+- `on_change` [trigger](/automations/actions#actions-trigger) is activated only when the user selects an item from the list. The new selected index is returned in the variable `x`. The [interaction](#triggers) LVGL event triggers also apply, and they also return the selected index in `x`.
 - `on_value` [trigger](/automations/actions#actions-trigger) is activated the selection changes, either by user interaction or programmatically. The new value is returned in the variable `x`.
 - `on_update` [trigger](/automations/actions#actions-trigger) is activated when the selection is changed programmatically (e.g. via `lvgl.dropdown.update`). The new value is returned in the variable `x`.
 - `on_cancel` [trigger](/automations/actions#actions-trigger) is also activated when you close the dropdown without selecting an item from the list. The currently selected index is returned in the variable `x`.
-- [interaction](#lvgl-automation-triggers) LVGL event triggers which also return the value in `x`.
+- [interaction](#triggers) LVGL event triggers which also return the value in `x`.
 
 **Example:**
 
@@ -973,8 +955,6 @@ on_...:
 
 The `dropdown` can be also integrated as [Select](/components/select/lvgl/) component.
 
-<span id="lvgl-widget-image"></span>
-
 ### `image`
 
 Images are the basic widgets used to display images.
@@ -992,7 +972,7 @@ Images are the basic widgets used to display images.
 - **pivot_y** (*Optional*): Vertical position of the pivot point of rotation, in pixels, relative to the top left corner of the image. Defaults to the center of the image. Must be specified along with `pivot_x`
 - **scale** (*Optional*, 0.1-10): Scale of the image. (The deprecated name `zoom` is also accepted.)
 - **image_recolor** (*Optional*, [color](/components/lvgl#lvgl-color)): Color to mix with every pixel of an image Note that `image_recolor_opa` defaults to TRANSP, so it must also be set.
-- **image_recolor_opa** (*Optional*, [opacity](/components/lvgl#lvgl-opacity)): Opacity of the image recoloring.
+- **image_recolor_opa** (*Optional*, [opacity](/components/lvgl#opacity)): Opacity of the image recoloring.
 - **bitmap_mask_src** (*Optional*, [image](/components/image#display-image)): The ID of an existing image of type `grayscale` to be used as an A8 bitmap mask on a layer created for this widget.
 - Some style options from [Style properties](/components/lvgl#lvgl-styling) for the background rectangle that uses the typical background style properties and the image itself using the image style properties.
 
@@ -1004,7 +984,7 @@ Images are the basic widgets used to display images.
 
 **Triggers:**
 
-- [interaction](#lvgl-automation-triggers) LVGL event triggers.
+- [interaction](#triggers) LVGL event triggers.
 
 **Example:**
 
@@ -1029,15 +1009,13 @@ on_...:
 > [!TIP]
 > `offset_x` and `offset_y` can be useful when the widget size is set to be smaller than the image source size. A "running image" effect can be created by animating these values.
 
-<span id="lvgl-widget-keyboard"></span>
-
 ### `keyboard`
 
-The keyboard widget is a special Button matrix with predefined keymaps and other features to show an on-screen keyboard usable to type text into a [`textarea`](#lvgl-widget-textarea).
+The keyboard widget is a special Button matrix with predefined keymaps and other features to show an on-screen keyboard usable to type text into a [`textarea`](#textarea).
 
 <Image src={lvglKeyboardImg} layout="constrained" alt="" />
 
-For styling, the `keyboard` widget uses the same settings as [`buttonmatrix`](#lvgl-widget-buttonmatrix).
+For styling, the `keyboard` widget uses the same settings as [`buttonmatrix`](#buttonmatrix).
 
 **Configuration variables:**
 
@@ -1091,8 +1069,6 @@ on_focus:
 > [!NOTE]
 > The Keyboard widget in ESPHome doesn't support popovers or custom layouts.
 
-<span id="lvgl-widget-label"></span>
-
 ### `label`
 
 A label is the basic widget type that is used to display text.
@@ -1102,9 +1078,9 @@ A label is the basic widget type that is used to display text.
 **Configuration variables:**
 
 - **text** (*Optional*, [Text property](#text-property)): Text to display on the label.
-- **text_font**: (*Optional*, [font](/components/lvgl#lvgl-fonts)): The ID of the font used to render the text or symbol. Inherited from parent.
+- **text_font**: (*Optional*, [font](/components/lvgl#fonts)): The ID of the font used to render the text or symbol. Inherited from parent.
 - **text_align** (*Optional*, enum): Alignment of the text in the widget - it doesn't align the object itself, only the lines inside of it. Effective when widget `width` is set to be different from the text width. One of `LEFT`, `CENTER`, `RIGHT`, `AUTO`. Inherited from parent. Defaults to `AUTO`, which detects the text base direction and uses left or right alignment accordingly.
-- **text_opa** (*Optional*, [opacity](/components/lvgl#lvgl-opacity)): Opacity of the text. Inherited from parent. Defaults to `COVER`.
+- **text_opa** (*Optional*, [opacity](/components/lvgl#opacity)): Opacity of the text. Inherited from parent. Defaults to `COVER`.
 - **text_color** (*Optional*, [color](/components/lvgl#lvgl-color)): Color to render the text in. Inherited from parent. Defaults to `0` (black).
 - **text_decor** (*Optional*, list): Choose decorations for the text: `NONE`, `UNDERLINE`, `STRIKETHROUGH` (multiple can be specified as YAML list). Inherited from parent. Defaults to `NONE`.
 - **text_letter_space** (*Optional*, int16): Extra character spacing of the text. Inherited from parent. Defaults to `0`.
@@ -1132,7 +1108,7 @@ A label is the basic widget type that is used to display text.
 
 **Triggers:**
 
-- [interaction](#lvgl-automation-triggers) LVGL event triggers.
+- [interaction](#triggers) LVGL event triggers.
 
 **Example:**
 
@@ -1161,8 +1137,6 @@ on_...:
 
 The `label` can be also integrated as [Text](/components/text/lvgl/) or [Text Sensor](/components/text_sensor/lvgl/) component.
 
-<span id="lvgl-widget-led"></span>
-
 ### `led`
 
 The LED widgets are either circular or rectangular widgets whose brightness can be adjusted. As their brightness decreases, the colors become darker.
@@ -1183,7 +1157,7 @@ The LED widgets are either circular or rectangular widgets whose brightness can 
 
 **Triggers:**
 
-- [interaction](#lvgl-automation-triggers) LVGL event triggers.
+- [interaction](#triggers) LVGL event triggers.
 
 **Example:**
 
@@ -1208,8 +1182,6 @@ The `led` can be also integrated as [Light](/components/light/lvgl/) component.
 > If configured as a light component, `color` and `brightness` are overridden by the light at startup, according to its `restore_mode` setting.
 
 Check out [A numeric input keypad](/cookbook/lvgl#lvgl-cookbook-keypad) in the Cookbook for an example which demonstrates how to change the `led` styling properties from an automation.
-
-<span id="lvgl-widget-line"></span>
 
 ### `line`
 
@@ -1261,8 +1233,6 @@ The points list may be defined with constants in the form `x, y` or as a list of
     line_color: 0x0000FF
     line_rounded: true
 ```
-
-<span id="lvgl-widget-meter"></span>
 
 ### `meter`
 
@@ -1325,7 +1295,7 @@ The meter widget can visualize data in very flexible ways. It can use arcs, need
       - **label_gap**: Label distance from the ticks with text proportional to the values of the tick line. Defaults to `4`.
       - **radial_offset** (*Optional*): Radial offset of the major ticks from the outer edge, in pixels. Defaults to `0`.
       - **stride**: How many minor ticks to skip when adding major ticks. Defaults to `3`.
-    - Style options from [Style properties](/components/lvgl#lvgl-styling) for the tick *lines* and *labels* using the [`line`](#lvgl-widget-line) and [`label`](#lvgl-widget-label) text style properties.
+    - Style options from [Style properties](/components/lvgl#lvgl-styling) for the tick *lines* and *labels* using the [`line`](#line) and [`label`](#label) text style properties.
 - Style options from [Style properties](/components/lvgl#lvgl-styling) for the background of the meter, using the typical background properties.
 - **ticks** (*Optional*, dict): Styling options for the ticks *part*, which will be applied to the tick lines and labels using standard *line* and *label* styles.
 - **indicator** (*Optional*, dict): Styling options for the indicator *part*, which will be applied to the needle line or image using standard *line* and *image* styles. Background properties applied here will style the pivot (the dot in the middle of the meter) for example to hide the pivot use `bg_opa: transp` in the `indicator` style.
@@ -1344,7 +1314,7 @@ The meter widget can visualize data in very flexible ways. It can use arcs, need
 
 **Triggers:**
 
-- [interaction](#lvgl-automation-triggers) LVGL event triggers.
+- [interaction](#triggers) LVGL event triggers.
 
 **Example:**
 
@@ -1405,10 +1375,10 @@ The text will be broken into multiple lines automatically and the height will be
     - Style options from [Style properties](/components/lvgl#lvgl-styling). Uses all the typical background properties and the text properties.
   - **buttons** (*Optional*, list): A list of footer buttons to show at the bottom of the message box. Each button is an individual widget (not a buttonmatrix) and supports full widget styling:
     - **text** (*Optional*, [Text property](#text-property)): Text to display on the button.
-    - Style options and [triggers](#lvgl-automation-triggers) as for any [`button`](#lvgl-widget-button) widget.
+    - Style options and [triggers](#triggers) as for any [`button`](#button) widget.
   - **header_buttons** (*Optional*, list): A list of image buttons to show in the header area of the message box:
     - **src** (**Required**, [image](/components/image#display-image)): The ID of an image to display on the header button.
-    - Style options and [triggers](#lvgl-automation-triggers) as for any [`button`](#lvgl-widget-button) widget.
+    - Style options and [triggers](#triggers) as for any [`button`](#button) widget.
   - **button_style** (*Optional*, dict): **Deprecated** — style the buttons directly instead.
   - **close_button** (*Optional*, boolean): Controls the presence of the close button to the top right of the message box. Defaults to true
 
@@ -1441,8 +1411,6 @@ lvgl:
 > [!TIP]
 > You can create your own more complex dialogs with a full-screen sized, half-opaque `obj` with any child widgets on it, and the `hidden` flag set to `true` by default. For non-modal dialogs, simply set the `clickable` flag to `false` on it.
 
-<span id="lvgl-widget-obj"></span>
-
 ### `obj`
 
 The base object is just a simple, empty widget. By default, it's nothing more than a rounded rectangle:
@@ -1459,7 +1427,7 @@ widgets.
 
 **Triggers:**
 
-- [interaction](#lvgl-automation-triggers) LVGL event triggers.
+- [interaction](#triggers) LVGL event triggers.
 
 **Example:**
 
@@ -1472,8 +1440,6 @@ widgets.
     widgets:
       - ...
 ```
-
-<span id="lvgl-widget-qrcode"></span>
 
 ### `qrcode`
 
@@ -1499,7 +1465,7 @@ Use this widget to generate and display a QR-code containing a string at run tim
 
 **Triggers:**
 
-- [interaction](#lvgl-automation-triggers) LVGL event triggers.
+- [interaction](#triggers) LVGL event triggers.
 
 **Example:**
 
@@ -1519,8 +1485,6 @@ on_...:
       text: home-assistant.io
 ```
 
-<span id="lvgl-widget-roller"></span>
-
 ### `roller`
 
 Roller allows you to simply select one option from a list by scrolling.
@@ -1534,9 +1498,9 @@ Roller allows you to simply select one option from a list by scrolling.
 - **options** (**Required**, list): The list of available options in the roller.
 - **selected_index** (*Optional*, int8): The index of the item you wish to be selected.
 - **selected_text** (*Optional*, string): The text of the item you wish to be selected.
-- **selected** (*Optional*, list): Settings for the selected *part* to show the value. Supports a list of [styles](/components/lvgl#lvgl-styling) and state-based styles to customize. The selected option in the middle. Besides the typical background properties it uses the [`label`](#lvgl-widget-label) text style properties to change the appearance of the text in the selected area.
+- **selected** (*Optional*, list): Settings for the selected *part* to show the value. Supports a list of [styles](/components/lvgl#lvgl-styling) and state-based styles to customize. The selected option in the middle. Besides the typical background properties it uses the [`label`](#label) text style properties to change the appearance of the text in the selected area.
 - **visible_row_count** (*Optional*, int8): The number of visible rows.
-- Style options from [Style properties](/components/lvgl#lvgl-styling). The background of the roller uses all the typical background properties and [`label`](#lvgl-widget-label) style properties. `text_line_space` adjusts the space between the options.
+- Style options from [Style properties](/components/lvgl#lvgl-styling). The background of the roller uses all the typical background properties and [`label`](#label) style properties. `text_line_space` adjusts the space between the options.
 
 **Actions:**
 
@@ -1547,10 +1511,10 @@ Roller allows you to simply select one option from a list by scrolling.
 
 **Triggers:**
 
-- `on_change` [trigger](/automations/actions#actions-trigger) is activated only when the user selects an item from the list. The new selected index is returned in the variable `x`. The [interaction](#lvgl-automation-triggers) LVGL event triggers also apply, and they also return the selected index in `x`.
+- `on_change` [trigger](/automations/actions#actions-trigger) is activated only when the user selects an item from the list. The new selected index is returned in the variable `x`. The [interaction](#triggers) LVGL event triggers also apply, and they also return the selected index in `x`.
 - `on_value` [trigger](/automations/actions#actions-trigger) is activated the selection changes, either by user interaction or programmatically. The new value is returned in the variable `x`.
 - `on_update` [trigger](/automations/actions#actions-trigger) is activated when the selection is changed programmatically (e.g. via `lvgl.roller.update`). The new value is returned in the variable `x`.
-- [interaction](#lvgl-automation-triggers) LVGL event triggers which also return the selected index in `x`.
+- [interaction](#triggers) LVGL event triggers which also return the selected index in `x`.
 
 **Example:**
 
@@ -1582,8 +1546,6 @@ on_...:
 ```
 
 The `roller` can be also integrated as [Select](/components/select/lvgl/) component.
-
-<span id="lvgl-widget-slider"></span>
 
 ### `slider`
 
@@ -1619,7 +1581,7 @@ If your slider is narrow, you can use `ext_click_area` styling property to incre
 - `on_value` [trigger](/automations/actions#actions-trigger) is activated when the slider value changes, either by user interaction or programmatically. The new value is returned in the variable `x`.
 - `on_change` [trigger](/automations/actions#actions-trigger) is activated when the slider value is changed by user interaction. The new value is returned in the variable `x`.
 - `on_update` [trigger](/automations/actions#actions-trigger) is activated when the slider value is changed programmatically (e.g. via `lvgl.slider.update`). The new value is returned in the variable `x`.
-- [interaction](#lvgl-automation-triggers) LVGL event triggers which also return the value in `x`.
+- [interaction](#triggers) LVGL event triggers which also return the value in `x`.
 
 **Example:**
 
@@ -1650,13 +1612,11 @@ on_...:
 ```
 
 > [!NOTE]
-> The `on_value` trigger is sent as the slider is dragged or changed with keys. The event is sent *continuously* while the slider is being dragged; this generally has a negative effect on performance. To mitigate this, consider using a [universal interaction trigger](#lvgl-automation-triggers) like `on_release`, to get the `x` variable once after the interaction has completed.
+> The `on_value` trigger is sent as the slider is dragged or changed with keys. The event is sent *continuously* while the slider is being dragged; this generally has a negative effect on performance. To mitigate this, consider using a [universal interaction trigger](#triggers) like `on_release`, to get the `x` variable once after the interaction has completed.
 
 The `slider` can be also integrated as [Number](/components/number/lvgl/) or [Sensor](/components/sensor/lvgl/) component.
 
 See [Light brightness slider](/cookbook/lvgl#lvgl-cookbook-bright) and [Media player volume slider](/cookbook/lvgl#lvgl-cookbook-volume) for examples which demonstrate how to use a slider to control entities in Home Assistant.
-
-<span id="lvgl-widget-spinbox"></span>
 
 ### `spinbox`
 
@@ -1696,7 +1656,7 @@ The spinbox contains a numeric value (as text) which can be increased or decreas
 
 - `on_value` [trigger](/automations/actions#actions-trigger) is activated when the spinbox value changes, either by user interaction or programmatically. The new value is returned in the variable `x`.
 - `on_update` [trigger](/automations/actions#actions-trigger) is activated when the spinbox value is changed programmatically (e.g. via `lvgl.spinbox.update`). The new value is returned in the variable `x`.
-- [interaction](#lvgl-automation-triggers) LVGL event triggers which also return the value in `x`.
+- [interaction](#triggers) LVGL event triggers which also return the value in `x`.
 
 **Example:**
 
@@ -1733,8 +1693,6 @@ The `spinbox` can be also integrated as a [Number](/components/number/lvgl/) or 
 
 See [Climate control](/cookbook/lvgl#lvgl-cookbook-climate) for an example which demonstrates how to implement a thermostat control using the spinbox.
 
-<span id="lvgl-widget-spinner"></span>
-
 ### `spinner`
 
 The Spinner widget is a spinning arc over a ring.
@@ -1745,7 +1703,7 @@ The Spinner widget is a spinning arc over a ring.
 
 - **arc_color** (*Optional*, [color](/components/lvgl#lvgl-color)): Color to draw the arcs.
 - **arc_length** (*Optional*, 0-360): Length of the spinning arc in degrees. Defaults to `200`.
-- **arc_opa** (*Optional*, [opacity](/components/lvgl#lvgl-opacity)): Opacity of the arc.
+- **arc_opa** (*Optional*, [opacity](/components/lvgl#opacity)): Opacity of the arc.
 - **arc_rounded** (*Optional*, boolean): Make the end points of the arcs rounded. `true` rounded, `false` perpendicular line ending.
 - **arc_width** (*Optional*, int16): Set the width of the arcs in pixels.
 - **indicator** (*Optional*, list): Settings for the indicator *part* to show the value. Supports a list of [styles](/components/lvgl#lvgl-styling) and state-based styles to customize. Draws *another arc using the arc style* properties. Its padding values are interpreted relative to the background arc.
@@ -1760,7 +1718,7 @@ The Spinner widget is a spinning arc over a ring.
 
 **Triggers:**
 
-- [interaction](#lvgl-automation-triggers) LVGL event triggers.
+- [interaction](#triggers) LVGL event triggers.
 
 **Example:**
 
@@ -1784,8 +1742,6 @@ on_...:
         arc_color: 0xffbc02
 ```
 
-<span id="lvgl-widget-switch"></span>
-
 ### `switch`
 
 The switch looks like a little slider and can be used to turn something on and off.
@@ -1803,7 +1759,7 @@ The switch looks like a little slider and can be used to turn something on and o
 - `on_value` [trigger](/automations/actions#actions-trigger) is activated when the switch value changes, either by user interaction or programmatically. The new value is returned in the variable `x`.
 - `on_change` [trigger](/automations/actions#actions-trigger) is activated when the switch value is changed by user interaction. The new value is returned in the variable `x`.
 - `on_update` [trigger](/automations/actions#actions-trigger) is activated when the switch value is changed programmatically (e.g. via `lvgl.widget.update`). The new value is returned in the variable `x`.
-- [interaction](#lvgl-automation-triggers) LVGL event triggers which also return the value in `x`.
+- [interaction](#triggers) LVGL event triggers which also return the value in `x`.
 
 **Example:**
 
@@ -1825,8 +1781,6 @@ The switch looks like a little slider and can be used to turn something on and o
 The `switch` can be also integrated as a [Switch](/components/switch/lvgl/) component.
 
 See [Local light switch](/cookbook/lvgl#lvgl-cookbook-relay) for an example which demonstrates how to use a switch to act on a local component.
-
-<span id="lvgl-widget-tabview"></span>
 
 ### `tabview`
 
@@ -1860,7 +1814,7 @@ The tabs are indexed (zero-based) in the order they appear in the configuration 
 - `on_value` [trigger](/automations/actions#actions-trigger) is activated when the tab value changes, either by user interaction or programmatically. The id of the new tab is returned in the variable `tab`.
 - `on_change` [trigger](/automations/actions#actions-trigger) is activated when the tab value is changed by user interaction. The id of the new tab is returned in the variable `tab`.
 - `on_update` [trigger](/automations/actions#actions-trigger) is activated when the tab is changed programmatically (e.g. via `lvgl.tabview.select`). The id of the new tab is returned in the variable `tab`.
-- [interaction](#lvgl-automation-triggers) LVGL event triggers.
+- [interaction](#triggers) LVGL event triggers.
 
 **Example:**
 
@@ -1902,8 +1856,6 @@ on_...:
             - logger.log: "Dog tab is now showing"
 ```
 
-<span id="lvgl-widget-textarea"></span>
-
 ### `textarea`
 
 The textarea is an extended label widget which displays a cursor and allows the user to input text. Long lines are wrapped and when the text becomes long enough the text area can be scrolled. It supports one line mode and password mode, where typed characters are replaced visually with bullets or asterisks.
@@ -1932,7 +1884,7 @@ The textarea is an extended label widget which displays a cursor and allows the 
 - `on_value` [trigger](/automations/actions#actions-trigger) is activated on every keystroke.
 - `on_update` [trigger](/automations/actions#actions-trigger) is activated when the text is changed programmatically (e.g. via `lvgl.textarea.update`).
 - `on_ready` [trigger](/automations/actions#actions-trigger) is activated when `one_line` is configured as `true` and the newline character is received (Enter/Ready key on the keyboard).
-- [interaction](#lvgl-automation-triggers) LVGL event triggers.
+- [interaction](#triggers) LVGL event triggers.
 
 For both triggers above, when triggered, the variable `text` (`std::string` type) is available for use in lambdas within these triggers and it will contain the entire contents of the textarea.
 
@@ -1966,8 +1918,6 @@ on_...:
 
 The `textarea` can be also integrated as [Text](/components/text/lvgl/) or [Text Sensor](/components/text_sensor/lvgl/) component.
 
-<span id="lvgl-widget-tileview"></span>
-
 ### `tileview`
 
 The tileview is a container object whose elements, called tiles, can be arranged in grid form. A user can navigate between the tiles by dragging or swiping. Any direction can be disabled on the tiles individually to not allow moving from one tile to another.
@@ -1996,7 +1946,7 @@ If the tileview is screen sized, the user interface resembles what you may have 
 
 - `on_value` [trigger](/automations/actions#actions-trigger) is activated when displayed tile changes. The new value is returned in the variable `tile` as the ID of the now-visible tile.
 - `on_update` [trigger](/automations/actions#actions-trigger) is activated when the tile is changed programmatically (e.g. via `lvgl.tileview.select`). The new value is returned in the variable `tile`.
-- [interaction](#lvgl-automation-triggers) LVGL event triggers.
+- [interaction](#triggers) LVGL event triggers.
 
 **Example:**
 
@@ -2180,8 +2130,6 @@ on_...:
 on_...:
   - lvgl.widget.focus: previous
 ```
-
-<span id="lvgl-automation-triggers"></span>
 
 ## Triggers
 

--- a/src/content/docs/components/mapping.mdx
+++ b/src/content/docs/components/mapping.mdx
@@ -56,7 +56,7 @@ text_sensor:
 You can also map to a class. This is useful when you want to map to a more complex type, such as an image or a color. There are several types of class specifiers you can use:
 
 - `image`  : Maps to an image as defined in the [Image](/components/image/) component. The values should each be an image ID.
-- `color`  : Maps to a predefined [Color](/components/display#config-color). The values should each be a color ID.
+- `color`  : Maps to a predefined [Color](/components/display#color). The values should each be a color ID.
 - The name of a C++ class defined by ESPHome, e.g. `Component`. The values should each be a ID of that class.
 
 ## Using a mapping

--- a/src/content/docs/components/media_player/index.mdx
+++ b/src/content/docs/components/media_player/index.mdx
@@ -27,7 +27,7 @@ Configuration variables:
 - **name** (*Optional*, string): The name of the media player. At least one of **id** and **name** must be specified.
 
 > [!NOTE]
-> If you have a [friendly_name](/components/esphome#esphome-configuration_variables) set for your device and
+> If you have a [friendly_name](/components/esphome#configuration-variables) set for your device and
 > you want the media player to use that name, you can set `name: None`.
 
 - **icon** (*Optional*, icon): Manually set the icon to use for the

--- a/src/content/docs/components/media_player/speaker.mdx
+++ b/src/content/docs/components/media_player/speaker.mdx
@@ -5,7 +5,7 @@ title: "Speaker Audio Media Player"
 
 The `speaker` media player platform allows you to play on-device and online audio media via [speaker components](/components/speaker/).
 
-This platform greatly benefits from having external PSRAM. See the [performance section](#media_player-speaker-performance) for details.
+This platform greatly benefits from having external PSRAM. See the [performance section](#performance) for details.
 
 It natively supports decoding `FLAC`, `MP3`, `OPUS`, and `WAV` audio files. Home Assistant (since version 2024.10) can proxy any media it sends and transcode it to a specified format and sample rate to minimize the device's computational load.
 
@@ -13,7 +13,7 @@ It supports two different audio pipelines: announcement and media. Each audio pi
 
 On-device files built directly into the firmware are played without a network connection. Encode on-device files with the configured sample rate, 1 or 2 channels, and 16 bits per sample.
 
-This platform only works on ESP32-based chips using the [ESP-IDF framework](/components/esp32#esp32-framework).
+This platform only works on ESP32-based chips using the [ESP-IDF framework](/components/esp32#framework).
 
 > [!WARNING]
 > Audio and voice components consume a significant amount of resources (RAM, CPU) on the device.
@@ -162,8 +162,6 @@ Configuration variables:
 - **announcement** (*Optional*, boolean, [templatable](/automations/templates)): Whether to play back the file as an announcement or media stream. Defaults to `false`.
 - **enqueue** (*Optional*, boolean, [templatable](/automations/templates)): Whether to add the media file to the end of the pipeline's internal playlist. Defaults to `false`.
 
-<span id="media_player-speaker-performance"></span>
-
 ## Performance
 
 Decoding audio files is CPU and memory intensive. PSRAM external memory is strongly recommended. To use the component on a memory constrained device, define only the announcement pipeline, decrease the buffer size, and set the pipeline transcode setting format to `WAV` with a low sample rate and only 1 channel.
@@ -188,8 +186,6 @@ If you experience stuttering at the start of playback, especially on the origina
 Increasing the buffer size may reduce stuttering, but do not set it to the entire size of the external memory. Each pipeline allocates the configured amount, and this setting also does not take into account other smaller buffers allocated throughout the audio stack.
 
 Only set `task_stack_in_psram` to true if you have many components configured and your logs show that memory allocation failed. It is slower, especially if your PSRAM doesn't support `octal` mode.
-
-<span id="media_player-speaker-troubleshooting"></span>
 
 ## Troubleshooting
 

--- a/src/content/docs/components/media_player/speaker_source.mdx
+++ b/src/content/docs/components/media_player/speaker_source.mdx
@@ -9,7 +9,7 @@ It supports two independent audio pipelines: media and announcement. Each pipeli
 
 Each pipeline maintains its own playlist with support for repeat (off, one, all) and shuffle modes. Volume and mute state are persisted to flash and restored on reboot.
 
-This platform only works on ESP32-based chips using the [ESP-IDF framework](/components/esp32#esp32-framework).
+This platform only works on ESP32-based chips using the [ESP-IDF framework](/components/esp32#framework).
 
 > [!WARNING]
 > Audio and voice components consume a significant amount of resources (RAM, CPU) on the device.

--- a/src/content/docs/components/mqtt.mdx
+++ b/src/content/docs/components/mqtt.mdx
@@ -42,7 +42,7 @@ mqtt:
   the MQTT session after disconnect. Defaults to `false`.
 
 - **client_id** (*Optional*, string): The client id to use for opening
-  connections. See [Defaults](#mqtt-defaults) for more information.
+  connections. See [Defaults](#defaults) for more information.
 
 - **discover_ip** (*Optional*, boolean): If Home Assistant automatic device
   discovery should be enabled. Defaults to `true`.
@@ -82,7 +82,7 @@ mqtt:
   The `log_topic` has an additional configuration option:
 
   - **level** (*Optional*, string): The log level to use for MQTT logs. See
-    [Log Levels](/components/logger#logger-log_levels) for options.
+    [Log Levels](/components/logger#log-levels) for options.
 
 - **birth_message** (*Optional*, [MQTTMessage](#mqtt-message)): The message to send when
   a connection to the broker is established. See [Last Will And Birth Messages](#mqtt-last_will_birth) for more information.
@@ -219,8 +219,6 @@ JSON keys:
 - **project_version** (*Optional*, string): `dashboard_import.package_import_url`.
 - **api_encryption** (*Optional*, string): API encryption type.
 
-<span id="mqtt-using_device_discovery_with_home_assistant"></span>
-
 ## Using device discovery with Home Assistant
 
 MQTT can be used to automatically discover the ESPHome devices in Home Assistant.
@@ -298,8 +296,6 @@ name part of the generated entity name. Setting `discovery_object_id_generator: 
 in the ESPHome MQTT component configuration will cause Home Assistant to include device name
 in the generated entity names (e.g. `sensor.uptime` becomes `sensor.<device name>_uptime`  ),
 making it easier to distinguish the entities in various entity lists.
-
-<span id="mqtt-defaults"></span>
 
 ## Defaults
 

--- a/src/content/docs/components/nrf52.mdx
+++ b/src/content/docs/components/nrf52.mdx
@@ -221,9 +221,7 @@ nrf52:
   - `2.9.2-0`  : Experimental
   - `3.2.0-0`  : Experimental (no Zigbee support)
 
-- **advanced** (*Optional*, mapping): See [Advanced Configuration](#nrf52-advanced_configuration) below.
-
-<span id="nrf52-advanced_configuration"></span>
+- **advanced** (*Optional*, mapping): See [Advanced Configuration](#advanced-configuration) below.
 
 ## Advanced Configuration
 

--- a/src/content/docs/components/number/index.mdx
+++ b/src/content/docs/components/number/index.mdx
@@ -35,7 +35,7 @@ Configuration variables:
 - **name** (*Optional*, string): The name for the number. At least one of **id** and **name** must be specified.
 
 > [!NOTE]
-> If you have a [friendly_name](/components/esphome#esphome-configuration_variables) set for your device and
+> If you have a [friendly_name](/components/esphome#configuration-variables) set for your device and
 > you want the number to use that name, you can set `name: None`.
 
 - **icon** (*Optional*, icon): Manually set the icon to use for the number in the frontend.
@@ -285,8 +285,6 @@ Configuration variables:
   Can be used with `DECREMENT` or `INCREMENT` to specify whether or not to
   wrap around the value when respectively the minimum or maximum value of the
   number is exceeded.
-
-<span id="number-lambda_calls"></span>
 
 ### lambda calls
 

--- a/src/content/docs/components/number/lvgl.mdx
+++ b/src/content/docs/components/number/lvgl.mdx
@@ -6,7 +6,7 @@ title: "LVGL Number"
 The `lvgl` number platform creates a number component from an LVGL widget
 and requires [LVGL](/components/lvgl/) to be configured.
 
-Supported widgets are [`arc`](/components/lvgl/widgets#lvgl-widget-arc), [`bar`](/components/lvgl/widgets#lvgl-widget-bar), [`slider`](/components/lvgl/widgets#lvgl-widget-slider) and [`spinbox`](/components/lvgl/widgets#lvgl-widget-spinbox). A single number supports only a single widget; in other words, it's not possible to have multiple widgets associated with a single ESPHome number component.
+Supported widgets are [`arc`](/components/lvgl/widgets#arc), [`bar`](/components/lvgl/widgets#bar), [`slider`](/components/lvgl/widgets#slider) and [`spinbox`](/components/lvgl/widgets#spinbox). A single number supports only a single widget; in other words, it's not possible to have multiple widgets associated with a single ESPHome number component.
 
 ## Configuration variables
 
@@ -38,10 +38,10 @@ number:
 ## See Also
 
 - [LVGL Main component](/components/lvgl/)
-- [Arc widget](/components/lvgl/widgets#lvgl-widget-arc)
-- [Bar widget](/components/lvgl/widgets#lvgl-widget-bar)
-- [Slider widget](/components/lvgl/widgets#lvgl-widget-slider)
-- [Spinbox widget](/components/lvgl/widgets#lvgl-widget-spinbox)
+- [Arc widget](/components/lvgl/widgets#arc)
+- [Bar widget](/components/lvgl/widgets#bar)
+- [Slider widget](/components/lvgl/widgets#slider)
+- [Spinbox widget](/components/lvgl/widgets#spinbox)
 - [LVGL Binary Sensor](/components/binary_sensor/lvgl/)
 - [LVGL Sensor](/components/sensor/lvgl/)
 - [LVGL Switch](/components/switch/lvgl/)

--- a/src/content/docs/components/openthread.mdx
+++ b/src/content/docs/components/openthread.mdx
@@ -64,7 +64,7 @@ openthread:
   network dataset on the device, ensuring configured parameters are always applied at startup. Defaults to `false`
 - **use_address** (*Optional*, string): Manually override what address to use to connect
   to the ESP. Defaults to auto-generated value.
-- **poll_period** (*Optional*, [Time](/guides/configuration-types#config-time)): When Poll_Period is set on an MTD device, the parent router will enqueue any messages and wait for the child to submit a poll data request
+- **poll_period** (*Optional*, [Time](/guides/configuration-types#time)): When Poll_Period is set on an MTD device, the parent router will enqueue any messages and wait for the child to submit a poll data request
 
 > [!NOTE]
 > esphome.ota does not work when poll_period > 0, instead use http_request.ota, timeout and watchdog_timeout need to be tested to find the correct values.  Values greater than 100sec may be required.

--- a/src/content/docs/components/output/bp1658cj.mdx
+++ b/src/content/docs/components/output/bp1658cj.mdx
@@ -12,7 +12,7 @@ ESPHome. Communication is done with two GPIO pins (DATA and CLK).
 
 To use the channels of this components, you first need to setup the
 global `bp1658cj` hub and give it an id, and then define the
-[individual output channels](#bp1658cj-output).
+[individual output channels](#output).
 It is used in some smart light bulbs:
 
 - Orein OS0100411267 RGBCT Bulb
@@ -86,8 +86,6 @@ bp1658cj:
 | 14 | 140 mA |
 | 15 | 150 mA |
 
-<span id="bp1658cj-output"></span>
-
 ## Output
 
 The BP1658CJ output component exposes a BP1658CJ channel of a global
@@ -115,7 +113,7 @@ output:
 
 > [!NOTE]
 > This driver does support enabling of both the color and the white channels
-> at the same time, but it is not encourage. Therefore, the [Color Interlock](/components/light/rgbw#rgbw_color_interlock)
+> at the same time, but it is not encourage. Therefore, the [Color Interlock](/components/light/rgbw#color-interlock)
 > should be set to true when using this driver for safest operation.
 
 ## See Also

--- a/src/content/docs/components/output/bp5758d.mdx
+++ b/src/content/docs/components/output/bp5758d.mdx
@@ -12,7 +12,7 @@ ESPHome. Communication is done with two GPIO pins (DATA and CLK).
 
 To use the channels of this components, you first need to setup the
 global `bp5758d` hub and give it an id, and then define the
-[individual output channels](#bp5758d-output).
+[individual output channels](#output).
 It is used in some smart light bulbs:
 
 - DoHome G25 Globe bulb
@@ -39,8 +39,6 @@ bp5758d:
 > the bulb is designed to handle, start with lower values
 > and increase slowly, comparing to a stock bulb to verify
 > what is safe for your model.
-
-<span id="bp5758d-output"></span>
 
 ## Output
 
@@ -71,7 +69,7 @@ output:
 
 > [!NOTE]
 > This driver does support enabling of both the color and the white channels
-> at the same time, but it is not encourage. Therefore, the [Color Interlock](/components/light/rgbw#rgbw_color_interlock)
+> at the same time, but it is not encourage. Therefore, the [Color Interlock](/components/light/rgbw#color-interlock)
 > should be set to true when using this driver for safest operation.
 
 ## See Also

--- a/src/content/docs/components/output/my9231.mdx
+++ b/src/content/docs/components/output/my9231.mdx
@@ -23,7 +23,7 @@ popular driver chips used in smart light bulbs:
 
 To use the channels of this components, you first need to setup the
 global `my9231` hub and give it an id, and then define the
-[individual output channels](#my9231-output).
+[individual output channels](#output).
 
 ```yaml
 # Example configuration entry
@@ -52,8 +52,6 @@ my9231:
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): The id to use for
    this `my9231` component. Use this if you have multiple MY9231/MY9291 chains
    connected at the same time.
-
-<span id="my9231-output"></span>
 
 ## Output
 

--- a/src/content/docs/components/output/sm16716.mdx
+++ b/src/content/docs/components/output/sm16716.mdx
@@ -20,7 +20,7 @@ driver chips can be chained. It is used in some smart light bulbs:
 
 To use the channels of this components, you first need to setup the
 global `sm16716` hub and give it an id, and then define the
-[individual output channels](#sm16716-output).
+[individual output channels](#output).
 
 ```yaml
 # Example configuration entry
@@ -46,8 +46,6 @@ sm16716:
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): The id to use for
    this `sm16716` component. Use this if you have multiple SM16716 chains
    connected at the same time.
-
-<span id="sm16716-output"></span>
 
 ## Output
 

--- a/src/content/docs/components/output/sm2135.mdx
+++ b/src/content/docs/components/output/sm2135.mdx
@@ -20,7 +20,7 @@ It is used in some smart light bulbs:
 
 To use the channels of this components, you first need to setup the
 global `sm2135` hub and give it an id, and then define the
-[individual output channels](#sm2135-output).
+[individual output channels](#output).
 
 ```yaml
 # Example configuration entry
@@ -50,8 +50,6 @@ sm2135:
 - **separate_modes** (*Optional*, bool): Use separate RGB/CW modes instead of writing all 5 values as RGB.
   Defaults to `true`, keep it at `true` if your SM2135 chip variant does not support simultaneous CW and RGB modes (e.g. SM2135E).
   Set this to `false` when your SM2135 chip variant supports having CW and RGB leds on at the same time (e.g. SM2135EH/SM2135EJ).
-
-<span id="sm2135-output"></span>
 
 ## Output
 
@@ -104,7 +102,7 @@ output:
 
 > [!NOTE]
 > This driver does not support enabling of both the color and the white channels
-> at the same time. Therefore, the [Color Interlock](/components/light/rgbw#rgbw_color_interlock) should be set to true
+> at the same time. Therefore, the [Color Interlock](/components/light/rgbw#color-interlock) should be set to true
 > when using this driver.
 
 ## See Also

--- a/src/content/docs/components/output/sm2235.mdx
+++ b/src/content/docs/components/output/sm2235.mdx
@@ -14,7 +14,7 @@ ESPHome. Communication is done with two GPIO pins (DATA and CLK).
 
 To use the channels of this components, you first need to setup the
 global `sm2235` hub and give it an id, and then define the
-[individual output channels](#sm2235-output).
+[individual output channels](#output).
 
 ```yaml
 # Example configuration entry
@@ -85,8 +85,6 @@ sm2235:
 | 14 | 60 mA |
 | 15 | 64 mA |
 
-<span id="sm2235-output"></span>
-
 ## Output
 
 The SM2235 output component exposes a SM2235 channel of a global
@@ -114,7 +112,7 @@ output:
 
 > [!NOTE]
 > This driver does support enabling of both the color and the white channels
-> at the same time, but it is not encourage. Therefore, the [Color Interlock](/components/light/rgbw#rgbw_color_interlock)
+> at the same time, but it is not encourage. Therefore, the [Color Interlock](/components/light/rgbw#color-interlock)
 > should be set to true when using this driver for safest operation.
 
 ## See Also

--- a/src/content/docs/components/output/sm2335.mdx
+++ b/src/content/docs/components/output/sm2335.mdx
@@ -15,7 +15,7 @@ It is used in some smart light bulbs:
 
 To use the channels of this components, you first need to setup the
 global `sm2335` hub and give it an id, and then define the
-[individual output channels](#sm2335-output).
+[individual output channels](#output).
 
 ```yaml
 # Example configuration entry
@@ -86,8 +86,6 @@ sm2335:
 | 14 | 150 mA |
 | 15 | 160 mA |
 
-<span id="sm2335-output"></span>
-
 ## Output
 
 The SM2335 output component exposes a SM2335 channel of a global
@@ -115,7 +113,7 @@ output:
 
 > [!NOTE]
 > This driver does support enabling of both the color and the white channels
-> at the same time, but it is not encourage. Therefore, the [Color Interlock](/components/light/rgbw#rgbw_color_interlock)
+> at the same time, but it is not encourage. Therefore, the [Color Interlock](/components/light/rgbw#color-interlock)
 > should be set to true when using this driver for safest operation.
 
 ## See Also

--- a/src/content/docs/components/output/tlc5947.mdx
+++ b/src/content/docs/components/output/tlc5947.mdx
@@ -25,7 +25,7 @@ which is used e.g. on this [board from Adafruit](https://www.adafruit.com/produc
 
 To use the channels of this components, you first need to setup the
 global `tlc5947` hub and give it an id, and then define the
-[individual output channels](#tlc5947-output).
+[individual output channels](#output).
 
 ```yaml
 # Example configuration entry
@@ -47,8 +47,6 @@ tlc5947:
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): The id to use for
    this `tlc5947` component. Use this if you have multiple TLC5947 chains
    connected at the same time.
-
-<span id="tlc5947-output"></span>
 
 ## Output
 

--- a/src/content/docs/components/output/tlc5971.mdx
+++ b/src/content/docs/components/output/tlc5971.mdx
@@ -25,7 +25,7 @@ which is used e.g. on this [board from Adafruit](https://www.adafruit.com/produc
 
 To use the channels of this components, you first need to setup the
 global `tlc5971` hub and give it an id, and then define the
-[individual output channels](#tlc5971-output).
+[individual output channels](#output).
 
 ```yaml
 # Example configuration entry
@@ -44,8 +44,6 @@ tlc5971:
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): The id to use for
    this `tlc5971` component. Use this if you have multiple TLC5971 chains
    connected at the same time.
-
-<span id="tlc5971-output"></span>
 
 ## Output
 

--- a/src/content/docs/components/packages.mdx
+++ b/src/content/docs/components/packages.mdx
@@ -17,7 +17,7 @@ override substitutions with the same name in a package.
 Dictionaries are merged key-by-key. Lists of components are merged by component ID (if specified). Other lists are
 merged by concatenation. All other configuration values are replaced with the later value.
 
-ESPHome uses `!include` to "bring in" packages from other files; this feature is described in [!include](/guides/yaml#yaml-include).
+ESPHome uses `!include` to "bring in" packages from other files; this feature is described in [!include](/guides/yaml#include).
 
 The `packages:` key may have a value that is:
 
@@ -227,8 +227,6 @@ ESPHome will expand `${platform}` before loading the file, so `device-${platform
 > [!NOTE]
 > Filename substitutions are not supported when using the YAML merge key (`<<: !include filename.yaml`).
 
-<span id="config-packages_extend"></span>
-
 ## Extend
 
 To make changes or add additional configuration to included configurations, `!extend config_id` can be used, where
@@ -305,8 +303,6 @@ switch:
   - id: !extend ${ switches[mains_switch] }
     name: "Mains switch"
 ```
-
-<span id="config-packages_remove"></span>
 
 ## Remove
 

--- a/src/content/docs/components/packet_transport/espnow.mdx
+++ b/src/content/docs/components/packet_transport/espnow.mdx
@@ -44,7 +44,7 @@ sensor:
 
 ## Configuration Variables
 
-- **espnow_id** (**Required**, [ID](/guides/configuration-types#config-id)): The esp-now ID to use for transport.
+- **espnow_id** (**Required**, [ID](/guides/configuration-types#id)): The esp-now ID to use for transport.
 - **peer_address** (*Optional*, MAC Address): MAC address to send packets to. This can be either a specific
   peer address for point-to-point communication, or the broadcast address. Default FF:FF:FF:FF:FF:FF
 - All other options from the [Packet Transport Component](/components/packet_transport)

--- a/src/content/docs/components/pn7150.mdx
+++ b/src/content/docs/components/pn7150.mdx
@@ -21,7 +21,7 @@ An [I²C](/components/i2c) bus must be defined within your device's ESPHome conf
 ESPHome supports both card/tag reading/writing as well as card/tag emulation with this component. By default,
 only read/write mode is enabled; card/tag emulation is enabled only if the `emulation_message` configuration
 variable is defined (see below). Regardless, reader/writer (polling) mode and card/tag emulation mode may be
-independently enabled and disabled by using the corresponding [Actions](#pn7150-actions) (see below).
+independently enabled and disabled by using the corresponding [Actions](#actions) (see below).
 
 In addition, the [Nfc](/components/binary_sensor/nfc/) platform may be used to quickly and easily identify tags presented to the reader.
 
@@ -63,8 +63,6 @@ pn7150_i2c:
   to use multiple I²C buses.
 
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID for this component.
-
-<span id="pn7150-actions"></span>
 
 ## Actions
 
@@ -227,7 +225,7 @@ message (if one is present).
 The parameter `x` this trigger provides is of type `std::string` and is the tag UID in the format
 `74-10-37-94`. The example configuration below will publish the tag ID on the MQTT topic `pn7150/tag`.
 
-See [NDEF Reading](#pn7150-ndef_reading) below for how to use the second `tag` parameter that is provided to this trigger.
+See [NDEF Reading](#ndef-reading) below for how to use the second `tag` parameter that is provided to this trigger.
 
 ```yaml
 pn7150_i2c:
@@ -303,13 +301,9 @@ pn7150_i2c:
       - rtttl.play: "alert:d=32,o=5,b=160:e6,p,e6,p,e6"
 ```
 
-<span id="pn7150-ndef"></span>
-
 ## NDEF
 
 The PN7150 supports reading NDEF messages from and writing NDEF messages to cards/tags.
-
-<span id="pn7150-ndef_reading"></span>
 
 ### NDEF Reading
 
@@ -326,8 +320,6 @@ pn7150_i2c:
     then:
       - homeassistant.tag_scanned: !lambda "return tag.has_ha_tag_id() ? tag.get_ha_tag_id() : x;"
 ```
-
-<span id="pn7150-ndef_writing"></span>
 
 ### NDEF Writing
 

--- a/src/content/docs/components/pn7160.mdx
+++ b/src/content/docs/components/pn7160.mdx
@@ -26,7 +26,7 @@ You must determine which version of the IC you have and then configure the corre
 ESPHome supports both card/tag reading/writing as well as card/tag emulation with this component. By default,
 only read/write mode is enabled; card/tag emulation is enabled only if the `emulation_message` configuration
 variable is defined (see below). Regardless, reader/writer (polling) mode and card/tag emulation mode may be
-independently enabled and disabled by using the corresponding [Actions](#pn7160-actions) (see below).
+independently enabled and disabled by using the corresponding [Actions](#actions) (see below).
 
 In addition, the [Nfc](/components/binary_sensor/nfc/) platform may be used to quickly and easily identify tags presented to the reader.
 
@@ -127,8 +127,6 @@ pn7160_i2c:
   to use multiple I²C buses.
 
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID for this component.
-
-<span id="pn7160-actions"></span>
 
 ## Actions
 
@@ -291,7 +289,7 @@ message (if one is present).
 The parameter `x` this trigger provides is of type `std::string` and is the tag UID in the format
 `74-10-37-94`. The example configuration below will publish the tag ID on the MQTT topic `pn7160/tag`.
 
-See [NDEF Reading](#pn7160-ndef_reading) below for how to use the second `tag` parameter that is provided to this trigger.
+See [NDEF Reading](#ndef-reading) below for how to use the second `tag` parameter that is provided to this trigger.
 
 ```yaml
 pn7160_...:
@@ -367,13 +365,9 @@ pn7160_...:
       - rtttl.play: "alert:d=32,o=5,b=160:e6,p,e6,p,e6"
 ```
 
-<span id="pn7160-ndef"></span>
-
 ## NDEF
 
 The PN7160 supports reading NDEF messages from and writing NDEF messages to cards/tags.
-
-<span id="pn7160-ndef_reading"></span>
 
 ### NDEF Reading
 
@@ -390,8 +384,6 @@ pn7160_...:
     then:
       - homeassistant.tag_scanned: !lambda "return tag.has_ha_tag_id() ? tag.get_ha_tag_id() : x;"
 ```
-
-<span id="pn7160-ndef_writing"></span>
 
 ### NDEF Writing
 

--- a/src/content/docs/components/prometheus.mdx
+++ b/src/content/docs/components/prometheus.mdx
@@ -28,7 +28,7 @@ prometheus:
 - **include_internal** (*Optional*, boolean): Whether `internal` entities should be displayed on the
   web interface. Defaults to `false`.
 
-- **relabel** (*Optional*): Override metric labels. See [`relabel`](#prometheus-relabel)
+- **relabel** (*Optional*): Override metric labels. See [`relabel`](#relabel)
 
 > [!NOTE]
 > Example integration into the configuration of your prometheus:
@@ -76,8 +76,6 @@ This is useful if you want to have different metric names or IDs than those show
 
 You can relabel metric name or ID labels by adding a `relabel` block in the `prometheus` configuration,
 and then adding a block with `id` and/or `name` fields for each sensor whose labels your want to override.
-
-<span id="prometheus-relabel"></span>
 
 ### `relabel`
 

--- a/src/content/docs/components/psram.mdx
+++ b/src/content/docs/components/psram.mdx
@@ -48,5 +48,5 @@ the datasheet for the module you are using to be sure.
 - Not all ESP32 modules have PSRAM available. If you are unsure, consult the datasheet of your module.
 - Not all modules support all modes and speeds.
 - 120MHz is not available with octal mode, unless using ESP-IDF and the `enable_idf_experimental_features` is enabled
-  in the ESP-IDF platform [Advanced Configuration](/components/esp32#esp32-advanced_configuration).
+  in the ESP-IDF platform [Advanced Configuration](/components/esp32#advanced-configuration).
 - Configuring an unsupported speed will usually result in the PSRAM running at the default speed.

--- a/src/content/docs/components/radio_frequency/index.mdx
+++ b/src/content/docs/components/radio_frequency/index.mdx
@@ -47,7 +47,7 @@ Configuration variables:
 - **name** (*Optional*, string): The name for the radio frequency entity. At least one of **id** and **name** must be specified.
 
 > [!NOTE]
-> If you have a [friendly_name](/components/esphome#esphome-configuration_variables) set for your device and
+> If you have a [friendly_name](/components/esphome#configuration-variables) set for your device and
 > you want the radio frequency entity to use that name, you can set `name: None`.
 
 - **icon** (*Optional*, icon): Manually set the icon to use for the radio frequency entity in the frontend.

--- a/src/content/docs/components/remote_receiver.mdx
+++ b/src/content/docs/components/remote_receiver.mdx
@@ -13,7 +13,7 @@ or 433 MHz radio frequency (RF) signals.
 The component is split into two parts:
 
 - The remote receiver "hub", which defines the pin and a few additional settings, and...
-- Individual [remote receiver binary sensors](#remote-receiver-binary-sensor) which will activate when their
+- Individual [remote receiver binary sensors](#binary-sensor) which will activate when their
   respective signal is received.
 
 **See** [Setting up IR Devices](/guides/setting_up_rmt_devices#remote-setting-up-infrared) **and** [Setting up RF Devices](/guides/setting_up_rmt_devices#remote-setting-up-rf) **for details.**
@@ -313,8 +313,6 @@ remote_receiver:
           - ...
 ```
 
-<span id="remote-receiver-binary-sensor"></span>
-
 ## Binary Sensor
 
 The `remote_receiver` binary sensor lets you track when a button on a remote control is pressed.
@@ -540,7 +538,7 @@ Remote code selection (exactly one of these has to be included):
   - **code** (**Required**, string): The remote code to listen for, copy this from the dumper output. To ignore a bit
     in the received data, use `x` at that place in the **code**.
 
-  - **protocol** (*Optional*): The RC Switch protocol to use, see [RC Switch Protocol](/components/remote_transmitter#remote_transmitter-rc_switch-protocol) for
+  - **protocol** (*Optional*): The RC Switch protocol to use, see [RC Switch Protocol](/components/remote_transmitter#rc-switch-protocol) for
     more info.
 
 - **rc_switch_type_a**: Trigger on a decoded RC Switch Type A remote code with the given data.
@@ -548,7 +546,7 @@ Remote code selection (exactly one of these has to be included):
   - **group** (**Required**, string): The group, binary string.
   - **device** (**Required**, string): The device in the group, binary string.
   - **state** (**Required**, boolean): The on/off state to trigger on.
-  - **protocol** (*Optional*): The RC Switch protocol to use, see [RC Switch Protocol](/components/remote_transmitter#remote_transmitter-rc_switch-protocol) for
+  - **protocol** (*Optional*): The RC Switch protocol to use, see [RC Switch Protocol](/components/remote_transmitter#rc-switch-protocol) for
     more info.
 
 - **rc_switch_type_b**: Trigger on a decoded RC Switch Type B remote code with the given data.
@@ -556,7 +554,7 @@ Remote code selection (exactly one of these has to be included):
   - **address** (**Required**, int): The address, int from 1 to 4.
   - **channel** (**Required**, int): The channel, int from 1 to 4.
   - **state** (**Required**, boolean): The on/off state to trigger on.
-  - **protocol** (*Optional*): The RC Switch protocol to use, see [RC Switch Protocol](/components/remote_transmitter#remote_transmitter-rc_switch-protocol) for
+  - **protocol** (*Optional*): The RC Switch protocol to use, see [RC Switch Protocol](/components/remote_transmitter#rc-switch-protocol) for
     more info.
 
 - **rc_switch_type_c**: Trigger on a decoded RC Switch Type C remote code with the given data.
@@ -565,7 +563,7 @@ Remote code selection (exactly one of these has to be included):
   - **group** (**Required**, int): The group. Range is 1 to 4.
   - **device** (**Required**, int): The device. Range is 1 to 4.
   - **state** (**Required**, boolean): The on/off state to trigger on.
-  - **protocol** (*Optional*): The RC Switch protocol to use, see [RC Switch Protocol](/components/remote_transmitter#remote_transmitter-rc_switch-protocol) for
+  - **protocol** (*Optional*): The RC Switch protocol to use, see [RC Switch Protocol](/components/remote_transmitter#rc-switch-protocol) for
     more info.
 
 - **rc_switch_type_d**: Trigger on a decoded RC Switch Type D remote code with the given data.
@@ -573,7 +571,7 @@ Remote code selection (exactly one of these has to be included):
   - **group** (**Required**, int): The group. Range is 1 to 4.
   - **device** (**Required**, int): The device. Range is 1 to 3.
   - **state** (**Required**, boolean): The on/off state to trigger on.
-  - **protocol** (*Optional*): The RC Switch protocol to use, see [RC Switch Protocol](/components/remote_transmitter#remote_transmitter-rc_switch-protocol) for
+  - **protocol** (*Optional*): The RC Switch protocol to use, see [RC Switch Protocol](/components/remote_transmitter#rc-switch-protocol) for
     more info.
 
 - **roomba**: Trigger on a decoded Roomba remote code with the given data.

--- a/src/content/docs/components/remote_transmitter.mdx
+++ b/src/content/docs/components/remote_transmitter.mdx
@@ -796,7 +796,7 @@ on_...:
 #### Configuration variables
 
 - **code** (**Required**, string, [templatable](/automations/templates)): The raw code to send, copy this from the dump output.
-- **protocol** (*Optional*, [templatable](/automations/templates)): The RC Switch protocol to use, see [RC Switch Protocol](#remote_transmitter-rc_switch-protocol)
+- **protocol** (*Optional*, [templatable](/automations/templates)): The RC Switch protocol to use, see [RC Switch Protocol](#rc-switch-protocol)
   for more information.
 
 - All other options from [Remote Transmitter Actions](#remote_transmitter-transmit_action).
@@ -822,7 +822,7 @@ on_...:
 - **group** (**Required**, string, [templatable](/automations/templates)): The group to send the command to.
 - **device** (**Required**, string, [templatable](/automations/templates)): The device in the group to send the command to.
 - **state** (**Required**, boolean, [templatable](/automations/templates)): The on/off state to send.
-- **protocol** (*Optional*, [templatable](/automations/templates)): The RC Switch protocol to use, see [RC Switch Protocol](#remote_transmitter-rc_switch-protocol)
+- **protocol** (*Optional*, [templatable](/automations/templates)): The RC Switch protocol to use, see [RC Switch Protocol](#rc-switch-protocol)
   for more information.
 
 - All other options from [Remote Transmitter Actions](#remote_transmitter-transmit_action).
@@ -848,7 +848,7 @@ on_...:
 - **address** (**Required**, int, [templatable](/automations/templates)): The address to send the command to.
 - **channel** (**Required**, int, [templatable](/automations/templates)): The channel to send the command to.
 - **state** (**Required**, boolean, [templatable](/automations/templates)): The on/off state to send.
-- **protocol** (*Optional*, [templatable](/automations/templates)): The RC Switch protocol to use, see [RC Switch Protocol](#remote_transmitter-rc_switch-protocol)
+- **protocol** (*Optional*, [templatable](/automations/templates)): The RC Switch protocol to use, see [RC Switch Protocol](#rc-switch-protocol)
   for more information.
 
 - All other options from [Remote Transmitter Actions](#remote_transmitter-transmit_action).
@@ -876,7 +876,7 @@ on_...:
 - **group** (**Required**, int, [templatable](/automations/templates)): The group to send the command to. Range is 1 to 4.
 - **device** (**Required**, int, [templatable](/automations/templates)): The device to send the command to. Range is 1 to 4.
 - **state** (**Required**, boolean, [templatable](/automations/templates)): The on/off state to send.
-- **protocol** (*Optional*, [templatable](/automations/templates)): The RC Switch protocol to use, see [RC Switch Protocol](#remote_transmitter-rc_switch-protocol)
+- **protocol** (*Optional*, [templatable](/automations/templates)): The RC Switch protocol to use, see [RC Switch Protocol](#rc-switch-protocol)
   for more information.
 
 - All other options from [Remote Transmitter Actions](#remote_transmitter-transmit_action).
@@ -902,7 +902,7 @@ on_...:
 - **group** (**Required**, string, [templatable](/automations/templates)): The group to send the command to. Range is `a` to `d`.
 - **device** (**Required**, int, [templatable](/automations/templates)): The device to send the command to. Range is 1 to 3.
 - **state** (**Required**, boolean, [templatable](/automations/templates)): The on/off state to send.
-- **protocol** (*Optional*, [templatable](/automations/templates)): The RC Switch protocol to use, see [RC Switch Protocol](#remote_transmitter-rc_switch-protocol)
+- **protocol** (*Optional*, [templatable](/automations/templates)): The RC Switch protocol to use, see [RC Switch Protocol](#rc-switch-protocol)
   for more information.
 
 - All other options from [Remote Transmitter Actions](#remote_transmitter-transmit_action).
@@ -1108,8 +1108,6 @@ on_...:
   the first one defined in the configuration.
 
 - **value** (**Required**, bool, [templatable](/automations/templates)): The output value of the pin.
-
-<span id="remote_transmitter-rc_switch-protocol"></span>
 
 ### RC Switch Protocol
 

--- a/src/content/docs/components/safe_mode.mdx
+++ b/src/content/docs/components/safe_mode.mdx
@@ -20,8 +20,6 @@ for `num_attempts` times (see below).
 safe_mode:
 ```
 
-<span id="safe_mode-configuration_variables"></span>
-
 ## Configuration variables
 
 - **disabled** (*Optional*, boolean): Set to `true` to disable safe_mode. [Ota](/components/ota/) automatically

--- a/src/content/docs/components/select/index.mdx
+++ b/src/content/docs/components/select/index.mdx
@@ -35,7 +35,7 @@ Configuration variables:
 - **name** (*Optional*, string): The name for the select. At least one of **id** and **name** must be specified.
 
 > [!NOTE]
-> If you have a [friendly_name](/components/esphome#esphome-configuration_variables) set for your device and
+> If you have a [friendly_name](/components/esphome#configuration-variables) set for your device and
 > you want the select to use that name, you can set `name: None`.
 
 - **icon** (*Optional*, icon): Manually set the icon to use for the select in the frontend.

--- a/src/content/docs/components/select/lvgl.mdx
+++ b/src/content/docs/components/select/lvgl.mdx
@@ -6,7 +6,7 @@ title: "LVGL Select"
 The `lvgl` select platform creates a select from an LVGL widget
 and requires [LVGL](/components/lvgl/) to be configured.
 
-Supported widgets are [`dropdown`](/components/lvgl/widgets#lvgl-widget-dropdown) and [`roller`](/components/lvgl/widgets#lvgl-widget-roller). A single select supports only a single widget; in other words, it's not possible to have multiple widgets associated with a single ESPHome select component.
+Supported widgets are [`dropdown`](/components/lvgl/widgets#dropdown) and [`roller`](/components/lvgl/widgets#roller). A single select supports only a single widget; in other words, it's not possible to have multiple widgets associated with a single ESPHome select component.
 
 ## Configuration variables
 
@@ -29,8 +29,8 @@ select:
 ## See Also
 
 - [LVGL Main component](/components/lvgl/)
-- [Roller widget](/components/lvgl/widgets#lvgl-widget-roller)
-- [Dropdown widget](/components/lvgl/widgets#lvgl-widget-dropdown)
+- [Roller widget](/components/lvgl/widgets#roller)
+- [Dropdown widget](/components/lvgl/widgets#dropdown)
 - [LVGL Binary Sensor](/components/binary_sensor/lvgl/)
 - [LVGL Sensor](/components/sensor/lvgl/)
 - [LVGL Number](/components/number/lvgl/)

--- a/src/content/docs/components/sensor/adc.mdx
+++ b/src/content/docs/components/sensor/adc.mdx
@@ -32,7 +32,7 @@ sensor:
   Or on the ESP8266 or Raspberry Pi Pico it could alternatively be set to `VCC`, see [Measuring VCC](#adc-vcc).
 
 - **attenuation** (*Optional*): Only on ESP32. Specify the ADC
-  attenuation to use. See [ESP32 Attenuation](#adc-esp32_attenuation). Defaults to `0db`.
+  attenuation to use. See [ESP32 Attenuation](#esp32-attenuation). Defaults to `0db`.
 
 - **raw** (*Optional*): Allows to read the raw ADC output without any conversion or calibration. See [Different ESP32-ADC behavior since 2021.11](#adc-raw). Defaults to `false`.
 - **samples** (*Optional*): The amount of ADC readings to take per sensor update. On the ESP32 this value is ignored if `attenuation` is set to `auto`. Defaults to `1`.
@@ -60,8 +60,6 @@ sensor:
 >     filters:
 >       - multiply: 3.3
 > ```
-
-<span id="adc-esp32_attenuation"></span>
 
 ## ESP32 Attenuation
 

--- a/src/content/docs/components/sensor/ads1115.mdx
+++ b/src/content/docs/components/sensor/ads1115.mdx
@@ -14,7 +14,7 @@ import APIRef from '@components/APIRef.astro';
 ## Component/Hub
 
 The `ads1115` domain creates a global hub so that you can later create
-individual sensors using the [ADS1115 Sensor Platform](#ads1115-sensor).
+individual sensors using the [ADS1115 Sensor Platform](#sensor).
 To use this hub, first setup the [I²C Bus](/components/i2c) and connect the sensor to the pins specified there.
 
 <Figure
@@ -53,8 +53,6 @@ change the i²c address.
 - If the address pin is pulled to VCC, the address is `0x49`.
 - If the address pin is tied to SDA, the address is `0x4a`.
 - If the address pin is tied to SCL, the address is `0x4B`.
-
-<span id="ads1115-sensor"></span>
 
 ## Sensor
 

--- a/src/content/docs/components/sensor/ads1118.mdx
+++ b/src/content/docs/components/sensor/ads1118.mdx
@@ -14,7 +14,7 @@ import APIRef from '@components/APIRef.astro';
 
 ADS1118 4-Channel 16-Bit A/D Converter ([datasheet](https://www.ti.com/lit/ds/symlink/ads1118.pdf))
 The `ads1118` domain creates a global hub so that you can later create
-individual sensors using the [ADS1118 Sensor Platform](#ads1118-sensor).
+individual sensors using the [ADS1118 Sensor Platform](#sensor).
 It uses the [SPI Bus](/components/spi) for communication.
 
 <Figure
@@ -34,8 +34,6 @@ ads1118:
 - **cs_pin** (**Required**, int): The SPI cable select pin to use.
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID for this ADS1118 Hub. Use this if you
   want to use multiple ADS1118 hubs at once.
-
-<span id="ads1118-sensor"></span>
 
 ## Sensor
 

--- a/src/content/docs/components/sensor/apds9306.mdx
+++ b/src/content/docs/components/sensor/apds9306.mdx
@@ -7,8 +7,6 @@ import { Image } from 'astro:assets';
 import Figure from '@components/Figure.astro';
 import APIRef from '@components/APIRef.astro';
 
-<span id="apds9306-component"></span>
-
 ## Component
 
 The `apds9306` sensor component allows you to use APDS9306 ambient light sensors ([datasheet](https://docs.broadcom.com/doc/AV02-4755EN), [Broadcom](https://www.broadcom.com/products/optical-sensors/ambient-light-photo-sensors/apds-9306-065)) with ESPHome.

--- a/src/content/docs/components/sensor/as5600.mdx
+++ b/src/content/docs/components/sensor/as5600.mdx
@@ -18,7 +18,7 @@ import APIRef from '@components/APIRef.astro';
 The `as5600` sensor platform you to use your AS5600 ([datasheet](https://ams.com/documents/20143/36005/AS5600_DS000365_5-00.pdf/649ee61c-8f9a-20df-9e10-43173a3eb323),
 [AMS](https://ams.com/en/as5600)) or AS5600L ([datasheet](https://ams.com/documents/20143/36005/AS5600L_DS000545_3-00.pdf/7ade6878-7a32-2294-b88d-479d50fab6de),
 [AMS](https://ams.com/en/as5600l)) 12-bit magnetic position sensor with ESPHome. Individual sensors will be added
-using the [AS5600 Sensor Platform](#as5600-sensor). To use this hub, first setup
+using the [AS5600 Sensor Platform](#sensor). To use this hub, first setup
 the [I²C Bus](/components/i2c) and connect the sensor to the pins specified there.
 
 <Figure
@@ -38,7 +38,7 @@ as5600:
 ### Configuration variables
 
 - **dir_pin** (*Optional*, int): The pin connected to the AS5600's direction pin.
-  See [Direction](#as5600_direction) for more information.
+  See [Direction](#direction) for more information.
 
 - **direction** (*Optional*, string): The direction that the magnet should rotate to increase values.
   Used in combination with the **dir_pin**.
@@ -96,8 +96,6 @@ as5600:
 
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID for this AS5600 Hub.
 - All other options for I²C devices described at [I²C Bus](/components/i2c).
-
-<span id="as5600_direction"></span>
 
 ## Direction
 
@@ -161,8 +159,6 @@ as5600:
 The AS5600 address is not configurable and must be `0x36`. However, if using an AS5600L,
 the default address should be `0x40` and it is configurable.
 
-<span id="as5600-sensor"></span>
-
 ## Sensor
 
 The `as5600` sensor allows you to publish the angle/position measurement from your AS5600 with ESPHome.
@@ -193,7 +189,7 @@ sensor:
 ### Configuration variables
 
 - **out_of_range_mode** (*Optional*, string): How to treat out of range values. Only applicable if configured
-  for a range less than 360 degrees. Defaults to `min_max`. See [Out of Range Mode](#as5600-out-of-range-mode).
+  for a range less than 360 degrees. Defaults to `min_max`. See [Out of Range Mode](#out-of-range-mode).
 
 - **as5600_id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID of the
   [AS5600 Hub](#as5600-component) you want to use this sensor.
@@ -217,12 +213,10 @@ sensor:
 
   - All other options from [Sensor](/components/sensor).
 - **status** (*Optional*): Information about the magnet status. Typically for diagnostic purposes.
-  See [Magnet Status](#as5600-magnet-status)
+  See [Magnet Status](#magnet-status)
 
   - All other options from [Sensor](/components/sensor).
 - All other options from [Sensor](/components/sensor).
-
-<span id="as5600-out-of-range-mode"></span>
 
 ### Out of Range Mode
 
@@ -234,8 +228,6 @@ splits that range in half and reports `0` while in the half of the "out-of-range
 `4095` while in the half of the "out-of-range" range closest to the `end_position` / end of the `range`. Alternatively, you may set to `nan`
 mode where the sensor will publish `NAN` (i.e. "Unknown") when the position falls outside the narrowed range.
 
-<span id="as5600-magnet-status"></span>
-
 ### Magnet Status
 
 The magnet status should report one of the following values:
@@ -244,8 +236,6 @@ The magnet status should report one of the following values:
 - `4` indicates that the magnet was detected and has good reading.
 - `5` indicates that the magnet was detected, but is too strong. Measurements may appear to be stuck if the magnet is too strong.
 - `6` indicates that the magnet was detected, but is too weak. Measurements may still be possible in this state.
-
-<span id="as5600-converting-position"></span>
 
 ### Converting Position
 

--- a/src/content/docs/components/sensor/bh1900nux.mdx
+++ b/src/content/docs/components/sensor/bh1900nux.mdx
@@ -27,7 +27,7 @@ sensor:
 
 - **address** (*Optional*, int): Manually specify the I²C address of the sensor. Defaults to `0x48`.  
 
-- **update_interval** (*Optional*, [Time](/guides/configuration-types#config-time)): The interval to check the sensor. Defaults to `60s`.
+- **update_interval** (*Optional*, [Time](/guides/configuration-types#time)): The interval to check the sensor. Defaults to `60s`.
 
 - All other options from [Sensor](/components/sensor#config-sensor).
 

--- a/src/content/docs/components/sensor/bl0942.mdx
+++ b/src/content/docs/components/sensor/bl0942.mdx
@@ -54,10 +54,8 @@ sensor:
 - **reset** (*Optional*, boolean): Whether to reset the BL0942 chip on startup, resetting all internal counters. Defaults to `true`.
 - **current_reference** (*Optional*, float): The calibration parameter for current readings. Defaults to `251065.6814`.
 - **voltage_reference** (*Optional*, float): The calibration parameter for voltage readings. Defaults to `15883.34116`.
-- **power_reference** (*Optional*, float): The calibration parameter for power readings. Defaults to `623.0270705` unless either `current_reference` or `voltage_reference` are explicitly set, in which case it is calculated. See [Calibration](#bl0942-calibration) for more details.
-- **energy_reference** (*Optional*, float): The calibration parameter for cumulative energy readings. Defaults to `5347.484240` unless any of `current_reference`, `voltage_reference` or `power_reference` are explicitly set, in which case it is calculated. See [Calibration](#bl0942-calibration) for more details.
-
-<span id="bl0942-calibration"></span>
+- **power_reference** (*Optional*, float): The calibration parameter for power readings. Defaults to `623.0270705` unless either `current_reference` or `voltage_reference` are explicitly set, in which case it is calculated. See [Calibration](#calibration) for more details.
+- **energy_reference** (*Optional*, float): The calibration parameter for cumulative energy readings. Defaults to `5347.484240` unless any of `current_reference`, `voltage_reference` or `power_reference` are explicitly set, in which case it is calculated. See [Calibration](#calibration) for more details.
 
 ## Calibration
 

--- a/src/content/docs/components/sensor/ble_rssi.mdx
+++ b/src/content/docs/components/sensor/ble_rssi.mdx
@@ -6,7 +6,7 @@ import APIRef from '@components/APIRef.astro';
 
 
 The `ble_rssi` sensor platform lets you track the RSSI value or signal strength of a
-BLE device. See [the binary sensor setup](/components/binary_sensor/ble_presence#esp32_ble_tracker-setting_up_devices) for
+BLE device. See [the binary sensor setup](/components/binary_sensor/ble_presence#setting-up-devices) for
 instructions for setting up this platform.
 
 > [!WARNING]

--- a/src/content/docs/components/sensor/bme680.mdx
+++ b/src/content/docs/components/sensor/bme680.mdx
@@ -99,8 +99,6 @@ configure this amount. Possible oversampling values:
 - `8x`
 - `16x` (default)
 
-<span id="bme680-advanced-configuration"></span>
-
 ## Advanced Configuration
 
 Add indoor air quality (IAQ) calculation and IAQ label, based on the values in the [BME680 BSEC component](/components/sensor/bme680_bsec.html?highlight=bme680#index-for-air-quality-iaq-measurement) index.

--- a/src/content/docs/components/sensor/dlms_meter.mdx
+++ b/src/content/docs/components/sensor/dlms_meter.mdx
@@ -42,10 +42,10 @@ sensor:
 
 ## Configuration Variables
 
-- **id** (*Optional*, [ID](/guides/configuration-types#config-id)): The ID of the `dlms_meter` component.
-- **uart_id** (*Optional*, [ID](/guides/configuration-types#config-id)): The ID of the UART component that is
+- **id** (*Optional*, [ID](/guides/configuration-types#id)): The ID of the `dlms_meter` component.
+- **uart_id** (*Optional*, [ID](/guides/configuration-types#id)): The ID of the UART component that is
 connected to the smart meter.
-- **receive_timeout** (*Optional*, [Time](/guides/configuration-types#config-time)): The timeout for receiving a complete frame. Defaults to `1000ms`.
+- **receive_timeout** (*Optional*, [Time](/guides/configuration-types#time)): The timeout for receiving a complete frame. Defaults to `1000ms`.
 - **decryption_key** (*Optional*, string): Specify if your smart meter uses encryption. You should request this key
 from your electricity provider (32 hex characters, case-insensitive).
 - **auth_key** (*Optional*, string): Authentication key. Specify if your smart meter uses encryption with
@@ -64,7 +64,7 @@ descriptor pattern** that tells the system how to parse the incoming data.
 All platforms (`sensor`, `text_sensor`, `binary_sensor`) support dynamic mapping using the `obis_code` property.
 This allows you to decode nearly any property your meter emits.
 
-- **dlms_meter_id** (*Optional*, [ID](/guides/configuration-types#config-id)): Manually specify the ID of the
+- **dlms_meter_id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID of the
 `dlms_meter` hub if you have multiple.
 - **obis_code** (**Required for dynamic mapping**, string): The OBIS code of the value you want to read. The code supports flexible formats
 like `1-0:32.7.0` or `1.0.32.7.0.255`.

--- a/src/content/docs/components/sensor/dsmr.mdx
+++ b/src/content/docs/components/sensor/dsmr.mdx
@@ -515,8 +515,6 @@ or a transistor-based circuit are not feasible options. Here's an example circui
 When using a type of MCU that provides 5V on the GPIO outputs instead of 3.3V, then use a 330 Ohm
 resistor instead of the 200 Ohm resistor.
 
-<span id="sensor-dsmr-improving_reader_results"></span>
-
 ## Improving reader results
 
 When telegrams are sometimes missed or when you get a lot of CRC errors, then you might have to do some

--- a/src/content/docs/components/sensor/emontx.mdx
+++ b/src/content/docs/components/sensor/emontx.mdx
@@ -9,7 +9,7 @@ import Figure from '@components/Figure.astro';
 
 The `emontx` component allows you to use ESPHome to create a connection to an OpenEnergyMonitor emonTX via a supported device (ESP32 recommended).
 This component is a global hub that establishes the connection to the EmonTx via [UART bus](/components/uart) and translates the received data.
-Using the [emontx sensors](#emontx-sensors), you can then create sensors for Home Assistant that track voltage, current, power as measured by CTs (up to 12), pulse data, and temperature depending on the configuration of the emonTX.
+Using the [emontx sensors](#sensors), you can then create sensors for Home Assistant that track voltage, current, power as measured by CTs (up to 12), pulse data, and temperature depending on the configuration of the emonTX.
 
 The component can send data to an MQTT Broker either as JSON or as individual topics to be consumed by any system.
 
@@ -111,9 +111,7 @@ sensor:
     name: "Energy CT1"
 ```
 
-This will create three sensors in Home Assistant tracking voltage, power, and energy from the first CT channel. See the [Sensors](#emontx-sensors) section below for all available sensor types and their tag names.
-
-<span id="emontx-sensors"></span>
+This will create three sensors in Home Assistant tracking voltage, power, and energy from the first CT channel. See the [Sensors](#sensors) section below for all available sensor types and their tag names.
 
 ## Sensors
 
@@ -504,7 +502,7 @@ For example, with device name `emontx_living_room` and the sensors defined below
 - `emontx_living_room/sensor/voltage/state` for the sensor named "Voltage"
 - `emontx_living_room/sensor/energy_ct2/state` for the sensor named "Energy CT2"
 
-> Only sensor(s) defined in the configuration will be published (see [Sensors](#emontx-sensors)).
+> Only sensor(s) defined in the configuration will be published (see [Sensors](#sensors)).
 
 Example:
 

--- a/src/content/docs/components/sensor/ezo.mdx
+++ b/src/content/docs/components/sensor/ezo.mdx
@@ -60,8 +60,6 @@ Automation triggers:
 
 - **on_custom** (*Optional*, [Action](/automations/actions#all-actions)): Triggered when the result of `get_custom()` is ready. The result is provided as a `std::string` variable named `x`.
 
-<span id="ezo_lambda_calls"></span>
-
 ## Lambda calls
 
 From [lambdas](/automations/templates#config-lambda), you can interact with the sensor in various ways. For any `get` command a trigger will be called

--- a/src/content/docs/components/sensor/grove_gas_mc_v2.mdx
+++ b/src/content/docs/components/sensor/grove_gas_mc_v2.mdx
@@ -65,8 +65,6 @@ Advanced:
 - **address** (*Optional*, int): The [I²C](/components/i2c) address of the sensor.
   Defaults to `0x08`
 
-<span id="grove-gas-mc-v2-preheating"></span>
-
 ## Preheating
 
 If the sensor is stored for a long period of time (without power) there is a recommended

--- a/src/content/docs/components/sensor/index.mdx
+++ b/src/content/docs/components/sensor/index.mdx
@@ -45,7 +45,7 @@ Configuration variables:
 - **name** (*Optional*, string): The name for the sensor. At least one of **id** and **name** must be specified.
 
 > [!NOTE]
-> If you have a [friendly_name](/components/esphome#esphome-configuration_variables) set for your device and
+> If you have a [friendly_name](/components/esphome#configuration-variables) set for your device and
 > you want the sensor to use that name, you can set `name: None`.
 
 - **unit_of_measurement** (*Optional*, string): Manually set the unit
@@ -308,8 +308,6 @@ Configuration variables:
 
 - **above** (*Optional*, float): The minimum for the condition.
 - **below** (*Optional*, float): The maximum for the condition.
-
-<span id="sensor-lambda_calls"></span>
 
 ### Lambda calls
 

--- a/src/content/docs/components/sensor/ld2410.mdx
+++ b/src/content/docs/components/sensor/ld2410.mdx
@@ -240,8 +240,6 @@ switch:
 - **ld2410_id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID for the [Ld2410](/components/sensor/ld2410/) component if you are
   using multiple components.
 
-<span id="ld2410-number"></span>
-
 ## Number
 
 The `ld2410` number allows you to control the configuration of your [Ld2410](/components/sensor/ld2410/).
@@ -501,7 +499,7 @@ In order to calibrate your `ld2410` sensor perform the following:
 
 1. Enable [engineering mode](#ld2410-engineering-mode).
 1. Monitor the `gX_move_energy` and `gX_still_energy` [sensors](#ld2410-sensors).
-1. Change the [thresholds](#ld2410-number) and repeat step 2 until satisfaction.
+1. Change the [thresholds](#number) and repeat step 2 until satisfaction.
 1. Disable [engineering mode](#ld2410-engineering-mode).
 
 ### Home Assistant Card

--- a/src/content/docs/components/sensor/ld2412.mdx
+++ b/src/content/docs/components/sensor/ld2412.mdx
@@ -248,8 +248,6 @@ switch:
 - **ld2412_id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID for the component. Required when using multiple
   components.
 
-<span id="ld2412-number"></span>
-
 ## Number
 
 The `ld2412` number allows you to control the configuration of your module.
@@ -477,7 +475,7 @@ To calibrate your sensor, perform the following:
 
 1. Enable [engineering mode](#ld2412-engineering-mode).
 1. Monitor the `gate_X_move_energy` and `gate_X_still_energy` [sensors](#ld2412-sensors).
-1. Change the [thresholds](#ld2412-number) and repeat step 2 until you are satisfied.
+1. Change the [thresholds](#number) and repeat step 2 until you are satisfied.
 1. Disable [engineering mode](#ld2412-engineering-mode).
 
 As an alternative, you can simply leave the room, turn on the "Dynamic background correction" and let it calibrate

--- a/src/content/docs/components/sensor/ld2450.mdx
+++ b/src/content/docs/components/sensor/ld2450.mdx
@@ -223,7 +223,7 @@ sensor:
 
       All options from [Sensor](/components/sensor).
 
-- **zone_N** (*Optional*): Target count details in the defined [zones](#ld2450-number) (N = 1 to 3). A maximum of
+- **zone_N** (*Optional*): Target count details in the defined [zones](#number) (N = 1 to 3). A maximum of
   three zones: `zone_1`, `zone_2`, `zone_3`.
 
   - **target_count** (*Optional*, int): Total targets detected in the zone, whether they are stationary or in motion.
@@ -254,8 +254,6 @@ sensor:
 >
 > To remove the default filters for any given sensor instance, add `filters: []` to its configuration.
 
-<span id="ld2450-switch"></span>
-
 ## Switch
 
 The `ld2450` switch allows you to control your [Ld2450](/components/sensor/ld2450/) `Bluetooth` and `Multi/Single Target Tracking`.
@@ -282,8 +280,6 @@ switch:
 
 - **multi_target** (*Optional*): Turn on/off the Multi Target Tracking option. The initial state set based on the
   corresponding setting as read from LD2450 module at boot. All options from [Switch](/components/switch#config-switch).
-
-<span id="ld2450-number"></span>
 
 ## Number
 

--- a/src/content/docs/components/sensor/lvgl.mdx
+++ b/src/content/docs/components/sensor/lvgl.mdx
@@ -6,7 +6,7 @@ title: "LVGL Sensor"
 The `lvgl` sensor platform creates a sensor component from an LVGL widget
 and requires [LVGL](/components/lvgl/) to be configured.
 
-Supported widgets are [`arc`](/components/lvgl/widgets#lvgl-widget-arc), [`bar`](/components/lvgl/widgets#lvgl-widget-bar), [`slider`](/components/lvgl/widgets#lvgl-widget-slider) and [`spinbox`](/components/lvgl/widgets#lvgl-widget-spinbox). A single sensor supports only a single widget; in other words, it's not possible to have multiple widgets associated with a single ESPHome sensor.
+Supported widgets are [`arc`](/components/lvgl/widgets#arc), [`bar`](/components/lvgl/widgets#bar), [`slider`](/components/lvgl/widgets#slider) and [`spinbox`](/components/lvgl/widgets#spinbox). A single sensor supports only a single widget; in other words, it's not possible to have multiple widgets associated with a single ESPHome sensor.
 
 ## Configuration variables
 
@@ -34,10 +34,10 @@ sensor:
 ## See Also
 
 - [LVGL Main component](/components/lvgl/)
-- [Arc widget](/components/lvgl/widgets#lvgl-widget-arc)
-- [Bar widget](/components/lvgl/widgets#lvgl-widget-bar)
-- [Slider widget](/components/lvgl/widgets#lvgl-widget-slider)
-- [Spinbox widget](/components/lvgl/widgets#lvgl-widget-spinbox)
+- [Arc widget](/components/lvgl/widgets#arc)
+- [Bar widget](/components/lvgl/widgets#bar)
+- [Slider widget](/components/lvgl/widgets#slider)
+- [Spinbox widget](/components/lvgl/widgets#spinbox)
 - [LVGL Binary Sensor](/components/binary_sensor/lvgl/)
 - [LVGL Switch](/components/switch/lvgl/)
 - [LVGL Select](/components/select/lvgl/)

--- a/src/content/docs/components/sensor/mcp3221.mdx
+++ b/src/content/docs/components/sensor/mcp3221.mdx
@@ -34,7 +34,7 @@ sensor:
 
 - **address** (*Optional*, int): Defaults to ``0x48``. ``0b1001XXX`` - ``X``: See packaging for the last 3 bits
 - **reference_voltage** (*Optional*, float): The reference voltage. Should be ``VCC``, range 2.7V to 5.5V
-- **update_interval** (*Optional*, [Time](/guides/configuration-types#config-time)): The interval to check the sensor. Defaults to ``60s``.
+- **update_interval** (*Optional*, [Time](/guides/configuration-types#time)): The interval to check the sensor. Defaults to ``60s``.
 - All other options from [Sensor](/components/sensor#config-sensor).
 
 ## See Also

--- a/src/content/docs/components/sensor/nextion.mdx
+++ b/src/content/docs/components/sensor/nextion.mdx
@@ -59,8 +59,8 @@ sensor:
 - **precision** (*Optional*, int): This is for Nextion float components. This sets
   the precision that the component is set to. This typically is the `vvs1` setting of the component.
 
-- **background_color** (*Optional*, [Color](/components/display#config-color)): The background color
-- **foreground_color** (*Optional*, [Color](/components/display#config-color)): The foreground color
+- **background_color** (*Optional*, [Color](/components/display#color)): The background color
+- **foreground_color** (*Optional*, [Color](/components/display#color)): The foreground color
 - **visible** (*Optional*, boolean): Visible or not
 
 ### Waveform Settings
@@ -81,7 +81,7 @@ sensor:
 > `background_color`, `foreground_color` and `visible` do not retain their state on page change. [Sensor Settings](#nextion_sensor_settings).
 > A [Nextion Sensor](#nextion_sensor) with a custom protocol sending the current page can be used to execute the API call [Update Components By Prefix](/components/display/nextion#update_components_by_prefix) to update all the components for that page
 
-See [How things Update](#nextion_sensor_how_things_update) for additional information
+See [How things Update](#how-things-update) for additional information
 
 ### Globals
 
@@ -130,9 +130,7 @@ Configuration variables:
   display which will update component. Default is true.
 
 > [!NOTE]
-> This action can also be written in lambdas. See [Lambda Calls](#nextion_sensor_lambda_calls)
-
-<span id="nextion_sensor_lambda_calls"></span>
+> This action can also be written in lambdas. See [Lambda Calls](#lambda-calls)
 
 ### Lambda Calls
 
@@ -153,8 +151,6 @@ some more advanced functions (see the full <APIRef text="nextion_sensor.h" path=
 - `set_foreground_color(Color color)`  : Sets the background color to **Color**
 - `set_visible(bool visible)` : Sets visible or not. If set to false, no updates will be sent to the component
 
-<span id="nextion_sensor_how_things_update"></span>
-
 ## How things Update
 
 A Nextion component with an integer value (.val) or Nextion variable will be automatically polled if **update_interval** is set.
@@ -172,7 +168,7 @@ Using the above yaml example:
 - "Current Humidity" will poll the Nextion for the `humidity.val` value and set the sensor accordingly.
 - "Current Temperature" will NOT poll the Nextion. Either the Nextion will need to use the [Nextion Custom Sensor Protocol](#nextion-custom-sensor-protocol) or use a lambda:
 
-- [Lambda Calls](#nextion_sensor_lambda_calls).
+- [Lambda Calls](#lambda-calls).
 
 > [!NOTE]
 > No updates will be sent to the Nextion if it is sleeping. Once it wakes, the components will be updated. If a component is invisible, `visible(false)`, then it won't update until it is set to be visible.

--- a/src/content/docs/components/sensor/sy6970.mdx
+++ b/src/content/docs/components/sensor/sy6970.mdx
@@ -41,7 +41,7 @@ sy6970:
 
 ## Configuration variables
 
-- **id** (*Optional*, [ID](/guides/configuration-types#config-id)): Manually specify the ID used for code generation.
+- **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID used for code generation.
 - **address** (*Optional*, int): The I²C address of the device. Defaults to `0x6A`.
 - **enable_status_led** (*Optional*, boolean): Enable or disable the status LED on the IC. Defaults to `true`.
 - **input_current_limit** (*Optional*, int): Input current in milliamps. Accepts values between 100 and 3200. Defaults to `500`.
@@ -51,7 +51,7 @@ sy6970:
 - **charge_enabled** (*Optional*, boolean): Enable or disable charging. Defaults to `true`.
 - **enable_adc** (*Optional*, boolean): Enable or disable the ADC. Defaults to `true`.
 - All other options from [I²C Device](/components/i2c).
-- **update_interval** (*Optional*, [Time](/guides/configuration-types#config-time)): The interval to check the sensor. Defaults to `5s`.
+- **update_interval** (*Optional*, [Time](/guides/configuration-types#time)): The interval to check the sensor. Defaults to `5s`.
 
 ## Sensor
 
@@ -76,7 +76,7 @@ sensor:
 
 ## Sensor Configuration variables
 
-- **sy6970_id** (*Optional*, [ID](/guides/configuration-types#config-id)): The ID of the SY6970 component. Defaults to the only SY6970 component in your configuration.
+- **sy6970_id** (*Optional*, [ID](/guides/configuration-types#id)): The ID of the SY6970 component. Defaults to the only SY6970 component in your configuration.
 - **vbus_voltage** (*Optional*): The voltage on the VBUS (USB) input in volts.
   - All options from [Sensor](/components/sensor).
 - **battery_voltage** (*Optional*): The battery voltage in volts.
@@ -108,7 +108,7 @@ binary_sensor:
 
 ## Binary Sensor Configuration variables
 
-- **sy6970_id** (*Optional*, [ID](/guides/configuration-types#config-id)): The ID of the SY6970 component. Defaults to the only SY6970 component in your configuration.
+- **sy6970_id** (*Optional*, [ID](/guides/configuration-types#id)): The ID of the SY6970 component. Defaults to the only SY6970 component in your configuration.
 - **vbus_connected** (*Optional*): Indicates whether VBUS (USB power) is connected.
   - All options from [Binary Sensor](/components/binary_sensor).
 - **charging** (*Optional*): Indicates whether the battery is currently charging.
@@ -136,7 +136,7 @@ text_sensor:
 
 ## Text Sensor Configuration variables
 
-- **sy6970_id** (*Optional*, [ID](/guides/configuration-types#config-id)): The ID of the SY6970 component. Defaults to the only SY6970 component in your configuration.
+- **sy6970_id** (*Optional*, [ID](/guides/configuration-types#id)): The ID of the SY6970 component. Defaults to the only SY6970 component in your configuration.
 - **bus_status** (*Optional*): The type of power source connected. Possible values are:
   - `No Input` - No power source connected
   - `USB SDP` - USB Standard Downstream Port

--- a/src/content/docs/components/sml.mdx
+++ b/src/content/docs/components/sml.mdx
@@ -123,7 +123,7 @@ identifies your smart meter. If you have only one hardware component attached to
 don't have to care about the server id and you may ommit it in your configuration.
 
 In order to get the server id and the available OBIS codes provided by your smart meter, simply set up the
-[SML platform](#sml-platform) and observe the log output (the [log level](/components/logger#logger-log_levels)
+[SML platform](#sml-platform) and observe the log output (the [log level](/components/logger#log-levels)
 must be set to at least `debug`  !).
 
 Your log output will show something like this:

--- a/src/content/docs/components/sprinkler.mdx
+++ b/src/content/docs/components/sprinkler.mdx
@@ -75,7 +75,7 @@ sprinkler:
         valve_switch_id: lawn_sprinkler_valve_sw1
 ```
 
-Please see the [Controller Examples](#sprinkler-controller-examples) section below for extensive, detailed configuration
+Please see the [Controller Examples](#controller-examples) section below for extensive, detailed configuration
 examples that are ready for you to copy and paste!
 
 ## Configuration variables
@@ -184,7 +184,7 @@ examples that are ready for you to copy and paste!
     [GPIO switch](/components/switch/gpio/) wired to control a relay or other switching device which in turn would
     activate the respective pump/valve. For latching valves/pumps, use an [H-Bridge switch](/components/switch/hbridge/).
     *It is not recommended to expose this switch to the front end; please see*
-    [An Important Note about GPIO Switches and Control](#sprinkler-controller-an_important_note_about_gpio_switches_and_control)
+    [An Important Note about GPIO Switches and Control](#an-important-note-about-gpio-switches-and-control)
     *below for more detail.*
 
   - **run_duration_number** (*Optional*, *string*): The name of the [number](/components/number/) component
@@ -204,10 +204,8 @@ examples that are ready for you to copy and paste!
     system. Typically this would be a [GPIO switch](/components/switch/gpio/) wired to control a relay
     or other switching device which in turn would activate the respective valve. For latching valves, use an
     [H-Bridge switch](/components/switch/hbridge/). *It is not recommended to expose this switch to the front end; please see*
-    [An Important Note about GPIO Switches and Control](#sprinkler-controller-an_important_note_about_gpio_switches_and_control)
+    [An Important Note about GPIO Switches and Control](#an-important-note-about-gpio-switches-and-control)
     *below for more detail.*
-
-<span id="sprinkler-controller-an_important_note_about_gpio_switches_and_control"></span>
 
 ## An Important Note about GPIO Switches and Control
 
@@ -257,8 +255,6 @@ In summary, to ensure that your sprinkler controller consistently operates as ex
 
 These simple configuration tweaks will help prevent any number of errors (human, automation, or otherwise) and may help
 to avert disaster!
-
-<span id="sprinkler-controller-actions"></span>
 
 ## Controller Actions
 
@@ -513,14 +509,12 @@ on_...:
 > - The `start_single_valve` action ignores whether a valve is enabled via its enable switch.
 > - The `next_valve` and `previous_valve` actions may not appear to respond immediately if either
 >   `manual_selection_delay` or any of the various delay mechanisms described in the
->   [Pump and Distribution Valve Coordination](#sprinkler-controller-pump_and_distribution_valve_coordination) section below are configured.
+>   [Pump and Distribution Valve Coordination](#pump-and-distribution-valve-coordination) section below are configured.
 >   If you are using any of these configuration options, be sure to allow the delay intervals to elapse
 >   before assuming something isn't working!
 >
 > - If a valve is active when its `run_duration` or the multiplier value is changed, the active
 >   valve's run duration will remain unaffected until the next time it is started.
-
-<span id="sprinkler-controller-pump_and_distribution_valve_coordination"></span>
 
 ## Pump and Distribution Valve Coordination
 
@@ -596,8 +590,6 @@ valve/zone. In these situations, `pump_switch_off_during_valve_open_delay` may p
 with `valve_open_delay`.
 
 In any case, the examples in the next section illustrate how/where to add these options into your configuration.
-
-<span id="sprinkler-controller-examples"></span>
 
 ## Controller Examples
 
@@ -1102,8 +1094,6 @@ component's specific configuration details before you can use them.
 With these points in mind, let's discuss some of the methods which indicate the state of the sprinkler controller.
 We'll approach this from the angle of *"how do I..."*
 
-<span id="sprinkler-controller-sprinkler_controller_understanding_state_how_do_i"></span>
-
 ### How Do I
 
 - **...determine if the sprinkler controller is running?**
@@ -1134,7 +1124,7 @@ We'll approach this from the angle of *"how do I..."*
   Use the method `optional<size_t> paused_valve()` to check if there is a paused valve. If the `optional` returned
   `has_value()`, the sprinkler controller is paused and you may use the `value()` method to check which specific
   valve is paused. In general, this follows the same pattern as the
-  [active_valve() example above](#sprinkler-controller-sprinkler_controller_understanding_state_how_do_i).
+  [active_valve() example above](#how-do-i).
 
 - **...determine the sprinkler controller's current mode?**
 

--- a/src/content/docs/components/stepper/index.mdx
+++ b/src/content/docs/components/stepper/index.mdx
@@ -290,8 +290,6 @@ stepper:
     id: my_stepper
 ```
 
-<span id="stepper-lambda_calls"></span>
-
 ## lambda calls
 
 From [lambdas](/automations/templates#config-lambda), you can call several methods on stepper motors to do some

--- a/src/content/docs/components/switch/gpio.mdx
+++ b/src/content/docs/components/switch/gpio.mdx
@@ -27,7 +27,7 @@ switch:
   GPIO pin to use for the switch.
 
 - **interlock** (*Optional*, list): A list of other GPIO switches in an interlock group. See
-  [Interlocking](#switch-gpio-interlocking).
+  [Interlocking](#interlocking).
 
 - **interlock_wait_time** (*Optional*, [Time](/guides/configuration-types#time)): For interlocking mode, set how long
   to wait after other items in an interlock group have been disabled before re-activating.
@@ -71,8 +71,6 @@ switch:
 ```
 
 <Image src={gateRemoteUiImg} layout="constrained" alt="" />
-
-<span id="switch-gpio-interlocking"></span>
 
 ## Interlocking
 

--- a/src/content/docs/components/switch/index.mdx
+++ b/src/content/docs/components/switch/index.mdx
@@ -27,7 +27,7 @@ Configuration variables:
 - **name** (*Optional*, string): The name of the switch. At least one of **id** and **name** must be specified.
 
 > [!NOTE]
-> If you have a [friendly_name](/components/esphome#esphome-configuration_variables) set for your device and
+> If you have a [friendly_name](/components/esphome#configuration-variables) set for your device and
 > you want the switch to use that name, you can set `name: None`.
 
 - **icon** (*Optional*, icon): Manually set the icon to use for the
@@ -149,8 +149,6 @@ on_...:
       # Same syntax for is_off
       switch.is_on: my_switch
 ```
-
-<span id="switch-lambda_calls"></span>
 
 ### lambda calls
 

--- a/src/content/docs/components/switch/lvgl.mdx
+++ b/src/content/docs/components/switch/lvgl.mdx
@@ -6,7 +6,7 @@ title: "LVGL Switch"
 The `lvgl` switch platform creates a switch from an LVGL widget
 and requires [LVGL](/components/lvgl/) to be configured.
 
-Supported widgets are [`button`](/components/lvgl/widgets#lvgl-widget-button) (with `checkable` option enabled), [`switch`](/components/lvgl/widgets#lvgl-widget-switch) and [`checkbox`](/components/lvgl/widgets#lvgl-widget-checkbox). A single switch supports only a single widget; in other words, it's not possible to have multiple widgets associated with a single ESPHome switch component.
+Supported widgets are [`button`](/components/lvgl/widgets#button) (with `checkable` option enabled), [`switch`](/components/lvgl/widgets#switch) and [`checkbox`](/components/lvgl/widgets#checkbox). A single switch supports only a single widget; in other words, it's not possible to have multiple widgets associated with a single ESPHome switch component.
 
 ## Configuration variables
 
@@ -25,9 +25,9 @@ switch:
 ## See Also
 
 - [LVGL Main component](/components/lvgl/)
-- [Button widget](/components/lvgl/widgets#lvgl-widget-button)
-- [Switch widget](/components/lvgl/widgets#lvgl-widget-switch)
-- [Checkbox widget](/components/lvgl/widgets#lvgl-widget-checkbox)
+- [Button widget](/components/lvgl/widgets#button)
+- [Switch widget](/components/lvgl/widgets#switch)
+- [Checkbox widget](/components/lvgl/widgets#checkbox)
 - [LVGL Binary Sensor](/components/binary_sensor/lvgl/)
 - [LVGL Sensor](/components/sensor/lvgl/)
 - [LVGL Number](/components/number/lvgl/)

--- a/src/content/docs/components/switch/nextion.mdx
+++ b/src/content/docs/components/switch/nextion.mdx
@@ -37,16 +37,16 @@ switch:
 - **component_name** (*Optional*, string): The name of the Nextion component.
 - **variable_name** (*Optional*, string): The name of the Nextion variable. Any value over `0` is considered to be **on**
 - **update_interval** (*Optional*, [Time](/guides/configuration-types#time)): The duration to update the sensor. If using a [Nextion Custom Switch Protocol](#nextion-custom-switch-protocol) this should not be used
-- **background_color** (*Optional*, [Color](/components/display#config-color)): The background color
-- **background_pressed_color** (*Optional*, [Color](/components/display#config-color)): The background color when pressed
-- **foreground_color** (*Optional*, [Color](/components/display#config-color)): The foreground color
-- **foreground_pressed_color** (*Optional*, [Color](/components/display#config-color)): The foreground color when pressed
+- **background_color** (*Optional*, [Color](/components/display#color)): The background color
+- **background_pressed_color** (*Optional*, [Color](/components/display#color)): The background color when pressed
+- **foreground_color** (*Optional*, [Color](/components/display#color)): The foreground color
+- **foreground_pressed_color** (*Optional*, [Color](/components/display#color)): The foreground color when pressed
 - **visible** (*Optional*, boolean): Visible or not
 - All other options from [Switch](/components/switch#config-switch).
 
 **Only one** *component_name* **or** *variable_name* **can be set**
 
-See [How things Update](#nextion_switch_how_things_update) for additional information
+See [How things Update](#how-things-update) for additional information
 
 ### Globals
 
@@ -95,9 +95,7 @@ Configuration options:
   display which will update component. Default is true.
 
 > [!NOTE]
-> This action can also be written in lambdas. See [Lambda Calls](#nextion_switch_lambda_calls)
-
-<span id="nextion_switch_lambda_calls"></span>
+> This action can also be written in lambdas. See [Lambda Calls](#lambda-calls)
 
 ### Lambda Calls
 
@@ -120,8 +118,6 @@ some more advanced functions (see the full <APIRef text="nextion_switch.h" path=
 - `set_foreground_pressed_color(Color color)`  : Sets the background color to **Color**
 - `set_visible(bool visible)` : Sets visible or not. If set to false, no updates will be sent to the component
 
-<span id="nextion_switch_how_things_update"></span>
-
 ## How things Update
 
 A Nextion component with an integer value (.val) or Nextion variable will be automatically polled if **update_interval** is set.
@@ -139,7 +135,7 @@ Using the above yaml example:
 - "Radio 0 switch" will poll the Nextion for the `r0.val` value and set the state accordingly.
 - "Is Darkmode Set" will NOT poll the Nextion. Either the Nextion will need to use the [Nextion Custom Switch Protocol](#nextion-custom-switch-protocol) or use a lambda:
 
-- [Lambda Calls](#nextion_switch_lambda_calls).
+- [Lambda Calls](#lambda-calls).
 
 > [!NOTE]
 > No updates will be sent to the Nextion if it is sleeping. Once it wakes, the components will be updated. If a component is invisible, `visible(false)`, then it won't update until it is set to be visible.

--- a/src/content/docs/components/text/index.mdx
+++ b/src/content/docs/components/text/index.mdx
@@ -35,7 +35,7 @@ Configuration variables:
 - **name** (**Required**, string): The name for the text.
 
 > [!NOTE]
-> If you have a [friendly_name](/components/esphome#esphome-configuration_variables) set for your device and
+> If you have a [friendly_name](/components/esphome#configuration-variables) set for your device and
 > you want the text to use that name, you can set `name: None`.
 
 - **icon** (*Optional*, icon): Manually set the icon to use for the text in the frontend.
@@ -105,8 +105,6 @@ Configuration variables:
 - **id** (**Required**, [ID](/guides/configuration-types#id)): The ID of the text to set.
 - **value** (**Required**, string, [templatable](/automations/templates)):
   The value to set the text to.
-
-<span id="text-lambda_calls"></span>
 
 ### lambda calls
 

--- a/src/content/docs/components/text/lvgl.mdx
+++ b/src/content/docs/components/text/lvgl.mdx
@@ -5,7 +5,7 @@ title: "LVGL Text"
 
 The `lvgl` text platform creates an editable text component from an LVGL textual widget and requires [LVGL](/components/lvgl/) to be configured.
 
-Supported widgets are [`label`](/components/lvgl/widgets#lvgl-widget-label) and [`textarea`](/components/lvgl/widgets#lvgl-widget-textarea). A single text supports only a single widget; in other words, it's not possible to have multiple widgets associated with a single ESPHome text component.
+Supported widgets are [`label`](/components/lvgl/widgets#label) and [`textarea`](/components/lvgl/widgets#textarea). A single text supports only a single widget; in other words, it's not possible to have multiple widgets associated with a single ESPHome text component.
 
 ## Configuration variables
 
@@ -27,8 +27,8 @@ text:
 ## See Also
 
 - [LVGL Main component](/components/lvgl/)
-- [Label widget](/components/lvgl/widgets#lvgl-widget-label)
-- [Textarea widget](/components/lvgl/widgets#lvgl-widget-textarea)
+- [Label widget](/components/lvgl/widgets#label)
+- [Textarea widget](/components/lvgl/widgets#textarea)
 - [LVGL Binary Sensor](/components/binary_sensor/lvgl/)
 - [LVGL Sensor](/components/sensor/lvgl/)
 - [LVGL Number](/components/number/lvgl/)

--- a/src/content/docs/components/text_sensor/index.mdx
+++ b/src/content/docs/components/text_sensor/index.mdx
@@ -29,7 +29,7 @@ Configuration variables:
 - **name** (*Optional*, string): The name for the sensor. At least one of **id** and **name** must be specified.
 
 > [!NOTE]
-> If you have a [friendly_name](/components/esphome#esphome-configuration_variables) set for your device and
+> If you have a [friendly_name](/components/esphome#configuration-variables) set for your device and
 > you want the text sensor to use that name, you can set `name: None`.
 
 - **icon** (*Optional*, icon): Manually set the icon to use for the sensor in the frontend.
@@ -255,8 +255,6 @@ Configuration variables:
 >   // do something
 > }
 > ```
-
-<span id="text_sensor-lambda_calls"></span>
 
 ### lambda calls
 

--- a/src/content/docs/components/text_sensor/lvgl.mdx
+++ b/src/content/docs/components/text_sensor/lvgl.mdx
@@ -6,7 +6,7 @@ title: "LVGL Text Sensor"
 The `lvgl` text sensor platform creates a Text Sensor from an LVGL textual widget
 and requires [LVGL](/components/lvgl/) to be configured.
 
-Supported widgets are [`label`](/components/lvgl/widgets#lvgl-widget-label) and [`textarea`](/components/lvgl/widgets#lvgl-widget-textarea). A single text sensor supports only a single widget; in other words, it's not possible to have multiple widgets associated with a single ESPHome text sensor component.
+Supported widgets are [`label`](/components/lvgl/widgets#label) and [`textarea`](/components/lvgl/widgets#textarea). A single text sensor supports only a single widget; in other words, it's not possible to have multiple widgets associated with a single ESPHome text sensor component.
 
 ## Configuration variables
 
@@ -28,8 +28,8 @@ text_sensor:
 ## See Also
 
 - [LVGL Main component](/components/lvgl/)
-- [Label widget](/components/lvgl/widgets#lvgl-widget-label)
-- [Textarea widget](/components/lvgl/widgets#lvgl-widget-textarea)
+- [Label widget](/components/lvgl/widgets#label)
+- [Textarea widget](/components/lvgl/widgets#textarea)
 - [LVGL Binary Sensor](/components/binary_sensor/lvgl/)
 - [LVGL Sensor](/components/sensor/lvgl/)
 - [LVGL Number](/components/number/lvgl/)

--- a/src/content/docs/components/text_sensor/nextion.mdx
+++ b/src/content/docs/components/text_sensor/nextion.mdx
@@ -34,15 +34,15 @@ text_sensor:
 - **nextion_id** (*Optional*, [ID](/guides/configuration-types#id)): The ID of the Nextion display.
 - **component_name** (**Required**, string): The name of the Nextion component.
 - **update_interval** (*Optional*, [Time](/guides/configuration-types#time)): The duration to update the sensor. If using a [Nextion Custom Text Sensor Protocol](#nextion-custom-text-sensor-protocol) this should not be used
-- **background_color** (*Optional*, [Color](/components/display#config-color)): The background color
-- **foreground_color** (*Optional*, [Color](/components/display#config-color)): The foreground color
+- **background_color** (*Optional*, [Color](/components/display#color)): The background color
+- **foreground_color** (*Optional*, [Color](/components/display#color)): The foreground color
 - **font_id** (*Optional*, int): The font id for the component
 - **visible** (*Optional*, boolean): Visible or not
 - All other options from [Text Sensor](/components/text_sensor#config-text_sensor).
 
 **Only one** *component_name* **or** *variable_name* **can be set**
 
-See [How things Update](#nextion_text_sensor_how_things_update) for additional information
+See [How things Update](#how-things-update) for additional information
 
 ### Globals
 
@@ -91,9 +91,7 @@ Configuration variables:
   display which will update component. Default is true.
 
 > [!NOTE]
-> This action can also be written in lambdas. See [Lambda Calls](#nextion_text_sensor_lambda_calls)
-
-<span id="nextion_text_sensor_lambda_calls"></span>
+> This action can also be written in lambdas. See [Lambda Calls](#lambda-calls)
 
 ### Lambda Calls
 
@@ -114,8 +112,6 @@ some more advanced functions (see the full <APIRef text="nextion_textsensor.h" p
 - `set_foreground_color(Color color)`  : Sets the background color to **Color**
 - `set_visible(bool visible)` : Sets visible or not. If set to false, no updates will be sent to the component
 
-<span id="nextion_text_sensor_how_things_update"></span>
-
 ## How things Update
 
 A Nextion component with an integer value (.val) or Nextion variable will be automatically polled if **update_interval** is set.
@@ -132,7 +128,7 @@ Using the above yaml example:
 
 - "text0" will poll the Nextion for `text0.txt` value and set the state accordingly.
 
-- [Lambda Calls](#nextion_text_sensor_lambda_calls).
+- [Lambda Calls](#lambda-calls).
 
 > [!NOTE]
 > No updates will be sent to the Nextion if it is sleeping. Once it wakes, the components will be updated. If a component is invisible, `visible(false)`, then it won't update until it is set to be visible.

--- a/src/content/docs/components/time/bm8563.mdx
+++ b/src/content/docs/components/time/bm8563.mdx
@@ -68,8 +68,8 @@ on_...:
 
 Configuration options:
 
-- **duration** (**Required**, [Time](/guides/configuration-types#config-time), [templatable](/automations/templates)): The time duration for the timer.
-- **id** (*Optional*, [ID](/guides/configuration-types#config-id)): Manually specify the ID of the BM8563 component if you have multiple components.
+- **duration** (**Required**, [Time](/guides/configuration-types#time), [templatable](/automations/templates)): The time duration for the timer.
+- **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID of the BM8563 component if you have multiple components.
 
 <span id="bm8563-config_example"></span>
 

--- a/src/content/docs/components/tinyusb.mdx
+++ b/src/content/docs/components/tinyusb.mdx
@@ -29,7 +29,7 @@ tinyusb:
 
 ## Configuration variables
 
-- **id** (*Optional*, [ID](/guides/configuration-types#config-id)): Manually specify the ID for this component.
+- **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID for this component.
 - **usb_product_id** (*Optional*, int): USB product identifier. Defaults to `0x4001`.
 - **usb_vendor_id** (*Optional*, int): USB vendor identifier. Defaults to `0x303A` (Espressif Systems).
 - **usb_lang_id** (*Optional*, int): USB language identifier. Defaults to `0x0409` (English - United States).

--- a/src/content/docs/components/touchscreen/cst816.mdx
+++ b/src/content/docs/components/touchscreen/cst816.mdx
@@ -45,7 +45,7 @@ touchscreen:
 ## Binary Sensor
 
 In addition to touch areas on the screen configured through the [Touchscreen](/components/touchscreen#config-touchscreen) component,
-the cst816 can report touches on a dedicated button outside the display area. This can be utilised by configuring a [touchscreen binary sensor](/components/touchscreen#touchscreen_binary_sensor)
+the cst816 can report touches on a dedicated button outside the display area. This can be utilised by configuring a [touchscreen binary sensor](/components/touchscreen#binary-sensor)
 with the `use_raw` option and min/max values representing the sensor touch area.
 
 ### Sample config for the T-Display S3 AMOLED

--- a/src/content/docs/components/touchscreen/index.mdx
+++ b/src/content/docs/components/touchscreen/index.mdx
@@ -52,7 +52,7 @@ touchscreen:
 
   - **x_min** (**Required**, int): The raw value corresponding to the left
 
-      (or top if `swap_xy` is specified) edge of the touchscreen. See [Calibration](#touchscreen-calibration)
+      (or top if `swap_xy` is specified) edge of the touchscreen. See [Calibration](#calibration)
       for the process to calibrate the touchscreen.
 
   - **x_max** (**Required**, int): The raw value corresponding to the right
@@ -92,8 +92,6 @@ The integer members for the touch positions below are in relation to the display
 - `x_prev` and `y_prev` are the previous position.
 - `x_org` and `y_org` are the position of the touch when it was first detected.
 - `x_raw` and `y_raw` are for calibrating the touchscreen in relation of the display. This replaces the properties with the same name in the touchscreen classes.
-
-<span id="touchscreen-calibration"></span>
 
 ## Calibration
 
@@ -247,8 +245,6 @@ Be aware that you need to check the state flag every time to see if the touch is
 This automation will be triggered when all touches are released from the touchscreen.
 
 At this point of time it has no extra arguments.
-
-<span id="touchscreen_binary_sensor"></span>
 
 ## Binary Sensor
 

--- a/src/content/docs/components/touchscreen/xpt2046.mdx
+++ b/src/content/docs/components/touchscreen/xpt2046.mdx
@@ -65,7 +65,7 @@ Base Configuration:
 
   - **x_min** (**Required**, int): The raw value corresponding to the left
 
-      (or top if `swap_xy` is specified) edge of the touchscreen. See [Calibration](/components/touchscreen#touchscreen-calibration)
+      (or top if `swap_xy` is specified) edge of the touchscreen. See [Calibration](/components/touchscreen#calibration)
       for the process to calibrate the touchscreen.
 
   - **x_max** (**Required**, int): The raw value corresponding to the right

--- a/src/content/docs/components/uart.mdx
+++ b/src/content/docs/components/uart.mdx
@@ -75,9 +75,7 @@ uart:
 - **parity** (*Optional*): The parity used on the UART bus. Options: `NONE`, `EVEN`, `ODD`. Defaults to `NONE`.
 - **stop_bits** (*Optional*, int): The number of stop bits to send. Options: 1, 2. Defaults to 1.
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID for this UART hub if you need multiple UART hubs.
-- **debug** (*Optional*, mapping): Options for debugging communication on the UART hub, see [Debugging](#uart-debugging).
-
-<span id="uart-hardware_uarts"></span>
+- **debug** (*Optional*, mapping): Options for debugging communication on the UART hub, see [Debugging](#debugging).
 
 ## Hardware UARTs
 
@@ -123,8 +121,6 @@ on_...:
       id: my_second_uart
       data: 'other data'
 ```
-
-<span id="uart-debugging"></span>
 
 ## Debugging
 

--- a/src/content/docs/components/update/esp32_hosted.mdx
+++ b/src/content/docs/components/update/esp32_hosted.mdx
@@ -71,8 +71,6 @@ The component will automatically select the highest version that is compatible w
 (i.e., the firmware version must be less than or equal to the ESP-Hosted library version compiled
 into ESPHome).
 
-<span id="update_esp32_hosted-configuration_variables"></span>
-
 ## Configuration variables
 
 - **type** (**Required**, string): The update mode to use. Must be either `embedded` or `http`.

--- a/src/content/docs/components/update/http_request.mdx
+++ b/src/content/docs/components/update/http_request.mdx
@@ -21,8 +21,6 @@ update:
     source: http://example.com/manifest.json
 ```
 
-<span id="update_http_request-configuration_variables"></span>
-
 ## Configuration variables
 
 - **source** (**Required**, string): The URL of the YAML manifest file containing the firmware metadata.

--- a/src/content/docs/components/update/index.mdx
+++ b/src/content/docs/components/update/index.mdx
@@ -24,7 +24,7 @@ update:
 - **name** (*Optional*, string): The name of the update entity. At least one of **id** and **name** must be specified.
 
 > [!NOTE]
-> If you have a [friendly_name](/components/esphome#esphome-configuration_variables) set for your device and
+> If you have a [friendly_name](/components/esphome#configuration-variables) set for your device and
 > you want the light to use that name, you can set `name: None`.
 
 - **device_class** (*Optional*, string): The device class for the update entity. See

--- a/src/content/docs/components/usb_cdc_acm.mdx
+++ b/src/content/docs/components/usb_cdc_acm.mdx
@@ -33,7 +33,7 @@ usb_cdc_acm:
 
 Each interface in the `interfaces` list consists of the following:
 
-- **id** (*Optional*, [ID](/guides/configuration-types#config-id)): The ID to use for this interface instance. This is
+- **id** (*Optional*, [ID](/guides/configuration-types#id)): The ID to use for this interface instance. This is
   used to refer to the interface in other components, platforms or lambdas.
 
 ## Multiple Interface Example

--- a/src/content/docs/components/valve/index.mdx
+++ b/src/content/docs/components/valve/index.mdx
@@ -35,7 +35,7 @@ Configuration variables:
 - **name** (*Optional*, string): The name for the valve. At least one of **id** and **name** must be specified.
 
 > [!NOTE]
-> If you have a [friendly_name](/components/esphome#esphome-configuration_variables) set for your device and you want the valve
+> If you have a [friendly_name](/components/esphome#configuration-variables) set for your device and you want the valve
 > to use that name, you can set `name: None`.
 
 - **device_class** (*Optional*, string): The device class for the sensor. See

--- a/src/content/docs/components/voice_assistant.mdx
+++ b/src/content/docs/components/voice_assistant.mdx
@@ -131,8 +131,6 @@ voice_assistant:
   The timers are available as `timers` which is a `std::vector` (array) of type
   <APIStruct text="voice_assistant::Timer" path="voice_assistant::Timer" />.
 
-<span id="voice_assistant-actions"></span>
-
 ## Actions
 
 The following actions are available for use in automations:

--- a/src/content/docs/components/water_heater/index.mdx
+++ b/src/content/docs/components/water_heater/index.mdx
@@ -30,7 +30,7 @@ Configuration variables:
 - **name** (*Optional*, string): The name for the water heater. At least one of **id** and **name** must be specified.
 
 > [!NOTE]
-> If you have a [friendly_name](/components/esphome#esphome-configuration_variables) set for your device and you want the water heater
+> If you have a [friendly_name](/components/esphome#configuration-variables) set for your device and you want the water heater
 > to use that name, you can set `name: None`.
 
 - **icon** (*Optional*, icon): Manually set the icon to use for the water heater in the frontend.

--- a/src/content/docs/components/wifi.mdx
+++ b/src/content/docs/components/wifi.mdx
@@ -36,8 +36,6 @@ wifi:
 > [!TIP]
 > For WiFi security recommendations including `min_auth_mode` configuration, see the [Security Best Practices](/guides/security_best_practices#wifi-security) guide.
 
-<span id="wifi-configuration_variables"></span>
-
 ## Configuration variables
 
 - **ssid** (*Optional*, string): The name (or [service set identifier](https://www.lifewire.com/definition-of-service-set-identifier-816547))
@@ -89,7 +87,7 @@ wifi:
   Does not apply when in access point mode.
 
 - **power_save_mode** (*Optional*, string): The power save mode for the WiFi interface.
-  See [Power Save Mode](#wifi-power_save_mode)
+  See [Power Save Mode](#power-save-mode)
 
 - **output_power** (*Optional*, string): The amount of TX power for the WiFi interface from 8.5dB to 20.5dB. Default
   for ESP8266 is 20dB, 20.5dB might cause unexpected restarts.
@@ -144,7 +142,7 @@ wifi:
   This helps devices recover from scenarios where they connect to a suboptimal
   AP (e.g., after an AP reboot or site power loss). Automatically disabled if
   `enable_btm` or `enable_rrm` is enabled. See
-  [Post-Connect Roaming](#wifi-post_connect_roaming). Defaults to `true`.
+  [Post-Connect Roaming](#post-connect-roaming). Defaults to `true`.
 
 - **on_connect** (*Optional*, [Automation](/automations)): An action to be performed when a connection is established.
 - **on_disconnect** (*Optional*, [Automation](/automations)): An action to be performed when the connection is dropped.
@@ -222,8 +220,6 @@ the OTA process will automatically choose that as the target for the upload.
 > [!NOTE]
 > See also [Changing ESPHome Node Name](/components/esphome#esphome-changing_node_name).
 
-<span id="wifi-power_save_mode"></span>
-
 ## Power Save Mode
 
 The WiFi interface of all ESPs offer three power save modes to reduce the amount of power spent on
@@ -275,8 +271,6 @@ wifi:
   password: VerySafePassword
   min_auth_mode: WPA3  # Only connect to WPA3 networks (most secure)
 ```
-
-<span id="wifi-post_connect_roaming"></span>
 
 ## Post-Connect Roaming
 

--- a/src/content/docs/components/wireguard.mdx
+++ b/src/content/docs/components/wireguard.mdx
@@ -169,8 +169,6 @@ Let's explain with some examples:
 > through the VPN link any traffic. It is like having set the wireguard
 > interface as the system default.
 
-<span id="wireguard-sensors"></span>
-
 ## Sensors
 
 Here after the sensors available for this component.
@@ -235,8 +233,6 @@ text_sensor:
 All options from [Text Sensor](/components/text_sensor#config-text_sensor) can be added to the
 above configuration.
 
-<span id="wireguard-actions"></span>
-
 ## Actions
 
 The following actions are available.
@@ -268,8 +264,6 @@ on_...:
 ```
 
 The lambda equivalent is `id(wireguard_id).enable()`.
-
-<span id="wireguard-conditions"></span>
 
 ## Conditions
 

--- a/src/content/docs/cookbook/leak-detector-m5stickC.mdx
+++ b/src/content/docs/cookbook/leak-detector-m5stickC.mdx
@@ -81,7 +81,7 @@ Once everything is hooked up and flashed, enable `esp32_touch:` `setup_mode: tru
 setting on the touch-sensitive binary sensor (GPIO33) to find the proper value for your particular moisture sensor and
 cabling situation. Grab a glass of water for testing, another for yourself, and dip away while watching the logs.
 Your goal is to find a threshold value that is sufficient to trigger the binary sensor in water, but not otherwise.
-See [ESP32 Touch Pad](/components/binary_sensor/esp32_touch#esp32-touch-binary-sensor) for more information.
+See [ESP32 Touch Pad](/components/binary_sensor/esp32_touch#binary-sensor) for more information.
 
 ------------
 

--- a/src/content/docs/cookbook/lvgl.mdx
+++ b/src/content/docs/cookbook/lvgl.mdx
@@ -44,7 +44,7 @@ Here are a couple recipes for various interesting things you can do with [Lvgl](
 
 <Image src="/images/lvgl_switch.png" width={61} height={39} layout="constrained" alt="" />
 
-The easiest way to integrate an LVGL [`switch`](/components/lvgl/widgets#lvgl-widget-switch) widget and a switch or light is with
+The easiest way to integrate an LVGL [`switch`](/components/lvgl/widgets#switch) widget and a switch or light is with
 [automations](/automations):
 
 ```yaml
@@ -77,7 +77,7 @@ lvgl:
 <Image src={lvglCookRemligbutImg} layout="constrained" alt="" />
 
 If you'd like to control a remote light which appears as an entity in Home Assistant from a checkable (toggle)
-[`button`](/components/lvgl/widgets#lvgl-widget-button), first you need to import the light state into ESPHome, and then control it using a
+[`button`](/components/lvgl/widgets#button), first you need to import the light state into ESPHome, and then control it using a
 action call:
 
 ```yaml
@@ -121,7 +121,7 @@ lvgl:
 
 <Image src="/images/lvgl_cook_volume.png" width={72} height={207} layout="constrained" alt="" />
 
-You can use a [slider](/components/lvgl/widgets#lvgl-widget-slider) or an [arc](/components/lvgl/widgets#lvgl-widget-arc) to control the brightness of a dimmable light.
+You can use a [slider](/components/lvgl/widgets#slider) or an [arc](/components/lvgl/widgets#arc) to control the brightness of a dimmable light.
 
 We can use a sensor to retrieve the current brightness of a light, which is stored in Home Assistant as an attribute
 of the entity, as an integer value between `0` (min) and `255` (max). It's convenient to set the slider's `min_value`
@@ -174,7 +174,7 @@ The `ext_click_area` option is used to enlarge the touchable area around the wid
 
 <Image src="/images/lvgl_cook_volume.png" width={72} height={207} layout="constrained" alt="" />
 
-Similarly, you can use a [slider](/components/lvgl/widgets#lvgl-widget-slider) or an [arc](/components/lvgl/widgets#lvgl-widget-arc) to control the volume level of a
+Similarly, you can use a [slider](/components/lvgl/widgets#slider) or an [arc](/components/lvgl/widgets#arc) to control the volume level of a
 media player, which uses float values.
 
 With a sensor we retrieve the current volume level of the media player, which is stored in Home Assistant as an
@@ -218,7 +218,7 @@ lvgl:
 ```
 
 The `adv_hittest` option ensures that accidental touches to the screen won't cause sudden volume changes (more details
-in the [slider doc](/components/lvgl/widgets#lvgl-widget-slider)).
+in the [slider doc](/components/lvgl/widgets#slider)).
 
 > [!NOTE]
 > Keep in mind that `on_value` is triggered *continuously* by the slider while it's being dragged. This generally has
@@ -231,15 +231,15 @@ in the [slider doc](/components/lvgl/widgets#lvgl-widget-slider)).
 
 ## Semicircle gauge
 
-A gauge similar to what Home Assistant shows in the Energy Dashboard can accomplished with [`meter`](/components/lvgl/widgets#lvgl-widget-meter)
-and [`label`](/components/lvgl/widgets#lvgl-widget-label) widgets:
+A gauge similar to what Home Assistant shows in the Energy Dashboard can accomplished with [`meter`](/components/lvgl/widgets#meter)
+and [`label`](/components/lvgl/widgets#label) widgets:
 
 <Image src={lvglCookGaugeImg} layout="constrained" alt="" />
 
-The trick here is to have a parent [`obj`](/components/lvgl/widgets#lvgl-widget-obj) which contains the other widgets as children. We place a
-[`meter`](/components/lvgl/widgets#lvgl-widget-meter) in the middle, which is made from an indicator `line` and two `arc` widgets. We use
-another, smaller [`obj`](/components/lvgl/widgets#lvgl-widget-obj) on top of it to hide the indicator's central parts and place some
-[`label`](/components/lvgl/widgets#lvgl-widget-label) widgets to display numeric information:
+The trick here is to have a parent [`obj`](/components/lvgl/widgets#obj) which contains the other widgets as children. We place a
+[`meter`](/components/lvgl/widgets#meter) in the middle, which is made from an indicator `line` and two `arc` widgets. We use
+another, smaller [`obj`](/components/lvgl/widgets#obj) on top of it to hide the indicator's central parts and place some
+[`label`](/components/lvgl/widgets#label) widgets to display numeric information:
 
 ```yaml
 sensor:
@@ -321,17 +321,17 @@ lvgl:
 
 ## Thermometer classic
 
-A thermometer with a precise gauge also made from a [`meter`](/components/lvgl/widgets#lvgl-widget-meter) widget and a numeric display using
-[`label`](/components/lvgl/widgets#lvgl-widget-label):
+A thermometer with a precise gauge also made from a [`meter`](/components/lvgl/widgets#meter) widget and a numeric display using
+[`label`](/components/lvgl/widgets#label):
 
 <Image src={lvglCookThermometerImg} layout="constrained" alt="" />
 
 Whenever a new value comes from the sensor, we update the needle indicator as well as the text in the
-[`label`](/components/lvgl/widgets#lvgl-widget-label). Since LVGL only handles integer values on the [`meter`](/components/lvgl/widgets#lvgl-widget-meter) scale,
+[`label`](/components/lvgl/widgets#label). Since LVGL only handles integer values on the [`meter`](/components/lvgl/widgets#meter) scale,
 but the sensor's value is a `float`, we use the same approach as in the examples above; we multiply the sensor's
-values by `10` and feed this value to the [`meter`](/components/lvgl/widgets#lvgl-widget-meter). It's essentially two scales on top of each
+values by `10` and feed this value to the [`meter`](/components/lvgl/widgets#meter). It's essentially two scales on top of each
 other: one to set the needle based on the multiplied value and the other to show sensor's original value in the
-[`label`](/components/lvgl/widgets#lvgl-widget-label).
+[`label`](/components/lvgl/widgets#label).
 
 ```yaml
 sensor:
@@ -474,7 +474,7 @@ lvgl:
 
 ## Climate control
 
-[`spinbox`](/components/lvgl/widgets#lvgl-widget-spinbox) is the ideal widget to control a thermostat:
+[`spinbox`](/components/lvgl/widgets#spinbox) is the ideal widget to control a thermostat:
 
 <Image src={lvglCookClimateImg} layout="constrained" alt="" />
 
@@ -790,7 +790,7 @@ If using multiple pages, a navigation bar can be useful at the bottom of the scr
 To save from repeating the same widgets on each page, there's the *top_layer* which is the *Always on Top* transparent
 page above all the pages. Everything you put on this page will be on top of all the others.
 
-For the navigation bar we can use a [`buttonmatrix`](/components/lvgl/widgets#lvgl-widget-buttonmatrix). Note how the *header_footer* style
+For the navigation bar we can use a [`buttonmatrix`](/components/lvgl/widgets#buttonmatrix). Note how the *header_footer* style
 definition is being applied to the widget and its children objects, and how a few more styles are configured manually
 at the main widget:
 
@@ -827,7 +827,7 @@ lvgl:
 ```
 
 For this example to appear correctly, use the theme and style options from [above](#lvgl-cookbook-theme) and LVGL's own
-library [fonts](/components/lvgl#lvgl-fonts).
+library [fonts](/components/lvgl#fonts).
 
 <span id="lvgl-cookbook-statico"></span>
 
@@ -1227,8 +1227,8 @@ this page for another example relying on **Grid**.
 ## ESPHome boot screen
 
 To display a boot image with a spinner animation which disappears automatically after a few moments or on touch of the
-screen you can use the *top layer*. The trick is to put a base [`obj`](/components/lvgl/widgets#lvgl-widget-obj) full screen and child
-[`image`](/components/lvgl/widgets#lvgl-widget-image) widget in its middle as the last item of the widgets list, so they draw on top of all the
+screen you can use the *top layer*. The trick is to put a base [`obj`](/components/lvgl/widgets#obj) full screen and child
+[`image`](/components/lvgl/widgets#image) widget in its middle as the last item of the widgets list, so they draw on top of all the
 others. To make it automatically disappear afer boot, you use ESPHome's `on_boot` trigger:
 
 ```yaml
@@ -1384,8 +1384,8 @@ binary size - it would uselessly include the entire set of glyphs in the flash.
 <Image src={lvglCookFontBinstatImg} layout="constrained" alt="" />
 
 A common use case for icons is a status display. For example, a checkable (toggle) button will display different
-icons based on the status of a light or switch. To put an icon on a button you use a [`label`](/components/lvgl/widgets#lvgl-widget-label)
-widget as the child of the [`button`](/components/lvgl/widgets#lvgl-widget-button). The coloring can already be different thanks to the
+icons based on the status of a light or switch. To put an icon on a button you use a [`label`](/components/lvgl/widgets#label)
+widget as the child of the [`button`](/components/lvgl/widgets#button). The coloring can already be different thanks to the
 [Theme and style definitions](#lvgl-cookbook-theme) where you can set a different color for the `checked` state.
 Additionally, by using a `text_sensor` to import the state from Home Assistant, we can not only track the `on` state,
 but also the `unavailable` or `unknown` states to apply *disabled styles* for these cases.
@@ -1540,7 +1540,7 @@ lvgl:
 
 <Image src={lvglCookAnimimgBattImg} layout="constrained" alt="" />
 
-To have an animation illustrating a battery charging, you can use [`animimg`](/components/lvgl/widgets#lvgl-widget-animimg) with a set of
+To have an animation illustrating a battery charging, you can use [`animimg`](/components/lvgl/widgets#animimg) with a set of
 [images rendered from MDI](/components/image#display-image) showing battery levels:
 
 ```yaml
@@ -1640,12 +1640,12 @@ lvgl:
 
 ## An analog clock
 
-Using the [`meter`](/components/lvgl/widgets#lvgl-widget-meter) and [`label`](/components/lvgl/widgets#lvgl-widget-label) widgets, we can create an analog clock which
+Using the [`meter`](/components/lvgl/widgets#meter) and [`label`](/components/lvgl/widgets#label) widgets, we can create an analog clock which
 shows the date too.
 
 <Image src={lvglCookClockImg} layout="constrained" alt="" />
 
-The [`meter`](/components/lvgl/widgets#lvgl-widget-meter) has three scales: one for minutes ticks and hand, ranged between `0` and `60`; one
+The [`meter`](/components/lvgl/widgets#meter) has three scales: one for minutes ticks and hand, ranged between `0` and `60`; one
 for the hour ticks and the labels as majors, ranged between `1` and `12`; and a higher resolution scale for the hour
 hand, ranged between `0` and `720`, to be able to naturally position the hand in between the hours. The second scale
 doesn't have an indicator, while the third scale doesn't have ticks nor labels.
@@ -1776,13 +1776,13 @@ script:
 
 ## A numeric input keypad
 
-The [`buttonmatrix`](/components/lvgl/widgets#lvgl-widget-buttonmatrix) widget can work together with the
+The [`buttonmatrix`](/components/lvgl/widgets#buttonmatrix) widget can work together with the
 [Key collector component](/components/key_collector#key_collector) to collect the button presses as key press sequences. It sends the `text` of
 the buttons (or `key_code` where configured) to the key collector.
 
 <Image src={lvglCookKeypadImg} layout="constrained" alt="" />
 
-If you key in the correct sequence, the [`led`](/components/lvgl/widgets#lvgl-widget-led) widget will change color accordingly:
+If you key in the correct sequence, the [`led`](/components/lvgl/widgets#led) widget will change color accordingly:
 
 ```yaml
 lvgl:
@@ -1928,7 +1928,7 @@ examples in this Cookbook, however, this time we take a different approach. Inst
 we'll be pushing it from Home Assistant, to native [Lvgl](/components/text/lvgl/) components.
 
 The weather condition icons we use are from MDI. We import just the ones corresponding to the weather conditions
-supported by the Weather integration in Home Assistant. For all the other labels you can use any [font](/components/lvgl#lvgl-fonts)
+supported by the Weather integration in Home Assistant. For all the other labels you can use any [font](/components/lvgl#fonts)
 of your choice.
 
 ```yaml
@@ -2217,7 +2217,7 @@ with the `text.set_value` action. For this purpose, we add the following
 The automations will be triggered to update the labels every time the corresponding entities change, and when the
 ESPHome comes alive - the reason you also need the [Status](/components/binary_sensor/status/). Note that you'll
 need to adjust the entity IDs corresponding to your ESPHome node depedning on how you
-[configured it to use its name](/components/esphome#esphome-configuration_variables).
+[configured it to use its name](/components/esphome#configuration-variables).
 
 <span id="lvgl-cookbook-idlescreen"></span>
 

--- a/src/content/docs/guides/configuration-types.mdx
+++ b/src/content/docs/guides/configuration-types.mdx
@@ -6,8 +6,6 @@ title: "Configuration Types"
 ESPHome's configuration files have several configuration types. This
 page describes them.
 
-<span id="config-id"></span>
-
 ## ID
 
 Quite an important aspect of ESPHome are “IDs”. They are used to
@@ -28,8 +26,6 @@ IDs are in reality just C++ variable names, they must also adhere to
 
 > [!NOTE]
 > These IDs are used only within ESPHome and are not translated to Home Assistant's Entity ID.
-
-<span id="config-pin"></span>
 
 ## Pin
 
@@ -54,8 +50,6 @@ some_config_option:
   # alias on the NodeMCU ESP8266:
   pin: D0
 ```
-
-<span id="config-pin_schema"></span>
 
 ## Pin Schema
 
@@ -129,8 +123,6 @@ Advanced options:
   However, some ESP32 board designs wire specific flash configurations that free up certain pins for general use.
   If you are *absolutely* certain that your specific board design allows a normally-reserved pin to be used,
   you can suppress the error by setting this option to `true`. Defaults to `false`.
-
-<span id="config-time"></span>
 
 ## Time
 

--- a/src/content/docs/guides/faq.mdx
+++ b/src/content/docs/guides/faq.mdx
@@ -264,7 +264,7 @@ If you *still* can't get it to work, you might want to revisit
 That's no good. Here are some steps that resolve some problems:
 
 - **If you're having Wi-Fi problems**: See [My node keeps reconnecting randomly](#wifi-problems).
-- [Enable verbose logs](/components/logger#logger-log_levels) in your ESPHome device's `logger:` section.
+- [Enable verbose logs](/components/logger#log-levels) in your ESPHome device's `logger:` section.
 - **If your device is crashing**: See the [Troubleshooting](/guides/troubleshooting/) guide for how to get a backtrace.
 - **Still seeing an error?** Check if there is a known issue in the
   [ESPHome issue tracker](https://github.com/esphome/esphome/issues). If not, you can create a new issue to describe
@@ -290,7 +290,7 @@ If you want the issue you're experiencing to be fixed quickly:
   Please read [How to create a Minimal, Complete, and Verifiable example](https://stackoverflow.com/help/mcve).
 
 - If it's a hardware communication issue (such as with an I²C or SPI device), try setting the
-  [log level](/components/logger#logger-log_levels) to `VERY_VERBOSE` as it may provide better insight into what is going on.
+  [log level](/components/logger#log-levels) to `VERY_VERBOSE` as it may provide better insight into what is going on.
 
 - Please describe what troubleshooting steps you've already tried as that may also help us track down the issue.
 
@@ -406,7 +406,7 @@ Here are some steps that may help mitigate the issue:
 
 - Give your ESPHome device a [static IP](/components/wifi#wifi-manual_ip).
 - Set the `power_save_mode` to `light` in your `wifi:` configuration. Note, however, that this may exacerbate the
-  problem in some situations. See [Power Save Mode](/components/wifi#wifi-power_save_mode).
+  problem in some situations. See [Power Save Mode](/components/wifi#power-save-mode).
 
 - The issue seems to happen with "cheap" boards more frequently -- especially the "cheap" NodeMCU boards from eBay
   which sometimes have bad antennas.
@@ -573,8 +573,6 @@ services:
 > `-e ESPHOME_DASHBOARD_USE_PING=true`
 >
 > See also [https://github.com/esphome/issues/issues/641#issuecomment-534156628](https://github.com/esphome/issues/issues/641#issuecomment-534156628).
-
-<span id="faq-notes_on_disabling_mdns"></span>
 
 ## Notes on disabling mDNS
 

--- a/src/content/docs/guides/made_for_esphome.mdx
+++ b/src/content/docs/guides/made_for_esphome.mdx
@@ -33,7 +33,7 @@ Note that these are **not** required for projects that only provide a physical/w
 - Your ESPHome configuration is open source, available for end users to modify/update
 - Users should be able to apply updates if your project sells ready-made devices
 - All components/platforms used must have an `id` specified so users can easily refer to,
-  [Extend](/components/packages#config-packages_extend) and/or [Remove](/components/packages#config-packages_remove) configuration variables should they choose to
+  [Extend](/components/packages#extend) and/or [Remove](/components/packages#remove) configuration variables should they choose to
   "take control"
 
 - Your project supports adoption via the `dashboard_import` feature of ESPHome (see

--- a/src/content/docs/guides/yaml.mdx
+++ b/src/content/docs/guides/yaml.mdx
@@ -37,8 +37,6 @@ foo:
   text: "# can be included in a string"
 ```
 
-<span id="yaml-scalars"></span>
-
 ### Scalars
 
 A YAML scalar is any value that doesn't contain a colon (`:`). It can be a string, number, boolean, or null.
@@ -66,8 +64,6 @@ esp8266:
 web_server:
   port: 80 # integer value
 ```
-
-<span id="yaml-sequences"></span>
 
 ### Sequences
 
@@ -134,8 +130,6 @@ two errors:
 - label: # Will throw an error "expected a dictionary"
   text: "Temperature 1"  # Wrong! Should be indented. Will throw error "text is an invalid option for ..."
 ```
-
-<span id="yaml-mappings"></span>
 
 ### Mappings
 
@@ -299,8 +293,6 @@ The secrets file must consist only of a flat mapping of keys to scalar values.
 The `substitutions:` feature allows you to define reusable values that can be referenced throughout your configuration.
 For full details see [Substitutions](/components/substitutions/)
 
-<span id="yaml-include"></span>
-
 ### !include
 
 - Insert the contents of another YAML file at this position.
@@ -334,8 +326,6 @@ your main configuration. The data is merged with the main configuration, with va
 precedence over values in the package data.
 
 See [Packages](/components/packages/) for more details.
-
-<span id="yaml-hidden-items"></span>
 
 ### Hidden items
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Follow-up cleanup to #6842, which added automatic anchors for dotted headings. This removes ~178 redundant `<span id="...">` anchors whose ids were merely a namespace prefix on the heading slug immediately following them (for example `api-actions` sitting just before the `Actions` heading), and repoints internal links from those prefixed fragments to the real heading anchors generated by the slugger. External deep-links that targeted the old prefixed anchors lose exact scroll position but still land on the correct page.

One span is deliberately kept: `as5600_position_range`. Its heading "Position / Range" slugs to `position--range` (double hyphen) under github-slugger, which the repo linter computes as `position-range`; keeping the span satisfies both the linter and the live site.

144 files changed, +351/-705. The anchor linter and a full Astro build both pass.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** N/A

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.