### PR TITLE
[libretiny] Update docs for LibreTiny 1.13.0

### DIFF
--- a/src/content/docs/components/libretiny.mdx
+++ b/src/content/docs/components/libretiny.mdx
@@ -6,9 +6,9 @@ title: "LibreTiny Platform"
 This component contains platform-specific options for the [LibreTiny](https://docs.libretiny.eu/) platform.
 It provides support for the following microcontrollers, commonly used in Tuya devices, amongst others:
 
-- **BK72xx**: BK7231T, BK7231N
+- **BK72xx**: BK7231T, BK7231N, BK7238
 - **RTL87xx**: RTL8710BN, RTL8710BX
-- **LN882x**: LN882HKI
+- **LN882x**: LN882H
 
 Since different microcontrollers are supported, you need to include the appropriate ESPHome component,
 depending on which processor your device has.
@@ -41,10 +41,10 @@ ln882x:
 - **framework** (*Optional*): Options for the underlying framework used by ESPHome.
 
   - **version** (*Optional*, string): The LibreTiny version number to use, from
-    [LibreTiny platform releases](https://github.com/kuba2k2/libretiny/releases). Defaults to `recommended`. Additional values
+    [LibreTiny platform releases](https://github.com/libretiny-eu/libretiny/releases). Defaults to `recommended`. Additional values
 
-    - `dev`  : Use the latest commit from [https://github.com/kuba2k2/libretiny](https://github.com/kuba2k2/libretiny), note this may break at any time
-    - `latest`  : Use the latest *release* from [https://github.com/kuba2k2/libretiny/releases](https://github.com/kuba2k2/libretiny/releases), even if it hasn't been recommended yet.
+    - `dev`  : Use the latest commit from [https://github.com/libretiny-eu/libretiny](https://github.com/libretiny-eu/libretiny), note this may break at any time
+    - `latest`  : Use the latest *release* from [https://github.com/libretiny-eu/libretiny/releases](https://github.com/libretiny-eu/libretiny/releases), even if it hasn't been recommended yet.
     - `recommended`  : Use the recommended framework version.
 
   - **source** (*Optional*, string): The PlatformIO package or repository to use for the framework. This can be used to use a custom or patched version of the framework.
@@ -52,14 +52,14 @@ ln882x:
   - [Advanced options](#advanced-options)
 
 - **family** (*Optional*, string): The family of LibreTiny-supported microcontrollers that is used on this board.
-  One of `bk7231n`, `bk7231t`, `rtl8710b`, `rtl8720c`, `bk7251`, `bk7231q`, `ln882h`.
+  One of `bk7231n`, `bk7231q`, `bk7231t`, `bk7238`, `bk7251`, `ln882h`, `rtl8710b`, `rtl8720c`.
   Defaults to the variant that is detected from the board, if a board that's unknown to ESPHome is used,
   this option is mandatory. **It's recommended not to include this option**.
 
 > [!NOTE]
 > Support for the LibreTiny platform is still in development and there could be issues or missing components.
 >
-> Please report any issues on [LibreTiny GitHub](https://github.com/kuba2k2/libretiny).
+> Please report any issues on [LibreTiny GitHub](https://github.com/libretiny-eu/libretiny).
 
 ## Getting Started
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

ESPHome updated LibreTiny to v1.13.0, this updates the platform docs to match. The supported chips list now shows BK7238 and LN882H; the family list now matches the values the config accepts; the GitHub links point to the libretiny-eu organization where the project lives now.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#17288

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
