### PR TITLE
[modbus_server] Document U_WORD_S and S_WORD_S value types

### DIFF
--- a/src/content/docs/components/modbus_server.mdx
+++ b/src/content/docs/components/modbus_server.mdx
@@ -67,6 +67,8 @@ On the bus side, you need 120 Ohm termination resistors at the ends of the bus c
 
     - `U_WORD`  : unsigned 16 bit integer, 1 register, `uint16_t`
     - `S_WORD`  : signed 16 bit integer, 1 register, `int16_t`
+    - `U_WORD_S`  : unsigned 16 bit integer, 1 register, **byte-swapped**, `uint16_t`
+    - `S_WORD_S`  : signed 16 bit integer, 1 register, **byte-swapped**, `int16_t`
     - `U_DWORD`  : unsigned 32 bit integer, 2 registers, `uint32_t`
     - `S_DWORD`  : signed 32 bit integer, 2 registers, `int32_t`
     - `U_DWORD_R`  : unsigned 32 bit integer, 2 registers, **low word first**, `uint32_t`
@@ -77,6 +79,12 @@ On the bus side, you need 120 Ohm termination resistors at the ends of the bus c
     - `S_QWORD_R`  : signed 64 bit integer, 4 registers, **low word first**, `int64_t`
     - `FP32`  : 32 bit IEEE 754 floating point, 2 registers, `float`
     - `FP32_R`  : 32 bit IEEE 754 floating point, 2 registers, **low word first**, `float`
+
+    > [!WARNING]
+    > `U_WORD_S` and `S_WORD_S` are a **rare, non-standard** configuration: bytes are swapped **within**
+    > one 16-bit register (byte-swapped). Modbus registers are big-endian (MSB first) per the
+    > specification. The `_S` suffix is not the same as `_R` (word order reversed / **low word first**
+    > across multiple registers).
 
     > [!NOTE]
     > The `_R` suffix means word order is reversed (**low word first**). It is not little-endian byte

--- a/src/content/docs/components/modbus_server.mdx
+++ b/src/content/docs/components/modbus_server.mdx
@@ -63,7 +63,7 @@ On the bus side, you need 120 Ohm termination resistors at the ends of the bus c
 - **registers** (*Optional*): A list of registers that are responded to when acting as a server.
 
   - **address** (**Required**, integer): start address of the first register in a range.
-  - **value_type** (*Optional*): data type of the modbus register data. The default data type for modbus is a 16-bit integer in **big endian** format (network byte order, MSB first).
+  - **value_type** (*Optional*): data type of the Modbus register data. The default data type for Modbus is a 16-bit integer in **big endian** format (network byte order, MSB first).
 
     - `U_WORD`  : unsigned 16 bit integer, 1 register, `uint16_t`
     - `S_WORD`  : signed 16 bit integer, 1 register, `int16_t`
@@ -81,10 +81,10 @@ On the bus side, you need 120 Ohm termination resistors at the ends of the bus c
     - `FP32_R`  : 32 bit IEEE 754 floating point, 2 registers, **low word first**, `float`
 
     > [!WARNING]
-    > `U_WORD_S` and `S_WORD_S` are a **rare, non-standard** configuration: bytes are swapped **within**
-    > one 16-bit register (byte-swapped). Modbus registers are big-endian (MSB first) per the
-    > specification. The `_S` suffix is not the same as `_R` (word order reversed / **low word first**
-    > across multiple registers).
+    > `U_WORD_S` and `S_WORD_S` are a **rare, non-standard** configuration: the two bytes
+    > **within** one 16-bit register are reversed (LSB first on the wire within that register).
+    > Modbus registers are big-endian (MSB first) per the specification. The `_S` suffix is not
+    > the same as `_R` (word order reversed / **low word first** across multiple registers).
 
     > [!NOTE]
     > The `_R` suffix means word order is reversed (**low word first**). It is not little-endian byte

--- a/src/content/docs/components/modbus_server.mdx
+++ b/src/content/docs/components/modbus_server.mdx
@@ -83,7 +83,7 @@ On the bus side, you need 120 Ohm termination resistors at the ends of the bus c
     > [!WARNING]
     > `U_WORD_S` and `S_WORD_S` are a **rare, non-standard** configuration: the two bytes
     > **within** one 16-bit register are reversed (LSB first on the wire within that register).
-    > Modbus registers are big-endian (MSB first) per the specification. The `_S` suffix is not
+    > Modbus registers are big endian (MSB first) per the specification. The `_S` suffix is not
     > the same as `_R` (word order reversed / **low word first** across multiple registers).
 
     > [!NOTE]


### PR DESCRIPTION
This PR is part of a series for byte-swapped Modbus word types (`U_WORD_S` / `S_WORD_S`).

esphome/esphome:
- esphome/esphome#17469
- esphome/esphome#17829 (merge after 17469)
- esphome/esphome#17831 (merge after 17469)
- esphome/esphome#17832 (merge after 17829)

esphome/esphome.io:
- #6949 (merged)
- #7042 (independent of #7043; both based on `next`)
- #7043 (this PR; depends on esphome 17469/17829)

---

**#6949 has been merged.** This PR is rebased onto `next` and contains only the new `U_WORD_S` / `S_WORD_S` documentation on `modbus_server`. It is independent of #7042 (both tip onto `next`).

## Description

Document `U_WORD_S` / `S_WORD_S` (byte-swapped within one 16-bit register) on the `modbus_server` page, with a WARNING that this is rare / non-standard versus Modbus MSB-first, and contrast with `_R` (word order reversed / low word first).

Depends on esphome/esphome#17469 and esphome/esphome#17829.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#17469
- esphome/esphome#17829

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.
