### PR TITLE
Rename the latest blog

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -140,6 +140,10 @@ export default defineConfig({
     remarkPlugins: [remarkAlert, remarkMath],
     rehypePlugins: [rehypeHeadingSlugs, rehypeKatex, rehypeExternalLinksBlog],
   },
+  redirects: {
+    "/blog/2026/07/02/unbox-your-creativity-with-esphome-2026-6-0/":
+      "/blog/2026/07/02/unbox-your-creativity-with-the-esphome-device-builder/",
+  },
   integrations: [
     starlight({
       title: "ESPHome - Smart Home Made Simple",

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -141,6 +141,8 @@ export default defineConfig({
     rehypePlugins: [rehypeHeadingSlugs, rehypeKatex, rehypeExternalLinksBlog],
   },
   redirects: {
+    "/blog/2026/07/02/unbox-your-creativity-with-esphome-2026-6-0":
+      "/blog/2026/07/02/unbox-your-creativity-with-the-esphome-device-builder/",
     "/blog/2026/07/02/unbox-your-creativity-with-esphome-2026-6-0/":
       "/blog/2026/07/02/unbox-your-creativity-with-the-esphome-device-builder/",
   },

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -140,12 +140,6 @@ export default defineConfig({
     remarkPlugins: [remarkAlert, remarkMath],
     rehypePlugins: [rehypeHeadingSlugs, rehypeKatex, rehypeExternalLinksBlog],
   },
-  redirects: {
-    "/blog/2026/07/02/unbox-your-creativity-with-esphome-2026-6-0":
-      "/blog/2026/07/02/unbox-your-creativity-with-the-esphome-device-builder/",
-    "/blog/2026/07/02/unbox-your-creativity-with-esphome-2026-6-0/":
-      "/blog/2026/07/02/unbox-your-creativity-with-the-esphome-device-builder/",
-  },
   integrations: [
     starlight({
       title: "ESPHome - Smart Home Made Simple",

--- a/netlify.toml
+++ b/netlify.toml
@@ -386,7 +386,7 @@ status = 301
 
 # Moved blog posts
 [[redirects]]
-  from = "/blog/2026/07/02/unbox-your-creativity-with-esphome-2026-6-0/*"
+  from = "/blog/2026/07/02/unbox-your-creativity-with-esphome-2026-6-0*"
   to = "/blog/2026/07/02/unbox-your-creativity-with-the-esphome-device-builder/"
   status = 301
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -384,6 +384,12 @@ status = 301
   to = "/components/display/mipi_spi.html"
   status = 301
 
+# Moved blog posts
+[[redirects]]
+  from = "/blog/2026/07/02/unbox-your-creativity-with-esphome-2026-6-0/*"
+  to = "/blog/2026/07/02/unbox-your-creativity-with-the-esphome-device-builder/"
+  status = 301
+
 # Starlight URL compatibility - trailing slash redirects
 # Hugo used .html extensions, Starlight uses trailing slashes
 [[redirects]]

--- a/src/content/docs/blog/2026/07/02/unbox-your-creativity-with-the-esphome-device-builder.mdx
+++ b/src/content/docs/blog/2026/07/02/unbox-your-creativity-with-the-esphome-device-builder.mdx
@@ -26,7 +26,7 @@ head:
   - tag: meta
     attrs:
       property: "og:image:title2"
-      content: "the ESPHome Device Builder"
+      content: "the ESPHome Device&nbsp;Builder"
   - tag: meta
     attrs:
       property: "og:image:author"

--- a/src/content/docs/blog/2026/07/02/unbox-your-creativity-with-the-esphome-device-builder.mdx
+++ b/src/content/docs/blog/2026/07/02/unbox-your-creativity-with-the-esphome-device-builder.mdx
@@ -26,7 +26,7 @@ head:
   - tag: meta
     attrs:
       property: "og:image:title2"
-      content: "the ESPHome Device&nbsp;Builder"
+      content: "the ESPHome Device Builder"
   - tag: meta
     attrs:
       property: "og:image:author"

--- a/src/content/docs/blog/2026/07/02/unbox-your-creativity-with-the-esphome-device-builder.mdx
+++ b/src/content/docs/blog/2026/07/02/unbox-your-creativity-with-the-esphome-device-builder.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Unbox your creativity with ESPHome 2026.6.0"
+title: "Unbox your creativity with the ESPHome Device Builder"
 description: "Discover a more approachable way to bring your smart home ideas to life: the new visual Device Builder in the latest ESPHome release."
 date: 2026-07-02
 authors:
@@ -8,17 +8,17 @@ tags:
   - Announcements
 excerpt: "Discover a more approachable way to bring your smart home ideas to life: the new visual Device Builder in the latest ESPHome release."
 cover:
-  alt: "Unbox your creativity with ESPHome 2026.6.0"
-  image: "https://assets.openhomefoundation.org/opengraph?url=https://esphome.io/blog/2026/07/02/unbox-your-creativity-with-esphome-2026-6-0"
+  alt: "Unbox your creativity with the ESPHome Device Builder"
+  image: "https://assets.openhomefoundation.org/opengraph?url=https://esphome.io/blog/2026/07/02/unbox-your-creativity-with-the-esphome-device-builder"
 head:
   - tag: meta
     attrs:
       property: "og:image"
-      content: "https://assets.openhomefoundation.org/opengraph?url=https://esphome.io/blog/2026/07/02/unbox-your-creativity-with-esphome-2026-6-0"
+      content: "https://assets.openhomefoundation.org/opengraph?url=https://esphome.io/blog/2026/07/02/unbox-your-creativity-with-the-esphome-device-builder"
   - tag: meta
     attrs:
       name: "twitter:image"
-      content: "https://assets.openhomefoundation.org/opengraph?url=https://esphome.io/blog/2026/07/02/unbox-your-creativity-with-esphome-2026-6-0"
+      content: "https://assets.openhomefoundation.org/opengraph?url=https://esphome.io/blog/2026/07/02/unbox-your-creativity-with-the-esphome-device-builder"
   - tag: meta
     attrs:
       property: "og:image:title1"
@@ -26,7 +26,7 @@ head:
   - tag: meta
     attrs:
       property: "og:image:title2"
-      content: "ESPHome 2026.6.0"
+      content: "the ESPHome Device Builder"
   - tag: meta
     attrs:
       property: "og:image:author"


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description
Changes the title from Unbox your creativity with ESPHome 2026.6.0 to Unbox your creativity with the ESPHome Device Builder.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
