### PR TITLE
Add Novoport Speed to Tormatic Compatibility list.

### DIFF
--- a/src/content/docs/components/cover/tormatic.mdx
+++ b/src/content/docs/components/cover/tormatic.mdx
@@ -15,6 +15,7 @@ be supported:
 * Novoferm Novomatic 423
 * Novoferm Novomatic 563 S
 * Novoferm Novoport IV
+* Novoferm Novoport Speed
 
 <Figure
   src="/images/tormatic.png"
@@ -27,7 +28,7 @@ be supported:
 
 > [!NOTE]
 > This component was written against a Novoferm 423. It has been successfully
-> tested with Novoferm 423 and Tormatic Black 600, so compatibility with other
+> tested with Novoferm 423, Tormatic Black 600 and Novoport Speed, so compatibility with other
 > models is currently not guaranteed. Please update this documentation if you
 > confirm this to work on other models as well.
 >


### PR DESCRIPTION
Confirmed compatibility with Novoport Speed.

Tested with:
- ESPHome 2026.6.5
- Waveshare ESP32-P4-WIFI6
- Novoport Speed garage door opener

Verified successful operation including:
- Status polling
- Open
- Close
- Stop

This PR updates the documentation to include Novoport Speed in the list of known compatible operators.

## Checklist

- [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.