### PR TITLE
Add restore_mode to Daly Charging and Discharging MOS

### DIFF
--- a/src/content/docs/components/sensor/daly_bms.mdx
+++ b/src/content/docs/components/sensor/daly_bms.mdx
@@ -189,6 +189,7 @@ Then you can add switches
 switch:
   - platform: template
     name: "Daly Charging MOS"
+    restore_mode: DISABLED
     lambda: |-
       if (id(bin_daly_chg_mos).state) {
         return true;
@@ -208,6 +209,7 @@ switch:
 
   - platform: template
     name: "Daly Discharging MOS"
+    restore_mode: DISABLED
     lambda: |-
       if (id(bin_daly_dischg_mos).state) {
         return true;


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Template switches default to `ALWAYS_OFF`, which invokes `turn_off_action`
during startup and disables both MOS outputs. Using `restore_mode: DISABLED`
prevents startup control commands; the actual state is subsequently reported
by the Daly BMS binary sensors.

Tested successfully with a Daly BMS and ESP8266.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** N/A

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
