### PR TITLE
Update ESP32-S31 and ESP32-H4 specs

### DIFF
--- a/src/content/docs/components/esp32.mdx
+++ b/src/content/docs/components/esp32.mdx
@@ -280,9 +280,9 @@ for Thread and Zigbee. It requires ESP-IDF 6.1 or later.
 
 - **CPU:** RISC-V HP core, up to 320 MHz + LP core
 - **Wi-Fi:** 802.11 b/g/n 2.4 GHz
-- **Bluetooth:** BLE
+- **Bluetooth:** Classic Bluetooth + BLE 5.4
 - **802.15.4:** Thread and Zigbee
-- **USB:** Native USB OTG; USB Serial/JTAG peripheral mode
+- **USB:** Native USB 2.0 OTG; USB Serial/JTAG peripheral mode
 - **Ethernet:** Built-in MAC (requires external PHY)
 - **GPIO:** 62 pins (0–61)
 - **UART:** 4 full-featured + 1 lite
@@ -301,7 +301,7 @@ Zigbee. It has no Wi-Fi. It requires ESP-IDF 6.1 or later.
 
 - **CPU:** RISC-V single-core, up to 96 MHz
 - **Wi-Fi:** None
-- **Bluetooth:** BLE
+- **Bluetooth:** BLE 5.4
 - **802.15.4:** Thread and Zigbee
 - **USB:** Native USB OTG; USB Serial/JTAG peripheral mode
 - **Ethernet:** None built-in (SPI-based controllers supported)


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Updated ESP32-S31 and ESP32-H4 specs

**Related issue (if applicable):** fixes n/a

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome# n/a

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
