### PR TITLE
[web_server] Document lack of cross-site protections

### DIFF
--- a/src/content/docs/components/web_server.mdx
+++ b/src/content/docs/components/web_server.mdx
@@ -139,6 +139,30 @@ interface are externally hosted at oi.esphome.io. If you want to use your own se
 >
 > See [Web Server](/components/ota/web_server/) for more information.
 
+## Security
+
+The web server exposes an HTTP API for viewing and controlling your device's entities. When the
+[`web_server` OTA platform](/components/ota/web_server/) is enabled, it can also update firmware.
+
+> [!WARNING]
+> The web server has no cross-site protections, by design. It performs no CSRF, `Origin`, or `Referer` checks and uses
+> a permissive CORS policy, so it can be called from other origins, including a web page you open while on the same
+> network as the device. Its only access controls are the `auth:` option and the network the device is on. Treat it as
+> an open control surface unless you enable `auth:`.
+
+Recommendations:
+
+- Enable `auth:` if the device is on a network you do not fully trust.
+- Keep devices on a trusted, segmented network and never expose the web server to the internet. See
+  [Security Best Practices](/guides/security_best_practices/).
+- If web OTA is enabled without `auth:`, anyone who can reach the device, including cross-origin through your browser,
+  can upload firmware. Protect it with web `auth:`, disable web OTA when it is not needed (`ota: false`), or use
+  password-protected [native OTA](/components/ota/) instead.
+
+Whether this cross-origin behavior is a bug is answered by the project
+[threat model](https://github.com/esphome/esphome/blob/dev/THREAT_MODEL.md): it is intentional and not a defended
+boundary.
+
 ## Example configurations
 
 Enabling HTTP authentication:

--- a/src/content/docs/guides/security_best_practices.mdx
+++ b/src/content/docs/guides/security_best_practices.mdx
@@ -72,6 +72,13 @@ web_server:
 - Control switches, buttons, and other entities via the web interface
 - Potentially interfere with device operation
 
+> [!NOTE]
+> The web server has no cross-site (CSRF) protection by design: it does not check the request `Origin` and uses a
+> permissive CORS policy. A web page you visit while on the same network can therefore send commands to the device
+> through your browser, even though the page's author is never on your network. Enabling `auth:` and keeping devices on
+> a trusted, segmented network are the defenses. This is intentional; see the project
+> [threat model](https://github.com/esphome/esphome/blob/dev/THREAT_MODEL.md).
+
 ### 3. OTA Password Protection
 
 [OTA (Over-The-Air)](/components/ota) updates allow you to update firmware wirelessly. Protect this with a password:


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Documents that the `web_server` component has no cross-site protections by design: it performs no CSRF, `Origin`, or `Referer` checks and uses a permissive CORS policy, so it can be driven cross-origin from a web page open on the same network. Adds a `Security` section to the web_server component page covering the web OTA implications and defenses (`auth:`, network segmentation, native OTA), and a matching CSRF `[!NOTE]` to the security best practices guide. Both link to the project threat model, which documents this as intentional.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.