### PR TITLE
[build] Move markdown plugins onto the unified processor

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,4 +1,5 @@
 import { defineConfig } from "astro/config";
+import { unified } from "@astrojs/markdown-remark";
 import starlight from "@astrojs/starlight";
 import starlightBlog from "starlight-blog";
 import sitemap from "@astrojs/sitemap";
@@ -134,11 +135,14 @@ export default defineConfig({
     domains: ["assets.openhomefoundation.org", "www.openhomefoundation.org"],
   },
   markdown: {
-    // Astro 6 no longer defaults `markdown.gfm` to true, and @astrojs/mdx only applies remark-gfm
-    // to .mdx files when this is explicitly truthy. Without it, GFM tables render as literal text.
-    gfm: true,
-    remarkPlugins: [remarkAlert, remarkMath],
-    rehypePlugins: [rehypeHeadingSlugs, rehypeKatex, rehypeExternalLinksBlog],
+    // Astro 7 defaults `markdown.processor` to Sätteri, which does not run remark/rehype plugins.
+    // The alert, math and heading-slug plugins below are unified plugins, so opt back into the
+    // unified processor. @astrojs/mdx inherits these settings for .mdx files.
+    processor: unified({
+      gfm: true,
+      remarkPlugins: [remarkAlert, remarkMath],
+      rehypePlugins: [rehypeHeadingSlugs, rehypeKatex, rehypeExternalLinksBlog],
+    }),
   },
   integrations: [
     starlight({

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.0.0",
       "license": "CC-BY-4.0",
       "dependencies": {
+        "@astrojs/markdown-remark": "^7.2.1",
         "@astrojs/starlight": "^0.41.3",
         "astro": "^7.0.7",
         "github-slugger": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "*.md": "markdownlint"
   },
   "dependencies": {
+    "@astrojs/markdown-remark": "^7.2.1",
     "@astrojs/starlight": "^0.41.3",
     "astro": "^7.0.7",
     "github-slugger": "^2.0.0",


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Astro 7 deprecated `markdown.remarkPlugins`, `markdown.rehypePlugins`, `markdown.remarkRehype` and `markdown.gfm`, so `astro build` now prints two deprecation warnings. It also changed `markdown.processor` to default to Sätteri, which does not run remark/rehype plugins at all - Astro was silently coercing our config back to `unified()` behind the warning. This declares the unified processor explicitly and moves the plugins and `gfm` onto it.

Staying on the unified processor is deliberate: `remark-github-blockquote-alert`, `remark-math` and `rehype-katex` are unified plugins, and Sätteri uses a different mdast/hast plugin system. Starlight supports both processors, so this is the behavior-preserving option.

`@astrojs/markdown-remark` is no longer installed by default now that Sätteri is Astro's default processor, so it becomes a direct dependency now that `astro.config.mjs` imports it.

The old comment about Astro 6 and `@astrojs/mdx` needing an explicitly truthy `markdown.gfm` no longer applies: `@astrojs/mdx` reads `processor.options.gfm` for `.mdx` files.

Build output is unchanged. I diffed the full `dist/` against a baseline build of `current` and got zero differing HTML files.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** N/A

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.