### PR TITLE
[esp32][openthread] Document ESP32-S31/H4/H21 variants

### DIFF
--- a/src/content/docs/components/esp32.mdx
+++ b/src/content/docs/components/esp32.mdx
@@ -14,7 +14,8 @@ esp32:
 ## Configuration variables
 
 - **variant** (*Optional*, string): The ESP32 mcu/chip to use for this device configuration. One of `esp32`,
-  `esp32s2`, `esp32s3`, `esp32c2`, `esp32c3`, `esp32c5`, `esp32c6`, `esp32c61`, `esp32h2` or `esp32p4`.
+  `esp32s2`, `esp32s3`, `esp32s31`, `esp32c2`, `esp32c3`, `esp32c5`, `esp32c6`, `esp32c61`, `esp32h2`,
+  `esp32h4`, `esp32h21` or `esp32p4`.
   This must match the hardware in use, or it will fail to flash.
 
 - **board** (*Optional*, string): The PlatformIO board ID that should be used. Choose the appropriate board from
@@ -53,6 +54,8 @@ esp32:
   - ESP32-C3: `80MHz`, `160MHz`
   - ESP32-C6, ESP32-C61: `80MHz`, `120MHz`, `160MHz`
   - ESP32-H2: `16MHz`, `32MHz`, `48MHz`, `64MHz`, `96MHz`
+  - ESP32-H4, ESP32-H21: `48MHz`, `64MHz`, `96MHz`
+  - ESP32-S31: `240MHz`, `320MHz`
   - ESP32-P4: `40MHz`, `360MHz`, `400MHz` (engineering samples are limited to `360MHz`)
 
   Some ESP32 modules -- typically OEM/single-core variants found in commercial
@@ -269,6 +272,67 @@ chip is required for wireless connectivity via [ESP-Hosted](/components/esp32_ho
 - **ADC:** 7 channels
 - **DAC:** None
 - **MIPI DSI/CSI:** Yes (display and camera interfaces)
+
+### ESP32-S31
+
+The ESP32-S31 is a high-performance RISC-V chip with Wi-Fi, Bluetooth LE, and a built-in 802.15.4 radio
+for Thread and Zigbee. It requires ESP-IDF 6.1 or later.
+
+- **CPU:** RISC-V HP core up to 320 MHz + LP core
+- **Wi-Fi:** 802.11 b/g/n 2.4 GHz
+- **Bluetooth:** BLE
+- **802.15.4:** Thread and Zigbee
+- **USB:** Native USB OTG; USB Serial/JTAG peripheral mode
+- **Ethernet:** Built-in MAC (requires external PHY)
+- **GPIO:** 62 pins (0–61)
+- **UART:** 4 full-featured + 1 lite
+- **I2C:** 3 (plus 1 low-power)
+- **SPI:** 3
+- **I2S:** Yes
+- **ADC:** 2 units, 8 channels
+- **DAC:** None
+- **Touch:** Yes (v3)
+- **LCD:** Parallel RGB / LCD_CAM
+
+### ESP32-H4
+
+The ESP32-H4 is a low-power RISC-V chip with Bluetooth LE and a built-in 802.15.4 radio for Thread and
+Zigbee. It has no Wi-Fi. It requires ESP-IDF 6.1 or later.
+
+- **CPU:** RISC-V single core up to 96 MHz
+- **Wi-Fi:** None
+- **Bluetooth:** BLE
+- **802.15.4:** Thread and Zigbee
+- **USB:** Native USB OTG; USB Serial/JTAG peripheral mode
+- **Ethernet:** None built-in (SPI-based controllers supported)
+- **GPIO:** 40 pins (0–39)
+- **UART:** 2
+- **I2C:** 2
+- **SPI:** 3
+- **I2S:** Yes
+- **ADC:** 1 unit, 5 channels
+- **DAC:** None
+- **Touch:** Yes (v3)
+
+### ESP32-H21
+
+The ESP32-H21 is a low-power RISC-V chip with Bluetooth LE and a built-in 802.15.4 radio for Thread and
+Zigbee. It has no Wi-Fi. It requires ESP-IDF 6.1 or later.
+
+- **CPU:** RISC-V single core up to 96 MHz
+- **Wi-Fi:** None
+- **Bluetooth:** BLE
+- **802.15.4:** Thread and Zigbee
+- **USB:** USB Serial/JTAG peripheral mode (no USB OTG)
+- **Ethernet:** None built-in (SPI-based controllers supported)
+- **GPIO:** 26 pins (0–25)
+- **UART:** 2
+- **I2C:** 2
+- **SPI:** 2
+- **I2S:** Yes
+- **ADC:** 1 unit, 5 channels
+- **DAC:** None
+- **Touch:** None
 
 <span id="esp32-toolchain"></span>
 

--- a/src/content/docs/components/esp32.mdx
+++ b/src/content/docs/components/esp32.mdx
@@ -278,7 +278,7 @@ chip is required for wireless connectivity via [ESP-Hosted](/components/esp32_ho
 The ESP32-S31 is a high-performance RISC-V chip with Wi-Fi, Bluetooth LE, and a built-in 802.15.4 radio
 for Thread and Zigbee. It requires ESP-IDF 6.1 or later.
 
-- **CPU:** RISC-V HP core up to 320 MHz + LP core
+- **CPU:** RISC-V HP core, up to 320 MHz + LP core
 - **Wi-Fi:** 802.11 b/g/n 2.4 GHz
 - **Bluetooth:** BLE
 - **802.15.4:** Thread and Zigbee
@@ -299,7 +299,7 @@ for Thread and Zigbee. It requires ESP-IDF 6.1 or later.
 The ESP32-H4 is a low-power RISC-V chip with Bluetooth LE and a built-in 802.15.4 radio for Thread and
 Zigbee. It has no Wi-Fi. It requires ESP-IDF 6.1 or later.
 
-- **CPU:** RISC-V single core up to 96 MHz
+- **CPU:** RISC-V single-core, up to 96 MHz
 - **Wi-Fi:** None
 - **Bluetooth:** BLE
 - **802.15.4:** Thread and Zigbee
@@ -319,7 +319,7 @@ Zigbee. It has no Wi-Fi. It requires ESP-IDF 6.1 or later.
 The ESP32-H21 is a low-power RISC-V chip with Bluetooth LE and a built-in 802.15.4 radio for Thread and
 Zigbee. It has no Wi-Fi. It requires ESP-IDF 6.1 or later.
 
-- **CPU:** RISC-V single core up to 96 MHz
+- **CPU:** RISC-V single-core, up to 96 MHz
 - **Wi-Fi:** None
 - **Bluetooth:** BLE
 - **802.15.4:** Thread and Zigbee

--- a/src/content/docs/components/esp32.mdx
+++ b/src/content/docs/components/esp32.mdx
@@ -286,7 +286,7 @@ for Thread and Zigbee. It requires ESP-IDF 6.1 or later.
 - **Ethernet:** Built-in MAC (requires external PHY)
 - **GPIO:** 62 pins (0–61)
 - **UART:** 4 full-featured + 1 lite
-- **I2C:** 3 (plus 1 low-power)
+- **I2C:** 2 (plus 1 low-power)
 - **SPI:** 3
 - **I2S:** Yes
 - **ADC:** 2 units, 8 channels

--- a/src/content/docs/components/openthread.mdx
+++ b/src/content/docs/components/openthread.mdx
@@ -18,7 +18,8 @@ This component allows ESPHome nodes to communicate with Home Assistant over a Th
 
 This component is supported on the following platforms:
 
-- **ESP32** (ESP32-C5, ESP32-C6, or ESP32-H2) with the ESP-IDF framework.
+- **ESP32** with an 802.15.4 radio (ESP32-C5, ESP32-C6, ESP32-H2, ESP32-H4, ESP32-H21, or ESP32-S31) with the
+  ESP-IDF framework.
 - **nRF52840** with the Zephyr framework.
 
 <span id="config-openthread"></span>

--- a/src/content/docs/components/zigbee.mdx
+++ b/src/content/docs/components/zigbee.mdx
@@ -21,8 +21,8 @@ Additional properties must be configured manually in Home Assistant. Each ESPHom
 
 ## Supported Hardware
 
-Zigbee is only supported on `nRF52` platforms and on `ESP32` with IEEE 802.15.4 connectivity (`ESP32-C5`, `ESP32-C6`,
-`ESP32-H2`, `ESP32-H4`, `ESP32-H21`, or `ESP32-S31`). Both platforms support different features and have different limitations:
+Zigbee is only supported on `nRF52` platforms and on `ESP32` with IEEE 802.15.4 connectivity (`ESP32-C5`, `ESP32-C6`, or `ESP32-H2` 
+and in the future `ESP32-H4` and `ESP32-H21`). Both platforms support different features and have different limitations:
 - On `nRF52` a maximum of 8 endpoints is supported.
 - `ESP32-H2` seems to work more reliably than `ESP32-C6`. There are reports of `ESP32-C6` boards that work only if placed next 
 to the coordinator.

--- a/src/content/docs/components/zigbee.mdx
+++ b/src/content/docs/components/zigbee.mdx
@@ -21,8 +21,8 @@ Additional properties must be configured manually in Home Assistant. Each ESPHom
 
 ## Supported Hardware
 
-Zigbee is only supported on `nRF52` platforms and on `ESP32` with IEEE 802.15.4 connectivity (`ESP32-C5`, `ESP32-C6`, or `ESP32-H2` 
-and in the future `ESP32-H4` and `ESP32-H21`). Both platforms support different features and have different limitations:
+Zigbee is only supported on `nRF52` platforms and on `ESP32` with IEEE 802.15.4 connectivity (`ESP32-C5`, `ESP32-C6`,
+`ESP32-H2`, `ESP32-H4`, `ESP32-H21`, or `ESP32-S31`). Both platforms support different features and have different limitations:
 - On `nRF52` a maximum of 8 endpoints is supported.
 - `ESP32-H2` seems to work more reliably than `ESP32-C6`. There are reports of `ESP32-C6` boards that work only if placed next 
 to the coordinator.


### PR DESCRIPTION
## Description

Documents the new ESP-IDF 6.1 ESP32 variants (ESP32-S31, ESP32-H4, ESP32-H21) on the radio-related pages: the `esp32` variant list / `cpu_frequency` ranges / per-variant capability sections, and OpenThread support (all three have an 802.15.4 radio).

Zigbee was dropped: `esp-zigbee-lib` / `esp-zboss-lib` have no prebuilt library for these variants yet (the lib errors `target ... is not supported`), so zigbee can't build on them — matching the esphome PR which also dropped zigbee.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#17186

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.