### PR TITLE
[sen6x] Rename voc/nox config keys to voc_index/nox_index

### DIFF
--- a/src/content/docs/components/sensor/sen6x.mdx
+++ b/src/content/docs/components/sensor/sen6x.mdx
@@ -45,15 +45,21 @@ sensor:
       name: Temperature
     humidity:
       name: Humidity
-    voc:
-      name: VOC
-    nox:
-      name: NOx
+    voc_index:
+      name: VOC Index
+    nox_index:
+      name: NOx Index
     co2:
       name: Carbon Dioxide
     formaldehyde:
       name: Formaldehyde
 ```
+
+> [!NOTE]
+> The `voc` and `nox` keys were renamed to `voc_index` and `nox_index`, since
+> these sensors report Sensirion's unitless Gas Index rather than a
+> concentration. The old keys still work but are deprecated and will be removed
+> in ESPHome 2027.2.0.
 
 ## Configuration variables
 
@@ -95,12 +101,12 @@ sensor:
 
   - All options from [Sensor](/components/sensor).
 
-- **voc** (*Optional*): VOC Index. Note: only available with SEN65, SEN66, SEN68 or SEN69C. The sensor will be
+- **voc_index** (*Optional*): VOC Index. Note: only available with SEN65, SEN66, SEN68 or SEN69C. The sensor will be
   ignored on unsupported models.
 
   - All options from [Sensor](/components/sensor).
 
-- **nox** (*Optional*): NOx Index. Note: only available with SEN65, SEN66, SEN68 or SEN69C. The sensor will be
+- **nox_index** (*Optional*): NOx Index. Note: only available with SEN65, SEN66, SEN68 or SEN69C. The sensor will be
   ignored on unsupported models.
 
   - All options from [Sensor](/components/sensor).


### PR DESCRIPTION
## Description

Renames the `voc` / `nox` sensor keys to `voc_index` / `nox_index` in the sen6x docs, and adds a deprecation note. These sensors report Sensirion's unitless Gas Index (1-500, baseline 100), not a concentration. The old keys still work but are deprecated and will be removed in ESPHome 2027.2.0.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#17725

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.
- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.
