### PR TITLE
[modbus] Unify value type wording (word order, not little-endian)

### DIFF
--- a/src/content/docs/components/modbus_controller.mdx
+++ b/src/content/docs/components/modbus_controller.mdx
@@ -152,7 +152,7 @@ modbus_controller:
 modbus_server:
   - modbus_id: modbus_server
     address: 0x4
-    server_registers:
+    registers:
       - address: 0x0002
         value_type: S_DWORD_R
         read_lambda: |-

--- a/src/content/docs/components/modbus_controller.mdx
+++ b/src/content/docs/components/modbus_controller.mdx
@@ -5,7 +5,7 @@ title: "Modbus Controller"
 
 import { Image } from 'astro:assets';
 
-The `modbus_controller` component creates a RS485 connection to control a Modbus server (slave) device, letting your ESPHome node act as a Modbus client (master). You can access the coils, inputs, holding, read registers from your devices as sensors, switches, selects, numbers or various other ESPHome components and present them to your favorite Home Automation system. You can even write them as binary or float outputs from ESPHome.
+The `modbus_controller` component creates an RS485 connection to control a Modbus server (slave) device, letting your ESPHome node act as a Modbus client (master). You can access the coils, inputs, holding, read registers from your devices as sensors, switches, selects, numbers or various other ESPHome components and present them to your favorite Home Automation system. You can even write them as binary or float outputs from ESPHome.
 
 Set the `role` attribute of the [Modbus](/components/modbus/) upon which this `modbus_controller` component relies to `client`, which is the default.
 
@@ -71,9 +71,9 @@ Automations:
 
 ## Example Client
 
-The following code creates a `modbus_controller` hub talking to a ModBUS device at address `1` with `115200` bps
+The following code creates a `modbus_controller` hub talking to a Modbus device at address `1` with `115200` bps
 
-ModBUS sensors can be directly defined (inline) under the `modbus_controller` hub or as standalone components
+Modbus sensors can be directly defined (inline) under the `modbus_controller` hub or as standalone components
 Technically there is no difference between the "inline" and the standard definitions approach.
 
 ```yaml
@@ -125,7 +125,7 @@ The configuration example above creates a `modbus_controller` hub talking to a M
 
 ## Example Server
 
-The following code allows a ModBUS client to read a sensor value from your ESPHome node, that the node itself read from a ModBUS server.
+The following code allows a Modbus client to read a sensor value from your ESPHome node, that the node itself read from a Modbus server.
 
 ```yaml
 uart:
@@ -248,12 +248,12 @@ uart:
 modbus:
   send_wait_time: 200ms
   uart_id: mod_uart
-  id: mod_bus
+  id: modbus
 
 modbus_controller:
 - id: sdm
   address: 2
-  modbus_id: mod_bus
+  modbus_id: modbus
   command_throttle: 100ms
   setup_priority: -10
   update_interval: 30s
@@ -578,7 +578,7 @@ The response is mapped to the sensor based on `register_count` and offset in byt
 >           ESP_LOGI("ModbusLambda", "EPSOLAR Battery set");
 >
 > uart:
->   id: mod_bus
+>   id: mod_uart
 >   tx_pin: GPIOXX
 >   rx_pin: GPIOXX
 >   baud_rate: 115200
@@ -587,13 +587,13 @@ The response is mapped to the sensor based on `register_count` and offset in byt
 > modbus:
 >   #flow_control_pin: GPIOXX
 >   send_wait_time: 200ms
->   id: mod_bus_epever
+>   id: modbus_epever
 >
 > modbus_controller:
 >   - id: epever
 >     ## the Modbus device addr
 >     address: 0x1
->     modbus_id: mod_bus_epever
+>     modbus_id: modbus_epever
 >     command_throttle: 0ms
 >     setup_priority: -10
 >     update_interval: ${updates}

--- a/src/content/docs/components/modbus_server.mdx
+++ b/src/content/docs/components/modbus_server.mdx
@@ -9,7 +9,7 @@ params:
 
 import { Image } from 'astro:assets';
 
-The `modbus_server` component creates a RS485 connection to let your ESPHome node act as a Modbus server, allowing a ModBUS client to read data (like sensor values) from your ESPHome node.
+The `modbus_server` component creates a RS485 connection to let your ESPHome node act as a Modbus server, allowing a Modbus client to read data (like sensor values) from your ESPHome node.
 
 You must set the `role` attribute of the [Modbus](/components/modbus/) to `server`.
 
@@ -62,21 +62,25 @@ On the bus side, you need 120 Ohm termination resistors at the ends of the bus c
 
 - **registers** (*Optional*): A list of registers that are responded to when acting as a server.
 
-  - **address** (**Required**, integer): start address of the first register in a range
-  - **value_type** (*Optional*): datatype of the mod_bus register data. The default data type for ModBUS is a 16 bit integer in **big endian** format (network byte order, MSB first)
+  - **address** (**Required**, integer): start address of the first register in a range.
+  - **value_type** (*Optional*): datatype of the modbus register data. The default data type for modbus is a 16-bit integer in **big endian** format (network byte order, MSB first).
 
     - `U_WORD`  : unsigned 16 bit integer, 1 register, `uint16_t`
     - `S_WORD`  : signed 16 bit integer, 1 register, `int16_t`
     - `U_DWORD`  : unsigned 32 bit integer, 2 registers, `uint32_t`
     - `S_DWORD`  : signed 32 bit integer, 2 registers, `int32_t`
-    - `U_DWORD_R`  : **little endian** unsigned 32 bit integer, 2 registers, `uint32_t`
-    - `S_DWORD_R`  : **little endian** signed 32 bit integer, 2 registers, `int32_t`
+    - `U_DWORD_R`  : unsigned 32 bit integer, 2 registers, **low word first**, `uint32_t`
+    - `S_DWORD_R`  : signed 32 bit integer, 2 registers, **low word first**, `int32_t`
     - `U_QWORD`  : unsigned 64 bit integer, 4 registers, `uint64_t`
-    - `S_QWORD`  : signed 64 bit integer, 4 registers `int64_t`
-    - `U_QWORD_R`  : **little endian** unsigned 64 bit integer, 4 registers, `uint64_t`
-    - `S_QWORD_R`  : **little endian** signed 64 bit integer, 4 registers, `int64_t`
+    - `S_QWORD`  : signed 64 bit integer, 4 registers, `int64_t`
+    - `U_QWORD_R`  : unsigned 64 bit integer, 4 registers, **low word first**, `uint64_t`
+    - `S_QWORD_R`  : signed 64 bit integer, 4 registers, **low word first**, `int64_t`
     - `FP32`  : 32 bit IEEE 754 floating point, 2 registers, `float`
-    - `FP32_R`  : **little endian** 32 bit IEEE 754 floating point, 2 registers, `float`
+    - `FP32_R`  : 32 bit IEEE 754 floating point, 2 registers, **low word first**, `float`
+
+    > [!NOTE]
+    > The `_R` suffix means word order is reversed (**low word first**). It is not little-endian byte
+    > order of the whole value; bytes within each register remain MSB first.
 
     Defaults to `U_WORD`.
 
@@ -86,7 +90,7 @@ On the bus side, you need 120 Ohm termination resistors at the ends of the bus c
   - **write_lambda** (*Optional*, [lambda](/automations/templates#config-lambda)):
     Lambda that sets the value of this register. A variable `x` of the appropriate type (`uint16_t`, `int32_t`, etc, see above) is provided with the value,
     as well as `address` containing the address of this register. You must return `true` if the operation was successful, `false` otherwise, in which case
-    a ModBUS exception code `4` will be sent to the client.
+    a Modbus exception code `4` will be sent to the client.
 
   - **allow_partial_read** (*Optional*, boolean): For a multi-register value type
     (`U_DWORD`, `S_QWORD`, `FP32`, …), allow a read request to cover only
@@ -116,7 +120,7 @@ On the bus side, you need 120 Ohm termination resistors at the ends of the bus c
 
 ## Example
 
-The following code allows a ModBUS client to read a sensor value from your ESPHome node, that the node itself read from some local sensor.
+The following code allows a Modbus client to read a sensor value from your ESPHome node, that the node itself read from some local sensor.
 
 ```yaml
 uart:

--- a/src/content/docs/components/modbus_server.mdx
+++ b/src/content/docs/components/modbus_server.mdx
@@ -9,7 +9,7 @@ params:
 
 import { Image } from 'astro:assets';
 
-The `modbus_server` component creates a RS485 connection to let your ESPHome node act as a Modbus server, allowing a Modbus client to read data (like sensor values) from your ESPHome node.
+The `modbus_server` component creates an RS485 connection to let your ESPHome node act as a Modbus server, allowing a Modbus client to read data (like sensor values) from your ESPHome node.
 
 You must set the `role` attribute of the [Modbus](/components/modbus/) to `server`.
 
@@ -63,7 +63,7 @@ On the bus side, you need 120 Ohm termination resistors at the ends of the bus c
 - **registers** (*Optional*): A list of registers that are responded to when acting as a server.
 
   - **address** (**Required**, integer): start address of the first register in a range.
-  - **value_type** (*Optional*): datatype of the modbus register data. The default data type for modbus is a 16-bit integer in **big endian** format (network byte order, MSB first).
+  - **value_type** (*Optional*): data type of the modbus register data. The default data type for modbus is a 16-bit integer in **big endian** format (network byte order, MSB first).
 
     - `U_WORD`  : unsigned 16 bit integer, 1 register, `uint16_t`
     - `S_WORD`  : signed 16 bit integer, 1 register, `int16_t`

--- a/src/content/docs/components/output/modbus_controller.mdx
+++ b/src/content/docs/components/output/modbus_controller.mdx
@@ -19,7 +19,7 @@ The `modbus_controller` platform creates an output from a modbus_controller. The
   - `U_QWORD` (unsigned 64 bit integer from 4 registers = 64bit)
   - `S_QWORD` (signed 64 bit integer from 4 registers = 64bit)
   - `U_QWORD_R` (unsigned 64 bit integer from 4 registers low word first)
-  - `S_QWORD_R` signed 64 bit integer from 4 registers low word first)
+  - `S_QWORD_R` (signed 64 bit integer from 4 registers low word first)
   - `FP32` (32 bit IEEE 754 floating point from 2 registers)
   - `FP32_R` (32 bit IEEE 754 floating point - same as FP32 but low word first)
 

--- a/src/content/docs/components/select/modbus_controller.mdx
+++ b/src/content/docs/components/select/modbus_controller.mdx
@@ -16,7 +16,7 @@ registers.
   this Select to values (int) of the modbus register and vice versa. All options and
   all values have to be unique.
 
-- **value_type** (*Optional*): The datatype of the modbus data. Defaults to `U_WORD`.
+- **value_type** (*Optional*): The data type of the modbus data. Defaults to `U_WORD`.
 
   - `U_WORD` (unsigned 16 bit integer from 1 register = 16bit)
   - `S_WORD` (signed 16 bit integer from 1 register = 16bit)

--- a/src/content/docs/components/select/modbus_controller.mdx
+++ b/src/content/docs/components/select/modbus_controller.mdx
@@ -27,7 +27,7 @@ registers.
   - `U_QWORD` (unsigned 64 bit integer from 4 registers = 64bit)
   - `S_QWORD` (signed 64 bit integer from 4 registers = 64bit)
   - `U_QWORD_R` (unsigned 64 bit integer from 4 registers low word first)
-  - `U_QWORD_R` (signed 64 bit integer from 4 registers low word first)
+  - `S_QWORD_R` (signed 64 bit integer from 4 registers low word first)
 
 - **register_count** (*Optional*): The number of registers which are used for this Select. Only
   required for uncommon response encodings or to


### PR DESCRIPTION
This PR is part of a series for byte-swapped Modbus word types (`U_WORD_S` / `S_WORD_S`).

esphome/esphome:
- esphome/esphome#17469
- esphome/esphome#17829 (merge after 17469)
- esphome/esphome#17831 (merge after 17469)
- esphome/esphome#17832 (merge after 17829)

esphome/esphome.io:
- #6949
- #7042 (merge after 6949; depends on esphome 17469)
- #7043 (merge after 6949; depends on esphome 17469/17829)

---

## Summary

**This PR is part of a series** — terminology-only documentation update for Modbus value types. No new value types are documented.

- On the Modbus Server page, replace multi-register `*_R` wording that said **little endian** with **low word first**, matching the Modbus Controller docs.
- Clarify that `_R` means word order reversed (low word first), not little-endian byte order of the whole value; bytes within each register stay MSB first.
- Small unrelated fixes: `server_registers:` → `registers:` in a controller example; select duplicate `U_QWORD_R` → `S_QWORD_R`; output broken `S_QWORD_R` parenthesis; `mod_bus` / `ModBUS` cleanup on the server page.

Byte-swapped single-register types (`U_WORD_S` / `S_WORD_S`) are intentionally **not** documented here. Those land in #7042 / #7043 after [esphome#17469](https://github.com/esphome/esphome/pull/17469) (and [esphome#17829](https://github.com/esphome/esphome/pull/17829) for server).

Related to exciton feedback on esphome#17469.

## Test plan

- [x] Review rendered Modbus Server value type list for consistent **low word first** wording
- [x] Confirm the `_R` NOTE is accurate and does not imply new types
- [x] Spot-check controller example uses `registers:`
- [x] Spot-check select/output value type list typos are fixed

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.
