### PR TITLE
[display] Document sleep and wakeup actions

### DIFF
--- a/src/content/docs/components/display/index.mdx
+++ b/src/content/docs/components/display/index.mdx
@@ -484,6 +484,45 @@ Configuration variables:
 
 RGB displays use red, green, and blue, while grayscale displays may use white.
 
+<span id="display-sleep-action"></span>
+
+### `display.sleep` Action
+
+Puts a supported display controller into its low-power sleep mode. This is separate from turning off the display
+backlight. For the largest power saving, turn off the backlight and put the display controller to sleep.
+
+ESPHome validates this action against the selected display model. Configuration fails if the driver or model does not
+support sleep, or if the configured hardware interface cannot send the sleep command. See the display driver's
+documentation for its supported models and any wiring restrictions.
+
+```yaml
+lvgl:
+  on_idle:
+    timeout: 30s
+    then:
+      - light.turn_off: display_backlight
+      - lvgl.pause:
+      - delay: 1s
+      - display.sleep: my_display
+```
+
+### `display.wakeup` Action
+
+Wakes a supported display controller from sleep. Wake the controller before resuming drawing or turning its backlight
+on.
+
+```yaml
+touchscreen:
+  - on_release:
+      - if:
+          condition:
+            lvgl.is_paused:
+          then:
+            - display.wakeup: my_display
+            - lvgl.resume:
+            - light.turn_on: display_backlight
+```
+
 ### Display Pages
 
 Certain display types also allow you to show "pages". With pages you can create drawing lambdas

--- a/src/content/docs/components/display/mipi_rgb.mdx
+++ b/src/content/docs/components/display/mipi_rgb.mdx
@@ -168,6 +168,15 @@ it will be inferred from the number of bytes provided. The SLPOUT, PIXFMT, INVON
 commands will be automatically appended based on config options and should not be included in
 the init sequence in yaml.
 
+## Sleep and Wakeup
+
+The [`display.sleep` and `display.wakeup` actions](/components/display/#display-sleep-action) are currently supported by
+the `GUITION-4848S040` model. The display must retain a usable SPI control interface after the RGB interface starts.
+
+ESPHome rejects these actions during configuration validation if the display has no SPI control interface or if an RGB
+or control pin is shared with another function. The validation error identifies the shared GPIO. This restriction is
+configuration-dependent because model pin defaults can be overridden and the SPI bus is configured separately.
+
 ## Example configurations
 
 This is an example of a custom configuration.

--- a/src/content/docs/components/display/mipi_rgb.mdx
+++ b/src/content/docs/components/display/mipi_rgb.mdx
@@ -170,8 +170,12 @@ the init sequence in yaml.
 
 ## Sleep and Wakeup
 
-The [`display.sleep` and `display.wakeup` actions](/components/display/#display-sleep-action) are currently supported by
-the `GUITION-4848S040` model. The display must retain a usable SPI control interface after the RGB interface starts.
+The [`display.sleep` and `display.wakeup` actions](/components/display/#display-sleep-action) are enabled only for the
+following models:
+
+- `GUITION-4848S040`
+
+The display must retain a usable SPI control interface after the RGB interface starts.
 
 ESPHome rejects these actions during configuration validation if the display has no SPI control interface or if an RGB
 or control pin is shared with another function. The validation error identifies the shared GPIO. This restriction is

--- a/src/content/docs/components/display/mipi_spi.mdx
+++ b/src/content/docs/components/display/mipi_spi.mdx
@@ -245,6 +245,19 @@ by the driver, but can be controlled by a separate GPIO pin. Depending on the di
 be able to be dimmed using a [Monochromatic](/components/light/monochromatic/) with a [Ledc](/components/output/ledc/). AMOLED displays do not have a backlight but
 their brightness can be set using the `brightness` option. This may also be controlled by a lambda API call.
 
+## Sleep and Wakeup
+
+The [`display.sleep` and `display.wakeup` actions](/components/display/#display-sleep-action) are enabled only for models
+that use a controller verified on hardware. The following models currently support these actions:
+
+- `ILI9341`
+- `ESP32-2432S028`
+- `M5CORE2`
+- `JC4827W543`
+
+Other models fail configuration validation when either action targets them. Turning off a backlight does not put the
+display controller to sleep; control the backlight separately when required.
+
 ## Touchscreens
 
 A touchscreen, if present, must be configured separately. See the [Touchscreen](/components/touchscreen/) documentation for more information.


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Documents the `display.sleep` and `display.wakeup` actions, configuration-time capability validation, supported MIPI
models, backlight handling, and the MIPI RGB control-pin restrictions.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#12015

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component, you can automatically generate a standardized black and white component name image
for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in
   **lower_case** format with **underscores** (for example, `bme280`, `sht3x`, or `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to
absolute paths.
</details>
