### PR TITLE
2026.6.3

### DIFF
--- a/data/version.yaml
+++ b/data/version.yaml
@@ -1,2 +1,2 @@
-release: 2026.6.2
+release: 2026.6.3
 version: '2026.6'

--- a/src/content/docs/changelog/2026.6.0.mdx
+++ b/src/content/docs/changelog/2026.6.0.mdx
@@ -539,6 +539,37 @@ For detailed migration guides and API documentation, see the
 
 </details>
 
+## Release 2026.6.3 - June 26
+
+<details>
+<summary></summary>
+
+- [core] Clarify resolve error when a device has no network log/OTA transport [esphome#17107](https://github.com/esphome/esphome/pull/17107) by [@bdraco](https://github.com/bdraco)
+- [audio] Fix mono channel MP3 playback [esphome#17106](https://github.com/esphome/esphome/pull/17106) by [@kahrendt](https://github.com/kahrendt)
+- [mipi_rgb] Fix offsets for Wave 5 1024x600 [esphome#17057](https://github.com/esphome/esphome/pull/17057) by [@clydebarrow](https://github.com/clydebarrow)
+- [json] Bump ArduinoJson to 7.4.3 [esphome#17126](https://github.com/esphome/esphome/pull/17126) by [@bdraco](https://github.com/bdraco)
+- Bump bundled esphome-device-builder to 1.0.13 [esphome#17132](https://github.com/esphome/esphome/pull/17132) by [@esphome[bot]](https://github.com/apps/esphome)
+- Bump zeroconf from 0.149.16 to 0.150.0 [esphome#17137](https://github.com/esphome/esphome/pull/17137) by [@dependabot[bot]](https://github.com/apps/dependabot)
+- [espidf] Don't fail framework check on broken unrelated PATH tools [esphome#17053](https://github.com/esphome/esphome/pull/17053) by [@swoboda1337](https://github.com/swoboda1337)
+- Bump bundled esphome-device-builder to 1.0.14 [esphome#17139](https://github.com/esphome/esphome/pull/17139) by [@esphome[bot]](https://github.com/apps/esphome)
+- [esp32_ble_server] Fix set_value action with by-reference triggers [esphome#17156](https://github.com/esphome/esphome/pull/17156) by [@swoboda1337](https://github.com/swoboda1337)
+- [esp32] Use POSIX path for secure-boot signing/verification keys Fixes #17164 [esphome#17166](https://github.com/esphome/esphome/pull/17166) by [@mnewton25](https://github.com/mnewton25)
+- [mipi_spi] Warn on MODE3 default for display without CS pin [esphome#17153](https://github.com/esphome/esphome/pull/17153) by [@clydebarrow](https://github.com/clydebarrow)
+- Bump bundled esphome-device-builder to 1.0.15 [esphome#17170](https://github.com/esphome/esphome/pull/17170) by [@esphome[bot]](https://github.com/apps/esphome)
+- [mipi_spi] Suppress sequence errors when page selection used [esphome#17176](https://github.com/esphome/esphome/pull/17176) by [@clydebarrow](https://github.com/clydebarrow)
+- [opentherm] Support power scaling disabled [esphome#17183](https://github.com/esphome/esphome/pull/17183) by [@GeoffreyFrogeye](https://github.com/GeoffreyFrogeye)
+- Bump bundled esphome-device-builder to 1.0.16 [esphome#17182](https://github.com/esphome/esphome/pull/17182) by [@esphome[bot]](https://github.com/apps/esphome)
+- Bump bundled esphome-device-builder to 1.0.17 [esphome#17199](https://github.com/esphome/esphome/pull/17199) by [@esphome[bot]](https://github.com/apps/esphome)
+- [esp32] Accept '#' as ESP-IDF source ref separator [esphome#17193](https://github.com/esphome/esphome/pull/17193) by [@swoboda1337](https://github.com/swoboda1337)
+- [network] Set IPv4 type tag on all lwIP platforms, not just esp32 [esphome#17200](https://github.com/esphome/esphome/pull/17200) by [@swoboda1337](https://github.com/swoboda1337)
+- [wifi] Report STA IP, not SoftAP IP, in wifi_info on ESP8266 [esphome#17185](https://github.com/esphome/esphome/pull/17185) by [@swoboda1337](https://github.com/swoboda1337)
+- [mipi][mipi_spi] Swap native dimensions for swap_xy hardware transform [esphome#17201](https://github.com/esphome/esphome/pull/17201) by [@clydebarrow](https://github.com/clydebarrow)
+- [hbridge] Fix light stuck on one polarity [esphome#17162](https://github.com/esphome/esphome/pull/17162) by [@swoboda1337](https://github.com/swoboda1337)
+- Bump bundled esphome-device-builder to 1.0.18 [esphome#17212](https://github.com/esphome/esphome/pull/17212) by [@esphome[bot]](https://github.com/apps/esphome)
+- Bump bundled esphome-device-builder to 1.0.19 [esphome#17217](https://github.com/esphome/esphome/pull/17217) by [@esphome[bot]](https://github.com/apps/esphome)
+
+</details>
+
 ## Full list of changes
 
 ### New Features

--- a/src/content/docs/guides/supporters.mdx
+++ b/src/content/docs/guides/supporters.mdx
@@ -155,6 +155,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Rémi K. (@antibill51)](https://github.com/antibill51)
 - [Antonio Fiol (@antonio-fiol)](https://github.com/antonio-fiol)
 - [Anton Verburg (@antonverburg)](https://github.com/antonverburg)
+- [Anunay Kulshrestha (@anunayk)](https://github.com/anunayk)
 - [Aodren Auffrédou-Heinicke (@aodrenah)](https://github.com/aodrenah)
 - [Павел Ануфриков (@apaex)](https://github.com/apaex)
 - [Andy Barratt (@apbarratt)](https://github.com/apbarratt)
@@ -254,6 +255,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Berend Haan (@berendhaan)](https://github.com/berendhaan)
 - [Arturo Casal (@berfenger)](https://github.com/berfenger)
 - [Bryan Berg (@berg)](https://github.com/berg)
+- [Berik Visschers (@berikv)](https://github.com/berikv)
 - [BerlinJoker (@BerlinJoker)](https://github.com/BerlinJoker)
 - [Bert Hertogen (@berthertogen)](https://github.com/berthertogen)
 - [Ivan Bessarabov (@bessarabov)](https://github.com/bessarabov)
@@ -533,6 +535,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Debashish Sahu (@debsahu)](https://github.com/debsahu)
 - [declanshanaghy (@declanshanaghy)](https://github.com/declanshanaghy)
 - [Ali Jafri (@deCodeIt)](https://github.com/deCodeIt)
+- [DeepCoreSystem (@DeepCoreSystem)](https://github.com/DeepCoreSystem)
 - [Deepyaman Datta (@deepyaman)](https://github.com/deepyaman)
 - [Maximilian (@DeerMaximum)](https://github.com/DeerMaximum)
 - [definitio (@definitio)](https://github.com/definitio)
@@ -2136,6 +2139,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [testbughub (@testbughub)](https://github.com/testbughub)
 - [Tudor Sandu (@tetele)](https://github.com/tetele)
 - [Greg Lincoln (@tetious)](https://github.com/tetious)
+- [Francois Steyn (@TFyre)](https://github.com/TFyre)
 - [Thane Gill (@thanegill)](https://github.com/thanegill)
 - [Terry Hardie (@thardie)](https://github.com/thardie)
 - [Craig Dean (@thargy)](https://github.com/thargy)
@@ -2407,4 +2411,4 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Christian Zufferey (@zuzu59)](https://github.com/zuzu59)
 - [Zynth-dev (@Zynth-dev)](https://github.com/Zynth-dev)
 
-*This page was last updated June 20, 2026.*
+*This page was last updated June 26, 2026.*


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- [script] Add EnumValues component for structured enum docs [docs#6618](https://github.com/esphome/esphome.io/pull/6618)
- [ci] Replace pre-commit with husky + lint-staged [docs#6834](https://github.com/esphome/esphome.io/pull/6834)
- [component-image] Grant pull-requests: write for PR comments [docs#6836](https://github.com/esphome/esphome.io/pull/6836)
- [component-image] Allow mixed-case component names in generate command [docs#6839](https://github.com/esphome/esphome.io/pull/6839)
- [docs] Auto-generate dotted heading anchors and drop redundant spans [docs#6842](https://github.com/esphome/esphome.io/pull/6842)
- [docs] Remove namespace-prefixed anchor spans, repoint links to headings [docs#6844](https://github.com/esphome/esphome.io/pull/6844)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
