### PR TITLE
[api] Document dropped Home Assistant actions before subscription

### DIFF
--- a/src/content/docs/components/api.mdx
+++ b/src/content/docs/components/api.mdx
@@ -229,6 +229,14 @@ on_...:
 - **on_error** (*Optional*, [Automation](/automations)): Optional automation to execute when the Home Assistant action
   call fails. See [Action Response Handling](#action-response-handling).
 
+> [!NOTE]
+> Home Assistant starts listening for device actions shortly *after* the API connection is established, so actions
+> triggered right at connection time (for example from `on_client_connected` or `on_time_sync`) can fire before
+> Home Assistant is ready for them. Such actions are not delivered and ESPHome logs a warning
+> (versions before 2026.8.0 dropped them silently). The same applies to `homeassistant.event`. If you need to
+> perform an action as soon as a connection is made, add a short `delay` before it so Home Assistant has time to
+> start listening.
+
 Data structures are not possible, but you can create a script in Home Assistant and call with all
 the parameters in plain format.
 


### PR DESCRIPTION
## Description

Documents the new warning behavior for `homeassistant.action`/`homeassistant.event`: Home Assistant starts listening for device actions shortly after the API connection is established, so actions triggered right at connection time (for example from `on_client_connected` or `on_time_sync`) cannot be delivered and are dropped with a warning in the device log (previously they were dropped silently). Also suggests adding a short `delay` when an action needs to run at connection time.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#17560

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.