### PR TITLE
[tflite_micro_helper] Add documentation

### DIFF
--- a/src/content/docs/components/index.mdx
+++ b/src/content/docs/components/index.mdx
@@ -1164,6 +1164,7 @@ ESPHome to cellular networks. **Does not encompass Wi-Fi.**
   ["Sprinkler", "/components/sprinkler/", "sprinkler-variant.svg", "dark-invert"],
   ["Status LED", "/components/status_led/", "led-on.svg", "dark-invert"],
   ["Sun", "/components/sun/", "weather-sunny.svg", "dark-invert"],
+  ["TFLite Micro Helper", "/components/tflite_micro_helper/", "chip.svg", "dark-invert"],
   ["Tuya MCU", "/components/tuya/", "tuya.png"],
   ["Z-Wave Proxy", "/components/zwave_proxy/", "server-network.svg", "dark-invert"],
 ]} />

--- a/src/content/docs/components/tflite_micro_helper.mdx
+++ b/src/content/docs/components/tflite_micro_helper.mdx
@@ -1,0 +1,76 @@
+---
+description: "Instructions for setting up the TFLite Micro helper component in ESPHome"
+title: "TFLite Micro Helper"
+---
+
+The `tflite_micro_helper` component provides a reusable TensorFlow Lite Micro runtime for ESP32 microcontrollers using the ESP-IDF
+framework. It manages model loading, tensor arena memory allocation, operator registration, and inference execution, serving
+as a foundation for TFLite-based components such as meter readers or object classifiers.
+
+> [!NOTE]
+> This is a **helper/library component** that is typically used as a dependency by other components. It does not expose sensors
+> or entities directly. It currently supports **ESP32** targets with the **ESP-IDF** framework only.
+
+```yaml
+# Example configuration entry
+tflite_micro_helper:
+  debug: false
+```
+
+## Configuration variables
+
+- **debug** (*Optional*, boolean): Enable debug logging and diagnostic features. Defaults to `false`. When enabled, the
+  `DEBUG_TFLITE_MICRO_HELPER` define is set, which enables additional verbose logging for model loading, tensor inspection,
+  and inference debugging.
+
+## Platform Support
+
+| Platform   | Supported | Framework |
+|------------|-----------|-----------|
+| ESP32      | Yes       | ESP-IDF   |
+| ESP32-S2   | Yes       | ESP-IDF   |
+| ESP32-S3   | Yes       | ESP-IDF   |
+| ESP32-C3   | Yes       | ESP-IDF   |
+| ESP32-C6   | Yes       | ESP-IDF   |
+| ESP32-H2   | Yes       | ESP-IDF   |
+| ESP8266    | No        | N/A       |
+| RP2040     | No        | N/A       |
+
+## ESP-IDF Component Dependencies
+
+This component automatically adds the following ESP-IDF components:
+
+- `espressif/esp-tflite-micro` (version 1.3.7)
+- `espressif/esp-nn` (version 1.2.3)
+
+Build flags:
+
+- `-DTF_LITE_STATIC_MEMORY`
+- `-DTF_LITE_DISABLE_X86_NEON`
+- `-DESP_NN`
+- `-DOPTIMIZED_KERNEL=esp_nn`
+
+## Usage as a Dependency
+
+Components that require TFLite Micro should declare a dependency in their `__init__.py`:
+
+```python
+DEPENDENCIES = ["tflite_micro_helper"]
+```
+
+This ensures the required build flags and IDF components are configured before the dependent component's code generation runs.
+
+## Memory Management
+
+The tensor arena is allocated using one of three strategies (in priority order):
+
+1. **PSRAM** (preferred): When PSRAM is available, the tensor arena is allocated there to avoid exhausting internal SRAM.
+2. **Internal SRAM** (fallback): When no PSRAM is present, the arena is allocated from internal RAM.
+3. **Force flags**: Build flags `-DTFLITE_FORCE_SRAM` or `-DTFLITE_FORCE_PSRAM` override the automatic selection.
+
+## See Also
+
+- [ESP32 Component](/components/esp32/)
+- [PSRAM Component](/components/psram/)
+- [TensorFlow Lite Micro](https://www.tensorflow.org/lite/micro)
+- [ESP-TFLite-Micro](https://components.espressif.com/components/espressif/esp-tflite-micro)


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Add documentation for the new tflite_micro_helper component — a reusable TensorFlow Lite Micro runtime helper for ESP32 microcontrollers using the ESP-IDF framework. This component manages model loading, tensor arena memory allocation (with PSRAM/SPIRAM support), operator registration, and inference execution. It serves as a foundation for TFLite-based ESPHome components such as meter readers or object classifiers.

This component has been battle-tested since 2025 in the external component repository https://github.com/nliaudat/esphome_ai_component and is now being upstreamed into ESPHome core.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#17478

## Checklist

- [ X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [X ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
