### PR TITLE
[libretiny] Rename LN882H board to generic-ln882h

### DIFF
--- a/src/content/docs/components/libretiny.mdx
+++ b/src/content/docs/components/libretiny.mdx
@@ -26,7 +26,7 @@ rtl87xx:
 
 # Example configuration entry for LN882x
 ln882x:
-  board: generic-ln882hki
+  board: generic-ln882h
 ```
 
 ## Configuration variables
@@ -52,7 +52,7 @@ ln882x:
   - [Advanced options](#advanced-options)
 
 - **family** (*Optional*, string): The family of LibreTiny-supported microcontrollers that is used on this board.
-  One of `bk7231n`, `bk7231t`, `rtl8710b`, `rtl8720c`, `bk7251`, `bk7231q`, `ln882hki`.
+  One of `bk7231n`, `bk7231t`, `rtl8710b`, `rtl8720c`, `bk7251`, `bk7231q`, `ln882h`.
   Defaults to the variant that is detected from the board, if a board that's unknown to ESPHome is used,
   this option is mandatory. **It's recommended not to include this option**.
 


### PR DESCRIPTION
## Description:

Updates the LibreTiny docs for the LN882H board rename in esphome/esphome#17288 (LibreTiny v1.13.0):

- Example config: `board: generic-ln882hki` → `generic-ln882h` (the `generic-ln882hki` board is removed in v1.13.0, so the old example no longer compiles).
- `family` option list: `ln882hki` → `ln882h` (the actual family value is `ln882h`; `ln882hki` was the old board suffix and never a valid family string).

Targets `next` since it lands with the v1.13.0 platform bump.

**Related code PR:**

- esphome/esphome#17288

## Checklist:

- [x] Branch: `next` (ships with the LibreTiny v1.13.0 update).