### PR TITLE
[remote_base] document haier short message support

### DIFF
--- a/src/content/docs/components/remote_receiver.mdx
+++ b/src/content/docs/components/remote_receiver.mdx
@@ -465,7 +465,7 @@ Remote code selection (exactly one of these has to be included):
 
 - **haier**: Trigger on a Haier remote code with the given code.
 
-  - **code** (**Required**, 13-bytes list): The code to listen for, see
+  - **code** (**Required**, 8 or 13-bytes list): The code to listen for, see
     [transmitter description](/components/remote_transmitter#remote_transmitter-transmit_haier) for more info. Usually you only need to copy
     this directly from the dumper output.
 

--- a/src/content/docs/components/remote_transmitter.mdx
+++ b/src/content/docs/components/remote_transmitter.mdx
@@ -509,7 +509,7 @@ on_...:
 
 ### `remote_transmitter.transmit_haier` Action
 
-This [action](/automations/actions#all-actions) sends a 104-bit Haier code to a remote transmitter. The 8-bit checksum is added
+This [action](/automations/actions#all-actions) sends a Haier code to a remote transmitter. The 8-bit checksum is added
 automatically.
 
 ```yaml
@@ -520,7 +520,7 @@ on_...:
 
 #### Configuration variables
 
-- **code** (**Required**, list, [templatable](/automations/templates)): The 13 byte Haier code to send.
+- **code** (**Required**, list, [templatable](/automations/templates)): The 8 or 13 byte Haier code to send.
 - All other options from [Remote Transmitter Actions](#remote_transmitter-transmit_action).
 
 <span id="remote_transmitter-transmit_lg"></span>


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#17826

## Checklist

- [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
