### PR TITLE
[lvgl] Document dynamic widget access

### DIFF
--- a/src/content/docs/components/lvgl/widgets.mdx
+++ b/src/content/docs/components/lvgl/widgets.mdx
@@ -196,7 +196,7 @@ one nested inside another widget's `widgets:` -- by specifying the widget that *
 indices to walk from it:
 
 - **parent** (**Required**, [ID](/guides/configuration-types#id)): The ID of a widget with children.
-- **path** (**Required**, list of templatable positive ints): Child indices to walk from `parent`. `path: [1]` selects
+- **path** (**Required**, list of templatable ordinal numbers): Child indices to walk from `parent`. `path: [1]` selects
   `parent`'s 2nd child (indices are zero-based); `path: [1, 0]` selects that child's own 1st child, and so on.
 
 ```yaml

--- a/src/content/docs/components/lvgl/widgets.mdx
+++ b/src/content/docs/components/lvgl/widgets.mdx
@@ -188,6 +188,40 @@ specific to a widget are described in each section below. Some of these properti
 `lvgl.<widget_type>.update` action, e.g. `lvgl.label.update` allows updating not only the common style properties,
 but also the `text` property of a label.
 
+### Updating a widget that has no `id:` of its own
+
+Every `lvgl.<widget_type>.update` action's `id:` normally refers to a widget's own configured
+[ID](/guides/configuration-types#id). It can instead be given a reference to a widget that was never assigned an `id:` --
+one nested inside another widget's `widgets:` -- by specifying the widget that *does* have an ID, plus a path of child
+indices to walk from it:
+
+- **parent** (**Required**, [ID](/guides/configuration-types#id)): The ID of a widget with children.
+- **path** (**Required**, list of templatable positive ints): Child indices to walk from `parent`. `path: [1]` selects
+  `parent`'s 2nd child (indices are zero-based); `path: [1, 0]` selects that child's own 1st child, and so on.
+
+```yaml
+- button:
+    id: my_button
+    widgets:
+      - label:
+          text: "Original"
+
+on_...:
+  - lvgl.label.update:
+      id:
+        parent: my_button
+        path: [0]
+      text: "Updated"
+```
+
+`parent` can be any widget with children, not only a `button` -- whatever widget the target is nested inside. If the
+path doesn't resolve to anything (for example, if the widget it used to point to no longer exists), the update is
+silently skipped rather than causing a crash.
+
+This isn't supported for widget types backed by a compound C++ object rather than a single LVGL object --
+`dropdown`, `page`, `msgbox` -- nor for the generic `lvgl.widget.update` action, only the per-widget-type
+`lvgl.<widget_type>.update` actions.
+
 ## Text property
 
 Several widgets have a `text` property, and the possible ways this can be specified are common to all `text` properties.


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#18021

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
