### PR TITLE
[usb] Document ESP32-S31/H4 USB-OTG support

### DIFF
--- a/src/content/docs/components/tinyusb.mdx
+++ b/src/content/docs/components/tinyusb.mdx
@@ -8,9 +8,11 @@ import APIRef from '@components/APIRef.astro';
 The `tinyusb` component implements a foundation for USB device functionality. It is currently supported on the
 following ESP32 microcontroller variants:
 
+- ESP32-H4
 - ESP32-P4
 - ESP32-S2
 - ESP32-S3
+- ESP32-S31
 
 The component simply initializes the TinyUSB driver, allowing the microcontroller to act as a USB device when connected
 to a USB host.

--- a/src/content/docs/components/usb_cdc_acm.mdx
+++ b/src/content/docs/components/usb_cdc_acm.mdx
@@ -13,9 +13,11 @@ You must have [Tinyusb](/components/tinyusb/) in your device's configuration to 
 
 The following ESP32 microcontroller variants are currently supported:
 
+- ESP32-H4
 - ESP32-P4
 - ESP32-S2
 - ESP32-S3
+- ESP32-S31
 
 ```yaml
 # Example minimal configuration entry

--- a/src/content/docs/components/usb_host.mdx
+++ b/src/content/docs/components/usb_host.mdx
@@ -5,7 +5,7 @@ title: "USB Host Interface"
 import APIRef from '@components/APIRef.astro';
 
 
-The USB Host interface on the ESP32-S3, ESP32-S2 and ESP32-P4 is used to connect to USB peripheral devices. Multiple
+The USB Host interface on the ESP32-S2, ESP32-S3, ESP32-S31, ESP32-P4 and ESP32-H4 is used to connect to USB peripheral devices. Multiple
 devices may be configured, but only one can be connected at any time. By default the device must be directly
 connected to the ESP32, but this can be changed by setting the `enable_hubs` option to `true`.
 

--- a/src/content/docs/components/usb_uart.mdx
+++ b/src/content/docs/components/usb_uart.mdx
@@ -5,7 +5,7 @@ title: "USB Host UART Interface"
 import APIRef from '@components/APIRef.astro';
 
 
-This component allows an ESP32 with USB host support (ESP32-S2, -S3, -S31, -P4 or -H4) to host USB-serial peripheral devices. It uses the [Usb Host](/components/usb_host/)
+This component allows an ESP32 with USB host support (ESP32-S2, ESP32-S3, ESP32-S31, ESP32-P4 or ESP32-H4) to host USB-serial peripheral devices. It uses the [Usb Host](/components/usb_host/)
 component to interface to the device as a USB-OTG host.
 
 Currently supported devices are listed in the table below:

--- a/src/content/docs/components/usb_uart.mdx
+++ b/src/content/docs/components/usb_uart.mdx
@@ -5,7 +5,7 @@ title: "USB Host UART Interface"
 import APIRef from '@components/APIRef.astro';
 
 
-This component allows an ESP32-S3 or ESP32-S2 to host USB-serial peripheral devices. It uses the [Usb Host](/components/usb_host/)
+This component allows an ESP32 with USB host support (ESP32-S2, -S3, -S31, -P4 or -H4) to host USB-serial peripheral devices. It uses the [Usb Host](/components/usb_host/)
 component to interface to the device as a USB-OTG host.
 
 Currently supported devices are listed in the table below:


### PR DESCRIPTION
## Description

Adds ESP32-S31 and ESP32-H4 to the supported-variant lists for tinyusb, usb_cdc_acm, usb_host and usb_uart (all have USB-OTG).

Split out of a previously combined docs PR so each docs change maps 1-1 to its esphome code PR, making merges independent.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#17190

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.