### PR TITLE
docs: document 'seiya' model for toshiba climate component

### DIFF
--- a/src/content/docs/components/climate/climate_ir.mdx
+++ b/src/content/docs/components/climate/climate_ir.mdx
@@ -227,12 +227,13 @@ climate:
 
 ### `toshiba`
 
-- **model** (*Optional*, string): There are four valid models:
+- **model** (*Optional*, string): There are five valid models:
 
   - `GENERIC`  : Temperature range is from 17 to 30 (default)
   - `RAC-PT1411HWRU-C`  : Temperature range is from 16 to 30; unit displays temperature in degrees Celsius
   - `RAC-PT1411HWRU-F`  : Temperature range is from 16 to 30; unit displays temperature in degrees Fahrenheit
   - `RAS-2819T`  : Temperature range is from 18 to 30; supports two-packet IR protocol
+  - `SEIYA`  : Temperature range is from 17 to 30; for Toshiba Seiya units (e.g. RAS-B13E2KVG-E). Supports AUTO/COOL/HEAT/DRY/FAN_ONLY modes, AUTO/QUIET/LOW/MEDIUM/HIGH fan speeds and OFF/VERTICAL/HORIZONTAL/BOTH swing modes
 
 > [!NOTE]
 > - While they are identified as separate models here, the `RAC-PT1411HWRU-C` and `RAC-PT1411HWRU-F` are
@@ -254,6 +255,11 @@ climate:
 >
 > - This climate IR component is also known to work with Midea model MAP14HS1TBL and may work with other similar
 >   models, as well. (Midea acquired Toshiba's product line and re-branded it.)
+>
+> - The `SEIYA` model uses a distinct IR timing and an 11-byte full-state frame (sent twice) plus a 9-byte short
+>   frame. Swing/direction is a momentary command: the swing code is only emitted when the swing mode changes,
+>   matching the physical remote; otherwise a neutral value is sent. The Omni direction code is mapped to
+>   `BOTH` on receive. OFF-timer frames are not handled.
 
 ```yaml
 # Example configuration entry for RAS-2819T
@@ -262,6 +268,16 @@ climate:
     name: "Toshiba AC"
     model: RAS-2819T
     sensor: room_temperature
+```
+
+```yaml
+# Example configuration entry for Seiya
+climate:
+  - platform: toshiba
+    name: "Toshiba Seiya AC"
+    model: SEIYA
+    transmitter_id: ir_transmitter
+    receiver_id: ir_receiver
 ```
 
 ### `whirlpool`


### PR DESCRIPTION
# What does this implement/fix?

Documents the new `model: seiya` option for the `toshiba` climate IR component, added in the companion code PR esphome/esphome#17830.

Adds the `SEIYA` entry (Toshiba Seiya, e.g. RAS-B13E2KVG-E) to the model list on the `climate_ir` components page, with its temperature range (17–30 °C), supported modes (AUTO/COOL/HEAT/DRY/FAN_ONLY), fan speeds (AUTO/QUIET/LOW/MEDIUM/HIGH) and swing modes (OFF/VERTICAL/HORIZONTAL/BOTH); a note describing its distinct IR timing, 11-byte full-state frame, momentary swing behaviour and Omni→BOTH mapping; and a configuration example.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Companion code PR: esphome/esphome#17830

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- this PR

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

Documentation-only change; no firmware build impact.

## Example entry for `config.yaml`:

```yaml
climate:
  - platform: toshiba
    name: "Toshiba Seiya AC"
    model: SEIYA
    transmitter_id: ir_transmitter
    receiver_id: ir_receiver
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).