### PR TITLE
[lvgl] Document pause option for round_trip animation

### DIFF
--- a/src/content/docs/components/lvgl/animation.mdx
+++ b/src/content/docs/components/lvgl/animation.mdx
@@ -119,9 +119,9 @@ reshapes the progression. A single timing may be given, or a list of them which 
 order. Each timing is one of:
 
 - **round_trip**: Plays the animation forwards over the first half of the `duration` and back to the
+  start over the second half.
   - **pause** (*Optional*, percentage): Allows inserting a pause between the first and second halves of
     the animation. A value of 50% will mean 50% of the total duration is the pause. Defaults to 0 (no pause.)
-  start over the second half. Takes no parameters.
 - **ease_in_out**: Eases the value in at the start and out at the end.
   - **weight** (*Optional*, float): How strongly the easing is applied. Defaults to `2.0`.
 - **gravity**: Accelerates the value as though under gravity, bouncing when it reaches the end.

--- a/src/content/docs/components/lvgl/animation.mdx
+++ b/src/content/docs/components/lvgl/animation.mdx
@@ -123,7 +123,7 @@ order. Each timing is one of:
   - **pause** (*Optional*, percentage): Allows inserting a pause between the first and second halves of
     the animation. A value of 50% will mean 50% of the total duration is the pause. Defaults to 0 (no pause.)
 - **ease_in_out**: Eases the value in at the start and out at the end.
-  - **weight** (*Optional*, float): How strongly the easing is applied. Defaults to `2.0`.
+  - **weight** (*Optional*, percentage): How strongly the easing is applied - range 0 to 100%. Defaults to `100%`.
 - **gravity**: Accelerates the value as though under gravity, bouncing when it reaches the end.
   - **acceleration** (*Optional*, float): The acceleration applied. Defaults to `0.5`.
   - **bounce** (*Optional*, float, `0`–`1`): The fraction of speed retained on each bounce.

--- a/src/content/docs/components/lvgl/animation.mdx
+++ b/src/content/docs/components/lvgl/animation.mdx
@@ -119,6 +119,8 @@ reshapes the progression. A single timing may be given, or a list of them which 
 order. Each timing is one of:
 
 - **round_trip**: Plays the animation forwards over the first half of the `duration` and back to the
+  - **pause** (*Optional*, percentage): Allows inserting a pause between the first and second halves of
+    the animation. A value of 50% will mean 50% of the total duration is the pause. Defaults to 0 (no pause.)
   start over the second half. Takes no parameters.
 - **ease_in_out**: Eases the value in at the start and out at the end.
   - **weight** (*Optional*, float): How strongly the easing is applied. Defaults to `2.0`.


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#17574

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
