### PR TITLE
2026.7.1

### DIFF
--- a/data/version.yaml
+++ b/data/version.yaml
@@ -1,2 +1,2 @@
-release: 2026.7.0
+release: 2026.7.1
 version: '2026.7'

--- a/src/content/docs/changelog/2026.7.0.mdx
+++ b/src/content/docs/changelog/2026.7.0.mdx
@@ -814,6 +814,7 @@ For detailed migration guides and API documentation, see the
 - [nrf52] Set ZEPHYR_SDK_INSTALL_DIR for Zephyr SDK discovery [esphome#17633](https://github.com/esphome/esphome/pull/17633) by [@jesserockz](https://github.com/jesserockz)
 - Bump bundled esphome-device-builder to 1.6.2 [esphome#17640](https://github.com/esphome/esphome/pull/17640) by [@esphome[bot]](https://github.com/apps/esphome)
 - Bump aioesphomeapi from 45.6.0 to 45.6.1 [esphome#17653](https://github.com/esphome/esphome/pull/17653) by [@dependabot[bot]](https://github.com/apps/dependabot)
+- Bump aioesphomeapi from 45.6.1 to 45.6.2 [esphome#17654](https://github.com/esphome/esphome/pull/17654) by [@dependabot[bot]](https://github.com/apps/dependabot)
 - Bump bundled esphome-device-builder to 1.6.3 [esphome#17651](https://github.com/esphome/esphome/pull/17651) by [@esphome[bot]](https://github.com/apps/esphome)
 - [espidf] Suggest installing missing system libraries when the tools install fails [esphome#17619](https://github.com/esphome/esphome/pull/17619) by [@swoboda1337](https://github.com/swoboda1337)
 - [core] Fix srcFilter exclusions being silently ignored on Windows [esphome#17648](https://github.com/esphome/esphome/pull/17648) by [@bharvey88](https://github.com/bharvey88)

--- a/src/content/docs/changelog/2026.7.0.mdx
+++ b/src/content/docs/changelog/2026.7.0.mdx
@@ -806,6 +806,9 @@ For detailed migration guides and API documentation, see the
 <details>
 <summary></summary>
 
+- [emc2101] Fix negative external temperatures reported as large positives [esphome#17494](https://github.com/esphome/esphome/pull/17494) by [@swoboda1337](https://github.com/swoboda1337)
+- [haier] Fix outdoor defrost temperature reporting the coil temperature [esphome#17492](https://github.com/esphome/esphome/pull/17492) by [@swoboda1337](https://github.com/swoboda1337)
+- [zephyr] implement ISRInternalGPIOPin::digital_write [esphome#17601](https://github.com/esphome/esphome/pull/17601) by [@quantum5](https://github.com/quantum5)
 - [as3935_i2c] Use repeated start when reading registers [esphome#17584](https://github.com/esphome/esphome/pull/17584) by [@swoboda1337](https://github.com/swoboda1337)
 - [micro_wake_word] Include the local model file in bundles [esphome#17604](https://github.com/esphome/esphome/pull/17604) by [@bdraco](https://github.com/bdraco)
 - [core] Improve framework mirror selection, download errors, and version parsing [esphome#17615](https://github.com/esphome/esphome/pull/17615) by [@swoboda1337](https://github.com/swoboda1337)

--- a/src/content/docs/changelog/2026.7.0.mdx
+++ b/src/content/docs/changelog/2026.7.0.mdx
@@ -801,6 +801,49 @@ For detailed migration guides and API documentation, see the
 
 {/* markdownlint-disable MD013 */}
 
+## Release 2026.7.1 - July 21
+
+<details>
+<summary></summary>
+
+- [as3935_i2c] Use repeated start when reading registers [esphome#17584](https://github.com/esphome/esphome/pull/17584) by [@swoboda1337](https://github.com/swoboda1337)
+- [micro_wake_word] Include the local model file in bundles [esphome#17604](https://github.com/esphome/esphome/pull/17604) by [@bdraco](https://github.com/bdraco)
+- [core] Improve framework mirror selection, download errors, and version parsing [esphome#17615](https://github.com/esphome/esphome/pull/17615) by [@swoboda1337](https://github.com/swoboda1337)
+- [http_request] Fix use-after-return of header collection state in IDF backend [esphome#17627](https://github.com/esphome/esphome/pull/17627) by [@swoboda1337](https://github.com/swoboda1337)
+- [web_server_idf] Use core format_hex_to helper for digest auth (fixes Arduino build) [esphome#17608](https://github.com/esphome/esphome/pull/17608) by [@swoboda1337](https://github.com/swoboda1337)
+- [nrf52] Set ZEPHYR_SDK_INSTALL_DIR for Zephyr SDK discovery [esphome#17633](https://github.com/esphome/esphome/pull/17633) by [@jesserockz](https://github.com/jesserockz)
+- Bump bundled esphome-device-builder to 1.6.2 [esphome#17640](https://github.com/esphome/esphome/pull/17640) by [@esphome[bot]](https://github.com/apps/esphome)
+- Bump aioesphomeapi from 45.6.0 to 45.6.1 [esphome#17653](https://github.com/esphome/esphome/pull/17653) by [@dependabot[bot]](https://github.com/apps/dependabot)
+- Bump bundled esphome-device-builder to 1.6.3 [esphome#17651](https://github.com/esphome/esphome/pull/17651) by [@esphome[bot]](https://github.com/apps/esphome)
+- [espidf] Suggest installing missing system libraries when the tools install fails [esphome#17619](https://github.com/esphome/esphome/pull/17619) by [@swoboda1337](https://github.com/swoboda1337)
+- [core] Fix srcFilter exclusions being silently ignored on Windows [esphome#17648](https://github.com/esphome/esphome/pull/17648) by [@bharvey88](https://github.com/bharvey88)
+- Pin cryptography to 48.0.1 on Intel macOS [esphome#17658](https://github.com/esphome/esphome/pull/17658) by [@bdraco](https://github.com/bdraco)
+- Ship component requirements.txt files in the sdist and wheel [esphome#17660](https://github.com/esphome/esphome/pull/17660) by [@bdraco](https://github.com/bdraco)
+- [logs] Cap the logs reconnect backoff for deep-sleep devices [esphome#17656](https://github.com/esphome/esphome/pull/17656) by [@bdraco](https://github.com/bdraco)
+- [nrf52] Install PlatformIO toolchain Python packages into a dedicated venv [esphome#17635](https://github.com/esphome/esphome/pull/17635) by [@jesserockz](https://github.com/jesserockz)
+- Bump bundled esphome-device-builder to 1.6.4 [esphome#17662](https://github.com/esphome/esphome/pull/17662) by [@esphome[bot]](https://github.com/apps/esphome)
+- [esp32] Bump recommended ESP-IDF to 5.5.5 and Arduino to 3.3.10 [esphome#17669](https://github.com/esphome/esphome/pull/17669) by [@swoboda1337](https://github.com/swoboda1337)
+- Bump bundled esphome-device-builder to 1.6.5 [esphome#17675](https://github.com/esphome/esphome/pull/17675) by [@esphome[bot]](https://github.com/apps/esphome)
+- Bump bundled esphome-device-builder to 1.6.6 [esphome#17681](https://github.com/esphome/esphome/pull/17681) by [@esphome[bot]](https://github.com/apps/esphome)
+- Bump bundled esphome-device-builder to 1.6.7 [esphome#17696](https://github.com/esphome/esphome/pull/17696) by [@esphome[bot]](https://github.com/apps/esphome)
+- Split multi-token build.flags entries when generating ESP-IDF component CMakeLists [esphome#17649](https://github.com/esphome/esphome/pull/17649) by [@bharvey88](https://github.com/bharvey88)
+- [ssd1306] Fix offset_x being ignored on SH1106/SH1107 displays [esphome#17700](https://github.com/esphome/esphome/pull/17700) by [@jesserockz](https://github.com/jesserockz)
+- [micro_wake_word] Download models in parallel [esphome#17701](https://github.com/esphome/esphome/pull/17701) by [@bdraco](https://github.com/bdraco)
+- [platformio] Accept git URLs passed as the library name [esphome#17697](https://github.com/esphome/esphome/pull/17697) by [@bdraco](https://github.com/bdraco)
+- [git] Detect interrupted clones and re-clone automatically [esphome#17690](https://github.com/esphome/esphome/pull/17690) by [@bdraco](https://github.com/bdraco)
+- [espidf] Make openocd-esp32 optional so its libusb check cannot break installs [esphome#17686](https://github.com/esphome/esphome/pull/17686) by [@bdraco](https://github.com/bdraco)
+- [light] Fix pulse and other effects [esphome#17645](https://github.com/esphome/esphome/pull/17645) by [@clydebarrow](https://github.com/clydebarrow)
+- Bump bundled esphome-device-builder to 1.6.8 [esphome#17708](https://github.com/esphome/esphome/pull/17708) by [@esphome[bot]](https://github.com/apps/esphome)
+- [core] Auto-clean the PlatformIO build environment when the Python version changes [esphome#17671](https://github.com/esphome/esphome/pull/17671) by [@bdraco](https://github.com/bdraco)
+- [platformio] Re-download library when cached copy is missing its manifest [esphome#17691](https://github.com/esphome/esphome/pull/17691) by [@bdraco](https://github.com/bdraco)
+- [http_request] Fix usage of http response body [esphome#17713](https://github.com/esphome/esphome/pull/17713) by [@kamaradclimber](https://github.com/kamaradclimber)
+- [platformio] Include cache path in invalid library error [esphome#17692](https://github.com/esphome/esphome/pull/17692) by [@bdraco](https://github.com/bdraco)
+- [espidf] Resume interrupted toolchain downloads instead of restarting [esphome#17706](https://github.com/esphome/esphome/pull/17706) by [@bdraco](https://github.com/bdraco)
+- [wireguard] Mark private keys sensitive, stop redacting public keys [esphome#17736](https://github.com/esphome/esphome/pull/17736) by [@bdraco](https://github.com/bdraco)
+- [esp8266] Fail fast when Rosetta 2 is missing on Apple Silicon Macs [esphome#17737](https://github.com/esphome/esphome/pull/17737) by [@bdraco](https://github.com/bdraco)
+
+</details>
+
 ## Full list of changes
 
 ### New Features

--- a/src/content/docs/guides/supporters.mdx
+++ b/src/content/docs/guides/supporters.mdx
@@ -1503,6 +1503,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Roger Barnes (@mindsocket)](https://github.com/mindsocket)
 - [mingan666 (@mingan666)](https://github.com/mingan666)
 - [Minideezel (@minideezel)](https://github.com/minideezel)
+- [Sven Kocksch (@miniskipper)](https://github.com/miniskipper)
 - [mipa87 (@mipa87)](https://github.com/mipa87)
 - [André Klitzing (@misery)](https://github.com/misery)
 - [Tomasz (@Misiu)](https://github.com/Misiu)
@@ -2422,4 +2423,4 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Christian Zufferey (@zuzu59)](https://github.com/zuzu59)
 - [Zynth-dev (@Zynth-dev)](https://github.com/Zynth-dev)
 
-*This page was last updated July 16, 2026.*
+*This page was last updated July 21, 2026.*


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- [changelog] Remove beta notice from 2026.7.0 [docs#6998](https://github.com/esphome/esphome.io/pull/6998)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
