### PR TITLE
[mipi_spi] Add M5STACK ATOM3SR display

### DIFF
--- a/src/content/docs/components/display/mipi_spi.mdx
+++ b/src/content/docs/components/display/mipi_spi.mdx
@@ -38,21 +38,22 @@ using an octal SPI bus, so references here to parallel and octal SPI are equival
 
 | Driver Chip | Typical Dimensions |
 | ----------- |--------------------|
-| RM690B0     | 320x240            |
+| AXS15231    | 320x240            |
+| GC9A01A     | 240x240            |
+| GC9D01N     | 240x240            |
+| GC9107      | 128x128            |
+| CO5300      | 466x466            |
 | ILI9341     | 320x240            |
 | ILI9342     | 240x320            |
 | ILI9481     | 320x480            |
 | ILI9486     | 320x480            |
 | ILI9488     | 320x480            |
 | ILI9488_A   | 320x480            |
+| RM690B0     | 320x240            |
 | ST7796      | 320x480            |
 | ST7789P     | 240x320            |
 | ST7789V     | 240x320            |
-| GC9A01A     | 240x240            |
-| GC9D01N     | 240x240            |
-| AXS15231    | 320x240            |
 | ST7735      | 128x160            |
-| CO5300      | 466x466            |
 | CUSTOM      | Customisable       |
 
 ### Display panels
@@ -68,20 +69,8 @@ the pins used to interface to the display to be specified.
 
 | Model                                | Manufacturer | Product Description                                               |
 | ------------------------------------ | ------------ | ----------------------------------------------------------------- |
-| ADAFRUIT-S2-TFT-FEATHER              | Adafruit     | [https://www.adafruit.com/product/6312](https://www.adafruit.com/product/6312)                           |
 | ADAFRUIT-FUNHOUSE                    | Adafruit     | [https://www.adafruit.com/product/4985](https://www.adafruit.com/product/4985)                           |
-| M5CORE                               | M5Stack      | [https://docs.m5stack.com/en/core/BASIC%20v2.6](https://docs.m5stack.com/en/core/BASIC%20v2.6) |
-| M5CORE2                              | M5Stack      | [https://docs.m5stack.com/en/core/core2](https://docs.m5stack.com/en/core/core2) |
-| S3BOX                                | Espressif | [https://www.espressif.com/en/products/devkits/esp32-s3-box](https://www.espressif.com/en/products/devkits/esp32-s3-box) |
-| S3BOXLITE                            | Espressif | [https://www.espressif.com/en/products/devkits/esp32-s3-box-lite](https://www.espressif.com/en/products/devkits/esp32-s3-box-lite) |
-| WAVESHARE-4-TFT                      | Waveshare | [https://www.waveshare.com/4inch-tft-touch-shield.htm](https://www.waveshare.com/4inch-tft-touch-shield.htm) |
-| PICO-RESTOUCH-LCD-3.5                | Waveshare | [https://www.waveshare.com/pico-restouch-lcd-3.5.htm](https://www.waveshare.com/pico-restouch-lcd-3.5.htm) |
-| WAVESHARE-ESP32-C6-LCD-1.47          | Waveshare | [https://www.waveshare.com/wiki/ESP32-C6-LCD-1.47](https://www.waveshare.com/wiki/ESP32-C6-LCD-1.47) |
-| WAVESHARE-ESP32-S3-GEEK              | Waveshare | [https://www.waveshare.com/esp32-s3-geek.htm](https://www.waveshare.com/esp32-s3-geek.htm) |
-| WAVESHARE-ESP32-S3-TOUCH-AMOLED-1.75 | Waveshare | [https://www.waveshare.com/esp32-s3-touch-amoled-1.75.htm](https://www.waveshare.com/esp32-s3-touch-amoled-1.75.htm) |
-| WAVESHARE-ESP32-S3-TOUCH-AMOLED-2.16 | Waveshare | [https://www.waveshare.com/esp32-s3-touch-amoled-2.16.htm](https://www.waveshare.com/esp32-s3-touch-amoled-2.16.htm) |
-| WAVESHARE-ESP32-S3-TOUCH-LCD-3.49    | Waveshare | [https://www.waveshare.com/esp32-s3-touch-lcd-3.49.htm](https://www.waveshare.com/esp32-s3-touch-lcd-3.49.htm) |
-| WT32-SC01-PLUS                       | Wireless-Tag | [https://www.wireless-tag.com/portfolio/wt32-sc01-plus/](https://www.wireless-tag.com/portfolio/wt32-sc01-plus/) |
+| ADAFRUIT-S2-TFT-FEATHER              | Adafruit     | [https://www.adafruit.com/product/6312](https://www.adafruit.com/product/6312)                           |
 | ESP32-2424S012                       | Sunton       | 1.28" round CYD with GC9A01A controller.     |
 | ESP32-2432S028                       | Sunton       | 2.8" CYD. Original micro-USB version with ILI9341 controller.     |
 | ESP32-2432S028-7789                  | Sunton       | Dual-USB version with ST7789V.                                    |
@@ -93,13 +82,26 @@ the pins used to interface to the display to be specified.
 | JC3636W518V2                         | Guition | [https://www.aliexpress.com/item/1005007890666293.html](https://www.aliexpress.com/item/1005007890666293.html) |
 | JC4827W543                           | Guition | [https://www.aliexpress.com/item/1005006729377800.html](https://www.aliexpress.com/item/1005006729377800.html) |
 | LANBON-L8                            | Lanbon | [https://www.lanbon.cn/product/lanbon-l8](https://www.lanbon.cn/product/lanbon-l8) |
-| T4-S3                                | Lilygo | [https://www.lilygo.cc/products/t4-s3](https://www.lilygo.cc/products/t4-s3) |
-| T-EMBED                              | Lilygo | [https://www.lilygo.cc/products/t-embed](https://www.lilygo.cc/products/t-embed) |
+| M5CORE                               | M5Stack      | [https://docs.m5stack.com/en/core/BASIC%20v2.6](https://docs.m5stack.com/en/core/BASIC%20v2.6) |
+| M5CORE2                              | M5Stack      | [https://docs.m5stack.com/en/core/core2](https://docs.m5stack.com/en/core/core2) |
+| M5STACKS3R-GC9107                    | M5Stack      | [https://shop.m5stack.com/products/atoms3r-dev-kit](https://shop.m5stack.com/products/atoms3r-dev-kit) |
+| PICO-RESTOUCH-LCD-3.5                | Waveshare | [https://www.waveshare.com/pico-restouch-lcd-3.5.htm](https://www.waveshare.com/pico-restouch-lcd-3.5.htm) |
+| S3BOX                                | Espressif | [https://www.espressif.com/en/products/devkits/esp32-s3-box](https://www.espressif.com/en/products/devkits/esp32-s3-box) |
+| S3BOXLITE                            | Espressif | [https://www.espressif.com/en/products/devkits/esp32-s3-box-lite](https://www.espressif.com/en/products/devkits/esp32-s3-box-lite) |
 | T-DISPLAY                            | Lilygo | [https://www.lilygo.cc/products/t-display](https://www.lilygo.cc/products/t-display) |
 | T-DISPLAY-S3                         | Lilygo | [https://www.lilygo.cc/products/t-display-s3](https://www.lilygo.cc/products/t-display-s3) |
-| T-DISPLAY-S3-PRO                     | Lilygo | [https://www.lilygo.cc/products/t-display-s3-pro](https://www.lilygo.cc/products/t-display-s3-pro) |
 | T-DISPLAY-S3-AMOLED                  | Lilygo | [https://www.lilygo.cc/products/t-display-s3-amoled](https://www.lilygo.cc/products/t-display-s3-amoled) |
 | T-DISPLAY-S3-AMOLED-PLUS             | Lilygo | [https://www.lilygo.cc/products/t-display-s3-amoled-plus](https://www.lilygo.cc/products/t-display-s3-amoled-plus) |
+| T-DISPLAY-S3-PRO                     | Lilygo | [https://www.lilygo.cc/products/t-display-s3-pro](https://www.lilygo.cc/products/t-display-s3-pro) |
+| T-EMBED                              | Lilygo | [https://www.lilygo.cc/products/t-embed](https://www.lilygo.cc/products/t-embed) |
+| T4-S3                                | Lilygo | [https://www.lilygo.cc/products/t4-s3](https://www.lilygo.cc/products/t4-s3) |
+| WAVESHARE-4-TFT                      | Waveshare | [https://www.waveshare.com/4inch-tft-touch-shield.htm](https://www.waveshare.com/4inch-tft-touch-shield.htm) |
+| WAVESHARE-ESP32-C6-LCD-1.47          | Waveshare | [https://www.waveshare.com/wiki/ESP32-C6-LCD-1.47](https://www.waveshare.com/wiki/ESP32-C6-LCD-1.47) |
+| WAVESHARE-ESP32-S3-GEEK              | Waveshare | [https://www.waveshare.com/esp32-s3-geek.htm](https://www.waveshare.com/esp32-s3-geek.htm) |
+| WAVESHARE-ESP32-S3-TOUCH-AMOLED-1.75 | Waveshare | [https://www.waveshare.com/esp32-s3-touch-amoled-1.75.htm](https://www.waveshare.com/esp32-s3-touch-amoled-1.75.htm) |
+| WAVESHARE-ESP32-S3-TOUCH-AMOLED-2.16 | Waveshare | [https://www.waveshare.com/esp32-s3-touch-amoled-2.16.htm](https://www.waveshare.com/esp32-s3-touch-amoled-2.16.htm) |
+| WAVESHARE-ESP32-S3-TOUCH-LCD-3.49    | Waveshare | [https://www.waveshare.com/esp32-s3-touch-lcd-3.49.htm](https://www.waveshare.com/esp32-s3-touch-lcd-3.49.htm) |
+| WT32-SC01-PLUS                       | Wireless-Tag | [https://www.wireless-tag.com/portfolio/wt32-sc01-plus/](https://www.wireless-tag.com/portfolio/wt32-sc01-plus/) |
 
 ## SPI Bus
 

--- a/src/content/docs/components/display/mipi_spi.mdx
+++ b/src/content/docs/components/display/mipi_spi.mdx
@@ -67,41 +67,41 @@ the pins used to interface to the display to be specified.
 
 ### Boards with integrated displays
 
-| Model                                | Manufacturer | Product Description                                               |
-| ------------------------------------ | ------------ | ----------------------------------------------------------------- |
-| ADAFRUIT-FUNHOUSE                    | Adafruit     | [https://www.adafruit.com/product/4985](https://www.adafruit.com/product/4985)                           |
-| ADAFRUIT-S2-TFT-FEATHER              | Adafruit     | [https://www.adafruit.com/product/6312](https://www.adafruit.com/product/6312)                           |
-| ESP32-2424S012                       | Sunton       | 1.28" round CYD with GC9A01A controller.     |
-| ESP32-2432S028                       | Sunton       | 2.8" CYD. Original micro-USB version with ILI9341 controller.     |
-| ESP32-2432S028-7789                  | Sunton       | Dual-USB version with ST7789V.                                    |
-| ESP32-2432S028-9342                  | Sunton       | Dual-USB version with ILI9342.                                    |
-| GEEKMAGIC-SMALLTV                    | GeekMagic    | [https://geekmagic.com/products/geekmagic-ultra-4](https://geekmagic.com/products/geekmagic-ultra-4) |
-| GEEKMAGIC-SMALLTV-PRO                | GeekMagic    | [https://geekmagic.com/products/geekmagic-ultra](https://geekmagic.com/products/geekmagic-ultra) |
-| JC3248W535                           | Guition | [https://www.aliexpress.com/item/1005007566332450.html](https://www.aliexpress.com/item/1005007566332450.html) |
-| JC3636W518                           | Guition | [https://www.aliexpress.com/item/1005007890666293.html](https://www.aliexpress.com/item/1005007890666293.html) |
-| JC3636W518V2                         | Guition | [https://www.aliexpress.com/item/1005007890666293.html](https://www.aliexpress.com/item/1005007890666293.html) |
-| JC4827W543                           | Guition | [https://www.aliexpress.com/item/1005006729377800.html](https://www.aliexpress.com/item/1005006729377800.html) |
-| LANBON-L8                            | Lanbon | [https://www.lanbon.cn/product/lanbon-l8](https://www.lanbon.cn/product/lanbon-l8) |
-| M5CORE                               | M5Stack      | [https://docs.m5stack.com/en/core/BASIC%20v2.6](https://docs.m5stack.com/en/core/BASIC%20v2.6) |
-| M5CORE2                              | M5Stack      | [https://docs.m5stack.com/en/core/core2](https://docs.m5stack.com/en/core/core2) |
-| M5STACKS3R-GC9107                    | M5Stack      | [https://shop.m5stack.com/products/atoms3r-dev-kit](https://shop.m5stack.com/products/atoms3r-dev-kit) |
-| PICO-RESTOUCH-LCD-3.5                | Waveshare | [https://www.waveshare.com/pico-restouch-lcd-3.5.htm](https://www.waveshare.com/pico-restouch-lcd-3.5.htm) |
-| S3BOX                                | Espressif | [https://www.espressif.com/en/products/devkits/esp32-s3-box](https://www.espressif.com/en/products/devkits/esp32-s3-box) |
-| S3BOXLITE                            | Espressif | [https://www.espressif.com/en/products/devkits/esp32-s3-box-lite](https://www.espressif.com/en/products/devkits/esp32-s3-box-lite) |
-| T-DISPLAY                            | Lilygo | [https://www.lilygo.cc/products/t-display](https://www.lilygo.cc/products/t-display) |
-| T-DISPLAY-S3                         | Lilygo | [https://www.lilygo.cc/products/t-display-s3](https://www.lilygo.cc/products/t-display-s3) |
-| T-DISPLAY-S3-AMOLED                  | Lilygo | [https://www.lilygo.cc/products/t-display-s3-amoled](https://www.lilygo.cc/products/t-display-s3-amoled) |
-| T-DISPLAY-S3-AMOLED-PLUS             | Lilygo | [https://www.lilygo.cc/products/t-display-s3-amoled-plus](https://www.lilygo.cc/products/t-display-s3-amoled-plus) |
-| T-DISPLAY-S3-PRO                     | Lilygo | [https://www.lilygo.cc/products/t-display-s3-pro](https://www.lilygo.cc/products/t-display-s3-pro) |
-| T-EMBED                              | Lilygo | [https://www.lilygo.cc/products/t-embed](https://www.lilygo.cc/products/t-embed) |
-| T4-S3                                | Lilygo | [https://www.lilygo.cc/products/t4-s3](https://www.lilygo.cc/products/t4-s3) |
-| WAVESHARE-4-TFT                      | Waveshare | [https://www.waveshare.com/4inch-tft-touch-shield.htm](https://www.waveshare.com/4inch-tft-touch-shield.htm) |
-| WAVESHARE-ESP32-C6-LCD-1.47          | Waveshare | [https://www.waveshare.com/wiki/ESP32-C6-LCD-1.47](https://www.waveshare.com/wiki/ESP32-C6-LCD-1.47) |
-| WAVESHARE-ESP32-S3-GEEK              | Waveshare | [https://www.waveshare.com/esp32-s3-geek.htm](https://www.waveshare.com/esp32-s3-geek.htm) |
-| WAVESHARE-ESP32-S3-TOUCH-AMOLED-1.75 | Waveshare | [https://www.waveshare.com/esp32-s3-touch-amoled-1.75.htm](https://www.waveshare.com/esp32-s3-touch-amoled-1.75.htm) |
-| WAVESHARE-ESP32-S3-TOUCH-AMOLED-2.16 | Waveshare | [https://www.waveshare.com/esp32-s3-touch-amoled-2.16.htm](https://www.waveshare.com/esp32-s3-touch-amoled-2.16.htm) |
-| WAVESHARE-ESP32-S3-TOUCH-LCD-3.49    | Waveshare | [https://www.waveshare.com/esp32-s3-touch-lcd-3.49.htm](https://www.waveshare.com/esp32-s3-touch-lcd-3.49.htm) |
-| WT32-SC01-PLUS                       | Wireless-Tag | [https://www.wireless-tag.com/portfolio/wt32-sc01-plus/](https://www.wireless-tag.com/portfolio/wt32-sc01-plus/) |
+| Model                                | Manufacturer | Product Description                                                                                                                |
+|--------------------------------------|--------------|------------------------------------------------------------------------------------------------------------------------------------|
+| ADAFRUIT-FUNHOUSE                    | Adafruit     | [https://www.adafruit.com/product/4985](https://www.adafruit.com/product/4985)                                                     |
+| ADAFRUIT-S2-TFT-FEATHER              | Adafruit     | [https://www.adafruit.com/product/6312](https://www.adafruit.com/product/6312)                                                     |
+| ESP32-2424S012                       | Sunton       | 1.28" round CYD with GC9A01A controller.                                                                                           |
+| ESP32-2432S028                       | Sunton       | 2.8" CYD. Original micro-USB version with ILI9341 controller.                                                                      |
+| ESP32-2432S028-7789                  | Sunton       | Dual-USB version with ST7789V.                                                                                                     |
+| ESP32-2432S028-9342                  | Sunton       | Dual-USB version with ILI9342.                                                                                                     |
+| GEEKMAGIC-SMALLTV                    | GeekMagic    | [https://geekmagic.com/products/geekmagic-ultra-4](https://geekmagic.com/products/geekmagic-ultra-4)                               |
+| GEEKMAGIC-SMALLTV-PRO                | GeekMagic    | [https://geekmagic.com/products/geekmagic-ultra](https://geekmagic.com/products/geekmagic-ultra)                                   |
+| JC3248W535                           | Guition      | [https://www.aliexpress.com/item/1005007566332450.html](https://www.aliexpress.com/item/1005007566332450.html)                     |
+| JC3636W518                           | Guition      | [https://www.aliexpress.com/item/1005007890666293.html](https://www.aliexpress.com/item/1005007890666293.html)                     |
+| JC3636W518V2                         | Guition      | [https://www.aliexpress.com/item/1005007890666293.html](https://www.aliexpress.com/item/1005007890666293.html)                     |
+| JC4827W543                           | Guition      | [https://www.aliexpress.com/item/1005006729377800.html](https://www.aliexpress.com/item/1005006729377800.html)                     |
+| LANBON-L8                            | Lanbon       | [https://www.lanbon.cn/product/lanbon-l8](https://www.lanbon.cn/product/lanbon-l8)                                                 |
+| M5CORE                               | M5Stack      | [https://docs.m5stack.com/en/core/BASIC%20v2.6](https://docs.m5stack.com/en/core/BASIC%20v2.6)                                     |
+| M5CORE2                              | M5Stack      | [https://docs.m5stack.com/en/core/core2](https://docs.m5stack.com/en/core/core2)                                                   |
+| M5STACK-ATOMS3R-GC9107               | M5Stack      | [https://shop.m5stack.com/products/atoms3r-dev-kit](https://shop.m5stack.com/products/atoms3r-dev-kit)                             |
+| PICO-RESTOUCH-LCD-3.5                | Waveshare    | [https://www.waveshare.com/pico-restouch-lcd-3.5.htm](https://www.waveshare.com/pico-restouch-lcd-3.5.htm)                         |
+| S3BOX                                | Espressif    | [https://www.espressif.com/en/products/devkits/esp32-s3-box](https://www.espressif.com/en/products/devkits/esp32-s3-box)           |
+| S3BOXLITE                            | Espressif    | [https://www.espressif.com/en/products/devkits/esp32-s3-box-lite](https://www.espressif.com/en/products/devkits/esp32-s3-box-lite) |
+| T-DISPLAY                            | Lilygo       | [https://www.lilygo.cc/products/t-display](https://www.lilygo.cc/products/t-display)                                               |
+| T-DISPLAY-S3                         | Lilygo       | [https://www.lilygo.cc/products/t-display-s3](https://www.lilygo.cc/products/t-display-s3)                                         |
+| T-DISPLAY-S3-AMOLED                  | Lilygo       | [https://www.lilygo.cc/products/t-display-s3-amoled](https://www.lilygo.cc/products/t-display-s3-amoled)                           |
+| T-DISPLAY-S3-AMOLED-PLUS             | Lilygo       | [https://www.lilygo.cc/products/t-display-s3-amoled-plus](https://www.lilygo.cc/products/t-display-s3-amoled-plus)                 |
+| T-DISPLAY-S3-PRO                     | Lilygo       | [https://www.lilygo.cc/products/t-display-s3-pro](https://www.lilygo.cc/products/t-display-s3-pro)                                 |
+| T-EMBED                              | Lilygo       | [https://www.lilygo.cc/products/t-embed](https://www.lilygo.cc/products/t-embed)                                                   |
+| T4-S3                                | Lilygo       | [https://www.lilygo.cc/products/t4-s3](https://www.lilygo.cc/products/t4-s3)                                                       |
+| WAVESHARE-4-TFT                      | Waveshare    | [https://www.waveshare.com/4inch-tft-touch-shield.htm](https://www.waveshare.com/4inch-tft-touch-shield.htm)                       |
+| WAVESHARE-ESP32-C6-LCD-1.47          | Waveshare    | [https://www.waveshare.com/wiki/ESP32-C6-LCD-1.47](https://www.waveshare.com/wiki/ESP32-C6-LCD-1.47)                               |
+| WAVESHARE-ESP32-S3-GEEK              | Waveshare    | [https://www.waveshare.com/esp32-s3-geek.htm](https://www.waveshare.com/esp32-s3-geek.htm)                                         |
+| WAVESHARE-ESP32-S3-TOUCH-AMOLED-1.75 | Waveshare    | [https://www.waveshare.com/esp32-s3-touch-amoled-1.75.htm](https://www.waveshare.com/esp32-s3-touch-amoled-1.75.htm)               |
+| WAVESHARE-ESP32-S3-TOUCH-AMOLED-2.16 | Waveshare    | [https://www.waveshare.com/esp32-s3-touch-amoled-2.16.htm](https://www.waveshare.com/esp32-s3-touch-amoled-2.16.htm)               |
+| WAVESHARE-ESP32-S3-TOUCH-LCD-3.49    | Waveshare    | [https://www.waveshare.com/esp32-s3-touch-lcd-3.49.htm](https://www.waveshare.com/esp32-s3-touch-lcd-3.49.htm)                     |
+| WT32-SC01-PLUS                       | Wireless-Tag | [https://www.wireless-tag.com/portfolio/wt32-sc01-plus/](https://www.wireless-tag.com/portfolio/wt32-sc01-plus/)                   |
 
 ## SPI Bus
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#17344
## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
