### PR TITLE
Update libc options in nrf52 documentation

### DIFF
--- a/src/content/docs/components/nrf52.mdx
+++ b/src/content/docs/components/nrf52.mdx
@@ -221,12 +221,12 @@ nrf52:
   - `2.9.2-0`  : Experimental
   - `3.2.0-0`  : Experimental (no Zigbee support)
 
-- **libc_nano** (*Optional*, boolean): Use the newlib-nano C library variant. Defaults to `true`.
-  Newlib-nano produces a smaller binary but does not support all printf format specifiers.
+- **libc_nano** (*Optional*, boolean): Use the newlib-nano C library variant,
+  newlib-nano produces a smaller binary but does not support all printf format specifiers.
   Notably, the `%zu` specifier is not handled correctly, which can
   cause incorrect log output when the [logger](/components/logger) component is used.
   Set to `false` to use the full newlib, which supports all standard printf format specifiers
-  including `%zu` and 64-bit integers at the cost of a larger binary.
+  including `%zu` and 64-bit integers at the cost of a larger binary. Defaults to `true`.
 
 - **advanced** (*Optional*, mapping): See [Advanced Configuration](#advanced-configuration) below.
 

--- a/src/content/docs/components/nrf52.mdx
+++ b/src/content/docs/components/nrf52.mdx
@@ -221,13 +221,12 @@ nrf52:
   - `2.9.2-0`  : Experimental
   - `3.2.0-0`  : Experimental (no Zigbee support)
 
-- **libc** (*Optional*, string): The C library variant to link against. One of:
-  - `newlib_libc_nano` (default): Newlib nano — smaller binary size, but does not support
-    all printf format specifiers. Notably, the `%zu` specifier (used for `size_t` values)
-    is not handled correctly, which can cause incorrect log output when the
-    [logger](/components/logger) component is used.
-  - `newlib_libc`: Full newlib — larger binary size, but supports all standard printf format
-    specifiers including `%zu` and 64-bit integers.
+- **libc_nano** (*Optional*, boolean): Use the newlib-nano C library variant. Defaults to `true`.
+  Newlib-nano produces a smaller binary but does not support all printf format specifiers.
+  Notably, the `%zu` specifier is not handled correctly, which can
+  cause incorrect log output when the [logger](/components/logger) component is used.
+  Set to `false` to use the full newlib, which supports all standard printf format specifiers
+  including `%zu` and 64-bit integers at the cost of a larger binary.
 
 - **advanced** (*Optional*, mapping): See [Advanced Configuration](#advanced-configuration) below.
 

--- a/src/content/docs/components/nrf52.mdx
+++ b/src/content/docs/components/nrf52.mdx
@@ -221,6 +221,14 @@ nrf52:
   - `2.9.2-0`  : Experimental
   - `3.2.0-0`  : Experimental (no Zigbee support)
 
+- **libc** (*Optional*, string): The C library variant to link against. One of:
+  - `newlib_libc_nano` (default): Newlib nano — smaller binary size, but does not support
+    all printf format specifiers. Notably, the `%zu` specifier (used for `size_t` values)
+    is not handled correctly, which can cause incorrect log output when the
+    [logger](/components/logger) component is used.
+  - `newlib_libc`: Full newlib — larger binary size, but supports all standard printf format
+    specifiers including `%zu` and 64-bit integers.
+
 - **advanced** (*Optional*, mapping): See [Advanced Configuration](#advanced-configuration) below.
 
 ## Advanced Configuration


### PR DESCRIPTION
Added details about libc options for linking against C library variants, including newlib and its limitations.

<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- https://github.com/esphome/esphome/pull/17408

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
