### PR TITLE
[web_server] Document auth type option (basic/digest)

### DIFF
--- a/src/content/docs/components/web_server.mdx
+++ b/src/content/docs/components/web_server.mdx
@@ -15,6 +15,7 @@ import tabHeaderExpandControlsExpandedImg from './images/tab-header-expand-contr
 import tabHeaderExpandLogsExpandedImg from './images/tab-header-expand-logs-expanded.png';
 import sensorHistoryGraphImg from './images/sensor-history-graph.png';
 import APIRef from '@components/APIRef.astro';
+import EnumValues from '@components/EnumValues.astro';
 
 The `web_server` component creates a simple web server on the node that can be accessed
 through any browser and a simple [REST API](/web-api#api-rest). Please note that enabling this component
@@ -67,10 +68,21 @@ web_server:
   Contents of this file will be served as `/0.js` and used as JS script by internal webserver.
   Useful when building device without internet access, where you want to use built-in AP and webserver.
 
-- **auth** (*Optional*): Enables a simple *Digest* authentication with username and password.
+- **auth** (*Optional*): Enables HTTP authentication with a username and password.
 
   - **username** (**Required**, string): The username to use for authentication.
   - **password** (**Required**, string): The password to check for authentication.
+  - **type** (*Optional*, string): The HTTP authentication scheme. Both show the same login prompt
+    in the browser; the difference is on the network. One of:
+
+    <EnumValues values={[
+      { value: "basic",  default: true, description: "Sends the password in an easily reversible (Base64) form on every request." },
+      { value: "digest", description: "Sends only hashes, keeping the password off the network. Recommended." },
+    ]} />
+
+    The default is currently `basic` but will change to `digest` in ESPHome `2027.1.0`; set
+    `type: basic` explicitly to keep it after that release. When using `digest`, REST API clients
+    must request it too (for example, `curl --digest`); plain `basic` clients are rejected.
 
 - **include_internal** (*Optional*, boolean): Whether `internal` entities should be displayed on the
   web interface. Defaults to `false`.


### PR DESCRIPTION
## Description

Documents the new `web_server` → `auth` → `type` option added in esphome/esphome#17541. It explains the two authentication schemes (`basic` and `digest`) using the `EnumValues` component, notes that both present the same browser login prompt while `digest` keeps the password off the network, and calls out that the default stays `basic` for now but will change to `digest` in ESPHome `2027.1.0` (and that REST clients must use `curl --digest` against a digest device).

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#17541

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.