### PR TITLE
[docs] Clarify fixed-address requirement for device status

### DIFF
--- a/src/content/docs/guides/faq.mdx
+++ b/src/content/docs/guides/faq.mdx
@@ -517,7 +517,7 @@ docker run --rm -v "${PWD}":/config -it ghcr.io/esphome/esphome logs livingroom.
 docker run --rm -v "${PWD}":/config --device=/dev/ttyUSB0 -it ghcr.io/esphome/esphome ...
 
 # Start dashboard on port 6052 (general command)
-# Note: on Docker Desktop, host networking must be enabled first. (see note below)
+# Note: on Docker Desktop 4.34+, host networking must be enabled first. (see note below)
 docker run --rm -v "${PWD}":/config --net=host -it ghcr.io/esphome/esphome
 
 # Start dashboard on port 6052 (without host networking, for example on macOS)
@@ -561,10 +561,10 @@ services:
 > Settings > Resources > Network.
 >
 > Without the host networking driver the Device Builder still runs, and a periodic ICMP ping sweep still tracks every
-> node - but multicast no longer reaches it, so `.local` names stop resolving through mDNS. That leaves whatever your
-> network can resolve on its own: a literal IP, or a hostname served by regular DNS. A `.local` name may still work,
-> because the Device Builder retries the bare hostname without the suffix. Devices that resolve no other way are
-> shown as offline.
+> node - but multicast no longer reaches the container, so `.local` names stop resolving through mDNS. That leaves
+> whatever your network can resolve on its own: a literal IP, or a hostname served by regular DNS. A `.local` name
+> may still work, because the Device Builder retries the bare hostname without the suffix, which your DNS may serve.
+> Devices that resolve no other way are shown as offline.
 >
 > To give a device an address that doesn't depend on mDNS, [`manual_ip`](/components/wifi#wifi-manual_ip) assigns it
 > a static IP, and [`use_address`](/components/wifi/) overrides the address used to connect to it.

--- a/src/content/docs/guides/faq.mdx
+++ b/src/content/docs/guides/faq.mdx
@@ -561,10 +561,11 @@ services:
 > Settings > Resources > Network.
 >
 > If you don't use the host networking driver, the Device Builder still runs, and it still checks devices with a
-> periodic ICMP ping sweep. Without multicast, however, `.local` names cannot be resolved, so the sweep only has an
-> address to ping for devices it can address by IP: either a static IP assigned with
-> [`manual_ip`](/components/wifi#wifi-manual_ip), or an IP given to `use_address`, which overrides the address used
-> to connect to the device. Other devices will show no status.
+> periodic ICMP ping sweep. Without multicast, however, `.local` names cannot be resolved by mDNS, so the sweep can
+> only reach devices whose address resolves another way: a literal IP, or a hostname your regular DNS serves. A
+> `.local` name also works when DNS resolves the bare hostname without the suffix.
+> [`manual_ip`](/components/wifi#wifi-manual_ip) gives a device a static IP; `use_address` overrides the address used
+> to connect to it. Devices that resolve no other way are shown as offline.
 >
 > Note that mDNS might not work if your Home Assistant server and your ESPHome nodes are on different subnets
 > and/or VLANs. If your router supports Avahi, you can configure mDNS to work across different subnets.

--- a/src/content/docs/guides/faq.mdx
+++ b/src/content/docs/guides/faq.mdx
@@ -563,7 +563,8 @@ services:
 > If you don't use the host networking driver, the Device Builder still runs, and it still checks devices with a
 > periodic ICMP ping sweep. Without multicast, however, `.local` names cannot be resolved by mDNS, so the sweep can
 > only reach devices whose address resolves another way: a literal IP, or a hostname your regular DNS serves. A
-> `.local` name also works when DNS resolves the bare hostname without the suffix.
+> `.local` name can still work too: when it fails to resolve, the Device Builder retries the bare hostname without
+> the suffix, which your DNS may serve.
 > [`manual_ip`](/components/wifi#wifi-manual_ip) gives a device a static IP; `use_address` overrides the address used
 > to connect to it. Devices that resolve no other way are shown as offline.
 >
@@ -586,16 +587,17 @@ is bound to cause problems -- mDNS is used to determine the IP address of each E
 
 If you disable mDNS, expect the following repercussions:
 
-- You will not be able to use the node's hostname to ping, find it's IP address or otherwise connect to it.
+- You will not be able to use the node's hostname to ping, find it's IP address or otherwise connect to it, unless
+  your regular DNS serves that hostname as well.
 - Automatic discovery in Home Assistant when using the [native API](/components/api/) relies on
   mDNS broadcast messages to detect the presence of new ESPHome nodes. If you need to use the native API with
   mDNS disabled, then you will have to use a static IP address and manually add the ESPHome component with its
   (static) IP address.
 
-- Because status detection in the [ESPHome Device Builder](/guides/getting_started_hassio#installing-esphome-device-builder) uses mDNS by
-  default, nodes with mDNS disabled will always appear as "offline". This does not affect any functionality; however,
-  if you want to see the online/offline status of your nodes, you may configure the ESPHome Device Builder to ping each
-  node instead. See the [notes in the Docker Reference section](#docker-reference-notes) for more information.
+- Status detection in the [ESPHome Device Builder](/guides/getting_started_hassio#installing-esphome-device-builder)
+  prefers mDNS, so a node with mDNS disabled is tracked by the periodic ping sweep instead. That works as long as the
+  node's address still resolves - see the [notes in the Docker Reference section](#docker-reference-notes). A node
+  whose address cannot be resolved at all is shown as "offline".
 
 ## Can configuration files be recovered from the device?
 

--- a/src/content/docs/guides/faq.mdx
+++ b/src/content/docs/guides/faq.mdx
@@ -562,8 +562,9 @@ services:
 >
 > If you don't use the host networking driver, the Device Builder still runs, and it still checks devices with a
 > periodic ICMP ping sweep. Without multicast, however, `.local` names cannot be resolved, so the sweep only has an
-> address to ping for devices with a fixed IP address - set with [`manual_ip`](/components/wifi#wifi-manual_ip), or
-> with `use_address` pointing at an IP rather than a hostname. Other devices will show no status.
+> address to ping for devices it can address by IP: either a static IP assigned with
+> [`manual_ip`](/components/wifi#wifi-manual_ip), or an IP given to `use_address`, which overrides the address used
+> to connect to the device. Other devices will show no status.
 >
 > Note that mDNS might not work if your Home Assistant server and your ESPHome nodes are on different subnets
 > and/or VLANs. If your router supports Avahi, you can configure mDNS to work across different subnets.

--- a/src/content/docs/guides/faq.mdx
+++ b/src/content/docs/guides/faq.mdx
@@ -517,10 +517,10 @@ docker run --rm -v "${PWD}":/config -it ghcr.io/esphome/esphome logs livingroom.
 docker run --rm -v "${PWD}":/config --device=/dev/ttyUSB0 -it ghcr.io/esphome/esphome ...
 
 # Start dashboard on port 6052 (general command)
-# Warning: this command is currently not working with Docker on MacOS. (see note below)
+# Warning: this command is currently not working with Docker on macOS. (see note below)
 docker run --rm -v "${PWD}":/config --net=host -it ghcr.io/esphome/esphome
 
-# Start dashboard on port 6052 (without host networking, for example on MacOS)
+# Start dashboard on port 6052 (without host networking, for example on macOS)
 docker run --rm -p 6052:6052 -v "${PWD}":/config -it ghcr.io/esphome/esphome
 
 # Setup a bash alias:
@@ -562,8 +562,8 @@ services:
 >
 > If you don't use the host networking driver, the Device Builder still runs, and it still checks devices with a
 > periodic ICMP ping sweep. Without multicast, however, `.local` names cannot be resolved, so the sweep only has an
-> address to ping for devices that have a fixed one - set with `use_address` or
-> [`manual_ip`](/components/wifi#wifi-manual_ip) in the device's own configuration. Other devices will show no status.
+> address to ping for devices with a fixed IP address - set with [`manual_ip`](/components/wifi#wifi-manual_ip), or
+> with `use_address` pointing at an IP rather than a hostname. Other devices will show no status.
 >
 > Note that mDNS might not work if your Home Assistant server and your ESPHome nodes are on different subnets
 > and/or VLANs. If your router supports Avahi, you can configure mDNS to work across different subnets.

--- a/src/content/docs/guides/faq.mdx
+++ b/src/content/docs/guides/faq.mdx
@@ -517,7 +517,7 @@ docker run --rm -v "${PWD}":/config -it ghcr.io/esphome/esphome logs livingroom.
 docker run --rm -v "${PWD}":/config --device=/dev/ttyUSB0 -it ghcr.io/esphome/esphome ...
 
 # Start dashboard on port 6052 (general command)
-# Warning: this command is currently not working with Docker on macOS. (see note below)
+# Note: on Docker Desktop, host networking must be enabled first. (see note below)
 docker run --rm -v "${PWD}":/config --net=host -it ghcr.io/esphome/esphome
 
 # Start dashboard on port 6052 (without host networking, for example on macOS)
@@ -560,13 +560,14 @@ services:
 > Docker Desktop version 4.34 and later it is available, but must first be enabled under
 > Settings > Resources > Network.
 >
-> If you don't use the host networking driver, the Device Builder still runs, and it still checks devices with a
-> periodic ICMP ping sweep. Without multicast, however, `.local` names cannot be resolved by mDNS, so the sweep can
-> only reach devices whose address resolves another way: a literal IP, or a hostname your regular DNS serves. A
-> `.local` name can still work too: when it fails to resolve, the Device Builder retries the bare hostname without
-> the suffix, which your DNS may serve.
-> [`manual_ip`](/components/wifi#wifi-manual_ip) gives a device a static IP; `use_address` overrides the address used
-> to connect to it. Devices that resolve no other way are shown as offline.
+> Without the host networking driver the Device Builder still runs, and a periodic ICMP ping sweep still tracks every
+> node - but multicast no longer reaches it, so `.local` names stop resolving through mDNS. That leaves whatever your
+> network can resolve on its own: a literal IP, or a hostname served by regular DNS. A `.local` name may still work,
+> because the Device Builder retries the bare hostname without the suffix. Devices that resolve no other way are
+> shown as offline.
+>
+> To give a device an address that doesn't depend on mDNS, [`manual_ip`](/components/wifi#wifi-manual_ip) assigns it
+> a static IP, and [`use_address`](/components/wifi/) overrides the address used to connect to it.
 >
 > Note that mDNS might not work if your Home Assistant server and your ESPHome nodes are on different subnets
 > and/or VLANs. If your router supports Avahi, you can configure mDNS to work across different subnets.
@@ -587,7 +588,7 @@ is bound to cause problems -- mDNS is used to determine the IP address of each E
 
 If you disable mDNS, expect the following repercussions:
 
-- You will not be able to use the node's hostname to ping, find it's IP address or otherwise connect to it, unless
+- You will not be able to use the node's hostname to ping, find its IP address or otherwise connect to it, unless
   your regular DNS serves that hostname as well.
 - Automatic discovery in Home Assistant when using the [native API](/components/api/) relies on
   mDNS broadcast messages to detect the presence of new ESPHome nodes. If you need to use the native API with
@@ -595,9 +596,10 @@ If you disable mDNS, expect the following repercussions:
   (static) IP address.
 
 - Status detection in the [ESPHome Device Builder](/guides/getting_started_hassio#installing-esphome-device-builder)
-  prefers mDNS, so a node with mDNS disabled is tracked by the periodic ping sweep instead. That works as long as the
-  node's address still resolves - see the [notes in the Docker Reference section](#docker-reference-notes). A node
-  whose address cannot be resolved at all is shown as "offline".
+  uses mDNS where it is available, but a periodic ICMP ping sweep runs for every node regardless, so a node with
+  mDNS disabled is still tracked as long as its address resolves some other way - see the
+  [notes in the Docker Reference section](#docker-reference-notes). A node whose address cannot be resolved at all
+  is shown as "offline".
 
 ## Can configuration files be recovered from the device?
 

--- a/src/content/docs/guides/getting_started_command_line.mdx
+++ b/src/content/docs/guides/getting_started_command_line.mdx
@@ -239,10 +239,10 @@ After that, you will be able to access the ESPHome Device Builder at `localhost:
 
 > [!NOTE]
 > `--net=host` lets the ESPHome Device Builder see mDNS, which is how it finds devices and tracks whether they are
-> online. Without host networking the Device Builder still runs, but `.local` names will not resolve, so it can only
-> reach devices it can address by IP: either a static IP assigned with
-> [`manual_ip`](/components/wifi#wifi-manual_ip), or an IP given to `use_address`, which overrides the address used
-> to connect to the device.
+> online. Without host networking the Device Builder still runs, but `.local` names will not resolve via mDNS, so it
+> can only reach devices whose address resolves another way: a literal IP, or a hostname your regular DNS serves.
+> [`manual_ip`](/components/wifi#wifi-manual_ip) gives a device a static IP; `use_address` overrides the address used
+> to connect to it.
 
 Logging level can be set with the env var `ESPHOME_LOG_LEVEL` (default is `INFO`).
 

--- a/src/content/docs/guides/getting_started_command_line.mdx
+++ b/src/content/docs/guides/getting_started_command_line.mdx
@@ -240,8 +240,9 @@ After that, you will be able to access the ESPHome Device Builder at `localhost:
 > [!NOTE]
 > `--net=host` lets the ESPHome Device Builder see mDNS, which is how it finds devices and tracks whether they are
 > online. Without host networking the Device Builder still runs, but `.local` names will not resolve, so it can only
-> reach devices that have a fixed IP address - set with [`manual_ip`](/components/wifi#wifi-manual_ip), or with
-> `use_address` pointing at an IP rather than a hostname, in the device's own configuration.
+> reach devices it can address by IP: either a static IP assigned with
+> [`manual_ip`](/components/wifi#wifi-manual_ip), or an IP given to `use_address`, which overrides the address used
+> to connect to the device.
 
 Logging level can be set with the env var `ESPHOME_LOG_LEVEL` (default is `INFO`).
 

--- a/src/content/docs/guides/getting_started_command_line.mdx
+++ b/src/content/docs/guides/getting_started_command_line.mdx
@@ -239,10 +239,11 @@ After that, you will be able to access the ESPHome Device Builder at `localhost:
 
 > [!NOTE]
 > `--net=host` lets the ESPHome Device Builder see mDNS, which is how it finds devices and tracks whether they are
-> online. Without host networking the Device Builder still runs, but `.local` names will not resolve via mDNS, so it
-> can only reach devices whose address resolves another way: a literal IP, or a hostname your regular DNS serves.
-> [`manual_ip`](/components/wifi#wifi-manual_ip) gives a device a static IP; `use_address` overrides the address used
-> to connect to it.
+> online. Without host networking it still runs and still pings devices to track their status, but `.local` names
+> stop resolving through mDNS, so it can only reach devices your network resolves another way: a literal IP, or a
+> hostname served by regular DNS. [`manual_ip`](/components/wifi#wifi-manual_ip) assigns a device a static IP, and
+> [`use_address`](/components/wifi/) overrides the address used to connect to it. See the
+> [FAQ](/guides/faq#docker-reference-notes) for the full details.
 
 Logging level can be set with the env var `ESPHOME_LOG_LEVEL` (default is `INFO`).
 

--- a/src/content/docs/guides/getting_started_command_line.mdx
+++ b/src/content/docs/guides/getting_started_command_line.mdx
@@ -240,8 +240,8 @@ After that, you will be able to access the ESPHome Device Builder at `localhost:
 > [!NOTE]
 > `--net=host` lets the ESPHome Device Builder see mDNS, which is how it finds devices and tracks whether they are
 > online. Without host networking the Device Builder still runs, but `.local` names will not resolve, so it can only
-> reach devices that have a fixed address - one set with `use_address` or
-> [`manual_ip`](/components/wifi#wifi-manual_ip) in the device's own configuration.
+> reach devices that have a fixed IP address - set with [`manual_ip`](/components/wifi#wifi-manual_ip), or with
+> `use_address` pointing at an IP rather than a hostname, in the device's own configuration.
 
 Logging level can be set with the env var `ESPHOME_LOG_LEVEL` (default is `INFO`).
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Follow-up to #7070, addressing review feedback that arrived after it was merged.

That PR said the Device Builder can reach devices with "a fixed address - set with `use_address` or `manual_ip`". Two things were wrong with that. `manual_ip` assigns a static IP to the node while `use_address` only overrides the address used to connect to it, so "set with" applied to both was misleading. And the requirement is not a literal IP: the ping sweep resolves the device address through the system resolver first and only falls back to the zeroconf cache for `.local` names, so any hostname regular DNS serves works too, including a `.local` whose bare hostname resolves.

Both notes now describe the requirement as an address that resolves without mDNS, and attribute the right mechanism to each option.

While confirming that against the device-builder source, two further errors turned up in the "Notes on disabling mDNS" section, both left over from the removed opt-in:

- It told users they "may configure the ESPHome Device Builder to ping each node instead" and linked to the Docker Reference notes for how. That option no longer exists, and the linked section no longer documents it.
- It said nodes with mDNS disabled "will always appear as offline". The ping sweep now runs unconditionally, so such a node is tracked as long as its address resolves.

Also corrects the earlier claim that unresolvable devices show no status - they are marked `OFFLINE`.

### Docker command reference

The comment above the `--net=host` example warned that the command "is currently not working with Docker on MacOS". That contradicted the note eight lines below it, which says host networking is available on Docker Desktop 4.34 and later once enabled under Settings > Resources > Network. It now points at that requirement instead, including the version floor, and the `MacOS` spelling is fixed in both comments.

### Review rounds

Successive rounds of review left both notes as patched-together sentences arguing with their own earlier versions, so the later commits restructure rather than patch: the FAQ note became two paragraphs (what breaks without host networking, then how to give a device a resolvable address) and the CLI note now defers to it rather than half-duplicating it.

**Related issue (if applicable):**

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** n/a

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.