### PR TITLE
[rp2_ble_tracker] Document active scanning

### DIFF
--- a/src/content/docs/components/rp2_ble_tracker.mdx
+++ b/src/content/docs/components/rp2_ble_tracker.mdx
@@ -10,10 +10,10 @@ Raspberry Pi **Pico W** and **Pico 2 W** — the platform analog of
 [ESP32 BLE Tracker](/components/esp32_ble_tracker/). It builds on the
 [RP2040 BLE](/components/rp2040_ble/) stack component and loads it automatically.
 
-Scanning is **passive only**: the tracker listens for advertisements but does not send
-scan requests, so scan response data (such as some device names) is not requested. The
-radio is shared between WiFi and Bluetooth on these boards; the default scan parameters
-use a 30% duty cycle to leave the radio mostly free for WiFi.
+Scanning can be passive or active. An active scan sends scan requests, and the scan
+response arrives as a separate advertisement report rather than being merged into the
+advertisement. The radio is shared between WiFi and Bluetooth on these boards; the
+default scan parameters use a 30% duty cycle to leave the radio mostly free for WiFi.
 
 > [!NOTE]
 > BLE sensor platforms such as `ble_presence` do not yet bind to this tracker; support
@@ -38,6 +38,11 @@ rp2_ble_tracker:
     scan period. In continuous mode the scan period restarts every `duration`; in
     non-continuous mode the scan stops after this long. Must cover at least three scan
     intervals. Defaults to `5min`.
+  - **active** (*Optional*, boolean): Whether to send scan requests asking devices for
+    more data after their advertisement. The scan response arrives as a separate report;
+    it is not merged into the advertisement. Turning this off saves power on the
+    advertising devices and radio time on the shared CYW43. Defaults to `true`.
+
   - **continuous** (*Optional*, boolean): If true, scanning starts at boot and runs
     forever. If false, scanning does **not** start automatically; a scan must be started
     from a lambda (`id(my_tracker).start_scan();`) and stops again after `duration`.

--- a/src/content/docs/components/rp2_ble_tracker.mdx
+++ b/src/content/docs/components/rp2_ble_tracker.mdx
@@ -10,10 +10,12 @@ Raspberry Pi **Pico W** and **Pico 2 W** — the platform analog of
 [ESP32 BLE Tracker](/components/esp32_ble_tracker/). It builds on the
 [RP2040 BLE](/components/rp2040_ble/) stack component and loads it automatically.
 
-Scanning can be passive or active. An active scan sends scan requests, and the scan
-response arrives as a separate advertisement report rather than being merged into the
-advertisement. The radio is shared between WiFi and Bluetooth on these boards; the
-default scan parameters use a 30% duty cycle to leave the radio mostly free for WiFi.
+Scanning is **active by default**: the tracker sends scan requests asking devices for
+more data, and the scan response (which can carry extra data such as some device names)
+arrives as a separate advertisement report rather than being merged into the
+advertisement. Set `active: false` for a lighter passive scan. The radio is shared
+between WiFi and Bluetooth on these boards; the default scan parameters use a 30% duty
+cycle to leave the radio mostly free for WiFi.
 
 > [!NOTE]
 > BLE sensor platforms such as `ble_presence` do not yet bind to this tracker; support
@@ -41,8 +43,7 @@ rp2_ble_tracker:
   - **active** (*Optional*, boolean): Whether to send scan requests asking devices for
     more data after their advertisement. The scan response arrives as a separate report;
     it is not merged into the advertisement. Turning this off saves power on the
-    advertising devices and radio time on the shared CYW43. Defaults to `true`.
-
+    advertising devices and radio time on the shared CYW43439. Defaults to `true`.
   - **continuous** (*Optional*, boolean): If true, scanning starts at boot and runs
     forever. If false, scanning does **not** start automatically; a scan must be started
     from a lambda (`id(my_tracker).start_scan();`) and stops again after `duration`.


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Documents the new active option on rp2_ble_tracker and updates the scanning paragraph; scan responses arrive as separate reports rather than being merged.

**Related issue (if applicable):**

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#18035

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
