### PR TITLE
[epaper_spi] Add collect_updates_for

### DIFF
--- a/src/content/docs/components/display/epaper_spi.mdx
+++ b/src/content/docs/components/display/epaper_spi.mdx
@@ -107,6 +107,9 @@ but can be overridden if needed.
   use `never` to only manually update the screen via `component.update`.
 - **full_update_every** (*Optional*, int): On screens that support partial updates, this sets the number of updates
   before a full update is forced. Defaults to `1` which will make every update a full update.
+- **collect_updates_for** (*Optional*, [Time](/guides/configuration-types#time)): When set, the display waits this
+  long after the first update before starting the refresh, collecting any additional updates that arrive in that window into a
+  single screen refresh. Defaults to `0ms` which starts the refresh immediately on each update.
 - **spi_id** (*Optional*, [ID](/guides/configuration-types#id)): Required to specify the ID of the [SPI Component](/components/spi) if your
   configuration defines multiple SPI buses. If only a single SPI bus is configured, this is optional.
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID used for code generation.


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Specify a duration of time that the display waits when idle after the first update for more updates to arrive before actually starting to update. Defaults to 0ms so as not to be a breaking change. When set to a small value like 100ms, it allows for many smaller display updates to be collected and displayed at once, rather than having to refresh multiple times. This comes at the cost of some added latency before the refresh, so it is user-configurable.

This is especially important for LVGL. As each element tends to update independently, you can end up with a series of small updates. LVGL's update_when_display_idle helps here by pausing between updates, but this ends up with many refreshes, one for each element. This streamlines it, while not blocking LVGL.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#17275

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
