### PR TITLE
[esp32_rmt_led_strip] Document new `rgb_order` option

### DIFF
--- a/src/content/docs/components/light/esp32_rmt_led_strip.mdx
+++ b/src/content/docs/components/light/esp32_rmt_led_strip.mdx
@@ -33,7 +33,7 @@ light:
   - `APA106`
   - `SM16703`
 
-- **rgb_order** (**Required**, string): The RGB order of the strip.
+- **rgb_order** (**Optional**, string): The RGB order of the strip.
 
   - `RGB`
   - `RBG`
@@ -44,6 +44,7 @@ light:
 
 - **is_rgbw** (*Optional*, boolean): Set to `true` if the strip is RGBW. Defaults to `false`.
 - **is_wrgb** (*Optional*, boolean): Set to `true` if the strip is WRGB. Defaults to `false`.
+- **rgbw_order** (**Optional**, string): The RGBW order of the strip. Options are the same as `rgb_order` but with the `W` channel placed at an arbitrary location in the order. Note that this is mutually exclusive with `rgb_order`, `is_rgbw`, and `is_wrgb`.
 - **max_refresh_rate** (*Optional*, [Time](/guides/configuration-types#time)): A time interval used to limit the number of commands a light
   can handle per second. For example, `16ms` will limit the light to a refresh rate of about 60Hz. Defaults to
   sending commands as quickly as changes are made to the lights.


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Add documentation for new `rgbw_order` option for `esp32_rmt_led_strip`.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#18028

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
