### PR TITLE
[espnow] Document max_payload_size

### DIFF
--- a/src/content/docs/components/espnow.mdx
+++ b/src/content/docs/components/espnow.mdx
@@ -24,7 +24,8 @@ espnow:
 - **enable_on_boot** (*Optional*, boolean): Enable the ESP-NOW component on boot. Defaults to `true`.
 - **max_payload_size** (*Optional*, int): The largest payload, in bytes, this device can send and receive in one frame.
   Values above `250` use ESP-NOW v2 frames (up to `1470` bytes), only work with peers that also support them, and
-  reserve proportionally more RAM for packet buffers. Defaults to `250`.
+  reserve proportionally more RAM for packet buffers. This only sizes this device's buffers; the protocol version
+  itself is negotiated with each peer automatically. Defaults to `250`.
 - **peers** (*Optional*, list of MAC Address): The list of MAC addresses of the devices that this device is allowed to
   communicate with. See [Peers](#peers) below.
 

--- a/src/content/docs/components/espnow.mdx
+++ b/src/content/docs/components/espnow.mdx
@@ -23,8 +23,8 @@ espnow:
   device as a peer. See [Peers](#peers) below. Defaults to `false`.
 - **enable_on_boot** (*Optional*, boolean): Enable the ESP-NOW component on boot. Defaults to `true`.
 - **max_payload_size** (*Optional*, int): The largest payload, in bytes, this device can send and receive in one frame.
-  Values above `250` use ESP-NOW v2 frames (up to `1470` bytes), require ESP-IDF 5.4 or newer, only work with peers that
-  also support them, and reserve proportionally more RAM for packet buffers. Defaults to `250`.
+  Values above `250` use ESP-NOW v2 frames (up to `1470` bytes), only work with peers that also support them, and
+  reserve proportionally more RAM for packet buffers. Defaults to `250`.
 - **peers** (*Optional*, list of MAC Address): The list of MAC addresses of the devices that this device is allowed to
   communicate with. See [Peers](#peers) below.
 

--- a/src/content/docs/components/espnow.mdx
+++ b/src/content/docs/components/espnow.mdx
@@ -22,6 +22,11 @@ espnow:
 - **auto_add_peer** (*Optional*, boolean): When set to `true`, the ESP-NOW component will automatically add any new incoming
   device as a peer. See [Peers](#peers) below. Defaults to `false`.
 - **enable_on_boot** (*Optional*, boolean): Enable the ESP-NOW component on boot. Defaults to `true`.
+- **max_payload_size** (*Optional*, int): The largest payload, in bytes, this device can send and receive in one frame.
+  Values above `250` use ESP-NOW v2 frames (up to `1470` bytes) and require ESP-IDF 5.4 or newer. The packet buffers are
+  sized from this value, so its static RAM cost is proportional — roughly 8 kB at `250` bytes and 44 kB at `1470`.
+  Sending more than 250 bytes to a peer that only supports ESP-NOW v1 fails at runtime, and received frames larger than
+  this value are dropped, so peers exchanging large frames need compatible settings on both ends. Defaults to `250`.
 - **peers** (*Optional*, list of MAC Address): The list of MAC addresses of the devices that this device is allowed to
   communicate with. See [Peers](#peers) below.
 
@@ -44,7 +49,7 @@ the received packet:
   - `info.rx_ctrl` — pointer to a Wi-Fi `wifi_pkt_rx_ctrl_t` structure containing low-level reception details such as
     `info.rx_ctrl->rssi` (signal strength in dBm).
 - **data**: A `const uint8_t *` pointer to the received payload.
-- **size**: A `uint8_t` giving the length of the payload in bytes.
+- **size**: A `uint16_t` giving the length of the payload in bytes.
 
 These variables are only valid for the duration of the synchronous part of the automation. If the automation
 includes any asynchronous actions (such as `delay`), the underlying memory may have been recycled by the time the
@@ -167,7 +172,7 @@ on_...:
 - **address** (**Required**, MAC Address, [templatable](/automations/templates)): The MAC address of the receiving
   device to send to. Must already be registered as a peer, or `auto_add_peer` must be set to `true`.
 - **data** (**Required**, string or list of bytes, [templatable](/automations/templates)): The data to be sent. The
-  maximum payload size is 250 bytes.
+  maximum payload size is the configured `max_payload_size` (250 bytes by default).
 - **wait_for_sent** (*Optional*, boolean): If `true`, the automation will wait for the underlying send operation to
   complete (and for any `on_sent` or `on_error` actions to finish) before continuing with the next action. Defaults
   to `true`.
@@ -197,7 +202,7 @@ on_...:
 
 #### Configuration variables
 - **data** (**Required**, string or list of bytes, [templatable](/automations/templates)): The data to be sent. The
-  maximum payload size is 250 bytes.
+  maximum payload size is the configured `max_payload_size` (250 bytes by default).
 - All other options from [`espnow.send`](#espnow-send-action) (`wait_for_sent`, `continue_on_error`, `on_sent`,
   `on_error`) are also accepted.
 

--- a/src/content/docs/components/espnow.mdx
+++ b/src/content/docs/components/espnow.mdx
@@ -23,10 +23,8 @@ espnow:
   device as a peer. See [Peers](#peers) below. Defaults to `false`.
 - **enable_on_boot** (*Optional*, boolean): Enable the ESP-NOW component on boot. Defaults to `true`.
 - **max_payload_size** (*Optional*, int): The largest payload, in bytes, this device can send and receive in one frame.
-  Values above `250` use ESP-NOW v2 frames (up to `1470` bytes) and require ESP-IDF 5.4 or newer. The packet buffers are
-  sized from this value, so its static RAM cost is proportional — roughly 8 kB at `250` bytes and 44 kB at `1470`.
-  Sending more than 250 bytes to a peer that only supports ESP-NOW v1 fails at runtime, and received frames larger than
-  this value are dropped, so peers exchanging large frames need compatible settings on both ends. Defaults to `250`.
+  Values above `250` use ESP-NOW v2 frames (up to `1470` bytes), require ESP-IDF 5.4 or newer, only work with peers that
+  also support them, and reserve proportionally more RAM for packet buffers. Defaults to `250`.
 - **peers** (*Optional*, list of MAC Address): The list of MAC addresses of the devices that this device is allowed to
   communicate with. See [Peers](#peers) below.
 


### PR DESCRIPTION
## Description:

Documents the new `max_payload_size` option on the espnow component: what it controls (this device's frame buffer size, not the negotiated protocol version), the ESP-IDF 5.4+ requirement above 250 bytes, the proportional static RAM cost, and the both-ends compatibility note. Also updates the trigger `size` argument type (`uint8_t` → `uint16_t`) and the two `espnow.send` payload-limit mentions to reference the configured value.

**Related issue (if applicable):** fixes https://github.com/esphome/esphome/issues/17312

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#17360

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.