### PR TITLE
Add epaper_spi trigger_full_update action

### DIFF
--- a/src/content/docs/components/display/epaper_spi.mdx
+++ b/src/content/docs/components/display/epaper_spi.mdx
@@ -197,6 +197,17 @@ display:
       it.filled_circle(400, 550, 80, YELLOW);
 ```
 
+## Actions
+
+### `display.epaper_spi.trigger_full_update` Action
+
+This action triggers a full update cycle on the display, clearing any ghosting. It also resets the internal update counter (so that subsequent updates will use partial refreshes again).
+
+```yaml
+on_page_change:
+  then:
+    - display.epaper_spi.trigger_full_update: eink_display
+```
 ## See Also
 
 - [ESPHome Display Rendering Engine](/components/display#display-engine)


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

This PR documents the new native `display.epaper_spi.trigger_full_update` action in the `epaper_spi` component, which forces a full refresh cycle and resets the partial update counter.

**Related issue (if applicable):** none

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#17528

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.
