### PR TITLE
[deep_sleep] Document interaction with OTA bootloader rollback

### DIFF
--- a/src/content/docs/components/deep_sleep.mdx
+++ b/src/content/docs/components/deep_sleep.mdx
@@ -319,7 +319,7 @@ bootloader reverts it instead.
 > [!WARNING]
 > On versions before 2026.8.0, a device that enters deep sleep before `boot_is_good_after` (default 1 minute) elapses
 > never confirms the new firmware, so the bootloader rolls back **every** OTA update on the next wake — the update
-> silently un-installs itself. On these versions, use one of the following workarounds:
+> silently uninstalls itself. On these versions, use one of the following workarounds:
 >
 > - Set `boot_is_good_after` in the [safe_mode](/components/safe_mode) configuration to a value shorter than the
 >   device's awake time, e.g. `boot_is_good_after: 10s`.

--- a/src/content/docs/components/deep_sleep.mdx
+++ b/src/content/docs/components/deep_sleep.mdx
@@ -296,6 +296,38 @@ on_...:
     - deep_sleep.allow: deep_sleep_1
 ```
 
+## Deep Sleep and OTA Rollback
+
+On platforms with bootloader OTA rollback support enabled — the default on ESP32 with the `esp-idf` framework and on
+nRF52, see `enable_ota_rollback` for [ESP32](/components/esp32#advanced-configuration) and
+[nRF52](/components/nrf52#advanced-configuration) — firmware installed by an OTA update must be confirmed as working,
+otherwise the bootloader reverts to the previous version on the next reset. The [safe_mode](/components/safe_mode)
+component confirms the new firmware once it considers the boot successful.
+
+Since ESPHome 2026.8.0, entering deep sleep counts as a successful boot: the firmware is confirmed automatically just
+before the device goes to sleep. No configuration is needed, and a device that crashes before the firmware is
+confirmed still rolls back, as intended.
+
+If you want stricter rollback semantics, set `boot_is_good_on_shutdown: false` in the
+[safe_mode](/components/safe_mode) configuration. Then only `boot_is_good_after` elapsing or the
+`safe_mode.mark_successful` action confirms the firmware — an update that goes back to sleep before proving itself
+healthy is rolled back on the next wake. For example, new firmware with a bug that enters deep sleep before Wi-Fi or
+OTA ever comes up would be confirmed by that first sleep with the default behavior; with the option disabled and
+`safe_mode.mark_successful` placed after the device's real work (e.g. after a successful sensor publish), the
+bootloader reverts it instead.
+
+> [!WARNING]
+> On versions before 2026.8.0, a device that enters deep sleep before `boot_is_good_after` (default 1 minute) elapses
+> never confirms the new firmware, so the bootloader rolls back **every** OTA update on the next wake — the update
+> silently un-installs itself. On these versions, use one of the following workarounds:
+>
+> - Set `boot_is_good_after` in the [safe_mode](/components/safe_mode) configuration to a value shorter than the
+>   device's awake time, e.g. `boot_is_good_after: 10s`.
+> - Run the [`safe_mode.mark_successful`](/components/safe_mode#safe_mode-mark_successful-action) action (available
+>   since ESPHome 2026.3.0) before entering deep sleep, for example in `on_boot`.
+> - Disable rollback entirely with `enable_ota_rollback: false` under `esp32: framework: advanced:`
+>   (or `nrf52: framework: advanced:`).
+
 ## See Also
 
 - [Shutdown Switch](/components/switch/shutdown/)

--- a/src/content/docs/components/esp32.mdx
+++ b/src/content/docs/components/esp32.mdx
@@ -507,8 +507,10 @@ esp32:
 - **enable_ota_rollback** (*Optional*, boolean): Enable OTA rollback support. When enabled, the bootloader will
   automatically roll back to the previous firmware if the device crashes or resets before the boot is marked as
   successful. This works in conjunction with the [safe_mode](/components/safe_mode) component - after the
-  `boot_is_good_after` time (default 60s), the firmware is marked as valid. If the device crashes before that,
-  it will roll back to the previous working firmware. Defaults to `true`.
+  `boot_is_good_after` time (default 60s), the firmware is marked as valid. Since ESPHome 2026.8.0, an orderly
+  shutdown — entering [deep sleep](/components/deep_sleep#deep-sleep-and-ota-rollback), a restart or a shutdown —
+  also counts as a successful boot and marks the firmware as valid. If the device crashes before the firmware is
+  marked as valid, it will roll back to the previous working firmware. Defaults to `true`.
 
   > [!NOTE]
   > OTA rollback requires the bootloader to be compiled with rollback support. Existing devices may need to be

--- a/src/content/docs/components/nrf52.mdx
+++ b/src/content/docs/components/nrf52.mdx
@@ -235,8 +235,10 @@ nrf52:
 - **enable_ota_rollback** (*Optional*, boolean): Enable OTA rollback support. When enabled, the bootloader will
   automatically roll back to the previous firmware if the device crashes or resets before the boot is marked as
   successful. This works in conjunction with the [safe_mode](/components/safe_mode) component - after the
-  `boot_is_good_after` time (default 60s), the firmware is marked as valid. If the device crashes before that,
-  it will roll back to the previous working firmware. Defaults to `true`.
+  `boot_is_good_after` time (default 60s), the firmware is marked as valid. Since ESPHome 2026.8.0, an orderly
+  shutdown — entering [deep sleep](/components/deep_sleep#deep-sleep-and-ota-rollback), a restart or a shutdown —
+  also counts as a successful boot and marks the firmware as valid. If the device crashes before the firmware is
+  marked as valid, it will roll back to the previous working firmware. Defaults to `true`.
 
 ## See Also
 

--- a/src/content/docs/components/safe_mode.mdx
+++ b/src/content/docs/components/safe_mode.mdx
@@ -28,6 +28,13 @@ safe_mode:
 - **boot_is_good_after** (*Optional*, [Time](/guides/configuration-types#time)): The amount of time after which the boot is considered successful.
    Defaults to `1min`.
 
+- **boot_is_good_on_shutdown** (*Optional*, boolean): Whether an orderly shutdown (entering deep sleep, a restart or
+   a shutdown) counts as a successful boot. When enabled, shutting down cleanly also confirms the running firmware
+   on platforms with OTA bootloader rollback support, so the bootloader does not roll back a fresh OTA update. Set
+   to `false` for strict rollback semantics: only `boot_is_good_after` elapsing or the
+   [`safe_mode.mark_successful`](#safe_mode-mark_successful-action) action confirm the firmware, so an update that
+   goes back to sleep before proving itself healthy is still rolled back on the next wake. Defaults to `true`.
+
 - **num_attempts** (*Optional*, int): The number of failed boot attempts which must occur before invoking safe mode.
    Defaults to `10`.
 
@@ -68,6 +75,18 @@ on_...:
   then:
     - safe_mode.mark_successful
 ```
+
+On platforms with OTA bootloader rollback support enabled (see `enable_ota_rollback` for
+[ESP32](/components/esp32#advanced-configuration) and [nRF52](/components/nrf52#advanced-configuration)), marking the
+boot as successful also confirms the currently running firmware, so the bootloader does not roll back to the previous
+version after an OTA update.
+
+> [!NOTE]
+> Since ESPHome 2026.8.0, an orderly shutdown — entering deep sleep, a restart or a shutdown — automatically marks
+> the boot as successful and confirms the firmware, so devices that sleep before `boot_is_good_after` elapses no
+> longer need to run this action to keep OTA updates from being rolled back. This can be disabled with the
+> `boot_is_good_on_shutdown` option, in which case only `boot_is_good_after` elapsing or this action confirm the
+> firmware. See [Deep Sleep and OTA Rollback](/components/deep_sleep#deep-sleep-and-ota-rollback) for details.
 
 ## Rebooting to the recovery app on ESP32
 

--- a/src/content/docs/components/safe_mode.mdx
+++ b/src/content/docs/components/safe_mode.mdx
@@ -32,7 +32,7 @@ safe_mode:
    a shutdown) counts as a successful boot. When enabled, shutting down cleanly also confirms the running firmware
    on platforms with OTA bootloader rollback support, so the bootloader does not roll back a fresh OTA update. Set
    to `false` for strict rollback semantics: only `boot_is_good_after` elapsing or the
-   [`safe_mode.mark_successful`](#safe_mode-mark_successful-action) action confirm the firmware, so an update that
+   [`safe_mode.mark_successful`](#safe_mode-mark_successful-action) action confirms the firmware, so an update that
    goes back to sleep before proving itself healthy is still rolled back on the next wake. Defaults to `true`.
 
 - **num_attempts** (*Optional*, int): The number of failed boot attempts which must occur before invoking safe mode.
@@ -85,7 +85,7 @@ version after an OTA update.
 > Since ESPHome 2026.8.0, an orderly shutdown — entering deep sleep, a restart or a shutdown — automatically marks
 > the boot as successful and confirms the firmware, so devices that sleep before `boot_is_good_after` elapses no
 > longer need to run this action to keep OTA updates from being rolled back. This can be disabled with the
-> `boot_is_good_on_shutdown` option, in which case only `boot_is_good_after` elapsing or this action confirm the
+> `boot_is_good_on_shutdown` option, in which case only `boot_is_good_after` elapsing or this action confirms the
 > firmware. See [Deep Sleep and OTA Rollback](/components/deep_sleep#deep-sleep-and-ota-rollback) for details.
 
 ## Rebooting to the recovery app on ESP32


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Documents the interaction between deep sleep and OTA bootloader rollback. On platforms with rollback support enabled (the default on ESP32 with ESP-IDF and on nRF52), a battery-powered device that entered deep sleep before `boot_is_good_after` elapsed never confirmed a freshly OTA-flashed image, so the bootloader rolled back every OTA update on the next wake. Since ESPHome 2026.8.0 an orderly shutdown (entering deep sleep, restart, shutdown) confirms the running firmware automatically.

- `deep_sleep`: new "Deep Sleep and OTA Rollback" section covering the behavior, the pre-2026.8.0 footgun and its workarounds, and the `boot_is_good_on_shutdown: false` strict-mode opt-out.
- `safe_mode`: documents the new `boot_is_good_on_shutdown` option and notes that `safe_mode.mark_successful` also confirms the firmware image on rollback-enabled platforms.
- `esp32`/`nrf52`: `enable_ota_rollback` descriptions updated to mention that orderly shutdown counts as a successful boot since 2026.8.0.

**Related issue (if applicable):** fixes

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#17699

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.