### PR TITLE
[lvgl] Document lvgl.widget.set_z_index action

### DIFF
--- a/src/content/docs/components/lvgl/widgets.mdx
+++ b/src/content/docs/components/lvgl/widgets.mdx
@@ -2166,6 +2166,38 @@ on_...:
   - lvgl.widget.focus: previous
 ```
 
+### `lvgl.widget.set_z_index` Action
+
+This [action](/automations/actions#actions-action) changes the stacking order (z-index) of a widget among its siblings, i.e. which
+widgets are drawn on top of which. It does not change any other widget property.
+
+- **id** (**Required**): The ID or a list of IDs of widgets configured in LVGL to reorder.
+- **position** (**Required**): One of `top`, `bottom`, `up`, `down`, or an integer sibling index.
+  - `top`: bring the widget fully to the front, in front of all its siblings.
+  - `bottom`: send the widget fully to the back, behind all its siblings.
+  - `up`: move the widget one step closer to the front.
+  - `down`: move the widget one step closer to the back.
+  - An integer: move the widget to that exact sibling index. `0` is the back-most position;
+    positive numbers count from the back. Negative numbers count from the front, so `-1` is
+    the same as `top`.
+
+```yaml
+on_...:
+  - lvgl.widget.set_z_index:
+      id: popup_box
+      position: top
+
+on_...:
+  - lvgl.widget.set_z_index:
+      id: [icon_1, icon_2]
+      position: down
+
+on_...:
+  - lvgl.widget.set_z_index:
+      id: background_image
+      position: 0
+```
+
 ## Triggers
 
 In addition to specific triggers like `on_value` which are available for certain widgets, here is a complete list of triggers available for them.


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#17993

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
