### PR TITLE
[esp32] Document platformio toolchain deprecation

### DIFF
--- a/src/content/docs/components/esp32.mdx
+++ b/src/content/docs/components/esp32.mdx
@@ -75,7 +75,8 @@ esp32:
   windows. Defaults to `5s`, valid range is `5s` to `60s`. Note: OTA updates temporarily raise the
   watchdog to `15s` when the configured timeout is below that threshold.
 
-- **toolchain** (*Optional*, [Toolchain](#esp32-toolchain)): Toolchain used to build the firmware.
+- **toolchain** (*Optional*, [Toolchain](#esp32-toolchain)): Toolchain used to build the firmware. The
+  `platformio` toolchain is deprecated and will be removed in 2027.2.0.
 
 ## Variants
 
@@ -343,9 +344,14 @@ ESPHome supports multiple toolchains for building firmware. The toolchain determ
 Currently supported toolchains include:
 
 - `esp-idf` (default)
-- `platformio`
+- `platformio` (deprecated)
 
 By default, ESPHome uses its native ESP-IDF integration, including automatic framework installation and environment management as described in this [documentation](/guides/esp_idf/).
+
+> [!WARNING]
+> The `platformio` toolchain is deprecated and will be removed in 2027.2.0. Both the ESP-IDF and Arduino
+> frameworks build on the default `esp-idf` toolchain; remove `toolchain: platformio` from your configuration
+> to migrate.
 
 **Example for using the PlatformIO toolchain:**
 


### PR DESCRIPTION
## Description:

Documents the deprecation of the `platformio` toolchain for ESP32: marks the `toolchain: platformio` value as deprecated in the option description and the toolchain list, and adds a warning to the Toolchain Configuration section noting it will be removed in 2027.2.0. Migration is removing `toolchain: platformio`, since both the ESP-IDF and Arduino frameworks build on the default `esp-idf` toolchain.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#17947

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.