### PR TITLE
Document chsc6x model option for CHSC6540

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,4 +1,5 @@
 import { defineConfig } from "astro/config";
+import { unified } from "@astrojs/markdown-remark";
 import starlight from "@astrojs/starlight";
 import starlightBlog from "starlight-blog";
 import sitemap from "@astrojs/sitemap";
@@ -134,11 +135,14 @@ export default defineConfig({
     domains: ["assets.openhomefoundation.org", "www.openhomefoundation.org"],
   },
   markdown: {
-    // Astro 6 no longer defaults `markdown.gfm` to true, and @astrojs/mdx only applies remark-gfm
-    // to .mdx files when this is explicitly truthy. Without it, GFM tables render as literal text.
-    gfm: true,
-    remarkPlugins: [remarkAlert, remarkMath],
-    rehypePlugins: [rehypeHeadingSlugs, rehypeKatex, rehypeExternalLinksBlog],
+    // Astro 7 defaults `markdown.processor` to Sätteri, which does not run remark/rehype plugins.
+    // The alert, math and heading-slug plugins below are unified plugins, so opt back into the
+    // unified processor. @astrojs/mdx inherits these settings for .mdx files.
+    processor: unified({
+      gfm: true,
+      remarkPlugins: [remarkAlert, remarkMath],
+      rehypePlugins: [rehypeHeadingSlugs, rehypeKatex, rehypeExternalLinksBlog],
+    }),
   },
   integrations: [
     starlight({

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -131,7 +131,7 @@ export default defineConfig({
   image: {
     breakpoints: imageBreakpoints,
     responsiveStyles: true,
-    domains: ["assets.openhomefoundation.org"],
+    domains: ["assets.openhomefoundation.org", "www.openhomefoundation.org"],
   },
   markdown: {
     // Astro 6 no longer defaults `markdown.gfm` to true, and @astrojs/mdx only applies remark-gfm

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.0.0",
       "license": "CC-BY-4.0",
       "dependencies": {
+        "@astrojs/markdown-remark": "^7.2.1",
         "@astrojs/starlight": "^0.41.3",
         "astro": "^7.0.7",
         "github-slugger": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "*.md": "markdownlint"
   },
   "dependencies": {
+    "@astrojs/markdown-remark": "^7.2.1",
     "@astrojs/starlight": "^0.41.3",
     "astro": "^7.0.7",
     "github-slugger": "^2.0.0",

--- a/script/schema_doc.py
+++ b/script/schema_doc.py
@@ -655,6 +655,44 @@ def is_title(title):
     return title.startswith("#")
 
 
+# Schemas (e.g. "LIGHT_STATE_SCHEMA") of the doc section currently being parsed,
+# keyed by name. Set per-section in parse_file() so a heading can be matched to a
+# sibling schema emitted from the code.
+current_component_schemas = {}
+
+
+def title_schema_name(title):
+    """Return the schema a heading names, or None.
+
+    The heading carries the schema's logical name without the trailing
+    ``_SCHEMA`` (e.g. "Light state" -> ``LIGHT_STATE_SCHEMA``); it matches only
+    when that schema is present in the current component's generated JSON. This
+    keeps the docs heading human-readable while still routing its config vars to
+    the schema they belong to.
+    """
+    slug = slugify(title)
+    if not slug:
+        return None
+    candidate = slug.replace("-", "_").upper() + "_SCHEMA"
+    return candidate if candidate in current_component_schemas else None
+
+
+def set_current_schemas(doc_type, doc_component, doc_platform):
+    """Record the schemas of the doc section being parsed for title matching."""
+    global current_component_schemas
+    if not doc_component:
+        current_component_schemas = {}
+        return
+    component_key = (
+        f"{doc_component}.{doc_platform}"
+        if doc_type == "platform_component"
+        else doc_component
+    )
+    current_component_schemas = (
+        (json_get(doc_component) or {}).get(component_key, {}).get("schemas", {})
+    )
+
+
 def is_break_title(title):
     if is_title(title):
         name = title.split(" ")[-1].lower()
@@ -665,6 +703,11 @@ def is_break_title(title):
         # Bare backtick heading (### `name`) — registry entry like a filter or effect.
         # Nothing after the closing backtick, so it's not a property sub-heading.
         if re.match(r"^#+\s+`[^`]+`\s*$", title):
+            return True
+        # A heading that names a sibling schema emitted from the code (e.g.
+        # "Light state" -> LIGHT_STATE_SCHEMA) ends the current config-vars walk
+        # so its options are routed to that schema instead of the base one.
+        if title_schema_name(title):
             return True
     return False
 
@@ -1122,6 +1165,29 @@ def parse_file(md_full_path):
                 print(
                     f"{md_full_path}:{index} {doc_platform}/{file_name} {title} not processed."
                 )
+
+        # A heading that names a sibling schema emitted from the code documents
+        # that schema (e.g. "Light state" -> LIGHT_STATE_SCHEMA) rather than the
+        # doc's main config schema. Routing its config vars there keeps shared
+        # sub-schemas documented where they belong instead of leaking their keys
+        # into the base component schema. Skip headings already claimed by the
+        # component/platform title logic or an action/condition/registry entry
+        # (e.g. "EMC2101 Component" -> EMC2101_COMPONENT_SCHEMA) so this doesn't
+        # hijack their handling.
+        set_current_schemas(doc_type, doc_component, doc_platform)
+        schema_name = (
+            None
+            if title_component or pending_schema
+            else title_schema_name(title)
+        )
+        if schema_name:
+            try:
+                index = process_config(
+                    md_full_path, lines, index, current_component_schemas[schema_name]
+                )
+            except Exception as err:
+                print(f"{md_full_path}:{index} {title} failed {repr(err)}")
+            continue
 
         if title == DOC_CONFIGURATION_VARIABLES:
             if not doc_component:

--- a/src/authors.mjs
+++ b/src/authors.mjs
@@ -5,4 +5,10 @@ export const authors = {
     picture: "https://avatars.githubusercontent.com/jesserockz?size=64",
     url: "https://github.com/jesserockz",
   },
+  darren: {
+    name: "Darren Griffin",
+    title: "Web Developer",
+    picture: "https://avatars.githubusercontent.com/mrdarrengriffin?size=64",
+    url: "https://github.com/mrdarrengriffin",
+  },
 };

--- a/src/components/CrosspostBadges.astro
+++ b/src/components/CrosspostBadges.astro
@@ -1,0 +1,56 @@
+---
+// Renders a "shared from" pill on blog grid cards for posts crossposted from another site.
+// Preview.astro (starlight-blog) has no override hook, so this patches the DOM client-side instead.
+// A post opts in by setting `crosspostSource` in its frontmatter (see content.config.ts).
+import { getCollection } from "astro:content";
+
+const crosspostEntries = await getCollection("docs", (entry) => Boolean(entry.data.crosspostSource));
+const crossposts = crosspostEntries.map((entry) => ({
+  path: `/${entry.data.slug ?? entry.id}/`,
+  label: `This article is shared from the ${entry.data.crosspostSource}`,
+}));
+---
+
+<script is:inline define:vars={{ crossposts }}>
+  const externalIconSvg =
+    '<svg viewBox="0 0 24 24" width="14" height="14" aria-hidden="true"><path d="M19.33 10.18a1 1 0 0 1-.77 0 1 1 0 0 1-.62-.93l.01-1.83-8.2 8.2a1 1 0 0 1-1.41-1.42l8.2-8.2H14.7a1 1 0 0 1 0-2h4.25a1 1 0 0 1 1 1v4.25a1 1 0 0 1-.62.93Z"/><path d="M11 4a1 1 0 1 1 0 2H7a1 1 0 0 0-1 1v10a1 1 0 0 0 1 1h10a1 1 0 0 0 1-1v-4a1 1 0 1 1 2 0v4a3 3 0 0 1-3 3H7a3 3 0 0 1-3-3V7a3 3 0 0 1 3-3h4Z"/></svg>';
+
+  const init = () => {
+    for (const link of document.querySelectorAll("article.preview > header > h2 > a")) {
+      const crosspost = crossposts.find((entry) => new URL(link.href).pathname === entry.path);
+      if (!crosspost) continue;
+
+      const heading = link.closest("h2");
+      if (!heading || heading.nextElementSibling?.classList.contains("crosspost-badge")) continue;
+
+      const badge = document.createElement("span");
+      badge.className = "crosspost-badge";
+      badge.innerHTML = externalIconSvg;
+      badge.append(document.createTextNode(crosspost.label));
+      heading.insertAdjacentElement("afterend", badge);
+    }
+  };
+
+  init();
+  document.addEventListener("astro:page-load", init);
+</script>
+
+<style is:global>
+  .crosspost-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    width: fit-content;
+    margin-bottom: 0.5rem;
+    padding: 0.25rem 0.75rem;
+    border-radius: 999px;
+    background: var(--sl-color-text-accent);
+    color: var(--sl-color-text-invert);
+    font-size: var(--sl-text-xs);
+    font-weight: 600;
+  }
+  .crosspost-badge svg {
+    flex-shrink: 0;
+    fill: currentColor;
+  }
+</style>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,6 +1,9 @@
 ---
 import EditLink from "virtual:starlight/components/EditLink";
 import LastUpdated from "virtual:starlight/components/LastUpdated";
+import CrosspostBadges from "./CrosspostBadges.astro";
+
+const isBlogPage = Astro.url.pathname.startsWith("/blog");
 
 const footerLinks = [
   {
@@ -30,6 +33,8 @@ const footerLinks = [
   },
 ];
 ---
+
+{isBlogPage && <CrosspostBadges />}
 
 <footer class="sl-flex">
   <div class="meta sl-flex">

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,4 +1,4 @@
-import { defineCollection } from "astro:content";
+import { defineCollection, z } from "astro:content";
 import { docsLoader } from "@astrojs/starlight/loaders";
 import { docsSchema } from "@astrojs/starlight/schema";
 import { blogSchema } from "starlight-blog/schema";
@@ -6,6 +6,15 @@ import { blogSchema } from "starlight-blog/schema";
 export const collections = {
   docs: defineCollection({
     loader: docsLoader(),
-    schema: docsSchema({ extend: (context) => blogSchema(context) }),
+    schema: docsSchema({
+      extend: (context) =>
+        blogSchema(context).extend({
+          /**
+           * If set, the post is a crosspost and its blog grid card gets a
+           * "shared from <crosspostSource>" badge. See CrosspostBadges.astro.
+           */
+          crosspostSource: z.string().optional(),
+        }),
+    }),
   }),
 };

--- a/src/content/docs/blog/2026/07/30/making-our-web-analytics-open-source-with-plausible.mdx
+++ b/src/content/docs/blog/2026/07/30/making-our-web-analytics-open-source-with-plausible.mdx
@@ -1,0 +1,57 @@
+---
+head:
+  - tag: link
+    attrs:
+      rel: "canonical"
+      href: "https://www.openhomefoundation.org/blog/making-our-web-analytics-open-source-with-plausible/"
+  - tag: meta
+    attrs:
+      http-equiv: "refresh"
+      content: "0; url=https://www.openhomefoundation.org/blog/making-our-web-analytics-open-source-with-plausible/"
+  - tag: script
+    content: |
+      window.location.replace("https://www.openhomefoundation.org/blog/making-our-web-analytics-open-source-with-plausible/");
+  - tag: meta
+    attrs:
+      property: "og:image"
+      content: "https://www.openhomefoundation.org/assets/images/blog/making-our-web-analytics-open-source-with-plausible/card.webp"
+  - tag: meta
+    attrs:
+      name: "twitter:image"
+      content: "https://www.openhomefoundation.org/assets/images/blog/making-our-web-analytics-open-source-with-plausible/card.webp"
+  - tag: meta
+    attrs:
+      property: "og:image:alt"
+      content: "Making our web analytics open source with Plausible"
+  - tag: meta
+    attrs:
+      property: "og:image:title1"
+      content: "Making our web analytics"
+  - tag: meta
+    attrs:
+      property: "og:image:title2"
+      content: "open source with Plausible"
+  - tag: meta
+    attrs:
+      property: "og:image:author"
+      content: "Darren Griffin"
+  - tag: meta
+    attrs:
+      property: "og:image:category"
+      content: "Announcements"
+
+title: "Making our web analytics open source with Plausible"
+description: "Find out how and why we're implementing analytics on our websites: via open source software with no personal data collection or tracking."
+crosspostSource: "Open Home Foundation"
+cover:
+  image: "https://www.openhomefoundation.org/assets/images/blog/making-our-web-analytics-open-source-with-plausible/card.webp"
+  alt: "Making our web analytics open source with Plausible"
+excerpt: "The Open Home Foundation fights for privacy, choice, and sustainability. These principles are at the heart of everything we do, including how we handle website analytics. Our position is clear: we reject tools that track individuals across the web to monetize their data. Instead, we want aggregated, anonymized analytics that show how our websites are performing overall — without identifying who our visitors are, or compromising their privacy."
+date: 2026-07-30
+authors:
+  - darren
+tags:
+  - Announcements
+---
+
+The Open Home Foundation fights for privacy, choice, and sustainability. These principles are at the heart of everything we do, including how we handle website analytics. Our position is clear: we reject tools that track individuals across the web to monetize their data. Instead, we want aggregated, anonymized analytics that show how our websites are performing overall — without identifying who our visitors are, or compromising their privacy.

--- a/src/content/docs/components/light/index.mdx
+++ b/src/content/docs/components/light/index.mdx
@@ -51,7 +51,7 @@ light:
   when the state is **not** restored based on `restore_mode` (below).
 
   - **state** (*Optional*, boolean, [templatable](/automations/templates)): The ON/OFF state for the light.
-  - All other options from [light state](#light-state_config).
+  - All other options from [light state](#light-state).
 
 - **restore_mode** (*Optional*): Control how the light attempts to restore state on bootup.
 
@@ -97,9 +97,7 @@ light:
 - If Webserver enabled and [version 3](/components/web_server#config-webserver-version-3-options) is selected, all other options from
   [Web Server](/components/web_server/).
 
-<span id="light-state_config"></span>
-
-**Light state:**
+### Light state
 
 Some actions/configuration refer to **light state**. A **light state** may consist of any of the following
 configuration variables:
@@ -220,7 +218,7 @@ on_...:
 - **effect** (*Optional*, string, [templatable](/automations/templates)): If set, will attempt to start an effect
   with the given name.
 
-- All other options from [light state](#light-state_config).
+- All other options from [light state](#light-state).
 
 > [!NOTE]
 > This action can also be expressed in [lambdas](/automations/templates#config-lambda):
@@ -310,7 +308,7 @@ on_...:
 
 - **id** (**Required**, [ID](/guides/configuration-types#id)): The ID of the light.
 - **state** (*Optional*, [templatable](/automations/templates), boolean): Change the ON/OFF state of the light.
-- All other options from [light state](#light-state_config).
+- All other options from [light state](#light-state).
 
 ### `light.dim_relative` Action
 
@@ -674,7 +672,7 @@ light:
   - **duration** (**Required**, [Time](/guides/configuration-types#time)): The duration this color should be active.
   - **transition_length** (*Optional*, [Time](/guides/configuration-types#time)): The duration of each transition. Defaults to `0s`.
 
-See [light state](#light-state_config) for more information on the various color fields.
+See [light state](#light-state) for more information on the various color fields.
 
 ### Flicker Effect
 

--- a/src/content/docs/components/touchscreen/chsc6x.mdx
+++ b/src/content/docs/components/touchscreen/chsc6x.mdx
@@ -36,8 +36,20 @@ touchscreen:
 
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually set the ID of this touchscreen.
 - **interrupt_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The touch detection pin.
+- **model** (*Optional*, string): The touch controller variant. Defaults to `CHSC6X`.
+
+  - `CHSC6X`: touch count at the first byte of the report, with single-byte
+    coordinates. Used by the Seeed Studio Round Display for XIAO.
+  - `CHSC6540`: three-byte report header and 9-bit coordinates. Required for the
+    CHSC6540, and for any panel wider or taller than 255 pixels, which single-byte
+    coordinates cannot address.
 
 - All other options from [Touchscreen](/components/touchscreen#config-touchscreen).
+
+If the controller is a CHSC6540 and touches are never registered, `model` is the first
+thing to check. With the default `CHSC6X` layout the touch count is read from a byte
+that is always zero on that part, so no touch is ever reported, and there is no error
+or log output to indicate why.
 
 ### Sample config for the ESP32S3
 

--- a/src/content/docs/guides/cli.mdx
+++ b/src/content/docs/guides/cli.mdx
@@ -255,41 +255,14 @@ configuration file — if none is provided, it will clean the `.esphome` directo
 working directory. Arguments can be YAML configuration files or directories containing them.
 
 Storage files (`.json` files and the `storage` directory inside `.esphome`) are preserved so that
-the dashboard continues to function correctly.
+the ESPHome Device Builder continues to function correctly.
 
 ### `dashboard` Command
 
-The `esphome dashboard <CONFIG>` command starts the ESPHome dashboard server for using ESPHome
-through a graphical user interface. This command accepts a configuration directory instead of a
-single configuration file.
-
-#### Options
-
-**`--address ADDRESS`**
-: Manually set the address to bind to (defaults to 0.0.0.0)
-
-
-**`--port PORT`**
-: Manually set the HTTP port to open connections on (defaults to 6052)
-
-
-**`--socket SOCKET`**
-: Manually set the unix socket to bind to. If specified along with `--address` or `--port` the values
-for those parameters will be ignored. Cannot be used along with `--systemd-socket`.
-
-
-**`--username USERNAME`**
-: The optional username to require for authentication.
-
-
-**`--password PASSWORD`**
-: The optional password to require for authentication.
-
-
-**`--open-ui`**
-: If set, opens the dashboard UI in a browser once the server is up and running. Does not work when using
-`--socket`.
-
+> [!NOTE]
+> The built-in `dashboard` command has been removed. To use ESPHome through a graphical user interface, run the
+> [ESPHome Device Builder](/guides/getting_started_command_line#esphome-device-builder-docker) instead. Home
+> Assistant app and Docker users are unaffected. Both already run the Device Builder.
 
 ### `analyze-memory` Command
 

--- a/src/content/docs/guides/faq.mdx
+++ b/src/content/docs/guides/faq.mdx
@@ -517,10 +517,10 @@ docker run --rm -v "${PWD}":/config -it ghcr.io/esphome/esphome logs livingroom.
 docker run --rm -v "${PWD}":/config --device=/dev/ttyUSB0 -it ghcr.io/esphome/esphome ...
 
 # Start dashboard on port 6052 (general command)
-# Warning: this command is currently not working with Docker on MacOS. (see note below)
+# Note: on Docker Desktop 4.34+, host networking must be enabled first. (see note below)
 docker run --rm -v "${PWD}":/config --net=host -it ghcr.io/esphome/esphome
 
-# Start dashboard on port 6052 (without host networking, for example on MacOS)
+# Start dashboard on port 6052 (without host networking, for example on macOS)
 docker run --rm -p 6052:6052 -v "${PWD}":/config -it ghcr.io/esphome/esphome
 
 # Setup a bash alias:
@@ -560,10 +560,14 @@ services:
 > Docker Desktop version 4.34 and later it is available, but must first be enabled under
 > Settings > Resources > Network.
 >
-> If you don't use the host networking driver, the Device Builder still runs, and it still checks devices with a
-> periodic ICMP ping sweep. Without multicast, however, `.local` names cannot be resolved, so the sweep only has an
-> address to ping for devices that have a fixed one - set with `use_address` or
-> [`manual_ip`](/components/wifi#wifi-manual_ip) in the device's own configuration. Other devices will show no status.
+> Without the host networking driver the Device Builder still runs, and a periodic ICMP ping sweep still tracks every
+> node - but multicast no longer reaches the container, so `.local` names stop resolving through mDNS. That leaves
+> whatever your network can resolve on its own: a literal IP, or a hostname served by regular DNS. A `.local` name
+> may still work, because the Device Builder retries the bare hostname without the suffix, which your DNS may serve.
+> Devices that resolve no other way are shown as offline.
+>
+> To give a device an address that doesn't depend on mDNS, [`manual_ip`](/components/wifi#wifi-manual_ip) assigns it
+> a static IP, and [`use_address`](/components/wifi/) overrides the address used to connect to it.
 >
 > Note that mDNS might not work if your Home Assistant server and your ESPHome nodes are on different subnets
 > and/or VLANs. If your router supports Avahi, you can configure mDNS to work across different subnets.
@@ -584,16 +588,18 @@ is bound to cause problems -- mDNS is used to determine the IP address of each E
 
 If you disable mDNS, expect the following repercussions:
 
-- You will not be able to use the node's hostname to ping, find it's IP address or otherwise connect to it.
+- You will not be able to use the node's hostname to ping, find its IP address or otherwise connect to it, unless
+  your regular DNS serves that hostname as well.
 - Automatic discovery in Home Assistant when using the [native API](/components/api/) relies on
   mDNS broadcast messages to detect the presence of new ESPHome nodes. If you need to use the native API with
   mDNS disabled, then you will have to use a static IP address and manually add the ESPHome component with its
   (static) IP address.
 
-- Because status detection in the [ESPHome Device Builder](/guides/getting_started_hassio#installing-esphome-device-builder) uses mDNS by
-  default, nodes with mDNS disabled will always appear as "offline". This does not affect any functionality; however,
-  if you want to see the online/offline status of your nodes, you may configure the ESPHome Device Builder to ping each
-  node instead. See the [notes in the Docker Reference section](#docker-reference-notes) for more information.
+- Status detection in the [ESPHome Device Builder](/guides/getting_started_hassio#installing-esphome-device-builder)
+  uses mDNS where it is available, but a periodic ICMP ping sweep runs for every node regardless, so a node with
+  mDNS disabled is still tracked as long as its address resolves some other way - see the
+  [notes in the Docker Reference section](#docker-reference-notes). A node whose address cannot be resolved at all
+  is shown as "offline".
 
 ## Can configuration files be recovered from the device?
 

--- a/src/content/docs/guides/faq.mdx
+++ b/src/content/docs/guides/faq.mdx
@@ -520,8 +520,8 @@ docker run --rm -v "${PWD}":/config --device=/dev/ttyUSB0 -it ghcr.io/esphome/es
 # Warning: this command is currently not working with Docker on MacOS. (see note below)
 docker run --rm -v "${PWD}":/config --net=host -it ghcr.io/esphome/esphome
 
-# Start dashboard on port 6052 (MacOS specific command)
-docker run --rm -p 6052:6052 -e ESPHOME_DASHBOARD_USE_PING=true -v "${PWD}":/config -it ghcr.io/esphome/esphome
+# Start dashboard on port 6052 (without host networking, for example on MacOS)
+docker run --rm -p 6052:6052 -v "${PWD}":/config -it ghcr.io/esphome/esphome
 
 # Setup a bash alias:
 alias esphome='docker run --rm -v "${PWD}":/config --net=host -it ghcr.io/esphome/esphome'
@@ -543,8 +543,8 @@ services:
       # if needed, add esp device(s) as in command line examples above
       - /dev/ttyUSB0:/dev/ttyUSB0
       - /dev/ttyACM0:/dev/ttyACM0
-    # The host networking driver only works on Linux hosts, but is available as a Beta feature,
-    # on Docker Desktop version 4.29 and later.
+    # The host networking driver only works on Linux hosts; on Docker Desktop version 4.34 and
+    # later it must first be enabled under Settings > Resources > Network.
     network_mode: host
     restart: always
 ```
@@ -552,14 +552,18 @@ services:
 <span id="docker-reference-notes"></span>
 
 > [!NOTE]
-> By default, ESPHome uses mDNS to resolve device IPs on the network; this is used to determine online/offline state
-> in the [ESPHome Device Builder](/guides/getting_started_hassio#installing-esphome-device-builder). In order for this feature to work, you
-> must use Docker's host networking mode.
+> By default, ESPHome uses mDNS to discover devices and resolve their IPs on the network; this is how the
+> [ESPHome Device Builder](/guides/getting_started_hassio#installing-esphome-device-builder) finds devices and tracks
+> whether they are online. In order for mDNS to work, you must use Docker's host networking mode.
 >
-> The [host networking driver](https://docs.docker.com/network/drivers/host/) only works on Linux hosts; it is
-> available on Docker Desktop version 4.29 and later.
+> The [host networking driver](https://docs.docker.com/engine/network/drivers/host/) only works on Linux hosts. On
+> Docker Desktop version 4.34 and later it is available, but must first be enabled under
+> Settings > Resources > Network.
 >
-> If you don't want to use the host networking driver, you have to use an alternate method as described below.
+> If you don't use the host networking driver, the Device Builder still runs, and it still checks devices with a
+> periodic ICMP ping sweep. Without multicast, however, `.local` names cannot be resolved, so the sweep only has an
+> address to ping for devices that have a fixed one - set with `use_address` or
+> [`manual_ip`](/components/wifi#wifi-manual_ip) in the device's own configuration. Other devices will show no status.
 >
 > Note that mDNS might not work if your Home Assistant server and your ESPHome nodes are on different subnets
 > and/or VLANs. If your router supports Avahi, you can configure mDNS to work across different subnets.
@@ -567,10 +571,6 @@ services:
 >
 > 1. Enable Avahi on both subnets (install Avahi modules on OpenWRT or pfSense).
 > 1. Enable UDP traffic from your ESPHome device's subnet to 224.0.0.251/32 on port 5353.
->
-> Alternatively, you can configure the [ESPHome Device Builder](/guides/getting_started_hassio#installing-esphome-device-builder) to use ICMP
-> pings to check the status of devices by setting `"status_use_ping": true` or, with Docker:
-> `-e ESPHOME_DASHBOARD_USE_PING=true`
 >
 > See also [https://github.com/esphome/issues/issues/641#issuecomment-534156628](https://github.com/esphome/issues/issues/641#issuecomment-534156628).
 

--- a/src/content/docs/guides/getting_started_command_line.mdx
+++ b/src/content/docs/guides/getting_started_command_line.mdx
@@ -228,15 +228,20 @@ pip install tornado esptool
 # Start the dashboard
 esphome dashboard config
 
-# On Docker, host networking mode is required for online status indicators
+# On Docker, host networking mode lets the dashboard find devices and track their status
 docker run --rm --net=host -v "${PWD}":/config -it ghcr.io/esphome/esphome
 
-# On Docker with MacOS, the host networking option doesn't work as expected. An
-# alternative is to use the following command if you are a MacOS user.
-docker run --rm -p 6052:6052 -e ESPHOME_DASHBOARD_USE_PING=true -v "${PWD}":/config -it ghcr.io/esphome/esphome
+# On Docker Desktop, where host networking is not enabled by default, publish the port instead
+docker run --rm -p 6052:6052 -v "${PWD}":/config -it ghcr.io/esphome/esphome
 ```
 
 After that, you will be able to access the ESPHome Device Builder at `localhost:6052`.
+
+> [!NOTE]
+> `--net=host` lets the ESPHome Device Builder see mDNS, which is how it finds devices and tracks whether they are
+> online. Without host networking the Device Builder still runs, but `.local` names will not resolve, so it can only
+> reach devices that have a fixed address - one set with `use_address` or
+> [`manual_ip`](/components/wifi#wifi-manual_ip) in the device's own configuration.
 
 Logging level can be set with the env var `ESPHOME_LOG_LEVEL` (default is `INFO`).
 

--- a/src/content/docs/guides/getting_started_command_line.mdx
+++ b/src/content/docs/guides/getting_started_command_line.mdx
@@ -238,9 +238,11 @@ After that, you will be able to access the ESPHome Device Builder at `localhost:
 
 > [!NOTE]
 > `--net=host` lets the ESPHome Device Builder see mDNS, which is how it finds devices and tracks whether they are
-> online. Without host networking the Device Builder still runs, but `.local` names will not resolve, so it can only
-> reach devices that have a fixed address - one set with `use_address` or
-> [`manual_ip`](/components/wifi#wifi-manual_ip) in the device's own configuration.
+> online. Without host networking it still runs and still pings devices to track their status, but `.local` names
+> stop resolving through mDNS, so it can only reach devices your network resolves another way: a literal IP, or a
+> hostname served by regular DNS. [`manual_ip`](/components/wifi#wifi-manual_ip) assigns a device a static IP, and
+> [`use_address`](/components/wifi/) overrides the address used to connect to it. See the
+> [FAQ](/guides/faq#docker-reference-notes) for the full details.
 
 Logging level can be set with the env var `ESPHOME_LOG_LEVEL` (default is `INFO`).
 

--- a/src/content/docs/guides/getting_started_command_line.mdx
+++ b/src/content/docs/guides/getting_started_command_line.mdx
@@ -218,20 +218,19 @@ The ESPHome Device Builder allows you to easily manage your nodes from a nice we
 as a [Home Assistant app](/guides/getting_started_hassio/), but can run in docker independently from
 Home Assistant.
 
-To start the ESPHome Device Builder, simply start ESPHome with the following command (with `config/` pointing to a
-directory where you want to store your configurations):
+When installing with `pip`, the Device Builder is a separate package from ESPHome itself; the Docker image already
+bundles it. Start it with one of the following commands (with `config` pointing to a directory where you want to
+store your configurations):
 
 ```bash
-# Install dashboard dependencies
-pip install tornado esptool
+# Option 1: install and run with pip
+pip install esphome-device-builder
+esphome-device-builder config
 
-# Start the dashboard
-esphome dashboard config
-
-# On Docker, host networking mode lets the dashboard find devices and track their status
+# Option 2: run in Docker. Host networking lets the Device Builder find devices and track their status
 docker run --rm --net=host -v "${PWD}":/config -it ghcr.io/esphome/esphome
 
-# On Docker Desktop, where host networking is not enabled by default, publish the port instead
+# Option 3: on Docker Desktop, where host networking is not enabled by default, publish the port instead
 docker run --rm -p 6052:6052 -v "${PWD}":/config -it ghcr.io/esphome/esphome
 ```
 


### PR DESCRIPTION
Documents the `model:` option added in esphome/esphome#17987.

The CHSC6540 uses a different report layout to the one `chsc6x` assumes (three-byte header, 9-bit coordinates), so with the default parsing the touch count is read from a byte that is always zero on that part and no touch is ever registered. The new option selects the correct layout; the default is unchanged.

Companion PR: esphome/esphome#17987
Issue: esphome/esphome#17986