### PR TITLE
Add Duravit SensoWash BLE external component to DIY list

### DIFF
--- a/src/content/docs/guides/diy.mdx
+++ b/src/content/docs/guides/diy.mdx
@@ -104,6 +104,7 @@ unless it's truly exceptional, etc.
 - [Connecting the PAJ7620 gesture sensor](https://github.com/apaex/PAJ7620-ESPHome) by [@apaex](https://github.com/apaex)
 - [Dew Point Sensor using Magnus formula](https://github.com/iret33/esphome-dew-point) by [@iret33](https://github.com/iret33)
 - [ESPHome Bluetooth Keyboard for Windows](https://github.com/markusg1234/ESPHome-espidf_ble_keyboard) by [@markusg1234](https://github.com/markusg1234)
+- [Duravit SensoWash (serial generation) shower-toilet/bidet BLE control](https://github.com/darrenweake/esphome-sensowash) by [@darrenweake](https://github.com/darrenweake)
 
 ## Sample Configurations
 


### PR DESCRIPTION
Adds my ESPHome external component for the Duravit SensoWash (serial generation) shower-toilet/bidet to the **Custom Components & Code** section of the DIY list.

The component controls the bidet over BLE from a cheap ESP32-S3, exposing native Home Assistant entities (and an optional built-in tablet dashboard). Repo: https://github.com/darrenweake/esphome-sensowash

Single-line addition, appended to the end of the existing list.