### PR TITLE
[mipi_dsi] Add JC8012P4A1-V2 as model

### DIFF
--- a/src/content/docs/components/display/mipi_dsi.mdx
+++ b/src/content/docs/components/display/mipi_dsi.mdx
@@ -69,6 +69,7 @@ will set the correct pins and dimensions for the display.
 | JC1060P470             | Guition        | [JC1060P470 product page](https://aliexpress.com/item/1005008328088576.html)                                     |
 | JC4880P443             | Guition        | [JC4880P443 product page](https://aliexpress.com/item/1005009618259341.html)                                     |
 | JC8012P4A1             | Guition        | [JC8012P4A1 product page](https://aliexpress.com/item/1005008789890066.html)                                     |
+| JC8012P4A1-V2          | Guition        | [JC8012P4A1-V2 product page](https://aliexpress.com/item/1005008789890066.html)                                     |
 | M5STACK-TAB5           | M5Stack        | [TAB5 product page](https://shop.m5stack.com/products/m5stack-tab5-iot-development-kit-esp32-p4)                 |
 | M5STACK-TAB5-V2        | M5Stack        | [TAB5-V2 product page](https://shop.m5stack.com/products/m5stack-tab5-iot-development-kit-esp32-p4)              |
 | SEEED-RETERMINAL-D1001 | Seeed Studio   | [D1001 product page](https://www.seeedstudio.com/reTerminal-D1001-p-6729.html)                                   |
@@ -92,6 +93,15 @@ Selection of the wrong touchscreen driver however will display an error message 
 verify the correct touchscreen driver first to accurately identify the board before configuring the display driver.
 
 <Image src={tab5VersionLabelImg} alt="Tab5 version label showing model identification" layout="constrained" style="width: 50%; height: auto; margin: 0 auto; display: block;" />
+
+> [!NOTE]
+The Guition JC8012P4A1 (also sold under JC8012P4A1C_I_W_Y) has two hardware revisions with different display panels requiring different model selections.
+
+You can check the correct model by the batch number, which is the number following the SKU on the sticker at the back of the device.
+Units manufactured in batch 2624 or later should use model `JC8012P4A1-V2`
+Units manufactured with a lower batch number should use model `JC8012P4A1`
+
+Selecting the incorrect driver will show horizontal lines on the display.
 
 ## Configuration
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Added a JC8012P4A1-V2 model for the MIPI DSI display driver. Some newer units (sold under modelnumber JC8012P4A1 and JC8012P4A1C_I_W_Y) are shipped with a different LCD panel, but still use the same driver chip. I extracted the timings and init sequence from the [reference driver](http://pan.jczn1688.com/directlink/1/HMI%20display/JC8012P4A1C_I_W_Y.zip).

With the [current information](https://github.com/jtenniswood/espframe/issues/106), it looks like the devices with a batch number of 2624 or higher have the new LCD panel.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#17457

## Checklist

- [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
