### PR TITLE
[wifi] Document lease_cache option

### DIFF
--- a/src/content/docs/components/wifi.mdx
+++ b/src/content/docs/components/wifi.mdx
@@ -128,6 +128,37 @@ wifi:
   > Be aware that marking networks as hidden prevents ESPHome from finding the best access point to connect to,
   > so the device may not connect to the AP with the best signal strength.
 
+- **lease_cache** (*Optional*): Only on `esp32` with the ESP-IDF framework. Remembers the DHCP lease the device is
+  assigned and, on the next boot, re-applies it as a static IP **without running DHCP** while it is still valid. This
+  skips the DHCP handshake, so the network is usable in milliseconds. It is most useful for battery-powered devices
+  that wake from deep sleep frequently. Disabled by default. Accepts a boolean, or a settings block:
+
+  ```yaml
+  wifi:
+    # ...
+    lease_cache:
+      storage: rtc
+      max_age: 12h
+  ```
+
+  - **enabled** (*Optional*, boolean): Whether the lease cache is active. Defaults to `true` when the block form is used.
+  - **storage** (*Optional*, string): Where to persist the cached lease. One of:
+
+    - `rtc`: stored in RTC memory, which survives software reboots and deep sleep but **not** power loss, and avoids
+      flash wear. This is the default where RTC memory is available.
+    - `flash`: survives power loss, but a DHCP lease changes on every renewal, so persisting it wears flash. It must
+      be selected explicitly.
+
+    On the ESP32-C2 and C61 variants, which have no RTC memory, the cache is inactive unless `storage: flash` is set.
+
+  - **max_age** (*Optional*, [Time](/guides/configuration-types#time)): Do not re-use a cached lease older than this,
+    regardless of the lease length the DHCP server granted. Defaults to the lease's own length.
+
+  > [!NOTE]
+  > A cached lease is only re-applied after a deep-sleep wake or a software reboot, where the device can measure how
+  > much time has passed; after a power cycle it cannot, so it falls back to a normal DHCP request. A user-configured
+  > `manual_ip` always takes precedence and disables the cache.
+
 - **min_auth_mode** (*Optional*, string): Only on `esp32` and `esp8266`. Sets the minimum WiFi authentication mode
   that the device will accept when connecting to access points. This controls the weakest encryption your device will
   allow. Possible values are:

--- a/src/content/docs/components/wifi.mdx
+++ b/src/content/docs/components/wifi.mdx
@@ -147,7 +147,8 @@ wifi:
     - `rtc`: stored in RTC memory, which survives software reboots and deep sleep but **not** power loss, and avoids
       flash wear. This is the default where RTC memory is available.
     - `flash`: survives power loss, but a DHCP lease changes on every renewal, so persisting it wears flash. It must
-      be selected explicitly.
+      be selected explicitly. After a power cycle the device cannot age the stored lease (see the note below), so it
+      runs DHCP and re-captures the lease before the cache is useful again.
 
     On the ESP32-C2 and C61 variants, which have no RTC memory, the cache is inactive unless `storage: flash` is set.
 
@@ -158,6 +159,14 @@ wifi:
   > A cached lease is only re-applied after a deep-sleep wake or a software reboot, where the device can measure how
   > much time has passed; after a power cycle it cannot, so it falls back to a normal DHCP request. A user-configured
   > `manual_ip` always takes precedence and disables the cache.
+
+  > [!WARNING]
+  > A cached lease is re-applied without checking that the address is still free. If the network behind the SSID
+  > changes — the router is replaced or moved to a different subnet, or the DHCP server forgets the lease and reassigns
+  > the address — the cached address may be wrong or clash with another device. An awake device recovers at the lease's
+  > renewal deadline (about half the lease by default) by falling back to DHCP; a deep-sleep device only re-checks on
+  > each wake, so it can keep applying a stale address until the lease ages past that deadline. Use `max_age` to bound
+  > this window, or a `manual_ip` if the address must never be stale.
 
 - **min_auth_mode** (*Optional*, string): Only on `esp32` and `esp8266`. Sets the minimum WiFi authentication mode
   that the device will accept when connecting to access points. This controls the weakest encryption your device will


### PR DESCRIPTION
## Description

Documents the new `wifi:` `lease_cache:` option added in esphome/esphome#17767. On ESP32 (ESP-IDF) it remembers the DHCP lease and, on the next boot, re-applies it as a static IP without running DHCP while the lease is still valid, cutting reconnect time for devices that wake from deep sleep. Documents the `enabled`, `storage` (`rtc`/`flash`) and `max_age` sub-options and the deep-sleep vs power-loss behaviour, mirroring the sibling `fast_connect` `storage` documentation.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#17767

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.
- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook. _(N/A: this adds an option to the existing WiFi component page, not a new component.)_
