### PR TITLE
Update Zigbee documentation for endpoint and device type

### DIFF
--- a/src/content/docs/components/zigbee.mdx
+++ b/src/content/docs/components/zigbee.mdx
@@ -135,14 +135,18 @@ Only on `ESP32`:
 > [!NOTE]
 > ZHA sets the minimum reporting interval to 30 seconds for some sensor devices. If a faster response is needed set `report` to `force`.
 
-- **endpoint** (*Optional*, int): Endpoint number in the range from 1 to 239. This can be used to define which entity goes on which endpoint to
-  get a more stable configuration and to manually combine multiple entities that logically belong together. Only entities of different categories
-  or device classes can be combined. If more than one entity on the same endpoint has a Zigbee device type set, one needs to set `use_device_type = true`.
-- **use_device_type** (*Optional*, boolean): Use the Zigbee Home Automation device type of this entity for the endpoint. Some entities have a
+- **endpoint** (*Optional*, int): Endpoint number in the range from 1 to 239. This defines which entity goes on which
+  endpoint, giving a more stable configuration and letting you manually combine entities that logically belong together.
+  Only entities that map to different Zigbee clusters can be combined (for example a `binary_sensor` and a `sensor`);
+  two entities of the same type, such as two sensors, cannot share an endpoint. If more than one entity on an endpoint
+  has a Zigbee device type, set `use_device_type: true` on one of them.
+- **use_device_type** (*Optional*, boolean): Use the Zigbee Home Automation device type of this entity for the endpoint.
+  Some entities have a
   [device type](https://community.nxp.com/pwmxy87654/attachments/pwmxy87654/wireless-connectivity/698/1/075367r03ZB_AFG-Home_Automation_Profile_for_Public_Download.pdf#G12.1028193)
-  that can be used by 3rd party devices to discover the device capabilities. Typically, this should be set for the main entity of an endpoint.
-  For exposing entities to Home Assitant device types are not needed. Can be set only for one entity on each endpoint.
-
+  that can be used by 3rd party devices to discover the device capabilities. Typically this should be set on the main
+  entity of an endpoint. If the selected entity has no device type of its own, the endpoint uses the generic
+  `CUSTOM_ATTR` type, which is how a default such as `SIMPLE_SENSOR` can be overridden. For exposing entities to Home
+  Assistant, device types are not needed. It can be set on only one entity per endpoint.
 
 ## Supported Components
 

--- a/src/content/docs/components/zigbee.mdx
+++ b/src/content/docs/components/zigbee.mdx
@@ -11,7 +11,7 @@ Zigbee uses the same RF technology as Thread (IEEE 802.15.4) but also defines mu
 The `zigbee` component, however, supports only the Home Automation profile.
 It allows exposing supported ESPHome components over a Zigbee network to Home Assistant via
 **Zigbee2MQTT** or **ZHA**. Due to the limitations of the Zigbee protocol, only basic properties are exposed.
-Additional properties must be configured manually in Home Assistant. Each ESPHome entity consumes one Zigbee endpoint.
+Additional properties must be configured manually in Home Assistant.
 
 > [!NOTE]
 > You will need a Zigbee coordinator like **Zigbee2MQTT** or **ZHA**. Other commercial Zigbee hubs most likely do not
@@ -23,7 +23,8 @@ Additional properties must be configured manually in Home Assistant. Each ESPHom
 
 Zigbee is only supported on `nRF52` platforms and on `ESP32` with IEEE 802.15.4 connectivity (`ESP32-C5`, `ESP32-C6`, or `ESP32-H2` 
 and in the future `ESP32-H4` and `ESP32-H21`). Both platforms support different features and have different limitations:
-- On `nRF52` a maximum of 8 endpoints is supported.
+- On `nRF52` a maximum of 8 endpoints is supported and each ESPHome entity consumes one Zigbee endpoint.
+- On `ESP32` a maximum of 239 endpoints is supported and ESPHome entities are combined on Zigbee endpoints.
 - `ESP32-H2` seems to work more reliably than `ESP32-C6`. There are reports of `ESP32-C6` boards that work only if placed next 
 to the coordinator.
 - On `ESP32` Zigbee can be used together with [WiFi](/components/wifi) with some limitations:

--- a/src/content/docs/components/zigbee.mdx
+++ b/src/content/docs/components/zigbee.mdx
@@ -134,6 +134,14 @@ Only on `ESP32`:
 > [!NOTE]
 > ZHA sets the minimum reporting interval to 30 seconds for some sensor devices. If a faster response is needed set `report` to `force`.
 
+- **endpoint** (*Optional*, int): Endpoint number in the range from 1 to 239. This can be used to define which entity goes on which endpoint to
+  get a more stable configuration and to manually combine multiple entities that logically belong together. Only entities of different categories
+  or device classes can be combined. If more than one entity on the same endpoint has a Zigbee device type set, one needs to set `use_device_type = true`.
+- **use_device_type** (*Optional*, boolean): Use the Zigbee Home Automation device type of this entity for the endpoint. Some entities have a
+  [device type](https://community.nxp.com/pwmxy87654/attachments/pwmxy87654/wireless-connectivity/698/1/075367r03ZB_AFG-Home_Automation_Profile_for_Public_Download.pdf#G12.1028193)
+  that can be used by 3rd party devices to discover the device capabilities. Typically, this should be set for the main entity of an endpoint.
+  For exposing entities to Home Assitant device types are not needed. Can be set only for one entity on each endpoint.
+
 
 ## Supported Components
 


### PR DESCRIPTION
Clarified optional parameters for Zigbee configuration, including endpoint and device type usage.

<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#17402

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.