### PR TITLE
[canbus] Document ESP32-S31/H4/H21 CAN support

### DIFF
--- a/src/content/docs/components/canbus/esp32_can.mdx
+++ b/src/content/docs/components/canbus/esp32_can.mdx
@@ -103,7 +103,7 @@ The following table lists the bit rates supported by the component for ESP32 var
 | 800KBPS           | x     | x               |
 | 1000KBPS          | x     | x               |
 
-Other variants: ESP32-C3, ESP32-C5, ESP32-C6, ESP32-H2, ESP32-P4, ESP32-S2, ESP32-S3
+Other variants: ESP32-C3, ESP32-C5, ESP32-C6, ESP32-H2, ESP32-H4, ESP32-H21, ESP32-P4, ESP32-S2, ESP32-S3, ESP32-S31
 
 > [!NOTE]
 > ESP32-C2 and ESP32-C61 do not have TWAI/CAN hardware and are not supported.

--- a/src/content/docs/components/canbus/esp32_can.mdx
+++ b/src/content/docs/components/canbus/esp32_can.mdx
@@ -11,7 +11,7 @@ import APIRef from '@components/APIRef.astro';
 <span id="esp32-can"></span>
 
 The ESP32 has an integrated CAN controller and therefore doesn't necessarily need an external controller.
-Some variants (ESP32-C5, ESP32-C6, ESP32-P4) have multiple CAN controllers - see [Multiple CAN Controllers](#multiple-can-controllers) below.
+Some variants (ESP32-C5, ESP32-C6, ESP32-P4, ESP32-S31) have multiple CAN controllers - see [Multiple CAN Controllers](#multiple-can-controllers) below.
 You only need to specify the RX and TX pins. Any GPIO will work.
 
 ```yaml
@@ -115,6 +115,7 @@ Some ESP32 variants have multiple CAN (TWAI) controllers:
 - **ESP32-C5**: 2 controllers
 - **ESP32-C6**: 2 controllers
 - **ESP32-P4**: 3 controllers
+- **ESP32-S31**: 2 controllers
 
 All other supported variants have a single controller. ESP32-C2 and ESP32-C61 do not have CAN hardware.
 


### PR DESCRIPTION
## Description

Documents CAN/TWAI support for the new ESP-IDF 6.1 variants: ESP32-S31 (2 controllers, added to the multiple-controllers list) and ESP32-H4 / ESP32-H21 (1 controller each, added to the CAN-capable variants list under the bit-rate table).

Split out of a previously combined docs PR so each docs change maps 1-1 to its esphome code PR, making merges independent.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#17189

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.