### PR TITLE
Rename Device Database to Device List

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -24,7 +24,7 @@ const footerLinks = [
     name: "Resources",
     children: [
       { name: "Changelog", url: "/changelog/" },
-      { name: "Device Database", url: "https://devices.esphome.io" },
+      { name: "Device List", url: "https://devices.esphome.io" },
       { name: "Development", url: "https://developers.esphome.io" },
     ],
   },

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -16,7 +16,7 @@ hero:
     - text: Browse Components
       link: /components/
       variant: minimal
-    - text: Device Database
+    - text: Device List
       link: https://devices.esphome.io/
       variant: minimal
 ---


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description
Remove the use of "Device Database" to avoid confusion with the upcoming Device Database by the Open Home Foundation

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
