### PR TITLE
2026.6.5

### DIFF
--- a/data/version.yaml
+++ b/data/version.yaml
@@ -1,2 +1,2 @@
-release: 2026.6.4
+release: 2026.6.5
 version: '2026.6'

--- a/src/content/docs/changelog/2026.6.0.mdx
+++ b/src/content/docs/changelog/2026.6.0.mdx
@@ -585,6 +585,21 @@ For detailed migration guides and API documentation, see the
 
 </details>
 
+## Release 2026.6.5 - July 9
+
+<details>
+<summary></summary>
+
+- Bump bundled esphome-device-builder to 1.0.24 [esphome#17332](https://github.com/esphome/esphome/pull/17332) by [@esphome[bot]](https://github.com/apps/esphome)
+- Bump bundled esphome-device-builder to 1.0.25 [esphome#17333](https://github.com/esphome/esphome/pull/17333) by [@esphome[bot]](https://github.com/apps/esphome)
+- Bump bundled esphome-device-builder to 1.0.26 [esphome#17369](https://github.com/esphome/esphome/pull/17369) by [@esphome[bot]](https://github.com/apps/esphome)
+- Bump bundled esphome-device-builder to 1.0.27 [esphome#17370](https://github.com/esphome/esphome/pull/17370) by [@esphome[bot]](https://github.com/apps/esphome)
+- Bump bundled esphome-device-builder to 1.0.28 [esphome#17382](https://github.com/esphome/esphome/pull/17382) by [@esphome[bot]](https://github.com/apps/esphome)
+- Bump bundled esphome-device-builder to 1.0.29 [esphome#17384](https://github.com/esphome/esphome/pull/17384) by [@esphome[bot]](https://github.com/apps/esphome)
+- Bump bundled esphome-device-builder to 1.1.0 [esphome#17412](https://github.com/esphome/esphome/pull/17412) by [@esphome[bot]](https://github.com/apps/esphome)
+
+</details>
+
 ## Full list of changes
 
 ### New Features

--- a/src/content/docs/guides/supporters.mdx
+++ b/src/content/docs/guides/supporters.mdx
@@ -475,6 +475,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Dale Higgs (@dale3h)](https://github.com/dale3h)
 - [damanti-me (@damanti-me)](https://github.com/damanti-me)
 - [Damien (@Dams51)](https://github.com/Dams51)
+- [Dan Long (@dan-long-dev)](https://github.com/dan-long-dev)
 - [Justin Grover (@dancingcactus)](https://github.com/dancingcactus)
 - [Dan C Williams (@dancwilliams)](https://github.com/dancwilliams)
 - [Dan Greco (@dangreco)](https://github.com/dangreco)
@@ -1107,6 +1108,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Jean-Luc Béchennec (@jlbirccyn)](https://github.com/jlbirccyn)
 - [JLo (@jlpouffier)](https://github.com/jlpouffier)
 - [Jonas De Kegel (@jlsjonas)](https://github.com/jlsjonas)
+- [Julian Lunz (@jlunz)](https://github.com/jlunz)
 - [Jeff Anderson (@jman203)](https://github.com/jman203)
 - [Jonathan Martens (@jmartens)](https://github.com/jmartens)
 - [jmichiel (@jmichiel)](https://github.com/jmichiel)
@@ -1933,6 +1935,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Rus Ti (@Rusti-gotrage)](https://github.com/Rusti-gotrage)
 - [Ramil Valitov (@rvalitov)](https://github.com/rvalitov)
 - [Roberto Wagner (@rwagnervm)](https://github.com/rwagnervm)
+- [rwalker777 (@rwalker777)](https://github.com/rwalker777)
 - [rweather (@rweather)](https://github.com/rweather)
 - [Rob Weir (@rweir)](https://github.com/rweir)
 - [rwilson131 (@rwilson131)](https://github.com/rwilson131)
@@ -2287,6 +2290,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [V1d1o7 (@V1d1o7)](https://github.com/V1d1o7)
 - [Vc (@Valcob)](https://github.com/Valcob)
 - [Nad (@valordk)](https://github.com/valordk)
+- [vanseforge (@vanseforge)](https://github.com/vanseforge)
 - [Vasileios Bimpikas (@vasileio)](https://github.com/vasileio)
 - [Vicent Climent (@vcliment89)](https://github.com/vcliment89)
 - [Veli Veromann (@velijv)](https://github.com/velijv)
@@ -2414,4 +2418,4 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Christian Zufferey (@zuzu59)](https://github.com/zuzu59)
 - [Zynth-dev (@Zynth-dev)](https://github.com/Zynth-dev)
 
-*This page was last updated July 1, 2026.*
+*This page was last updated July 9, 2026.*


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- Bump eslint from 10.4.1 to 10.6.0 [docs#6884](https://github.com/esphome/esphome.io/pull/6884)
- Bump sharp from 0.34.5 to 0.35.2 [docs#6885](https://github.com/esphome/esphome.io/pull/6885)
- Bump prettier from 3.8.4 to 3.9.4 [docs#6882](https://github.com/esphome/esphome.io/pull/6882)
- Bump astro to 7.0.5 and @astrojs/starlight to 0.41.2 [docs#6892](https://github.com/esphome/esphome.io/pull/6892)
- Add Duravit SensoWash BLE external component to DIY list [docs#6863](https://github.com/esphome/esphome.io/pull/6863)
- [diy] Rename Custom Components & Code to External Components & Code [docs#6893](https://github.com/esphome/esphome.io/pull/6893)
- [mipi_spi] Clarify and enhance documentation of `transform` option. [docs#6828](https://github.com/esphome/esphome.io/pull/6828)
- [select] Remove specific example from component index page [docs#6896](https://github.com/esphome/esphome.io/pull/6896)
- Add blog feature and initial post [docs#6901](https://github.com/esphome/esphome.io/pull/6901)
- Fix typo in blog post about ESPHome Starter Kit [docs#6902](https://github.com/esphome/esphome.io/pull/6902)
- Bump eslint-plugin-astro from 1.7.0 to 2.1.1 [docs#6895](https://github.com/esphome/esphome.io/pull/6895)
- Bump astro from 7.0.5 to 7.0.6 [docs#6908](https://github.com/esphome/esphome.io/pull/6908)
- Add my blog posts to the DIY page [docs#6888](https://github.com/esphome/esphome.io/pull/6888)
- [physical_device_connection] Escape price ranges and align cost table [docs#6894](https://github.com/esphome/esphome.io/pull/6894)
- [physical_device_connection] Fix spelling in materials table [docs#6923](https://github.com/esphome/esphome.io/pull/6923)
- Bump astral-sh/ruff-action from 4.0.0 to 4.1.0 [docs#6924](https://github.com/esphome/esphome.io/pull/6924)
- Bump @astrojs/starlight from 0.41.2 to 0.41.3 [docs#6925](https://github.com/esphome/esphome.io/pull/6925)
- Add authors configuration and update styles for metadata display [docs#6910](https://github.com/esphome/esphome.io/pull/6910)
- Update bedjet.mdx (fixing extended heat mode doc line) [docs#6681](https://github.com/esphome/esphome.io/pull/6681)
- Update espnow.mdx with provider field explanation [docs#6607](https://github.com/esphome/esphome.io/pull/6607)
- Bump typescript-eslint from 8.62.1 to 8.63.0 [docs#6935](https://github.com/esphome/esphome.io/pull/6935)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
