### PR TITLE
[rp2_ble_tracker] Add component documentation

### DIFF
--- a/src/content/docs/components/index.mdx
+++ b/src/content/docs/components/index.mdx
@@ -128,6 +128,7 @@ ESPHome-specific components or components supporting ESPHome device provisioning
   ["Improv via BLE", "/components/esp32_improv/", "improv.svg", "dark-invert"],
   ["LN882H BLE", "/components/ln882h_ble/", "bluetooth.svg", "dark-invert"],
   ["Nordic UART Service (NUS)", "/components/ble_nus/", "bluetooth.svg", "dark-invert"],
+  ["RP2 BLE Tracker", "/components/rp2_ble_tracker/", "bluetooth.svg", "dark-invert"],
   ["RP2040 BLE", "/components/rp2040_ble/", "bluetooth.svg", "dark-invert"],
   ["Zephyr BLE Server", "/components/zephyr_ble_server/", "bluetooth.svg", "dark-invert"],
 ]} />

--- a/src/content/docs/components/rp2040_ble.mdx
+++ b/src/content/docs/components/rp2040_ble.mdx
@@ -13,7 +13,7 @@ boards with this chip.
 
 > [!NOTE]
 > This component initializes the BLE stack and provides the scan primitives used by the
-> RP2 BLE Tracker component. Additional components for connecting
+> [RP2 BLE Tracker](/components/rp2_ble_tracker/). Additional components for connecting
 > and acting as a server will be added in future releases.
 
 > [!NOTE]

--- a/src/content/docs/components/rp2_ble_tracker.mdx
+++ b/src/content/docs/components/rp2_ble_tracker.mdx
@@ -18,9 +18,6 @@ use a 30 % duty cycle to leave the radio mostly free for WiFi.
 ```yaml
 # Example configuration entry
 rp2_ble_tracker:
-  scan_parameters:
-    interval: 100ms
-    window: 30ms
 ```
 
 ## Configuration variables
@@ -37,9 +34,10 @@ rp2_ble_tracker:
     scan period. In continuous mode a scan end event fires each period; in
     non-continuous mode the scan stops after this long. Must cover at least three scan
     intervals. Defaults to `5min`.
-  - **continuous** (*Optional*, boolean): If true, scanning runs forever. If false, a
-    started scan stops after `duration` and is restarted from an automation. Defaults to
-    `true`.
+  - **continuous** (*Optional*, boolean): If true, scanning starts at boot and runs
+    forever. If false, scanning does **not** start automatically; a scan must be started
+    from a lambda (`id(my_tracker).start_scan();`) and stops again after `duration`.
+    Defaults to `true`.
 
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID used
   to reference this component.

--- a/src/content/docs/components/rp2_ble_tracker.mdx
+++ b/src/content/docs/components/rp2_ble_tracker.mdx
@@ -57,6 +57,7 @@ rp2_ble_tracker:
 
 ## See Also
 
+- [RP2 Platform](/components/rp2/)
 - [RP2040 BLE](/components/rp2040_ble/)
 - [ESP32 BLE Tracker](/components/esp32_ble_tracker/)
 - <APIRef text="rp2_ble_tracker.h" path="rp2_ble_tracker/rp2_ble_tracker.h" />

--- a/src/content/docs/components/rp2_ble_tracker.mdx
+++ b/src/content/docs/components/rp2_ble_tracker.mdx
@@ -10,10 +10,12 @@ Raspberry Pi **Pico W** and **Pico 2 W** — the platform analog of
 [ESP32 BLE Tracker](/components/esp32_ble_tracker/). It builds on the
 [RP2040 BLE](/components/rp2040_ble/) stack component and loads it automatically.
 
-Scanning is **passive only**: the tracker listens for advertisements but does not send
-scan requests, so scan response data (such as some device names) is not requested. The
-radio is shared between WiFi and Bluetooth on these boards; the default scan parameters
-use a 30% duty cycle to leave the radio mostly free for WiFi.
+Scanning is **active by default**: the tracker sends scan requests asking devices for
+more data, and the scan response (which can carry extra data such as some device names)
+arrives as a separate advertisement report rather than being merged into the
+advertisement. Set `active: false` for a lighter passive scan. The radio is shared
+between WiFi and Bluetooth on these boards; the default scan parameters use a 30% duty
+cycle to leave the radio mostly free for WiFi.
 
 > [!NOTE]
 > BLE sensor platforms such as `ble_presence` do not yet bind to this tracker; support
@@ -38,6 +40,10 @@ rp2_ble_tracker:
     scan period. In continuous mode the scan period restarts every `duration`; in
     non-continuous mode the scan stops after this long. Must cover at least three scan
     intervals. Defaults to `5min`.
+  - **active** (*Optional*, boolean): Whether to send scan requests asking devices for
+    more data after their advertisement. The scan response arrives as a separate report;
+    it is not merged into the advertisement. Turning this off saves power on the
+    advertising devices and radio time on the shared CYW43439. Defaults to `true`.
   - **continuous** (*Optional*, boolean): If true, scanning starts at boot and runs
     forever. If false, scanning does **not** start automatically; a scan must be started
     from a lambda (`id(my_tracker).start_scan();`) and stops again after `duration`.

--- a/src/content/docs/components/rp2_ble_tracker.mdx
+++ b/src/content/docs/components/rp2_ble_tracker.mdx
@@ -1,0 +1,51 @@
+---
+description: "Instructions for setting up the RP2 BLE tracker to scan for Bluetooth Low Energy devices on the Raspberry Pi Pico W."
+title: "RP2 BLE Tracker"
+---
+
+import APIRef from '@components/APIRef.astro';
+
+The `rp2_ble_tracker` component scans for Bluetooth Low Energy advertisements on the
+Raspberry Pi **Pico W** and **Pico 2 W** — the platform analog of
+[ESP32 BLE Tracker](/components/esp32_ble_tracker/). It builds on the
+[RP2040 BLE](/components/rp2040_ble/) stack component and loads it automatically.
+
+Scanning is **passive only**: the tracker listens for advertisements but does not send
+scan requests, so scan response data (such as some device names) is not requested. The
+radio is shared between WiFi and Bluetooth on these boards; the default scan parameters
+use a 30 % duty cycle to leave the radio mostly free for WiFi.
+
+```yaml
+# Example configuration entry
+rp2_ble_tracker:
+  scan_parameters:
+    interval: 100ms
+    window: 30ms
+```
+
+## Configuration variables
+
+- **scan_parameters** (*Optional*): Tune how the scan runs.
+
+  - **interval** (*Optional*, [Time](/guides/configuration-types#time)): How often the
+    radio opens a scan window. The controller accepts 2.5 ms to 10240 ms in 0.625 ms
+    steps. Defaults to `100ms`.
+  - **window** (*Optional*, [Time](/guides/configuration-types#time)): How long the radio
+    listens within each interval. Must not be larger than the interval; the same range
+    and step apply. Defaults to `30ms`.
+  - **duration** (*Optional*, [Time](/guides/configuration-types#time)): Length of one
+    scan period. In continuous mode a scan end event fires each period; in
+    non-continuous mode the scan stops after this long. Must cover at least three scan
+    intervals. Defaults to `5min`.
+  - **continuous** (*Optional*, boolean): If true, scanning runs forever. If false, a
+    started scan stops after `duration` and is restarted from an automation. Defaults to
+    `true`.
+
+- **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID used
+  to reference this component.
+
+## See Also
+
+- [RP2040 BLE](/components/rp2040_ble/)
+- [ESP32 BLE Tracker](/components/esp32_ble_tracker/)
+- <APIRef text="rp2_ble_tracker.h" path="rp2_ble_tracker/rp2_ble_tracker.h" />

--- a/src/content/docs/components/rp2_ble_tracker.mdx
+++ b/src/content/docs/components/rp2_ble_tracker.mdx
@@ -13,7 +13,8 @@ Raspberry Pi **Pico W** and **Pico 2 W** — the platform analog of
 Scanning is **active by default**: the tracker sends scan requests asking devices for
 more data, and the scan response (which can carry extra data such as some device names)
 arrives as a separate advertisement report rather than being merged into the
-advertisement. Set `active: false` for a lighter passive scan. The radio is shared
+advertisement. Set `active: false` under `scan_parameters` for a lighter passive
+scan. The radio is shared
 between WiFi and Bluetooth on these boards; the default scan parameters use a 30% duty
 cycle to leave the radio mostly free for WiFi.
 

--- a/src/content/docs/components/rp2_ble_tracker.mdx
+++ b/src/content/docs/components/rp2_ble_tracker.mdx
@@ -13,7 +13,11 @@ Raspberry Pi **Pico W** and **Pico 2 W** — the platform analog of
 Scanning is **passive only**: the tracker listens for advertisements but does not send
 scan requests, so scan response data (such as some device names) is not requested. The
 radio is shared between WiFi and Bluetooth on these boards; the default scan parameters
-use a 30 % duty cycle to leave the radio mostly free for WiFi.
+use a 30% duty cycle to leave the radio mostly free for WiFi.
+
+> [!NOTE]
+> BLE sensor platforms such as `ble_presence` do not yet bind to this tracker; support
+> arrives as those platforms migrate to the shared BLE layer in follow-up releases.
 
 ```yaml
 # Example configuration entry
@@ -31,7 +35,7 @@ rp2_ble_tracker:
     listens within each interval. Must not be larger than the interval; the same range
     and step apply. Defaults to `30ms`.
   - **duration** (*Optional*, [Time](/guides/configuration-types#time)): Length of one
-    scan period. In continuous mode a scan end event fires each period; in
+    scan period. In continuous mode the scan period restarts every `duration`; in
     non-continuous mode the scan stops after this long. Must cover at least three scan
     intervals. Defaults to `5min`.
   - **continuous** (*Optional*, boolean): If true, scanning starts at boot and runs
@@ -39,6 +43,8 @@ rp2_ble_tracker:
     from a lambda (`id(my_tracker).start_scan();`) and stops again after `duration`.
     Defaults to `true`.
 
+- **rp2040_ble_id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify
+  the ID of the [RP2040 BLE](/components/rp2040_ble/) component this tracker uses.
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID used
   to reference this component.
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Adds the documentation page for the new rp2_ble_tracker component, a BLE scanner for the Raspberry Pi Pico W and Pico 2 W that scans actively by default with a passive option, and links it from the component index.

**Related issue (if applicable):**

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#18002
- esphome/esphome#18035

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [x] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>

