### PR TITLE
Add note about display breaking changes

### DIFF
--- a/src/content/docs/changelog/2026.7.0.mdx
+++ b/src/content/docs/changelog/2026.7.0.mdx
@@ -623,6 +623,7 @@ methods were deprecated 6 months ago in favor of buffer-based variants that avoi
   [#16826](https://github.com/esphome/esphome/pull/16826))
 - **`mipi_` display driver model config changes**: Use of `swap_xy=cv.UNDEFINED` in a model definition is deprecated.
   [#17405](https://github.com/esphome/esphome/pull/17405)
+
 For detailed migration guides and API documentation, see the
 [ESPHome Developers Documentation](https://developers.esphome.io/).
 {/* BREAKING_CHANGES_DEVELOPERS_END */}

--- a/src/content/docs/changelog/2026.7.0.mdx
+++ b/src/content/docs/changelog/2026.7.0.mdx
@@ -526,6 +526,10 @@ tested pre-releases, and helped in the community.
 - **Zigbee**: on ESP32 endpoint merging now combines endpoints of components by default and lets users manually
   combine them. Existing configurations require re-joining, re-interviewing, and re-configuring
   [#17402](https://github.com/esphome/esphome/pull/17402)
+- **Display Components**: The MIPI family of display drivers (`mipi_spi`, `mipi_dsi` and `mipi_rgb`) now enforce
+  configuration of mandatory components such as PSRAM and I/O expanders where required. This applies only to those
+  display models that identify integrated boards with known hardware assignments.
+  It is unlikely that any working configurations will be affected.
 {/* BREAKING_CHANGES_USERS_END */}
 
 ### Undocumented API Changes

--- a/src/content/docs/changelog/2026.7.0.mdx
+++ b/src/content/docs/changelog/2026.7.0.mdx
@@ -621,7 +621,8 @@ methods were deprecated 6 months ago in favor of buffer-based variants that avoi
   continue to work as deprecated aliases through 2027.7.0 via the new alias infrastructure
   ([#17145](https://github.com/esphome/esphome/pull/17145),
   [#16826](https://github.com/esphome/esphome/pull/16826))
-
+- **`mipi_` display driver model config changes**: Use of `swap_xy=cv.UNDEFINED` in a model definition is deprecated.
+  [#17405](https://github.com/esphome/esphome/pull/17405)
 For detailed migration guides and API documentation, see the
 [ESPHome Developers Documentation](https://developers.esphome.io/).
 {/* BREAKING_CHANGES_DEVELOPERS_END */}

--- a/src/content/docs/changelog/2026.7.0.mdx
+++ b/src/content/docs/changelog/2026.7.0.mdx
@@ -529,7 +529,7 @@ tested pre-releases, and helped in the community.
 - **Display Components**: The MIPI family of display drivers (`mipi_spi`, `mipi_dsi` and `mipi_rgb`) now enforce
   configuration of mandatory components such as PSRAM and I/O expanders where required. This applies only to those
   display models that identify integrated boards with known hardware assignments.
-  It is unlikely that any working configurations will be affected.
+  [#17405](https://github.com/esphome/esphome/pull/17405)
 {/* BREAKING_CHANGES_USERS_END */}
 
 ### Undocumented API Changes


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#17405

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
