### PR TITLE
[changelog] Remove beta notice from 2026.7.0

### DIFF
--- a/src/content/docs/changelog/2026.7.0.mdx
+++ b/src/content/docs/changelog/2026.7.0.mdx
@@ -7,9 +7,6 @@ slug: "changelog/2026.7.0"
 
 import ImgTable from "@components/ImgTable.astro";
 
-> [!NOTE]
-> This is a beta release. Details on this page may change before the stable release is published.
-
 {/* MANUAL: Add featured components here */}
 <ImgTable items={[
   ["UFM-01 Flow Meter", "/components/ufm01/", "ufm01.png", "Flow & Temperature"],


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Remove the beta release notice from the 2026.7.0 changelog now that the stable release is published.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.