### PR TITLE
Update Zigbee documentation for clarity and links

### DIFF
--- a/src/content/docs/components/zigbee.mdx
+++ b/src/content/docs/components/zigbee.mdx
@@ -9,9 +9,8 @@ only small amounts of data, such as switches, sensors, and motion detectors.
 
 Zigbee uses the same RF technology as Thread (IEEE 802.15.4) but also defines multiple application standards.
 The `zigbee` component, however, supports only the Zigbee Home Automation profile.
-It allows exposing supported ESPHome components over a Zigbee network via either 
-[Home Assistant's ZHA integration](https://www.home-assistant.io/integrations/zha) or 
-[Zigbee2MQTT](https://www.zigbee2mqtt.io/). Due to the limitations of the Zigbee protocol, only basic properties are exposed.
+It allows exposing supported ESPHome components over a Zigbee network via either
+[Home Assistant's ZHA integration](https://www.home-assistant.io/integrations/zha) or [Zigbee2MQTT](https://www.zigbee2mqtt.io/). Due to the limitations of the Zigbee protocol, only basic properties are exposed.
 Additional properties must be configured manually in Home Assistant. Each ESPHome entity consumes one Zigbee endpoint.
 
 > [!NOTE]

--- a/src/content/docs/components/zigbee.mdx
+++ b/src/content/docs/components/zigbee.mdx
@@ -8,14 +8,15 @@ it well-suited for battery-powered smart-home devices, while its limited bandwid
 only small amounts of data, such as switches, sensors, and motion detectors.
 
 Zigbee uses the same RF technology as Thread (IEEE 802.15.4) but also defines multiple application standards.
-The `zigbee` component, however, supports only the Home Automation profile.
-It allows exposing supported ESPHome components over a Zigbee network to Home Assistant via
-**Zigbee2MQTT** or **ZHA**. Due to the limitations of the Zigbee protocol, only basic properties are exposed.
+The `zigbee` component, however, supports only the Zigbee Home Automation profile.
+It allows exposing supported ESPHome components over a Zigbee network via either 
+[Home Assistant's ZHA integration](https://www.home-assistant.io/integrations/zha) or 
+[Zigbee2MQTT](https://www.zigbee2mqtt.io/). Due to the limitations of the Zigbee protocol, only basic properties are exposed.
 Additional properties must be configured manually in Home Assistant. Each ESPHome entity consumes one Zigbee endpoint.
 
 > [!NOTE]
-> You will need a Zigbee coordinator like **Zigbee2MQTT** or **ZHA**. Other commercial Zigbee hubs most likely do not
-> support ESPHome components and might have issues with changing firmware.
+> You will need a Zigbee gateway like **Home Assistant's ZHA integration** or **Zigbee2MQTT**. Other commercial Zigbee 
+> gateways/hubs most likely do not support ESPHome components and might have issues with changing firmware.
 > When using Zigbee2MQTT, make sure to use at least version 2.8.0. Otherwise, names cannot contain spaces.
 > You also need to set up at least 2 endpoints in this case.
 
@@ -196,5 +197,5 @@ and present_value attributes. Available only on `nRF52` platforms.
 
 ## See Also
 
-- [Zigbee2MQTT](https://www.zigbee2mqtt.io/)
 - [Zigbee Home Automation](https://www.home-assistant.io/integrations/zha/)
+- [Zigbee2MQTT](https://www.zigbee2mqtt.io/)


### PR DESCRIPTION


<!-- markdownlint-disable -->

## Description

Clarified the description of the Zigbee component and its limitations. Updated the platform support statement for better readability. Also list ZHA before Zigbee2MQTT (since zha and zigpy is govered by the Open Home Foundation same as ESPHome and is a first-party citizen in Home Assistant, while Zigbee2MQTT is only partnered with Open Home Foundation.. 

**Related issue (if applicable):** Not applicable.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** Not applicable.

- esphome/esphome#<esphome PR number goes here> Not applicable.

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
