### PR TITLE
[sen5x] Rename voc/nox config keys to voc_index/nox_index

### DIFF
--- a/src/content/docs/components/sensor/sen5x.mdx
+++ b/src/content/docs/components/sensor/sen5x.mdx
@@ -37,11 +37,17 @@ sensor:
       name: Temperature
     humidity:
       name: Humidity
-    voc:
-      name: VOC
-    nox:
-      name: NOX
+    voc_index:
+      name: VOC Index
+    nox_index:
+      name: NOx Index
 ```
+
+> [!NOTE]
+> The `voc` and `nox` keys were renamed to `voc_index` and `nox_index`, since
+> these sensors report Sensirion's unitless Gas Index rather than a
+> concentration. The old keys still work but are deprecated and will be removed
+> in ESPHome 2027.2.0.
 
 ## Configuration variables
 
@@ -77,7 +83,7 @@ sensor:
 
   - All options from [Sensor](/components/sensor).
 
-- **voc** (*Optional*): VOC Index. Note only available with Sen54 or Sen55. The sensor will be ignored on
+- **voc_index** (*Optional*): VOC Index. Note only available with Sen54 or Sen55. The sensor will be ignored on
   unsupported models.
 
   - **algorithm_tuning** (*Optional*): The VOC algorithm can be customized by tuning 6 different parameters.
@@ -102,7 +108,7 @@ sensor:
 
   - All other options from [Sensor](/components/sensor).
 
-- **nox** (*Optional*): NOx Index. Note: Only available with Sen55. The sensor will be ignored on unsupported models.
+- **nox_index** (*Optional*): NOx Index. Note: Only available with Sen55. The sensor will be ignored on unsupported models.
 
   - **algorithm_tuning** (*Optional*): The NOx algorithm can be customized by tuning 5 different parameters.
     For more details see [Engineering Guidelines for SEN5x](https://sensirion.com/media/documents/25AB572C/62B463AA/Sensirion_Engineering_Guidelines_SEN5x.pdf)


### PR DESCRIPTION
## Description

Renames the `voc` / `nox` sensor keys to `voc_index` / `nox_index` in the sen5x docs, and adds a deprecation note. These sensors report Sensirion's unitless Gas Index (1-500, baseline 100), not a concentration. The old keys still work but are deprecated and will be removed in ESPHome 2027.2.0.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#17724

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.
- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.
