### PR TITLE
[lvgl] Fix broken anchor links and redundant span anchors

### DIFF
--- a/src/content/docs/components/lvgl/index.mdx
+++ b/src/content/docs/components/lvgl/index.mdx
@@ -664,13 +664,11 @@ on_...:
   - lvgl.display.set_rotation: !lambda "return id(my_rotation_number).state;"
 ```
 
-<span id="lvgl-update-action"></span>
-
 ### `lvgl.update` Action
 
 This [action](/automations/actions#actions-action) allows changing/updating the styling and layout of the active screen and the LVGL display layers at runtime. Top-level [style properties](#lvgl-styling) and a `layout:` apply to the currently active screen; you can also style and lay out the `top_layer` and/or `bottom_layer`.
 
-- **layout** (*Optional*): Update the [layout](/components/lvgl/layouts#lvgl-layouts-update) options of the active screen. Only the layout options may be changed, not the layout type.
+- **layout** (*Optional*): Update the [layout](/components/lvgl/layouts#updating-a-layout-at-runtime) options of the active screen. Only the layout options may be changed, not the layout type.
 - **top_layer** / **bottom_layer** (*Optional*): Update the [style properties](#lvgl-styling) and `layout:` of the respective display layer.
 
 ```yaml
@@ -848,15 +846,13 @@ lvgl:
     - component.update: my_display_id
 ```
 
-<span id="lvgl-on-landscape-trigger"></span>
-
 ### `on_landscape` / `on_portrait` triggers
 
-These [triggers](/components/lvgl/widgets#lvgl-automation-triggers) fire when the display orientation changes, as
+These [triggers](/components/lvgl/widgets#triggers) fire when the display orientation changes, as
 determined by the effective width/height ratio of the display: `on_landscape` fires when the display becomes wider than
 it is tall (a square display is treated as landscape), and `on_portrait` fires when it becomes taller than it is wide.
 The matching trigger also fires once at boot to establish the initial orientation. A subsequent change typically results
-from the [`lvgl.display.set_rotation`](#lvgl-display-set-rotation-action) action.
+from the [`lvgl.display.set_rotation`](#lvgl-display-set_rotation-action) action.
 
 ```yaml
 lvgl:

--- a/src/content/docs/components/lvgl/layouts.mdx
+++ b/src/content/docs/components/lvgl/layouts.mdx
@@ -294,8 +294,6 @@ Values for use with `grid_column_align`, `grid_row_align`, `grid_cell_x_align`, 
 > [!TIP]
 > To visualize real, calculated sizes of transparent widgets you can temporarily set `outline_width: 1` on them.
 
-<span id="lvgl-layouts-update"></span>
-
 ### Updating a layout at runtime
 
 A `layout:` option may be supplied to the [`lvgl.update`](/components/lvgl#lvgl-update-action) and

--- a/src/content/docs/components/lvgl/widgets.mdx
+++ b/src/content/docs/components/lvgl/widgets.mdx
@@ -2061,7 +2061,7 @@ This powerful [action](/automations/actions#actions-action) allows changing/upda
 
 - **id** (**Required**): The ID or a list of IDs of widgets configured in LVGL to be updated.
 - The widget's common [style property](/components/lvgl#lvgl-styling), state (templatable) or [flag](#lvgl-widget-flags).
-- **layout** (*Optional*): Update the [layout](/components/lvgl/layouts#lvgl-layouts-update) options of the widget. Only the layout options may be changed; the layout type and grid structure are fixed when the widget is created.
+- **layout** (*Optional*): Update the [layout](/components/lvgl/layouts#updating-a-layout-at-runtime) options of the widget. Only the layout options may be changed; the layout type and grid structure are fixed when the widget is created.
 
 ```yaml
 # Example for updating styles (in states):


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Follow-up to #6726, which introduced links to anchors that don't exist (`#lvgl-layouts-update`, `#lvgl-automation-triggers`, `#lvgl-display-set-rotation-action`) and added explicit `<span id>` anchors that duplicate the auto-generated heading ids. This points the links at the correct generated anchors (`#updating-a-layout-at-runtime`, `#triggers`, `#lvgl-display-set_rotation-action`) and removes the redundant spans.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- N/A — documentation-only fix

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.