### PR TITLE
Add ESP-VOCAT display information to documentation

### DIFF
--- a/src/content/docs/components/display/mipi_spi.mdx
+++ b/src/content/docs/components/display/mipi_spi.mdx
@@ -75,6 +75,7 @@ the pins used to interface to the display to be specified.
 | ESP32-2432S028                       | Sunton       | 2.8" CYD. Original micro-USB version with ILI9341 controller.                                                                      |
 | ESP32-2432S028-7789                  | Sunton       | Dual-USB version with ST7789V.                                                                                                     |
 | ESP32-2432S028-9342                  | Sunton       | Dual-USB version with ILI9342.                                                                                                     |
+| ESP-VOCAT                            | Espressif    | 1.43" 360×360 round QSPI display with ST77916 controller. [https://github.com/espressif/esp-vocat](https://github.com/espressif/esp-vocat) |
 | GEEKMAGIC-SMALLTV                    | GeekMagic    | [https://geekmagic.com/products/geekmagic-ultra-4](https://geekmagic.com/products/geekmagic-ultra-4)                               |
 | GEEKMAGIC-SMALLTV-PRO                | GeekMagic    | [https://geekmagic.com/products/geekmagic-ultra](https://geekmagic.com/products/geekmagic-ultra)                                   |
 | JC3248W535                           | Guition      | [https://www.aliexpress.com/item/1005007566332450.html](https://www.aliexpress.com/item/1005007566332450.html)                     |


### PR DESCRIPTION
## Description

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#17679

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.