### PR TITLE
[esp32] Document verification_key as ecdsa_v1-only for signed OTA

### DIFF
--- a/src/content/docs/components/esp32.mdx
+++ b/src/content/docs/components/esp32.mdx
@@ -521,19 +521,34 @@ esp32:
   Both Secure Boot V2 (RSA-3072 or ECDSA-V2) and Secure Boot V1 (ECDSA) signing schemes are supported.
   Contains the following options:
 
+  Adding this block — even with no options inside — compiles signature verification into the firmware: the
+  device will reject any OTA update that is not signed with a trusted key. The options below only control how
+  the firmware gets signed.
+
   - **signing_key** (*Optional*, filename): Path to a PEM-encoded private signing key. When provided, the firmware
     is **automatically signed during build** using `espsecure`. This is the simplest workflow — the public key is
-    derived automatically and embedded in the signature block. **Mutually exclusive with `verification_key`.**
-  - **verification_key** (*Optional*, filename): Path to a public verification key. When provided, the
-    public key is embedded for verification but the binary is **not signed during build**. You must sign the firmware
-    externally before flashing. This is useful for CI/CD pipelines where the private key is stored in a secure vault.
+    derived automatically and embedded in the signature block. When omitted, the firmware is **not signed during
+    build**; you must sign it externally before flashing, which is useful for CI/CD pipelines where the private
+    key is stored in a secure vault. **Mutually exclusive with `verification_key`.**
+  - **verification_key** (*Optional*, filename): Path to a public verification key, **only for the `ecdsa_v1`
+    scheme**. Secure Boot V1 signatures do not carry the public key, so when the firmware is signed externally
+    the public key must be embedded in the build to verify updates. The key is in raw binary format (`.bin`);
+    extract it from the PEM private key using
+    `espsecure.py extract_public_key --keyfile private.pem public_key.bin`.
     **Mutually exclusive with `signing_key`.**
 
     > [!NOTE]
-    > The verification key format depends on the signing scheme:
-    > - For `rsa3072` and `ecdsa256` (Secure Boot V2): PEM-encoded public key.
-    > - For `ecdsa_v1` (Secure Boot V1): Raw binary format (`.bin`). Extract from a PEM private key using:
-    >   `espsecure.py extract_public_key --keyfile private.pem public_key.bin`
+    > The Secure Boot V2 schemes (`rsa3072` and `ecdsa256`) do not use a verification key — updates are verified
+    > against the public key carried in the running firmware's own signature block. To sign externally with a V2
+    > scheme, omit both keys; a bare block is a complete configuration:
+    >
+    > ```yaml
+    > esp32:
+    >   framework:
+    >     advanced:
+    >       # Verify OTA updates against externally-applied rsa3072 signatures
+    >       signed_ota_verification:
+    > ```
 
   - **signing_scheme** (*Optional*, string): The signing algorithm. One of `rsa3072`, `ecdsa256`, or `ecdsa_v1`.
     Defaults to `rsa3072`. **Not all schemes are supported on all variants** — see the table below.
@@ -567,7 +582,8 @@ esp32:
 
   > [!NOTE]
   > The **first firmware** flashed to a device must also be signed. When using `signing_key`, this happens
-  > automatically. Flash the initial firmware via serial — serial flashing does not perform signature verification.
+  > automatically; when signing externally, sign the image before flashing it via serial — a device running
+  > unsigned firmware has no trusted key and cannot verify (or accept) any OTA update.
   > All subsequent OTA updates will be verified against the public key in the running firmware.
 
   To generate a signing key, use the `espsecure.py` tool from ESP-IDF:
@@ -579,8 +595,8 @@ esp32:
   # Generate an ECDSA signing key (Secure Boot V1 — original ESP32 pre-rev 3.0)
   espsecure.py generate-signing-key --version 1 secure_boot_signing_key.pem
 
-  # Extract the public verification key (for the verification_key workflow)
-  espsecure.py extract_public_key --keyfile secure_boot_signing_key.pem secure_boot_verification_key.pem
+  # Extract the public verification key (only needed for ecdsa_v1 external signing)
+  espsecure.py extract_public_key --keyfile secure_boot_signing_key.pem secure_boot_verification_key.bin
   ```
 
 - **nvs_encryption** (*Optional*, mapping): Encrypts the device's non-volatile storage (NVS), where ESPHome


### PR DESCRIPTION
## Description

Updates the `signed_ota_verification` documentation to match what ESP-IDF actually requires for each signing scheme:

- `verification_key` is only used with the Secure Boot V1 scheme (`ecdsa_v1`), where the public key must be compiled into the app to verify externally-signed images. The key is a raw binary file, not PEM.
- The Secure Boot V2 schemes (`rsa3072`, `ecdsa256`) carry the public key in each image's signature block, so verifying externally-signed binaries needs no key in the config — a bare `signed_ota_verification:` block is a complete configuration.
- Clarifies that adding the block (even empty) is what compiles OTA signature verification into the firmware, and that with external signing the initial serial-flashed image must also be signed.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#17497

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.