### PR TITLE
[spi] Document ESP32-S31 octal SPI support

### DIFF
--- a/src/content/docs/components/spi.mdx
+++ b/src/content/docs/components/spi.mdx
@@ -31,7 +31,7 @@ output lines. This is required only for use with certain components.
 > [!NOTE]
 > - Software mode supports only single-bit SPI.
 > - Quad mode SPI is available only on ESP32 devices (all variants).
-> - Octal mode is available only on ESP32-S3, -S2 and -P4 variants.
+> - Octal mode is available only on ESP32-S3, -S2, -S31 and -P4 variants.
 
 To set up SPI devices in ESPHome, you first need to place a top-level SPI component which defines the pins to
 use for the functions described above. The **CS** pins are individually managed by the other components that


### PR DESCRIPTION
## Description

Adds ESP32-S31 to the list of variants that support octal SPI.

Split out of a previously combined docs PR so each docs change maps 1-1 to its esphome code PR, making merges independent.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#17188

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.