### PR TITLE
2026.7.0b3

### DIFF
--- a/data/version.yaml
+++ b/data/version.yaml
@@ -1,2 +1,2 @@
-release: 2026.7.0b2
+release: 2026.7.0b3
 version: '2026.7'

--- a/src/content/docs/changelog/2026.7.0.mdx
+++ b/src/content/docs/changelog/2026.7.0.mdx
@@ -742,6 +742,14 @@ For detailed migration guides and API documentation, see the
 - [core] Classify entity metadata visibility for the visual editor [esphome#17503](https://github.com/esphome/esphome/pull/17503) by [@jesserockz](https://github.com/jesserockz)
 - [api] Provision encryption keys over an encrypted zero-PSK noise connection [esphome#17482](https://github.com/esphome/esphome/pull/17482) by [@bdraco](https://github.com/bdraco)
 - [zwave_proxy] Fix parser gaps and harden frame and subscription handling [esphome#17461](https://github.com/esphome/esphome/pull/17461) by [@kbx81](https://github.com/kbx81)
+- [gsl3670] Fix i2c package variant in esp32-s3-idf test [esphome#17535](https://github.com/esphome/esphome/pull/17535) by [@jesserockz](https://github.com/jesserockz)
+- [web_server] Add CORS origin checking with allowed_origins [esphome#17530](https://github.com/esphome/esphome/pull/17530) by [@jesserockz](https://github.com/jesserockz) (breaking-change)
+- [esp32] Do not require verification_key with Secure Boot V2 signing schemes [esphome#17497](https://github.com/esphome/esphome/pull/17497) by [@kbx81](https://github.com/kbx81)
+- [web_server] Use dict-style packages in tests so they can be batch-grouped [esphome#17544](https://github.com/esphome/esphome/pull/17544) by [@jesserockz](https://github.com/jesserockz)
+- [web_server] Add HTTP digest authentication with selectable scheme [esphome#17541](https://github.com/esphome/esphome/pull/17541) by [@jesserockz](https://github.com/jesserockz) (new-feature)
+- [libretiny] Keep renamed board generic-ln882hki validating against generic-ln882h [esphome#17542](https://github.com/esphome/esphome/pull/17542) by [@bdraco](https://github.com/bdraco)
+- [veml7700][as7341][ltr501] Fix device class on raw-count sensors [esphome#17549](https://github.com/esphome/esphome/pull/17549) by [@swoboda1337](https://github.com/swoboda1337)
+- [nextion] Fix unbounded queue growth and OOM crash when display sends no data [esphome#17553](https://github.com/esphome/esphome/pull/17553) by [@kbx81](https://github.com/kbx81)
 
 ### All changes
 

--- a/src/content/docs/components/esp32.mdx
+++ b/src/content/docs/components/esp32.mdx
@@ -521,19 +521,34 @@ esp32:
   Both Secure Boot V2 (RSA-3072 or ECDSA-V2) and Secure Boot V1 (ECDSA) signing schemes are supported.
   Contains the following options:
 
+  Adding this block — even with no options inside — compiles signature verification into the firmware: the
+  device will reject any OTA update that is not signed with a trusted key. The options below only control how
+  the firmware gets signed.
+
   - **signing_key** (*Optional*, filename): Path to a PEM-encoded private signing key. When provided, the firmware
     is **automatically signed during build** using `espsecure`. This is the simplest workflow — the public key is
-    derived automatically and embedded in the signature block. **Mutually exclusive with `verification_key`.**
-  - **verification_key** (*Optional*, filename): Path to a public verification key. When provided, the
-    public key is embedded for verification but the binary is **not signed during build**. You must sign the firmware
-    externally before flashing. This is useful for CI/CD pipelines where the private key is stored in a secure vault.
+    derived automatically and embedded in the signature block. When omitted, the firmware is **not signed during
+    build**; you must sign it externally before flashing, which is useful for CI/CD pipelines where the private
+    key is stored in a secure vault. **Mutually exclusive with `verification_key`.**
+  - **verification_key** (*Optional*, filename): Path to a public verification key, **only for the `ecdsa_v1`
+    scheme**. Secure Boot V1 signatures do not carry the public key, so when the firmware is signed externally
+    the public key must be embedded in the build to verify updates. The key is in raw binary format (`.bin`);
+    extract it from the PEM private key using
+    `espsecure.py extract_public_key --keyfile private.pem public_key.bin`.
     **Mutually exclusive with `signing_key`.**
 
     > [!NOTE]
-    > The verification key format depends on the signing scheme:
-    > - For `rsa3072` and `ecdsa256` (Secure Boot V2): PEM-encoded public key.
-    > - For `ecdsa_v1` (Secure Boot V1): Raw binary format (`.bin`). Extract from a PEM private key using:
-    >   `espsecure.py extract_public_key --keyfile private.pem public_key.bin`
+    > The Secure Boot V2 schemes (`rsa3072` and `ecdsa256`) do not use a verification key — updates are verified
+    > against the public key carried in the running firmware's own signature block. To sign externally with a V2
+    > scheme, omit both keys; a bare block is a complete configuration:
+    >
+    > ```yaml
+    > esp32:
+    >   framework:
+    >     advanced:
+    >       # Verify OTA updates against externally-applied rsa3072 signatures
+    >       signed_ota_verification:
+    > ```
 
   - **signing_scheme** (*Optional*, string): The signing algorithm. One of `rsa3072`, `ecdsa256`, or `ecdsa_v1`.
     Defaults to `rsa3072`. **Not all schemes are supported on all variants** — see the table below.
@@ -567,7 +582,8 @@ esp32:
 
   > [!NOTE]
   > The **first firmware** flashed to a device must also be signed. When using `signing_key`, this happens
-  > automatically. Flash the initial firmware via serial — serial flashing does not perform signature verification.
+  > automatically; when signing externally, sign the image before flashing it via serial — a device running
+  > unsigned firmware has no trusted key and cannot verify (or accept) any OTA update.
   > All subsequent OTA updates will be verified against the public key in the running firmware.
 
   To generate a signing key, use the `espsecure.py` tool from ESP-IDF:
@@ -579,8 +595,8 @@ esp32:
   # Generate an ECDSA signing key (Secure Boot V1 — original ESP32 pre-rev 3.0)
   espsecure.py generate-signing-key --version 1 secure_boot_signing_key.pem
 
-  # Extract the public verification key (for the verification_key workflow)
-  espsecure.py extract_public_key --keyfile secure_boot_signing_key.pem secure_boot_verification_key.pem
+  # Extract the public verification key (only needed for ecdsa_v1 external signing)
+  espsecure.py extract_public_key --keyfile secure_boot_signing_key.pem secure_boot_verification_key.bin
   ```
 
 - **nvs_encryption** (*Optional*, mapping): Encrypts the device's non-volatile storage (NVS), where ESPHome

--- a/src/content/docs/components/speaker/i2s_audio.mdx
+++ b/src/content/docs/components/speaker/i2s_audio.mdx
@@ -52,12 +52,12 @@ speaker:
 
 - **buffer_duration** (*Optional*, [Time](/guides/configuration-types#time)): The duration of the internal ring buffer. Larger values can reduce stuttering but uses more memory. Defaults to `500ms`.
 - **timeout** (*Optional*, [Time](/guides/configuration-types#time)): How long to wait after finishing playback before releasing the bus. Set to `never` to never stop the speaker due to a timeout. Defaults to `500ms`. **Note:** With `spdif_mode: true` (see below), buffer underflows are filled with silence frames until the specified interval elapses; this maintains the SPDIF signal to prevent the receiver from detecting a loss of signal/source change, which may otherwise lengthen gaps of silence.
-- **spdif_mode** (*Optional*, boolean): Enable SPDIF (Sony/Philips Digital Interface Format) mode for digital audio output. When enabled, the speaker outputs a SPDIF-encoded bitstream suitable for optical (TOSLINK) or coaxial digital audio transmission. Defaults to `false`.
+- **spdif_mode** (*Optional*, boolean): Enable S/PDIF (Sony/Philips Digital Interface) mode for digital audio output. When enabled, the speaker outputs a SPDIF-encoded bitstream format suitable for optical (TOSLINK optical fiber connector) or coaxial digital audio transmission. Defaults to `false`.
 - All other options from [Speaker Component](/components/speaker#config-speaker).
 
 ## SPDIF Mode
 
-SPDIF (Sony/Philips Digital Interface Format) mode enables digital audio transmission over optical (TOSLINK) or coaxial connections. This mode encodes PCM audio data into a SPDIF bitstream that can be received by soundbars, A/V receivers, DACs, and other digital audio equipment.
+SPDIF mode enables S/PDIF (Sony/Philips Digital Interface) digital audio transmission over optical (TOSLINK) or coaxial digital audio connections. This mode encodes PCM audio data format into a SPDIF bitstream that can be received by soundbars, A/V receivers, DACs, and other digital audio equipment.
 
 ### Hardware Setup
 

--- a/src/content/docs/components/web_server.mdx
+++ b/src/content/docs/components/web_server.mdx
@@ -15,6 +15,7 @@ import tabHeaderExpandControlsExpandedImg from './images/tab-header-expand-contr
 import tabHeaderExpandLogsExpandedImg from './images/tab-header-expand-logs-expanded.png';
 import sensorHistoryGraphImg from './images/sensor-history-graph.png';
 import APIRef from '@components/APIRef.astro';
+import EnumValues from '@components/EnumValues.astro';
 
 The `web_server` component creates a simple web server on the node that can be accessed
 through any browser and a simple [REST API](/web-api#api-rest). Please note that enabling this component
@@ -67,10 +68,21 @@ web_server:
   Contents of this file will be served as `/0.js` and used as JS script by internal webserver.
   Useful when building device without internet access, where you want to use built-in AP and webserver.
 
-- **auth** (*Optional*): Enables a simple *Digest* authentication with username and password.
+- **auth** (*Optional*): Enables HTTP authentication with a username and password.
 
   - **username** (**Required**, string): The username to use for authentication.
   - **password** (**Required**, string): The password to check for authentication.
+  - **type** (*Optional*, string): The HTTP authentication scheme. Both show the same login prompt
+    in the browser; the difference is on the network. One of:
+
+    <EnumValues values={[
+      { value: "basic",  default: true, description: "Sends the password in an easily reversible (Base64) form on every request." },
+      { value: "digest", description: "Sends only hashes, keeping the password off the network. Recommended." },
+    ]} />
+
+    The default is currently `basic` but will change to `digest` in ESPHome `2027.1.0`; set
+    `type: basic` explicitly to keep it after that release. When using `digest`, REST API clients
+    must request it too (for example, `curl --digest`); plain `basic` clients are rejected.
 
 - **include_internal** (*Optional*, boolean): Whether `internal` entities should be displayed on the
   web interface. Defaults to `false`.

--- a/src/content/docs/guides/supporters.mdx
+++ b/src/content/docs/guides/supporters.mdx
@@ -2421,4 +2421,4 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Christian Zufferey (@zuzu59)](https://github.com/zuzu59)
 - [Zynth-dev (@Zynth-dev)](https://github.com/Zynth-dev)
 
-*This page was last updated July 13, 2026.*
+*This page was last updated July 14, 2026.*


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- Clarify spdif_mode and S/PDIF format descriptions [docs#6604](https://github.com/esphome/esphome.io/pull/6604)
- [esp32] Document verification_key as ecdsa_v1-only for signed OTA [docs#6956](https://github.com/esphome/esphome.io/pull/6956)
- [web_server] Document auth type option (basic/digest) [docs#6975](https://github.com/esphome/esphome.io/pull/6975)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
