### PR TITLE
[mimi_spi] Add Waveshare-ESP32-S3-TOUCH-AMOLED-1.64

### DIFF
--- a/src/content/docs/components/display/mipi_spi.mdx
+++ b/src/content/docs/components/display/mipi_spi.mdx
@@ -53,6 +53,7 @@ using an octal SPI bus, so references here to parallel and octal SPI are equival
 | AXS15231    | 320x240            |
 | ST7735      | 128x160            |
 | CO5300      | 466x466            |
+| SH8601      | 280x456            |
 | CUSTOM      | Customisable       |
 
 ### Display panels
@@ -80,6 +81,7 @@ the pins used to interface to the display to be specified.
 | WAVESHARE-ESP32-S3-GEEK              | Waveshare | [https://www.waveshare.com/esp32-s3-geek.htm](https://www.waveshare.com/esp32-s3-geek.htm) |
 | WAVESHARE-ESP32-S3-TOUCH-AMOLED-1.75 | Waveshare | [https://www.waveshare.com/esp32-s3-touch-amoled-1.75.htm](https://www.waveshare.com/esp32-s3-touch-amoled-1.75.htm) |
 | WAVESHARE-ESP32-S3-TOUCH-AMOLED-2.16 | Waveshare | [https://www.waveshare.com/esp32-s3-touch-amoled-2.16.htm](https://www.waveshare.com/esp32-s3-touch-amoled-2.16.htm) |
+| WAVESHARE-ESP32-S3-TOUCH-AMOLED-1.64 | Waveshare | [https://www.waveshare.com/ESP32-S3-Touch-AMOLED-1.64.htm](https://www.waveshare.com/ESP32-S3-Touch-AMOLED-1.64.htm) |
 | WAVESHARE-ESP32-S3-TOUCH-LCD-3.49    | Waveshare | [https://www.waveshare.com/esp32-s3-touch-lcd-3.49.htm](https://www.waveshare.com/esp32-s3-touch-lcd-3.49.htm) |
 | WT32-SC01-PLUS                       | Wireless-Tag | [https://www.wireless-tag.com/portfolio/wt32-sc01-plus/](https://www.wireless-tag.com/portfolio/wt32-sc01-plus/) |
 | ESP32-2424S012                       | Sunton       | 1.28" round CYD with GC9A01A controller.     |


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Added support for [Waveshare ESP32-S3-Touch-Amoled-1.64](https://www.waveshare.com/ESP32-S3-Touch-AMOLED-1.64.htm), using the SH8601 display.

**Related issue (if applicable):** 

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist

- [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
