### PR TITLE
Add authors configuration and update styles for metadata display

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -13,6 +13,7 @@ import { rehypeHeadingSlugs } from "./src/lib/rehype-heading-slugs.mjs";
 import { rehypeExternalLinksBlog } from "./src/lib/rehype-external-links-blog.mjs";
 import componentsJson from "./src/integrations/components-json.ts";
 import routeIndex from "./src/integrations/route-index.ts";
+import { authors } from "./src/authors.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -148,11 +149,7 @@ export default defineConfig({
       plugins: [
         starlightBlog({
           navigation: "none",
-          authors: {
-            jesse: {
-              name: "Jesse Hills",
-            },
-          },
+          authors,
         }),
       ],
       logo: {

--- a/src/authors.mjs
+++ b/src/authors.mjs
@@ -1,0 +1,8 @@
+export const authors = {
+  jesse: {
+    name: "Jesse Hills",
+    title: "ESPHome Developer",
+    picture: "https://avatars.githubusercontent.com/jesserockz?size=64",
+    url: "https://github.com/jesserockz",
+  },
+};

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -190,27 +190,6 @@ dialog::backdrop {
   color: var(--sl-color-white);
 }
 
-/* Blog post metadata (starlight-blog): show the author and date on one line.
-   The `.not-content` class is included to outrank starlight-blog's own scoped
-   `.metadata` rule (which sets flex-direction: column). */
-.metadata.not-content {
-  flex-direction: row;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-}
-.metadata.not-content .authors {
-  order: -1;
-}
-/* Separator between the author and date. Placed on `.dates` (rather than inside
-   `.authors`, which has its own larger gap) so the spacing on both sides matches
-   the `.metadata` gap. Only shown when an author precedes the date. */
-.metadata.not-content .dates:has(~ .authors)::before {
-  content: "•";
-  margin-inline-end: 0.5rem;
-  color: var(--sl-color-gray-3);
-}
-
 /* Blog list post previews (starlight-blog): tighten the default 1.5rem gap
    between the title/metadata, excerpt paragraph and tags. */
 article.preview {

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -738,3 +738,28 @@ html[data-has-hero] .hero img {
   max-height: 100%;
   margin-left: 0;
 }
+
+.metadata.not-content {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-bottom: 2rem;
+}
+
+.posts .metadata.not-content {
+  margin-bottom: 0;
+}
+
+.metadata.not-content .dates:before {
+  display: none;
+}
+
+.metadata.not-content .authors {
+  order: 1;
+}
+
+.metadata.not-content .authors img {
+  border: none;
+}


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
