### PR TITLE
[lvgl] Document `lvgl.theme.update:` action

### DIFF
--- a/src/content/docs/components/lvgl/index.mdx
+++ b/src/content/docs/components/lvgl/index.mdx
@@ -606,6 +606,11 @@ implement dynamic themes, e.g. light/dark mode, or to change the appearance of w
 
 The action takes a style ID and a dictionary of properties to update. The properties can be any of the style properties listed above, and can be constants or lambdas.
 
+> [!NOTE]
+> Updating a style doesn't automatically redraw the widgets using it. Follow up with the
+> [`lvgl.widget.redraw`](/components/lvgl/widgets#lvgl-redraw-action) action (omit its `id` to redraw the whole screen) so the
+> change actually becomes visible.
+
 ```yaml
 # Example configuration entry
 lvgl:
@@ -622,6 +627,48 @@ on_...:
       id: my_style
       bg_color: 0xFF0000
       border_color: 0x00FF00
+  - lvgl.widget.redraw: # redraw the whole screen so the change becomes visible
+```
+
+### `lvgl.theme.update` Action
+
+This [action](/automations/actions#actions-action) allows changing/updating, at run time, the styles applied to all widgets of a
+given type by the [`theme:`](#lvgl-theme) configuration. This can be used, for example, to switch the accent color used by every
+`button` widget in response to a user action, without having to update each widget individually.
+
+The action takes a dictionary shaped just like `theme:` — keyed by widget type, optionally nested by
+[part and state](/components/lvgl/widgets#lvgl-widgetproperty-state) — mapping to the style properties to apply.
+
+You don't need to declare a widget type under `theme:` before targeting it with this action: if a widget type (or a specific
+part/state under it) was never mentioned under `theme:` at all, it's created automatically the first time it's referenced,
+either by `theme:` itself or by an `lvgl.theme.update` action anywhere in your configuration, and gets applied to every widget
+of that type. Since the action's own properties are only applied when it runs, a widget type introduced this way has no visual
+effect until the action fires for the first time.
+
+> [!NOTE]
+> Updating a theme style doesn't automatically redraw the widgets using it. Follow up with the
+> [`lvgl.widget.redraw`](/components/lvgl/widgets#lvgl-redraw-action) action (omit its `id` to redraw the whole screen) so the
+> change actually becomes visible.
+
+```yaml
+# Example configuration entry
+lvgl:
+  ...
+  theme:
+    button:
+      border_width: 2
+
+# Action to update the theme
+on_...:
+  - lvgl.theme.update:
+      button:
+        border_width: 4
+        pressed:
+          border_color: 0xFF0000
+      # `label` was never declared under `theme:` above, so this creates it
+      label:
+        text_color: 0x0000FF
+  - lvgl.widget.redraw: # redraw the whole screen so the change becomes visible
 ```
 
 ### `lvgl.pause` Action

--- a/src/content/docs/components/lvgl/index.mdx
+++ b/src/content/docs/components/lvgl/index.mdx
@@ -604,12 +604,7 @@ Several actions are available for the LVGL component itself, these are outlined 
 This [action](/automations/actions#actions-action) allows changing/updating the properties of a style at run time. This can be used to
 implement dynamic themes, e.g. light/dark mode, or to change the appearance of widgets based on user interaction.
 
-The action takes a style ID and a dictionary of properties to update. The properties can be any of the style properties listed above, and can be constants or lambdas.
-
-> [!NOTE]
-> Updating a style doesn't automatically redraw the widgets using it. Follow up with the
-> [`lvgl.widget.redraw`](/components/lvgl/widgets#lvgl-redraw-action) action (omit its `id` to redraw the whole screen) so the
-> change actually becomes visible.
+The action takes a style ID and a dictionary of properties to update. The properties can be any of the style properties listed above, and can be constants or lambdas. Every widget using the style is automatically refreshed and redrawn, so there's no need to follow up with a separate redraw action.
 
 ```yaml
 # Example configuration entry
@@ -627,7 +622,6 @@ on_...:
       id: my_style
       bg_color: 0xFF0000
       border_color: 0x00FF00
-  - lvgl.widget.redraw: # redraw the whole screen so the change becomes visible
 ```
 
 ### `lvgl.theme.update` Action
@@ -643,12 +637,8 @@ You don't need to declare a widget type under `theme:` before targeting it with 
 part/state under it) was never mentioned under `theme:` at all, it's created automatically the first time it's referenced,
 either by `theme:` itself or by an `lvgl.theme.update` action anywhere in your configuration, and gets applied to every widget
 of that type. Since the action's own properties are only applied when it runs, a widget type introduced this way has no visual
-effect until the action fires for the first time.
-
-> [!NOTE]
-> Updating a theme style doesn't automatically redraw the widgets using it. Follow up with the
-> [`lvgl.widget.redraw`](/components/lvgl/widgets#lvgl-redraw-action) action (omit its `id` to redraw the whole screen) so the
-> change actually becomes visible.
+effect until the action fires for the first time. Every widget using an updated style is automatically refreshed and redrawn,
+so there's no need to follow up with a separate redraw action.
 
 ```yaml
 # Example configuration entry
@@ -668,7 +658,6 @@ on_...:
       # `label` was never declared under `theme:` above, so this creates it
       label:
         text_color: 0x0000FF
-  - lvgl.widget.redraw: # redraw the whole screen so the change becomes visible
 ```
 
 ### `lvgl.pause` Action


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#17678
## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
