### PR TITLE
[light] Document light state on its own schema

### DIFF
--- a/script/schema_doc.py
+++ b/script/schema_doc.py
@@ -655,6 +655,44 @@ def is_title(title):
     return title.startswith("#")
 
 
+# Schemas (e.g. "LIGHT_STATE_SCHEMA") of the doc section currently being parsed,
+# keyed by name. Set per-section in parse_file() so a heading can be matched to a
+# sibling schema emitted from the code.
+current_component_schemas = {}
+
+
+def title_schema_name(title):
+    """Return the schema a heading names, or None.
+
+    The heading carries the schema's logical name without the trailing
+    ``_SCHEMA`` (e.g. "Light state" -> ``LIGHT_STATE_SCHEMA``); it matches only
+    when that schema is present in the current component's generated JSON. This
+    keeps the docs heading human-readable while still routing its config vars to
+    the schema they belong to.
+    """
+    slug = slugify(title)
+    if not slug:
+        return None
+    candidate = slug.replace("-", "_").upper() + "_SCHEMA"
+    return candidate if candidate in current_component_schemas else None
+
+
+def set_current_schemas(doc_type, doc_component, doc_platform):
+    """Record the schemas of the doc section being parsed for title matching."""
+    global current_component_schemas
+    if not doc_component:
+        current_component_schemas = {}
+        return
+    component_key = (
+        f"{doc_component}.{doc_platform}"
+        if doc_type == "platform_component"
+        else doc_component
+    )
+    current_component_schemas = (
+        (json_get(doc_component) or {}).get(component_key, {}).get("schemas", {})
+    )
+
+
 def is_break_title(title):
     if is_title(title):
         name = title.split(" ")[-1].lower()
@@ -665,6 +703,11 @@ def is_break_title(title):
         # Bare backtick heading (### `name`) — registry entry like a filter or effect.
         # Nothing after the closing backtick, so it's not a property sub-heading.
         if re.match(r"^#+\s+`[^`]+`\s*$", title):
+            return True
+        # A heading that names a sibling schema emitted from the code (e.g.
+        # "Light state" -> LIGHT_STATE_SCHEMA) ends the current config-vars walk
+        # so its options are routed to that schema instead of the base one.
+        if title_schema_name(title):
             return True
     return False
 
@@ -1122,6 +1165,29 @@ def parse_file(md_full_path):
                 print(
                     f"{md_full_path}:{index} {doc_platform}/{file_name} {title} not processed."
                 )
+
+        # A heading that names a sibling schema emitted from the code documents
+        # that schema (e.g. "Light state" -> LIGHT_STATE_SCHEMA) rather than the
+        # doc's main config schema. Routing its config vars there keeps shared
+        # sub-schemas documented where they belong instead of leaking their keys
+        # into the base component schema. Skip headings already claimed by the
+        # component/platform title logic or an action/condition/registry entry
+        # (e.g. "EMC2101 Component" -> EMC2101_COMPONENT_SCHEMA) so this doesn't
+        # hijack their handling.
+        set_current_schemas(doc_type, doc_component, doc_platform)
+        schema_name = (
+            None
+            if title_component or pending_schema
+            else title_schema_name(title)
+        )
+        if schema_name:
+            try:
+                index = process_config(
+                    md_full_path, lines, index, current_component_schemas[schema_name]
+                )
+            except Exception as err:
+                print(f"{md_full_path}:{index} {title} failed {repr(err)}")
+            continue
 
         if title == DOC_CONFIGURATION_VARIABLES:
             if not doc_component:

--- a/src/content/docs/components/light/index.mdx
+++ b/src/content/docs/components/light/index.mdx
@@ -51,7 +51,7 @@ light:
   when the state is **not** restored based on `restore_mode` (below).
 
   - **state** (*Optional*, boolean, [templatable](/automations/templates)): The ON/OFF state for the light.
-  - All other options from [light state](#light-state_config).
+  - All other options from [light state](#light-state).
 
 - **restore_mode** (*Optional*): Control how the light attempts to restore state on bootup.
 
@@ -97,9 +97,7 @@ light:
 - If Webserver enabled and [version 3](/components/web_server#config-webserver-version-3-options) is selected, all other options from
   [Web Server](/components/web_server/).
 
-<span id="light-state_config"></span>
-
-**Light state:**
+### Light state
 
 Some actions/configuration refer to **light state**. A **light state** may consist of any of the following
 configuration variables:
@@ -220,7 +218,7 @@ on_...:
 - **effect** (*Optional*, string, [templatable](/automations/templates)): If set, will attempt to start an effect
   with the given name.
 
-- All other options from [light state](#light-state_config).
+- All other options from [light state](#light-state).
 
 > [!NOTE]
 > This action can also be expressed in [lambdas](/automations/templates#config-lambda):
@@ -310,7 +308,7 @@ on_...:
 
 - **id** (**Required**, [ID](/guides/configuration-types#id)): The ID of the light.
 - **state** (*Optional*, [templatable](/automations/templates), boolean): Change the ON/OFF state of the light.
-- All other options from [light state](#light-state_config).
+- All other options from [light state](#light-state).
 
 ### `light.dim_relative` Action
 
@@ -674,7 +672,7 @@ light:
   - **duration** (**Required**, [Time](/guides/configuration-types#time)): The duration this color should be active.
   - **transition_length** (*Optional*, [Time](/guides/configuration-types#time)): The duration of each transition. Defaults to `0s`.
 
-See [light state](#light-state_config) for more information on the various color fields.
+See [light state](#light-state) for more information on the various color fields.
 
 ### Flicker Effect
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Config schema headings in a component's docs are now matched to the schemas emitted from the code: a heading whose name resolves to a `*_SCHEMA` present in that component's generated JSON (for example "Light state" -> `LIGHT_STATE_SCHEMA`) documents that schema directly instead of the doc's main config schema. The generator change is generic and guarded so it does not hijack headings already handled as component/platform titles or action/condition/registry entries.

For the light component this fixes a leak: the light state color channels (`red`, `green`, `blue`, `white`, `brightness`, `color_temperature`, `cold_white`, `warm_white`) were being flattened onto the base `LIGHT_SCHEMA`, so they surfaced as top-level options on every light platform (including addressable ones such as `esp32_rmt_led_strip`). They are now documented on `LIGHT_STATE_SCHEMA` where they belong, and `color_mode`/`color_brightness` — which previously had no docs anywhere — are documented too. A full docs build shows only `light.json` changes as a result.

**Related issue (if applicable):** esphome/device-builder-frontend#1225

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- N/A

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.