### PR TITLE
Note Adafruit STEMMA QT MLX90393 address change (0x18 vs 0x0C)

### DIFF
--- a/src/content/docs/components/sensor/mlx90393.mdx
+++ b/src/content/docs/components/sensor/mlx90393.mdx
@@ -100,6 +100,15 @@ sensor:
 - **address** (*Optional*, int): Manually specify the I²C address of
   the sensor. Defaults to `0x0C`.
 
+  :::note
+  Adafruit STEMMA QT MLX90393 breakouts shipped since May 2023 default to
+  address `0x18`, not `0x0C`, due to a chip substitution (see the
+  [product page](https://www.adafruit.com/product/4022)). If your sensor
+  shows up in an I²C bus scan but every subsequent read/write fails with
+  "Communication failed," check the scanned address and set `address: 0x18`
+  explicitly if needed.
+  :::
+
 - **i2c_id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID of the [I²C Component](/components/i2c) if you want
   to use multiple I²C buses.
 


### PR DESCRIPTION
Adafruit's MLX90393 STEMMA QT breakout has shipped with default I2C address 0x18 instead of 0x0C since May 2023 due to a chip substitution (see product page changelog). This causes the sensor to be found on an i2c bus scan but fail all subsequent communication, since the component still assumes 0x0C. Adding a note so future users don't burn hours debugging what looks like a hardware fault.

<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
