### PR TITLE
Fix typo in blog post about ESPHome Starter Kit

### DIFF
--- a/src/content/docs/blog/2026/07/02/unbox-your-creativity-with-esphome-2026-6-0.mdx
+++ b/src/content/docs/blog/2026/07/02/unbox-your-creativity-with-esphome-2026-6-0.mdx
@@ -135,7 +135,7 @@ inspiration for your next project:
    project without typing a single line of code.
 3. **Get ready for the Starter Kit:** If you don't have any components yet and don't know where to begin, help is
    coming! Stay tuned to our ESPHome social channels and [our website](https://esphome.io/): the official ESPHome Starter
-   Kit, made by our commercial partners Apollo Automation, will be shipping soon… and we have more updates on the way!
+   Kit, made by Apollo Automation, will be shipping soon… and we have more updates on the way!
 
 ## Quick note for returning users
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
