### PR TITLE
[zigbee] Update 'use_device_type' explanation in zigbee.mdx

### DIFF
--- a/src/content/docs/components/zigbee.mdx
+++ b/src/content/docs/components/zigbee.mdx
@@ -144,9 +144,9 @@ Only on `ESP32`:
   Some entities have a
   [device type](https://community.nxp.com/pwmxy87654/attachments/pwmxy87654/wireless-connectivity/698/1/075367r03ZB_AFG-Home_Automation_Profile_for_Public_Download.pdf#G12.1028193)
   that can be used by 3rd party devices to discover the device capabilities. Typically this should be set on the main
-  entity of an endpoint. If the selected entity has no device type of its own, the endpoint uses the generic
-  `CUSTOM_ATTR` type, which is how a default such as `SIMPLE_SENSOR` can be overridden. For exposing entities to Home
-  Assistant, device types are not needed. It can be set on only one entity per endpoint.
+  entity of an endpoint. Set this to `false` to remove the device type of the entity. In this case, or if the
+  entity has no device type of its own, the endpoint uses the generic `CUSTOM_ATTR` type. For exposing entities to Home
+  Assistant, device types are not needed. It can be set to `true` on only one entity per endpoint.
 
 ## Supported Components
 


### PR DESCRIPTION
Clarified the usage of the 'use_device_type' option for Zigbee endpoints, specifying its default behavior and conditions for setting it.

<!-- markdownlint-disable -->

## Description

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#17511

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.