### PR TITLE
[esphome] Document merge_warnings option

### DIFF
--- a/src/content/docs/components/esphome.mdx
+++ b/src/content/docs/components/esphome.mdx
@@ -83,6 +83,8 @@ Advanced options:
   Defaults to the number of cores of the CPU which is also the maximum you can set.
 
 - **debug_scheduler** (*Optional*, boolean): If set, the scheduler will print debug information about scheduled tasks at log level DEBUG.
+- **merge_warnings** (*Optional*, boolean): Whether to warn when a YAML merge key (`<<:`)
+  silently drops a key. Defaults to `true`. See [Merge key warnings](#esphome-merge_warnings).
 - **areas** (*Optional*, list of [Area Configuration](#esphome-area)): Additional areas that can be referenced by devices.
 - **devices** (*Optional*, list of [Sub-Devices](#esphome-devices)): Sub-devices to group entities under.
 
@@ -416,6 +418,38 @@ available in a newer version of ESPHome. This allows for a more friendly error m
 # Example configuration
 esphome:
   min_version: 2025.11.0
+```
+
+<span id="esphome-merge_warnings"></span>
+
+## Merge key warnings
+
+YAML merge keys (`<<:`), often combined with `!include`, merge mappings *shallowly*
+following the [YAML merge spec](https://yaml.org/type/merge.html): each key is inserted
+only if it does not already exist, and the first definition wins. This means that if two
+merged-in files both define the same top-level key, the second one is **dropped entirely**
+rather than combined:
+
+```yaml
+# main.yaml
+<<: !include a.yaml   # defines api: { reboot_timeout: 5min }
+<<: !include b.yaml   # also defines api: { encryption: ... }  -> silently dropped
+```
+
+In the example above only the `api:` block from `a.yaml` survives; the one from `b.yaml`
+is discarded. By default ESPHome prints a warning whenever this happens so the data loss
+is not silent.
+
+If you want to *combine* sections instead of having one win, use [`packages:`](/components/packages/),
+which performs a recursive deep merge.
+
+To silence the warning (for example when the drop is intentional), set `merge_warnings` to
+`false`:
+
+```yaml
+esphome:
+  name: my_device
+  merge_warnings: false
 ```
 
 <span id="esphome-area"></span>


### PR DESCRIPTION
## Description

Add documentation for the new `merge_warnings` option in the `esphome:`
section. It also explains how YAML merge keys (`<<:`) work: they merge in a
shallow way, so if the same top-level key appears twice, the second one is
dropped. The new section points readers to `packages:` when they want the
sections combined instead, and shows how to turn the warning off.


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#17246

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
