### PR TITLE
[select] Remove specific example from component index page

### DIFF
--- a/src/content/docs/components/select/index.mdx
+++ b/src/content/docs/components/select/index.mdx
@@ -371,27 +371,6 @@ From [lambdas](/automations/templates#config-lambda), you can call several metho
     }
 ```
 
-## Example
-
-Setting up three options and set component state to selected option value.
-
-```yaml
-select:
-  - platform: template
-    name: Mode
-    id: mode
-    options:
-     - "Option1"
-     - "Option2"
-     - "Option3"
-    initial_option: "Option1"
-    optimistic: true
-    set_action:
-      - logger.log:
-          format: "Chosen option: %s"
-          args: ["x.c_str()"]
-```
-
 ## See Also
 
 - <APIClass text="Select" path="select::Select" />


### PR DESCRIPTION
## Description

Removes the specific usage `## Example` section from the bottom of the select component index page. Specific usage examples don't belong on core component pages.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.