### PR TITLE
[pd_pioneer_ir] Document Pioneer mini-split IR climate component

### DIFF
--- a/src/content/docs/components/climate/climate_ir.mdx
+++ b/src/content/docs/components/climate/climate_ir.mdx
@@ -30,6 +30,7 @@ submit a feature request (see FAQ).
 | [LG](#climate_ir_lg) | `climate_ir_lg`                    | yes |
 | [Midea](#midea_ir) | `midea_ir`                         | yes |
 | [Mitsubishi](#mitsubishi) | `mitsubishi`                       | yes |
+| [Pioneer mini-split (Parker Davis)](#pd_pioneer_ir) | `pd_pioneer_ir`                    | yes |
 | Noblex | `noblex`                           | yes |
 | Electrolux, TCL, Fuego | `tcl112`                           | yes |
 | [Toshiba](#toshiba) | `toshiba`                          | yes |
@@ -186,6 +187,44 @@ climate:
 > [!NOTE]
 > - See [Transmit Midea](/components/remote_transmitter#remote_transmitter-transmit_midea) to send custom commands, including Follow Me mode.
 > - See [Toshiba](#toshiba) below if you are looking for compatibility with Midea model MAP14HS1TBL or similar.
+
+### `pd_pioneer_ir`
+
+This platform controls Pioneer mini-split air conditioners that use the PD Pioneer infrared protocol.
+These units are manufactured by Parker Davis (the "PD" in the protocol name). It has been tested with
+the ESPIR1 IR adapter module. Other Pioneer mini-split models that use the same protocol may also work.
+
+Supported modes are Off, Cool, Heat, Dry, and Fan Only. Fan speeds Auto, Low, Medium, and High are supported.
+Swing modes Off, Vertical, and Horizontal are supported. The ECO preset is supported.
+
+- **use_fahrenheit** (*Optional*, boolean): When enabled, the target temperature is sent in half-degree
+  Fahrenheit steps and the unit display shows Fahrenheit. When disabled, whole-degree Celsius is used.
+  Defaults to `false`.
+
+```yaml
+# Example configuration entry
+remote_transmitter:
+  pin: GPIO4
+  carrier_duty_percent: 50%
+  id: ir_tx
+
+remote_receiver:
+  pin:
+    number: GPIO14
+    inverted: true
+  id: ir_rx
+
+climate:
+  - platform: pd_pioneer_ir
+    name: "Pioneer AC"
+    transmitter_id: ir_tx
+    receiver_id: ir_rx
+    use_fahrenheit: true
+```
+
+> [!NOTE]
+> See [Transmit PD Pioneer](/components/remote_transmitter#remote_transmitter-transmit_pd_pioneer) to send
+> custom raw frames for debugging or advanced use.
 
 ### `mitsubishi`
 
@@ -375,6 +414,7 @@ Additional configuration must be specified for this platform:
 - <APIRef text="hitachi_ac344.h" path="hitachi_ac344/hitachi_ac344.h" />
 - <APIRef text="midea_ir.h" path="midea_ir/midea_ir.h" />
 - <APIRef text="mitsubishi.h" path="mitsubishi/mitsubishi.h" />
+- <APIRef text="pd_pioneer_ir.h" path="pd_pioneer_ir/pd_pioneer_ir.h" />
 - <APIRef text="tcl112.h" path="tcl112/tcl112.h" />
 - <APIRef text="toshiba.h" path="toshiba/toshiba.h" />
 - <APIRef text="whirlpool.h" path="whirlpool/whirlpool.h" />

--- a/src/content/docs/components/remote_receiver.mdx
+++ b/src/content/docs/components/remote_receiver.mdx
@@ -57,6 +57,7 @@ Multiple remote receivers can be configured as a list of dict definitions within
   - **nec**: Decode and dump NEC infrared codes.
   - **nexa**: Decode and dump Nexa (RF) codes.
   - **panasonic**: Decode and dump Panasonic infrared codes.
+  - **pd_pioneer**: Decode and dump PD Pioneer mini-split infrared codes.
   - **pioneer**: Decode and dump Pioneer infrared codes.
   - **pronto**: Print remote code in Pronto form. Useful for using arbitrary protocols.
   - **raw**: Print all remote codes in their raw form. Also useful for using arbitrary protocols.
@@ -240,6 +241,10 @@ To enable signal demodulation, configure the signal carrier frequency and duty c
 
 - **on_panasonic** (*Optional*, [Automation](/automations)): An automation to perform when a
   Panasonic remote code has been decoded. A variable `x` of type <APIStruct text="remote_base::PanasonicData" path="remote_base::PanasonicData" />
+  is passed to the automation for use in lambdas.
+
+- **on_pd_pioneer** (*Optional*, [Automation](/automations)): An automation to perform when a
+  PD Pioneer mini-split remote code has been decoded. A variable `x` of type <APIStruct text="remote_base::PDPioneerData" path="remote_base::PDPioneerData" />
   is passed to the automation for use in lambdas.
 
 - **on_pioneer** (*Optional*, [Automation](/automations)): An automation to perform when a
@@ -503,6 +508,12 @@ Remote code selection (exactly one of these has to be included):
 
   - **address** (**Required**, int): The address to trigger on, see dumper output for more info.
   - **command** (**Required**, int): The command.
+
+- **pd_pioneer**: Trigger on a decoded PD Pioneer mini-split remote code with the given data.
+
+  - **code** (**Required**, 13- or 14-byte list): The code to listen for, see
+    [transmitter description](/components/remote_transmitter#remote_transmitter-transmit_pd_pioneer) for more info.
+    Usually you only need to copy this directly from the dumper output.
 
 - **pioneer**: Trigger on a decoded Pioneer remote code with the given data.
 

--- a/src/content/docs/components/remote_transmitter.mdx
+++ b/src/content/docs/components/remote_transmitter.mdx
@@ -662,6 +662,26 @@ on_...:
 - **command** (**Required**, int, [templatable](/automations/templates)): The command to send.
 - All other options from [Remote Transmitter Actions](#remote_transmitter-transmit_action).
 
+<span id="remote_transmitter-transmit_pd_pioneer"></span>
+
+### `remote_transmitter.transmit_pd_pioneer` Action
+
+This [action](/automations/actions#all-actions) sends a PD Pioneer mini-split infrared code to a remote transmitter.
+The checksum byte is added automatically when 13 data bytes are provided.
+
+```yaml
+on_...:
+  - remote_transmitter.transmit_pd_pioneer:
+      code: [0xA1, 0xC0, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]
+```
+
+#### Configuration variables
+
+- **code** (**Required**, list, [templatable](/automations/templates)): The 13- or 14-byte PD Pioneer code to send as a
+  list of hex or integers. See dumper output for more info.
+
+- All other options from [Remote Transmitter Actions](#remote_transmitter-transmit_action).
+
 <span id="remote_transmitter-transmit_pioneer"></span>
 
 ### `remote_transmitter.transmit_pioneer` Action


### PR DESCRIPTION
## Description

Documents the new `pd_pioneer_ir` climate platform for Pioneer mini-split air conditioners (manufactured by Parker Davis — the "PD" in the protocol name), tested with the ESPIR1 IR adapter.

Changes across three component pages:

- **IR Remote Climate** (`climate_ir.mdx`): supported-units table entry, a full `pd_pioneer_ir` section (supported modes/fan/swing/ECO, `use_fahrenheit` option, example config), and an API reference link.
- **Remote Receiver** (`remote_receiver.mdx`): `pd_pioneer` dumper entry, `on_pd_pioneer` trigger, and binary-sensor/trigger code entry.
- **Remote Transmitter** (`remote_transmitter.mdx`): `transmit_pd_pioneer` action with example and config variable.

## Related code PR

- esphome/esphome#17680