### PR TITLE
[diy] Rename Custom Components & Code to External Components & Code

### DIFF
--- a/src/content/docs/guides/diy.mdx
+++ b/src/content/docs/guides/diy.mdx
@@ -64,7 +64,7 @@ unless it's truly exceptional, etc.
 - [How to create an ESPHome external component](https://medium.com/@vinsce/create-an-esphome-external-component-part-1-introduction-config-validation-and-code-generation-e0389e674bd6) by [@vinsce](https://github.com/vinsce)
 - [Smart garage door remote modification when direct opener wiring isn't feasible](https://github.com/linux4life798/smart-garage-remote) by [@linux4life798](https://github.com/linux4life798)
 
-## Custom Components & Code
+## External Components & Code
 
 - [Custom RGBW Light Output emulating color temperature support](https://gist.github.com/madjam002/31cc88640efa370630fed6914fa4eb7f) by [@madjam002](https://github.com/madjam002)
 - [Custom ESPHome native API to influxdb python script](https://gist.github.com/fpletz/d071c72e45d17ba274fd61ca7a465033#file-esphome-sensor-influxdb-py) by [@fpletz](https://github.com/fpletz)


### PR DESCRIPTION
## Description

Renames the "Custom Components & Code" heading in the DIY examples guide to "External Components & Code" to align with current ESPHome terminology.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.