### PR TITLE
[modbus_controller] Document U_WORD_S and S_WORD_S value types

### DIFF
--- a/src/content/docs/components/number/modbus_controller.mdx
+++ b/src/content/docs/components/number/modbus_controller.mdx
@@ -13,6 +13,8 @@ When the Number is updated a modbus write command is created sent to the device.
 
   - `U_WORD` (unsigned 16 bit integer from 1 register = 16bit)
   - `S_WORD` (signed 16 bit integer from 1 register = 16bit)
+  - `U_WORD_S` (unsigned 16 bit integer from 1 register with bytes swapped within the register)
+  - `S_WORD_S` (signed 16 bit integer from 1 register with bytes swapped within the register)
   - `U_DWORD` (unsigned 32 bit integer from 2 registers = 32bit)
   - `S_DWORD` (signed 32 bit integer from 2 registers = 32bit)
   - `U_DWORD_R` (unsigned 32 bit integer from 2 registers low word first)
@@ -23,6 +25,13 @@ When the Number is updated a modbus write command is created sent to the device.
   - `S_QWORD_R` (signed 64 bit integer from 4 registers low word first)
   - `FP32` (32 bit IEEE 754 floating point from 2 registers)
   - `FP32_R` (32 bit IEEE 754 floating point - same as FP32 but low word first)
+
+> [!WARNING]
+> `U_WORD_S` and `S_WORD_S` are a **rare, non-standard** configuration: bytes are swapped **within**
+> the register (byte-swapped). Modbus registers are big-endian (MSB first) per the specification.
+> The `_S` suffix is not the same as `_R` (word order reversed / low word first across multiple
+> registers).
+
 
 - **min_value** (*Optional*, float): The minimum value this number can be.
 - **max_value** (*Optional*, float): The maximum value this number can be.

--- a/src/content/docs/components/number/modbus_controller.mdx
+++ b/src/content/docs/components/number/modbus_controller.mdx
@@ -13,8 +13,8 @@ When the Number is updated a modbus write command is created sent to the device.
 
   - `U_WORD` (unsigned 16 bit integer from 1 register = 16bit)
   - `S_WORD` (signed 16 bit integer from 1 register = 16bit)
-  - `U_WORD_S` (unsigned 16 bit integer from 1 register with bytes swapped within the register)
-  - `S_WORD_S` (signed 16 bit integer from 1 register with bytes swapped within the register)
+  - `U_WORD_S` (unsigned 16 bit integer from 1 register with bytes swapped within the register = 16bit)
+  - `S_WORD_S` (signed 16 bit integer from 1 register with bytes swapped within the register = 16bit)
   - `U_DWORD` (unsigned 32 bit integer from 2 registers = 32bit)
   - `S_DWORD` (signed 32 bit integer from 2 registers = 32bit)
   - `U_DWORD_R` (unsigned 32 bit integer from 2 registers low word first)
@@ -27,10 +27,10 @@ When the Number is updated a modbus write command is created sent to the device.
   - `FP32_R` (32 bit IEEE 754 floating point - same as FP32 but low word first)
 
 > [!WARNING]
-> `U_WORD_S` and `S_WORD_S` are a **rare, non-standard** configuration: bytes are swapped **within**
-> the register (byte-swapped). Modbus registers are big-endian (MSB first) per the specification.
-> The `_S` suffix is not the same as `_R` (word order reversed / low word first across multiple
-> registers).
+> `U_WORD_S` and `S_WORD_S` are a **rare, non-standard** configuration: the two bytes
+> **within** one 16-bit register are reversed (LSB first on the wire within that register).
+> Modbus registers are big-endian (MSB first) per the specification. The `_S` suffix is not
+> the same as `_R` (word order reversed / **low word first** across multiple registers).
 
 
 - **min_value** (*Optional*, float): The minimum value this number can be.

--- a/src/content/docs/components/output/modbus_controller.mdx
+++ b/src/content/docs/components/output/modbus_controller.mdx
@@ -12,6 +12,8 @@ The `modbus_controller` platform creates an output from a modbus_controller. The
 
   - `U_WORD` (unsigned 16 bit integer from 1 register = 16bit)
   - `S_WORD` (signed 16 bit integer from 1 register = 16bit)
+  - `U_WORD_S` (unsigned 16 bit integer from 1 register with bytes swapped within the register)
+  - `S_WORD_S` (signed 16 bit integer from 1 register with bytes swapped within the register)
   - `U_DWORD` (unsigned 32 bit integer from 2 registers = 32bit)
   - `S_DWORD` (signed 32 bit integer from 2 registers = 32bit)
   - `U_DWORD_R` (unsigned 32 bit integer from 2 registers low word first)
@@ -22,6 +24,13 @@ The `modbus_controller` platform creates an output from a modbus_controller. The
   - `S_QWORD_R` (signed 64 bit integer from 4 registers low word first)
   - `FP32` (32 bit IEEE 754 floating point from 2 registers)
   - `FP32_R` (32 bit IEEE 754 floating point - same as FP32 but low word first)
+
+> [!WARNING]
+> `U_WORD_S` and `S_WORD_S` are a **rare, non-standard** configuration: bytes are swapped **within**
+> the register (byte-swapped). Modbus registers are big-endian (MSB first) per the specification.
+> The `_S` suffix is not the same as `_R` (word order reversed / low word first across multiple
+> registers).
+
 
 - **register_type** (*Optional*):
   - `coil`  : Write Coil - Write the ON/OFF status of a discrete coil in the device with *Function Code 5 or 15*. This will create a binary output.

--- a/src/content/docs/components/output/modbus_controller.mdx
+++ b/src/content/docs/components/output/modbus_controller.mdx
@@ -12,8 +12,8 @@ The `modbus_controller` platform creates an output from a modbus_controller. The
 
   - `U_WORD` (unsigned 16 bit integer from 1 register = 16bit)
   - `S_WORD` (signed 16 bit integer from 1 register = 16bit)
-  - `U_WORD_S` (unsigned 16 bit integer from 1 register with bytes swapped within the register)
-  - `S_WORD_S` (signed 16 bit integer from 1 register with bytes swapped within the register)
+  - `U_WORD_S` (unsigned 16 bit integer from 1 register with bytes swapped within the register = 16bit)
+  - `S_WORD_S` (signed 16 bit integer from 1 register with bytes swapped within the register = 16bit)
   - `U_DWORD` (unsigned 32 bit integer from 2 registers = 32bit)
   - `S_DWORD` (signed 32 bit integer from 2 registers = 32bit)
   - `U_DWORD_R` (unsigned 32 bit integer from 2 registers low word first)
@@ -26,10 +26,10 @@ The `modbus_controller` platform creates an output from a modbus_controller. The
   - `FP32_R` (32 bit IEEE 754 floating point - same as FP32 but low word first)
 
 > [!WARNING]
-> `U_WORD_S` and `S_WORD_S` are a **rare, non-standard** configuration: bytes are swapped **within**
-> the register (byte-swapped). Modbus registers are big-endian (MSB first) per the specification.
-> The `_S` suffix is not the same as `_R` (word order reversed / low word first across multiple
-> registers).
+> `U_WORD_S` and `S_WORD_S` are a **rare, non-standard** configuration: the two bytes
+> **within** one 16-bit register are reversed (LSB first on the wire within that register).
+> Modbus registers are big-endian (MSB first) per the specification. The `_S` suffix is not
+> the same as `_R` (word order reversed / **low word first** across multiple registers).
 
 
 - **register_type** (*Optional*):

--- a/src/content/docs/components/select/modbus_controller.mdx
+++ b/src/content/docs/components/select/modbus_controller.mdx
@@ -20,8 +20,8 @@ registers.
 
   - `U_WORD` (unsigned 16 bit integer from 1 register = 16bit)
   - `S_WORD` (signed 16 bit integer from 1 register = 16bit)
-  - `U_WORD_S` (unsigned 16 bit integer from 1 register with bytes swapped within the register)
-  - `S_WORD_S` (signed 16 bit integer from 1 register with bytes swapped within the register)
+  - `U_WORD_S` (unsigned 16 bit integer from 1 register with bytes swapped within the register = 16bit)
+  - `S_WORD_S` (signed 16 bit integer from 1 register with bytes swapped within the register = 16bit)
   - `U_DWORD` (unsigned 32 bit integer from 2 registers = 32bit)
   - `S_DWORD` (signed 32 bit integer from 2 registers = 32bit)
   - `U_DWORD_R` (unsigned 32 bit integer from 2 registers low word first)
@@ -32,10 +32,10 @@ registers.
   - `S_QWORD_R` (signed 64 bit integer from 4 registers low word first)
 
 > [!WARNING]
-> `U_WORD_S` and `S_WORD_S` are a **rare, non-standard** configuration: bytes are swapped **within**
-> the register (byte-swapped). Modbus registers are big-endian (MSB first) per the specification.
-> The `_S` suffix is not the same as `_R` (word order reversed / low word first across multiple
-> registers).
+> `U_WORD_S` and `S_WORD_S` are a **rare, non-standard** configuration: the two bytes
+> **within** one 16-bit register are reversed (LSB first on the wire within that register).
+> Modbus registers are big-endian (MSB first) per the specification. The `_S` suffix is not
+> the same as `_R` (word order reversed / **low word first** across multiple registers).
 
 
 - **register_count** (*Optional*): The number of registers which are used for this Select. Only

--- a/src/content/docs/components/select/modbus_controller.mdx
+++ b/src/content/docs/components/select/modbus_controller.mdx
@@ -20,6 +20,8 @@ registers.
 
   - `U_WORD` (unsigned 16 bit integer from 1 register = 16bit)
   - `S_WORD` (signed 16 bit integer from 1 register = 16bit)
+  - `U_WORD_S` (unsigned 16 bit integer from 1 register with bytes swapped within the register)
+  - `S_WORD_S` (signed 16 bit integer from 1 register with bytes swapped within the register)
   - `U_DWORD` (unsigned 32 bit integer from 2 registers = 32bit)
   - `S_DWORD` (signed 32 bit integer from 2 registers = 32bit)
   - `U_DWORD_R` (unsigned 32 bit integer from 2 registers low word first)
@@ -28,6 +30,13 @@ registers.
   - `S_QWORD` (signed 64 bit integer from 4 registers = 64bit)
   - `U_QWORD_R` (unsigned 64 bit integer from 4 registers low word first)
   - `S_QWORD_R` (signed 64 bit integer from 4 registers low word first)
+
+> [!WARNING]
+> `U_WORD_S` and `S_WORD_S` are a **rare, non-standard** configuration: bytes are swapped **within**
+> the register (byte-swapped). Modbus registers are big-endian (MSB first) per the specification.
+> The `_S` suffix is not the same as `_R` (word order reversed / low word first across multiple
+> registers).
+
 
 - **register_count** (*Optional*): The number of registers which are used for this Select. Only
   required for uncommon response encodings or to

--- a/src/content/docs/components/sensor/modbus_controller.mdx
+++ b/src/content/docs/components/sensor/modbus_controller.mdx
@@ -20,6 +20,8 @@ and requires [Modbus Controller](/components/modbus_controller/) to be configure
 
   - `U_WORD`  : unsigned 16 bit integer from 1 register = 16bit
   - `S_WORD`  : signed 16 bit integer from 1 register = 16bit
+  - `U_WORD_S`  : unsigned 16 bit integer from 1 register with bytes swapped within the register
+  - `S_WORD_S`  : signed 16 bit integer from 1 register with bytes swapped within the register
   - `U_DWORD`  : unsigned 32 bit integer from 2 registers = 32bit
   - `S_DWORD`  : signed 32 bit integer from 2 registers = 32bit
   - `U_DWORD_R`  : unsigned 32 bit integer from 2 registers low word first
@@ -30,6 +32,13 @@ and requires [Modbus Controller](/components/modbus_controller/) to be configure
   - `S_QWORD_R`  : signed 64 bit integer from 4 registers low word first
   - `FP32`  : 32 bit IEEE 754 floating point from 2 registers
   - `FP32_R`  : 32 bit IEEE 754 floating point - same as FP32 but low word first
+
+> [!WARNING]
+> `U_WORD_S` and `S_WORD_S` are a **rare, non-standard** configuration: bytes are swapped **within**
+> the register (byte-swapped). Modbus registers are big-endian (MSB first) per the specification.
+> The `_S` suffix is not the same as `_R` (word order reversed / low word first across multiple
+> registers).
+
 
 - **bitmask** (*Optional*, int): sometimes multiple values are packed in a single register's response. The bitmask can be used to extract a value from the response. See [Bitmasks](/components/modbus_controller#bitmasks).
 - **skip_updates** (*Optional*, int): By default, all sensors of a modbus_controller are updated together. For data points that don't change very frequently, updates can be skipped. A value of 5 would only update this sensor range in every 6th update cycle. Note: The modbus_controller groups components by address ranges to reduce number of transactions. All components with the same starting address will be updated in one request. `skip_updates` applies for *all* components in the same range.

--- a/src/content/docs/components/sensor/modbus_controller.mdx
+++ b/src/content/docs/components/sensor/modbus_controller.mdx
@@ -20,8 +20,8 @@ and requires [Modbus Controller](/components/modbus_controller/) to be configure
 
   - `U_WORD`  : unsigned 16 bit integer from 1 register = 16bit
   - `S_WORD`  : signed 16 bit integer from 1 register = 16bit
-  - `U_WORD_S`  : unsigned 16 bit integer from 1 register with bytes swapped within the register
-  - `S_WORD_S`  : signed 16 bit integer from 1 register with bytes swapped within the register
+  - `U_WORD_S`  : unsigned 16 bit integer from 1 register with bytes swapped within the register = 16bit
+  - `S_WORD_S`  : signed 16 bit integer from 1 register with bytes swapped within the register = 16bit
   - `U_DWORD`  : unsigned 32 bit integer from 2 registers = 32bit
   - `S_DWORD`  : signed 32 bit integer from 2 registers = 32bit
   - `U_DWORD_R`  : unsigned 32 bit integer from 2 registers low word first
@@ -34,10 +34,10 @@ and requires [Modbus Controller](/components/modbus_controller/) to be configure
   - `FP32_R`  : 32 bit IEEE 754 floating point - same as FP32 but low word first
 
 > [!WARNING]
-> `U_WORD_S` and `S_WORD_S` are a **rare, non-standard** configuration: bytes are swapped **within**
-> the register (byte-swapped). Modbus registers are big-endian (MSB first) per the specification.
-> The `_S` suffix is not the same as `_R` (word order reversed / low word first across multiple
-> registers).
+> `U_WORD_S` and `S_WORD_S` are a **rare, non-standard** configuration: the two bytes
+> **within** one 16-bit register are reversed (LSB first on the wire within that register).
+> Modbus registers are big-endian (MSB first) per the specification. The `_S` suffix is not
+> the same as `_R` (word order reversed / **low word first** across multiple registers).
 
 
 - **bitmask** (*Optional*, int): sometimes multiple values are packed in a single register's response. The bitmask can be used to extract a value from the response. See [Bitmasks](/components/modbus_controller#bitmasks).


### PR DESCRIPTION
This PR is part of a series for byte-swapped Modbus word types (`U_WORD_S` / `S_WORD_S`).

esphome/esphome:
- esphome/esphome#17469
- esphome/esphome#17829 (merge after 17469)
- esphome/esphome#17831 (merge after 17469)
- esphome/esphome#17832 (merge after 17829)

esphome/esphome.io:
- #6949 (merged)
- #7042 (this PR; depends on esphome 17469)
- #7043 (independent of #7042; both based on `next`)

---

**#6949 has been merged.** This PR is rebased onto `next` and contains only the new `U_WORD_S` / `S_WORD_S` documentation on `modbus_controller` entity pages.

## Description

Documents the new `U_WORD_S` and `S_WORD_S` value types on `modbus_controller` entity pages (sensor, number, select, output). These are unsigned/signed 16-bit types with bytes swapped within the register (byte-swapped). A WARNING callout notes this is a rare, non-standard encoding and distinguishes `_S` from `_R` (word order reversed / low word first).

**Depends on** esphome/esphome#17469 for the feature.

Index page left unchanged (no value_type enumeration list to keep in sync). `modbus_server.mdx` is intentionally not edited in this PR (see #7043).

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#17469

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.
