### PR TITLE
[web-api] Document the new entity id format and drop name_id

### DIFF
--- a/src/content/docs/web-api/index.mdx
+++ b/src/content/docs/web-api/index.mdx
@@ -47,14 +47,15 @@ of a component. Each of these JSON payloads has the following identifier field:
 - `id`: Identifier using the format `domain/entity_name` (for example `sensor/Temperature`),
   or `domain/device_name/entity_name` for sub-device entities.
 
-Since ESPHome 2026.8.0 the `id` field uses this format and the temporary `name_id` field is
-no longer sent. Between 2026.1.3 and 2026.8.0, `name_id` carried this format while `id` still
-carried the legacy `domain-object_id` format (for example `sensor-temperature`).
+Since ESPHome 2026.8.0, the `id` field uses this format and the temporary `name_id` field is no
+longer sent. From 2026.1.3 up to 2026.8.0, `name_id` carried this format while `id` still carried
+the legacy `domain-object_id` format (for example `sensor-temperature`). Before 2026.1.3, only the
+legacy format was available.
 
-Third-party integrations that support both old and new firmware should read `name_id` and fall
-back to `id`, which selects the new format on either version. An identifier is in the new format
-when it contains a `/`. Integrations that require the legacy format must build it themselves
-(similar to `aioesphomeapi`).
+Third-party integrations that also support firmware from the 2026.1.3 up to 2026.8.0 window should
+read `name_id` and fall back to `id`, which gives the new format on both those versions and the
+legacy format on older firmware. An identifier is in the new format when it contains a `/`.
+Integrations that require the legacy format must build it themselves (similar to `aioesphomeapi`).
 
 The `state` field contains a simple text-based representation of the state of the underlying
 component, for example ON/OFF or 21.4 °C. Several components also have additional fields in

--- a/src/content/docs/web-api/index.mdx
+++ b/src/content/docs/web-api/index.mdx
@@ -42,21 +42,19 @@ Currently, there are three types of events sent: `ping`, `state` and `log`. The 
 is repeatedly sent out to keep the connection alive. `log` events are sent every time a log
 message is triggered and is used to show the debug log on the index page. `state` is where
 the real magic happens. All events with this type have a JSON payload that describes the state
-of a component. Each of these JSON payloads has the following identifier fields:
+of a component. Each of these JSON payloads has the following identifier field:
 
-- `name_id`: **Temporary field (removed in 2026.8.0)** providing the new identifier format
-  `domain/entity_name` (for example `sensor/Temperature`) or `domain/device_name/entity_name`
-  for sub-device entities.
-- `id`: Legacy identifier using the format `domain-object_id` (for example `sensor-temperature`).
-  Provided for backward compatibility. In 2026.8.0, this field switches to the new format
-  (matching `name_id`) and `name_id` is removed.
+- `id`: Identifier using the format `domain/entity_name` (for example `sensor/Temperature`),
+  or `domain/device_name/entity_name` for sub-device entities.
 
-Third-party integrations **MUST** prefer `name_id` over `id` to get the new ID format,
-falling back to `id` for compatibility with older firmware and for when `name_id` is
-removed. The `id` field will switch to the new format (matching `name_id`) in ESPHome
-2026.8.0, at which point `name_id` will be removed. Third-party integrations that require
-the legacy format after 2026.8.0 must implement their own conversion logic (similar to
-`aioesphomeapi`).
+Since ESPHome 2026.8.0 the `id` field uses this format and the temporary `name_id` field is
+no longer sent. Between 2026.1.3 and 2026.8.0, `name_id` carried this format while `id` still
+carried the legacy `domain-object_id` format (for example `sensor-temperature`).
+
+Third-party integrations that support both old and new firmware should read `name_id` and fall
+back to `id`, which selects the new format on either version. An identifier is in the new format
+when it contains a `/`. Integrations that require the legacy format must build it themselves
+(similar to `aioesphomeapi`).
 
 The `state` field contains a simple text-based representation of the state of the underlying
 component, for example ON/OFF or 21.4 °C. Several components also have additional fields in
@@ -72,10 +70,8 @@ this payload, for example lights have a `brightness` attribute.
 Additionally, each time a client connects to the event source the server sends out all current
 states so that the client can catch up with reality.
 
-The payloads of these state events are similar to the REST API GET calls, except SSE includes
-both `name_id` and `id` fields during the deprecation period (until 2026.8.0), while REST
-responses only include `id` in the new format. I would recommend just opening the network
-debug panel of your web browser to see what's sent.
+The payloads of these state events are similar to the REST API GET calls. I would recommend just
+opening the network debug panel of your web browser to see what's sent.
 
 <span id="api-rest"></span>
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Documents the entity id format switch shipping in 2026.8.0; the `id` field in the web server JSON now carries `domain/entity_name` and the temporary `name_id` field is no longer sent.

The identifier section now describes `id` as the single identifier field, with a short note on what firmware between 2026.1.3 and 2026.8.0 sends so integrations supporting both versions still have the guidance they need; reading `name_id` and falling back to `id` picks the new format on either version. Also drops the sentence claiming SSE and REST differ in which id fields they include, since they share the same payload builder and no longer differ.

The 2026.1.0 changelog entry is left alone; it is a record of what that release shipped.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#17586

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.
