### PR TITLE
Add dark mode comments

### DIFF
--- a/src/components/DiscourseComments.astro
+++ b/src/components/DiscourseComments.astro
@@ -20,17 +20,40 @@ const embedUrl = new URL(Astro.url.pathname, Astro.site).href;
   <h2 id="comments">Comments</h2>
   <div id="discourse-comments"></div>
   <script is:inline define:vars={{ discourseUrl, embedUrl }}>
-    window.DiscourseEmbed = {
-      discourseUrl,
-      discourseEmbedUrl: embedUrl,
-    };
-
     (function () {
+      // Starlight sets data-theme="light"|"dark" on <html>.
+      function siteTheme() {
+        return document.documentElement.dataset.theme === "dark" ? "dark" : "light";
+      }
+
+      // Mirror the site's light/dark mode into the cross-origin embed. Discourse
+      // applies className as a class on the iframe's own <html> element, so the
+      // forum's Embedded CSS can target it (e.g. `html.dark`).
+      window.DiscourseEmbed = {
+        discourseUrl,
+        discourseEmbedUrl: embedUrl,
+        className: siteTheme(),
+      };
+
       const d = document.createElement("script");
       d.type = "text/javascript";
       d.async = true;
       d.src = window.DiscourseEmbed.discourseUrl + "javascripts/embed.js";
       (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(d);
+
+      // The class is baked into the iframe URL, so re-point the frame whenever
+      // the visitor toggles the site theme to keep the comments in sync.
+      new MutationObserver(function () {
+        const frame = document.getElementById("discourse-embed-frame");
+        if (!frame || !frame.src) return;
+        const url = new URL(frame.src);
+        if (url.searchParams.get("class_name") === siteTheme()) return;
+        url.searchParams.set("class_name", siteTheme());
+        frame.src = url.toString();
+      }).observe(document.documentElement, {
+        attributes: true,
+        attributeFilter: ["data-theme"],
+      });
     })();
   </script>
 </section>


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description
Adds param to comments if dark mode active

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
