### PR TITLE
[sgp4x] Rename voc/nox config keys to voc_index/nox_index

### DIFF
--- a/src/content/docs/components/sensor/sgp4x.mdx
+++ b/src/content/docs/components/sensor/sgp4x.mdx
@@ -25,15 +25,21 @@ The [I²C Bus](/components/i2c) is required to be set up in your configuration f
 # Example configuration entry
 sensor:
   - platform: sgp4x
-    voc:
+    voc_index:
       name: "VOC Index"
-    nox:
+    nox_index:
       name: "NOx Index"
 ```
 
+> [!NOTE]
+> The `voc` and `nox` keys were renamed to `voc_index` and `nox_index`, since
+> these sensors report Sensirion's unitless Gas Index rather than a
+> concentration. The old keys still work but are deprecated and will be removed
+> in ESPHome 2027.2.0.
+
 ## Configuration variables
 
-- **voc** (*Optional*): VOC Index
+- **voc_index** (*Optional*): VOC Index
 
   - **algorithm_tuning** (*Optional*): The VOC algorithm can be customized by tuning 6 different parameters. For more details see [Engineering Guidelines for SEN5x](https://sensirion.com/media/documents/25AB572C/62B463AA/Sensirion_Engineering_Guidelines_SEN5x.pdf)
 
@@ -46,7 +52,7 @@ sensor:
 
   - All other options from [Sensor](/components/sensor).
 
-- **nox** (*Optional*): NOx Index. Only available with SGP41. If a SGP40 sensor is detected this sensor will be ignored
+- **nox_index** (*Optional*): NOx Index. Only available with SGP41. If a SGP40 sensor is detected this sensor will be ignored
 
   - **algorithm_tuning** (*Optional*): The NOx algorithm can be customized by tuning 5 different parameters.For more details see [Engineering Guidelines for SEN5x](https://sensirion.com/media/documents/25AB572C/62B463AA/Sensirion_Engineering_Guidelines_SEN5x.pdf)
 
@@ -76,9 +82,9 @@ sensor:
 # Example configuration entry
 sensor:
 - platform: sgp4x
-  voc:
+  voc_index:
     name: "VOC Index"
-  nox:
+  nox_index:
     name: "NOx Index"
   compensation:
     humidity_source: dht1_hum


### PR DESCRIPTION
## Description

Renames the `voc` / `nox` sensor keys to `voc_index` / `nox_index` in the sgp4x docs, and adds a deprecation note. These sensors report Sensirion's unitless Gas Index (1-500, baseline 100), not a concentration. The old keys still work but are deprecated and will be removed in ESPHome 2027.2.0.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#17723

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.
- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.
