### PR TITLE
[docs] Remove references to removed ESPHOME_DASHBOARD_USE_PING

### DIFF
--- a/src/content/docs/guides/faq.mdx
+++ b/src/content/docs/guides/faq.mdx
@@ -520,8 +520,8 @@ docker run --rm -v "${PWD}":/config --device=/dev/ttyUSB0 -it ghcr.io/esphome/es
 # Warning: this command is currently not working with Docker on MacOS. (see note below)
 docker run --rm -v "${PWD}":/config --net=host -it ghcr.io/esphome/esphome
 
-# Start dashboard on port 6052 (MacOS specific command)
-docker run --rm -p 6052:6052 -e ESPHOME_DASHBOARD_USE_PING=true -v "${PWD}":/config -it ghcr.io/esphome/esphome
+# Start dashboard on port 6052 (without host networking, for example on MacOS)
+docker run --rm -p 6052:6052 -v "${PWD}":/config -it ghcr.io/esphome/esphome
 
 # Setup a bash alias:
 alias esphome='docker run --rm -v "${PWD}":/config --net=host -it ghcr.io/esphome/esphome'
@@ -552,14 +552,17 @@ services:
 <span id="docker-reference-notes"></span>
 
 > [!NOTE]
-> By default, ESPHome uses mDNS to resolve device IPs on the network; this is used to determine online/offline state
-> in the [ESPHome Device Builder](/guides/getting_started_hassio#installing-esphome-device-builder). In order for this feature to work, you
-> must use Docker's host networking mode.
+> By default, ESPHome uses mDNS to discover devices and resolve their IPs on the network; this is how the
+> [ESPHome Device Builder](/guides/getting_started_hassio#installing-esphome-device-builder) finds devices and tracks
+> whether they are online. In order for mDNS to work, you must use Docker's host networking mode.
 >
 > The [host networking driver](https://docs.docker.com/network/drivers/host/) only works on Linux hosts; it is
 > available on Docker Desktop version 4.29 and later.
 >
-> If you don't want to use the host networking driver, you have to use an alternate method as described below.
+> If you don't use the host networking driver, the Device Builder still runs, and it still checks devices with a
+> periodic ICMP ping sweep. Without multicast, however, `.local` names cannot be resolved, so the sweep only has an
+> address to ping for devices that have a fixed one - set with `use_address` or
+> [`manual_ip`](/components/wifi#wifi-manual_ip) in the device's own configuration. Other devices will show no status.
 >
 > Note that mDNS might not work if your Home Assistant server and your ESPHome nodes are on different subnets
 > and/or VLANs. If your router supports Avahi, you can configure mDNS to work across different subnets.
@@ -567,10 +570,6 @@ services:
 >
 > 1. Enable Avahi on both subnets (install Avahi modules on OpenWRT or pfSense).
 > 1. Enable UDP traffic from your ESPHome device's subnet to 224.0.0.251/32 on port 5353.
->
-> Alternatively, you can configure the [ESPHome Device Builder](/guides/getting_started_hassio#installing-esphome-device-builder) to use ICMP
-> pings to check the status of devices by setting `"status_use_ping": true` or, with Docker:
-> `-e ESPHOME_DASHBOARD_USE_PING=true`
 >
 > See also [https://github.com/esphome/issues/issues/641#issuecomment-534156628](https://github.com/esphome/issues/issues/641#issuecomment-534156628).
 

--- a/src/content/docs/guides/faq.mdx
+++ b/src/content/docs/guides/faq.mdx
@@ -543,8 +543,8 @@ services:
       # if needed, add esp device(s) as in command line examples above
       - /dev/ttyUSB0:/dev/ttyUSB0
       - /dev/ttyACM0:/dev/ttyACM0
-    # The host networking driver only works on Linux hosts, but is available as a Beta feature,
-    # on Docker Desktop version 4.29 and later.
+    # The host networking driver only works on Linux hosts; on Docker Desktop version 4.34 and
+    # later it must first be enabled under Settings > Resources > Network.
     network_mode: host
     restart: always
 ```
@@ -556,8 +556,9 @@ services:
 > [ESPHome Device Builder](/guides/getting_started_hassio#installing-esphome-device-builder) finds devices and tracks
 > whether they are online. In order for mDNS to work, you must use Docker's host networking mode.
 >
-> The [host networking driver](https://docs.docker.com/network/drivers/host/) only works on Linux hosts; it is
-> available on Docker Desktop version 4.29 and later.
+> The [host networking driver](https://docs.docker.com/engine/network/drivers/host/) only works on Linux hosts. On
+> Docker Desktop version 4.34 and later it is available, but must first be enabled under
+> Settings > Resources > Network.
 >
 > If you don't use the host networking driver, the Device Builder still runs, and it still checks devices with a
 > periodic ICMP ping sweep. Without multicast, however, `.local` names cannot be resolved, so the sweep only has an

--- a/src/content/docs/guides/getting_started_command_line.mdx
+++ b/src/content/docs/guides/getting_started_command_line.mdx
@@ -231,7 +231,7 @@ esphome dashboard config
 # On Docker, host networking mode lets the dashboard find devices and track their status
 docker run --rm --net=host -v "${PWD}":/config -it ghcr.io/esphome/esphome
 
-# On Docker Desktop, where host networking is unavailable, publish the port instead
+# On Docker Desktop, where host networking is not enabled by default, publish the port instead
 docker run --rm -p 6052:6052 -v "${PWD}":/config -it ghcr.io/esphome/esphome
 ```
 

--- a/src/content/docs/guides/getting_started_command_line.mdx
+++ b/src/content/docs/guides/getting_started_command_line.mdx
@@ -228,15 +228,20 @@ pip install tornado esptool
 # Start the dashboard
 esphome dashboard config
 
-# On Docker, host networking mode is required for online status indicators
+# On Docker, host networking mode lets the dashboard find devices and track their status
 docker run --rm --net=host -v "${PWD}":/config -it ghcr.io/esphome/esphome
 
-# On Docker with MacOS, the host networking option doesn't work as expected. An
-# alternative is to use the following command if you are a MacOS user.
-docker run --rm -p 6052:6052 -e ESPHOME_DASHBOARD_USE_PING=true -v "${PWD}":/config -it ghcr.io/esphome/esphome
+# On Docker Desktop, where host networking is unavailable, publish the port instead
+docker run --rm -p 6052:6052 -v "${PWD}":/config -it ghcr.io/esphome/esphome
 ```
 
 After that, you will be able to access the ESPHome Device Builder at `localhost:6052`.
+
+> [!NOTE]
+> `--net=host` lets the ESPHome Device Builder see mDNS, which is how it finds devices and tracks whether they are
+> online. Without host networking the Device Builder still runs, but `.local` names will not resolve, so it can only
+> reach devices that have a fixed address - one set with `use_address` or
+> [`manual_ip`](/components/wifi#wifi-manual_ip) in the device's own configuration.
 
 Logging level can be set with the env var `ESPHOME_LOG_LEVEL` (default is `INFO`).
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

`ESPHOME_DASHBOARD_USE_PING` no longer exists (zero code-search hits in esphome/esphome), and the dashboard has moved out of that repo into esphome/device-builder where the ICMP ping sweep starts unconditionally rather than as an opt-in. This removes the env var from the two Docker commands that still set it, in `guides/getting_started_command_line.mdx` and `guides/faq.mdx`.

Removing it left the surrounding text wrong, so that is corrected too. Both pages tied online/offline status to host networking. What `--net=host` actually gates is mDNS, which is how the Device Builder finds devices and tracks whether they are online. Without host networking the dashboard still runs and still runs its periodic ping sweep, but `.local` names do not resolve, so it can only reach devices that have a fixed address - one set with `use_address` or `manual_ip` in the device's own configuration. The FAQ's "use an alternate method as described below" pointer is replaced for the same reason: the alternate method it pointed at was the removed opt-in.

Changelog entries that mention `ESPHOME_DASHBOARD_USE_PING` and `status_use_ping` are intentionally left as-is, since they are historical records of what shipped at the time.

**Related issue (if applicable):**

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** n/a

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.