### PR TITLE
[voice_assistant] Document downloading wake word models

### DIFF
--- a/src/content/docs/components/voice_assistant.mdx
+++ b/src/content/docs/components/voice_assistant.mdx
@@ -36,6 +36,10 @@ voice_assistant:
 - **micro_wake_word** (*Optional*, [ID](/guides/configuration-types#id)): The [micro_wake_word](/components/micro_wake_word/)
   component used for wake word detection. Configuring this allows Home Assistant to change which wake word model is enabled.
 
+- **http_request_id** (*Optional*, [ID](/guides/configuration-types#id)): The [HTTP Request](/components/http_request/)
+  component used to download wake word models offered by Home Assistant. Requires `micro_wake_word` above.
+  See [Downloading wake word models](#downloading-wake-word-models) below.
+
 - **speaker** (*Optional*, [ID](/guides/configuration-types#id)): The [speaker](/components/speaker/) to use to output
   the response. Cannot be used with `media_player` below.
 
@@ -194,6 +198,42 @@ voice_assistant:
 
 See our [example YAML files on GitHub](https://github.com/esphome/wake-word-voice-assistants/blob/main/m5stack-atom-echo/m5stack-atom-echo.yaml)
 for continuous wake word detection.
+
+## Downloading wake word models
+
+Home Assistant can offer wake word models that are not built into the firmware. Add `http_request_id` and the device
+downloads a model the first time you turn that wake word on in Home Assistant, then runs it alongside any models listed
+under [micro_wake_word](/components/micro_wake_word/).
+
+```yaml
+http_request:
+  id: model_http_request
+
+micro_wake_word:
+  id: mww_id
+  microphone: mic_id
+  models:
+    - model: okay_nabu
+
+voice_assistant:
+  microphone: mic_id
+  micro_wake_word: mww_id
+  http_request_id: model_http_request
+```
+
+Models can also be left out of `micro_wake_word` entirely, in which case every wake word comes from Home Assistant.
+
+Downloaded models are held in RAM, so a device with [PSRAM](/components/psram/) is recommended. They are not written to
+flash, so a model is downloaded again after a reboot. Which wake words you turned on is remembered, so the device
+restores the same set on its own.
+
+Home Assistant sends the list of models it offers each time it asks the device for its configuration, and the device
+keeps its own list in step. A model is unloaded and its memory freed once Home Assistant stops offering it. A model that
+fails to download or does not suit the device is left turned off rather than retried on every boot.
+
+> [!NOTE]
+> Only microWakeWord models are supported. A downloaded model also has to use the same `feature_step_size` as the
+> models already configured, otherwise it is rejected. Models offered for other wake word engines are ignored.
 
 ## Push to Talk
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Documents the new ability to download new wake word models from Home Assistant at runtime.

**Related issue (if applicable):** not applicable

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#17928

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
