### PR TITLE
Add documentation for a new model configuration for gsl3670 component

### DIFF
--- a/src/content/docs/components/touchscreen/gsl3670.mdx
+++ b/src/content/docs/components/touchscreen/gsl3670.mdx
@@ -5,10 +5,10 @@ title: "GSL3670 Touch Screen Controller"
 
 import APIRef from '@components/APIRef.astro';
 
-The `gsl3670` touchscreen platform allows using the touch screen controllers based on the GSL3670 chip with ESPHome.
+The `gsl3670` touchscreen platform allows using the touch screen controllers based on the GSL3670 and the GSL3680 chips with ESPHome.
 An [I²C](/components/i2c) bus is required to be set up in your configuration for this touchscreen to work.
 
-This controller is used in the Seeed Studio reTerminal D1001.
+The GSL3670 chip is used in the Seeed Studio reTerminal D1001. The GSL3680 chip is used in the Guition JC8012P4A1.
 
 The component requires a binary firmware file to be loaded into the controller during initialization. When using a built-in model, this firmware is downloaded automatically from the [esphome-libs/gsl3670-firmware](https://github.com/esphome-libs/gsl3670-firmware) release and cached locally, so it does not need to be supplied manually. The download is verified against a known SHA-256 checksum. Alternatively, a firmware file can be supplied from a custom URL or from a local file.
 
@@ -20,6 +20,14 @@ touchscreen:
   platform: gsl3670
   id: my_touchscreen
   model: SEEED-RETERMINAL-D1001
+```
+
+```yaml
+# Example configuration entry using the built-in Guition JC8012P4A1 model
+touchscreen:
+  platform: gsl3670
+  id: my_touchscreen
+  model: GUITION-JC8012P4A1
 ```
 
 ```yaml
@@ -50,6 +58,7 @@ touchscreen:
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually set the ID of this touchscreen.
 - **model** (*Optional*, string): A predefined model that sets default values for pin assignments, calibration, and firmware. Currently supported:
   - `SEEED-RETERMINAL-D1001`: Seeed Studio reTerminal D1001. Sets appropriate defaults for interrupt pin, reset pin, calibration, axis mirroring/swapping, and the firmware download URL and checksum.
+  - `GUITION-JC8012P4A1`: Guition JC8012P4A1. Sets appropriate defaults for interrupt pin, reset pin, calibration, axis mirroring/swapping, and the firmware download URL and checksum.
   - `CUSTOM`: No defaults are applied; all options must be configured manually. This is the default.
 - **interrupt_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The touch detection pin.
 - **reset_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The chip reset pin.
@@ -80,6 +89,24 @@ touchscreen:
   - platform: gsl3670
     i2c_id: lcd_i2c
     model: SEEED-RETERMINAL-D1001
+```
+
+### Sample config for the Guition JC8012P4A1
+
+```yaml
+i2c:
+  - id: lcd_i2c
+    sda: GPIO07
+    scl: GPIO08
+    scan: true
+    frequency: 400kHz
+    sda_pullup_enabled: False
+    scl_pullup_enabled: False
+
+touchscreen:
+  - platform: gsl3670
+    i2c_id: lcd_i2c
+    model: GUITION-JC8012P4A1
 ```
 
 ## See Also


### PR DESCRIPTION

<!-- markdownlint-disable -->

## Description

This adds documentation for a new model configuration for the gsl3670 component that can also be used for the gsl3680 chip of the Guition JC8012P4A1.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#17843

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
