### PR TITLE
[docs] Remove the dashboard command from the CLI page

### DIFF
--- a/src/content/docs/guides/cli.mdx
+++ b/src/content/docs/guides/cli.mdx
@@ -262,7 +262,7 @@ the ESPHome Device Builder continues to function correctly.
 > [!NOTE]
 > The built-in `dashboard` command has been removed. To use ESPHome through a graphical user interface, run the
 > [ESPHome Device Builder](/guides/getting_started_command_line#esphome-device-builder-docker) instead. Home
-> Assistant app and Docker users are unaffected - both already run the Device Builder.
+> Assistant app and Docker users are unaffected. Both already run the Device Builder.
 
 ### `analyze-memory` Command
 

--- a/src/content/docs/guides/cli.mdx
+++ b/src/content/docs/guides/cli.mdx
@@ -255,41 +255,14 @@ configuration file — if none is provided, it will clean the `.esphome` directo
 working directory. Arguments can be YAML configuration files or directories containing them.
 
 Storage files (`.json` files and the `storage` directory inside `.esphome`) are preserved so that
-the dashboard continues to function correctly.
+the ESPHome Device Builder continues to function correctly.
 
 ### `dashboard` Command
 
-The `esphome dashboard <CONFIG>` command starts the ESPHome dashboard server for using ESPHome
-through a graphical user interface. This command accepts a configuration directory instead of a
-single configuration file.
-
-#### Options
-
-**`--address ADDRESS`**
-: Manually set the address to bind to (defaults to 0.0.0.0)
-
-
-**`--port PORT`**
-: Manually set the HTTP port to open connections on (defaults to 6052)
-
-
-**`--socket SOCKET`**
-: Manually set the unix socket to bind to. If specified along with `--address` or `--port` the values
-for those parameters will be ignored. Cannot be used along with `--systemd-socket`.
-
-
-**`--username USERNAME`**
-: The optional username to require for authentication.
-
-
-**`--password PASSWORD`**
-: The optional password to require for authentication.
-
-
-**`--open-ui`**
-: If set, opens the dashboard UI in a browser once the server is up and running. Does not work when using
-`--socket`.
-
+> [!NOTE]
+> The built-in `dashboard` command has been removed. To use ESPHome through a graphical user interface, run the
+> [ESPHome Device Builder](/guides/getting_started_command_line#esphome-device-builder-docker) instead. Home
+> Assistant app and Docker users are unaffected - both already run the Device Builder.
 
 ### `analyze-memory` Command
 

--- a/src/content/docs/guides/getting_started_command_line.mdx
+++ b/src/content/docs/guides/getting_started_command_line.mdx
@@ -218,8 +218,9 @@ The ESPHome Device Builder allows you to easily manage your nodes from a nice we
 as a [Home Assistant app](/guides/getting_started_hassio/), but can run in docker independently from
 Home Assistant.
 
-The Device Builder is a separate package from ESPHome itself. Start it with one of the following commands (with
-`config/` pointing to a directory where you want to store your configurations):
+When installing with `pip`, the Device Builder is a separate package from ESPHome itself; the Docker image already
+bundles it. Start it with one of the following commands (with `config` pointing to a directory where you want to
+store your configurations):
 
 ```bash
 # Option 1: install and run with pip

--- a/src/content/docs/guides/getting_started_command_line.mdx
+++ b/src/content/docs/guides/getting_started_command_line.mdx
@@ -222,16 +222,14 @@ The Device Builder is a separate package from ESPHome itself. Start it with one 
 `config/` pointing to a directory where you want to store your configurations):
 
 ```bash
-# Install the Device Builder
+# Option 1: install and run with pip
 pip install esphome-device-builder
-
-# Start the Device Builder
 esphome-device-builder config
 
-# On Docker, host networking mode lets the Device Builder find devices and track their status
+# Option 2: run in Docker. Host networking lets the Device Builder find devices and track their status
 docker run --rm --net=host -v "${PWD}":/config -it ghcr.io/esphome/esphome
 
-# On Docker Desktop, where host networking is not enabled by default, publish the port instead
+# Option 3: on Docker Desktop, where host networking is not enabled by default, publish the port instead
 docker run --rm -p 6052:6052 -v "${PWD}":/config -it ghcr.io/esphome/esphome
 ```
 

--- a/src/content/docs/guides/getting_started_command_line.mdx
+++ b/src/content/docs/guides/getting_started_command_line.mdx
@@ -222,13 +222,13 @@ To start the ESPHome Device Builder, simply start ESPHome with the following com
 directory where you want to store your configurations):
 
 ```bash
-# Install dashboard dependencies
-pip install tornado esptool
+# Install the Device Builder
+pip install esphome-device-builder
 
-# Start the dashboard
-esphome dashboard config
+# Start the Device Builder
+esphome-device-builder config
 
-# On Docker, host networking mode lets the dashboard find devices and track their status
+# On Docker, host networking mode lets the Device Builder find devices and track their status
 docker run --rm --net=host -v "${PWD}":/config -it ghcr.io/esphome/esphome
 
 # On Docker Desktop, where host networking is not enabled by default, publish the port instead

--- a/src/content/docs/guides/getting_started_command_line.mdx
+++ b/src/content/docs/guides/getting_started_command_line.mdx
@@ -218,8 +218,8 @@ The ESPHome Device Builder allows you to easily manage your nodes from a nice we
 as a [Home Assistant app](/guides/getting_started_hassio/), but can run in docker independently from
 Home Assistant.
 
-To start the ESPHome Device Builder, simply start ESPHome with the following command (with `config/` pointing to a
-directory where you want to store your configurations):
+The Device Builder is a separate package from ESPHome itself. Start it with one of the following commands (with
+`config/` pointing to a directory where you want to store your configurations):
 
 ```bash
 # Install the Device Builder


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

The built-in Tornado web dashboard was removed in 2026.7.0, but the CLI page still documented the `dashboard` command and all six of its options. Replace that section with a note pointing at the ESPHome Device Builder (the heading is kept so the `#dashboard-command` anchor still resolves), and reword the `clean-all` line that referred to "the dashboard".

The note links to the Device Builder section of the command line getting-started guide, which still told pip users to `pip install tornado esptool` and run `esphome dashboard config`, so that snippet is updated to `pip install esphome-device-builder` / `esphome-device-builder config`.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.