### PR TITLE
[docs] Require Python 3.12 or newer

### DIFF
--- a/src/content/docs/guides/installing_esphome.mdx
+++ b/src/content/docs/guides/installing_esphome.mdx
@@ -28,7 +28,7 @@ python --version
 It should show something like:
 
 ```shell
-Python 3.11.13
+Python 3.12.11
 ```
 
 Looks good? You can go ahead and install ESPHome:
@@ -99,7 +99,7 @@ and may need additional dependencies and path settings. Setting up a virtual env
 highly recommended. If you are not familiar with Python virtual environments, Homebrew
 may be easier.
 
-You will require Python 3.11 or newer. While your Mac may have a version of Python installed it may not be up-to-date.
+You will require Python 3.12 or newer. While your Mac may have a version of Python installed it may not be up-to-date.
 Python can be installed from the [official site](https://www.python.org/downloads)
 or with Homebrew. Once Python is installed, create and activate a virtual environment and install ESPHome with pip:
 
@@ -121,7 +121,7 @@ For development purposes, we recommend cloning the repository. See our
 ## Linux
 
 Your distribution probably already has Python installed. Confirm that it is at
-least version 3.11:
+least version 3.12:
 
 ```shell
 python3 --version
@@ -130,7 +130,7 @@ python3 --version
 It should show something like:
 
 ```shell
-Python 3.11.13
+Python 3.12.11
 ```
 
 Looks good? Now create a virtual environment to contain ESPHome and it's dependencies.


### PR DESCRIPTION
## Description:

Updates the installation guide to state Python 3.12 (was 3.11) as the minimum required version, matching the ESPHome change that drops Python 3.11 support.

**Related issue or feature (if applicable):**

- Documents esphome/esphome#17280

## Checklist:

- [x] Branch: targets `next` to land with the 3.11 drop at the next release.