### PR TITLE
[deep_sleep] Document on_wake automation triggers

### DIFF
--- a/src/content/docs/components/deep_sleep.mdx
+++ b/src/content/docs/components/deep_sleep.mdx
@@ -118,7 +118,7 @@ deep_sleep:
 
 ## `on_wake` Trigger
 
-This automation runs once at boot when the device woke from deep sleep. It does not run after a cold boot,
+This automation runs once at boot when the device wakes from deep sleep. It does not run after a cold boot,
 a reset or a restart (for example after an OTA update). It is available on ESP32, ESP8266 and BK72xx.
 
 The variable `cause` of type `deep_sleep::WakeupCause` tells you what woke the device:

--- a/src/content/docs/components/deep_sleep.mdx
+++ b/src/content/docs/components/deep_sleep.mdx
@@ -156,7 +156,7 @@ deep_sleep:
   run_duration: 30s
   sleep_duration: 12h
   esp32_ext1_wakeup:
-    mode: ANY_LOW
+    mode: ANY_LOW  # ESP32‑C5/C6/C61/H2/P4/S2/S3 only
     pins:
       - pin: GPIO3
         on_wake:  # left button: previous page

--- a/src/content/docs/components/deep_sleep.mdx
+++ b/src/content/docs/components/deep_sleep.mdx
@@ -57,6 +57,8 @@ deep_sleep:
 - **wakeup_pin_mode** (*Optional*): Only on ESP32/BK72xx. Specify how to handle waking up from a `wakeup_pin` if
   the wakeup pin is already in the state with which it would wake up when attempting to enter deep sleep.
   See [Wakeup Pin Mode](#deep_sleep-esp32_wakeup_pin_mode). Defaults to `IGNORE`
+- **on_wake** (*Optional*, [Automation](/automations)): An automation to run when the device boots after waking
+  from deep sleep. Only on ESP32, ESP8266 and BK72xx. See [`on_wake` Trigger](#on_wake-trigger).
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID used for code generation.
 
 Advanced features:
@@ -64,7 +66,11 @@ Advanced features:
 - **esp32_ext1_wakeup** (*Optional*): Use the EXT1 wakeup source of the ESP32 to wake from deep sleep to
   wake up on multiple pins. This cannot be used together with wakeup pin.
 
-  - **pins** (**Required**, list of pin numbers): The pins to wake up on.
+  - **pins** (**Required**, list): The pins to wake up on. Each entry is either a
+    [Pin Schema](/guides/configuration-types#pin-schema) directly, or a mapping of:
+    - **pin** (**Required**, [Pin Schema](/guides/configuration-types#pin-schema)): The pin to wake up on.
+    - **on_wake** (*Optional*, [Automation](/automations)): An automation to run when this specific pin
+      woke the device from deep sleep. See [`on_wake` Trigger](#on_wake-trigger).
   - **mode** (**Required**): The mode to use for the wakeup source. Must be one of:
     - `ANY_LOW`: wake up when any selected pin is LOW (ESP32‑C5/C6/C61/H2/P4/S2/S3 only)
     - `ALL_LOW`: wake up when all selected pins are LOW (ESP32 only)
@@ -109,6 +115,67 @@ deep_sleep:
     - pin: P24 # will wake up when P24 goes high
       wakeup_pin_mode: INVERT_WAKEUP # flips the trigger level after each wake
 ```
+
+## `on_wake` Trigger
+
+This automation runs once at boot when the device woke from deep sleep. It does not run after a cold boot,
+a reset or a restart (for example after an OTA update). It is available on ESP32, ESP8266 and BK72xx.
+
+The variable `cause` of type `deep_sleep::WakeupCause` tells you what woke the device:
+
+- `deep_sleep::WAKEUP_CAUSE_TIMER`: The sleep timer.
+- `deep_sleep::WAKEUP_CAUSE_GPIO`: A pin (`wakeup_pin` or `esp32_ext1_wakeup`).
+- `deep_sleep::WAKEUP_CAUSE_TOUCH`: A touch pad.
+- `deep_sleep::WAKEUP_CAUSE_UNKNOWN`: The device woke from deep sleep, but the source could not be identified.
+
+On the ESP8266 the cause is always `WAKEUP_CAUSE_TIMER`, as it can only wake up through the RTC timer.
+
+```yaml
+deep_sleep:
+  # ...
+  on_wake:
+    - if:
+        condition:
+          lambda: 'return cause == deep_sleep::WAKEUP_CAUSE_TIMER;'
+        then:
+          - logger.log: Woken by the timer
+```
+
+When waking up on multiple pins with `esp32_ext1_wakeup`, an `on_wake` automation can also be attached to
+each pin. It only runs when that pin caused the wakeup. This is useful for devices with multiple buttons
+that should each do something different when they wake the device:
+
+```yaml
+globals:
+  - id: page_index
+    type: int
+    restore_value: true
+    initial_value: '0'
+
+deep_sleep:
+  run_duration: 30s
+  sleep_duration: 12h
+  esp32_ext1_wakeup:
+    mode: ANY_LOW
+    pins:
+      - pin: GPIO3
+        on_wake:  # left button: previous page
+          - lambda: 'id(page_index) -= 1;'
+      - pin: GPIO4
+        on_wake:  # right button: next page
+          - lambda: 'id(page_index) += 1;'
+      - pin: GPIO5
+        on_wake:  # green button: cycle view
+          - script.execute: cycle_view
+```
+
+`on_wake` automations run after restored [global variables](/components/globals) have been loaded and
+before `on_boot` automations with a priority below 700 (which includes the default priority of 600).
+This means an `on_wake` automation can update a global variable that an `on_boot` automation then uses.
+
+> [!NOTE]
+> With the `ALL_LOW` mode, all configured pins must be LOW to wake the device, so every pin's `on_wake`
+> automation will run.
 
 ## ESP32 Wakeup Cause
 

--- a/src/content/docs/components/deep_sleep.mdx
+++ b/src/content/docs/components/deep_sleep.mdx
@@ -128,7 +128,7 @@ The variable `cause` of type `deep_sleep::WakeupCause` tells you what woke the d
 - `deep_sleep::WAKEUP_CAUSE_TOUCH`: A touch pad.
 - `deep_sleep::WAKEUP_CAUSE_UNKNOWN`: The device woke from deep sleep, but the source could not be identified.
 
-On the ESP8266 the cause is always `WAKEUP_CAUSE_TIMER`, as it can only wake up through the RTC timer.
+On the ESP8266, the cause is always `deep_sleep::WAKEUP_CAUSE_TIMER`, as it can only wake up through the RTC timer.
 
 ```yaml
 deep_sleep:


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Documents the new `on_wake` automation triggers for the `deep_sleep` component: the component-level `on_wake` trigger (ESP32, ESP8266, BK72xx) with its `cause` variable of type `deep_sleep::WakeupCause`, the per-pin `on_wake` triggers on `esp32_ext1_wakeup` pins with a multi-button page-navigation example, the extended `esp32_ext1_wakeup.pins` schema (bare pin or `pin:` + `on_wake:` mapping), and the ordering guarantee relative to restored globals and `on_boot` automations.

**Related issue (if applicable):** fixes

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#17569

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.