### PR TITLE
Fix type description for 'on_pronto' automation

### DIFF
--- a/src/content/docs/components/remote_receiver.mdx
+++ b/src/content/docs/components/remote_receiver.mdx
@@ -247,7 +247,7 @@ To enable signal demodulation, configure the signal carrier frequency and duty c
   is passed to the automation for use in lambdas.
 
 - **on_pronto** (*Optional*, [Automation](/automations)): An automation to perform when a
-  Pronto remote code has been decoded. A variable `x` of type `std::string`
+  Pronto remote code has been decoded. A variable `x` of type <APIStruct text="remote_base::ProntoData" path="remote_base::ProntoData" />
   is passed to the automation for use in lambdas.
 
 - **on_raw** (*Optional*, [Automation](/automations)): An automation to perform when a


### PR DESCRIPTION

<!-- markdownlint-disable -->

## Description
Updated the description for the 'on_pronto' automation to reflect the correct type for the variable 'x'.


## Checklist

- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

