### PR TITLE
Document ZMP IR receiver for heatpumpir

### DIFF
--- a/src/content/docs/components/climate/climate_ir.mdx
+++ b/src/content/docs/components/climate/climate_ir.mdx
@@ -37,7 +37,7 @@ submit a feature request (see FAQ).
 | Yashima | `yashima`                          | |
 | [Whynter](#whynter) | `whynter`                          | yes |
 | [ZH/LT-01](#zhlt01) | `zhlt01`                           | yes |
-| [Arduino-HeatpumpIR](#heatpumpir) library | `heatpumpir`                       | |
+| [Arduino-HeatpumpIR](#heatpumpir) library | `heatpumpir`                       | ZMP |
 
 This component requires that you have configured a [Remote Transmitter](/components/remote_transmitter/).
 


### PR DESCRIPTION
Documents the ZMP IR receiver feature for the heatpumpir component.\n\nRelated PR: https://github.com/esphome/esphome/pull/17099