### PR TITLE
Add ESPHome Device Builder blog

### DIFF
--- a/.claude/skills/create-blog-post/SKILL.md
+++ b/.claude/skills/create-blog-post/SKILL.md
@@ -1,0 +1,460 @@
+---
+name: create-blog-post
+description: Use this if the user wants to convert a blog post from Google Docs markdown to the format used on the ESPHome website, or wants to publish an externally linked (crosspost) blog post that redirects to an article hosted on another site.
+---
+
+# Create Blog Post
+
+Convert a draft markdown file into a properly formatted ESPHome blog post (Astro/Starlight MDX).
+
+There are two kinds of blog posts this skill handles:
+
+- **Standard blog posts** — full content hosted on the ESPHome website, converted from a Google Docs markdown draft.
+  This is the default path, described in the sections below.
+- **Externally linked (crosspost) blog posts** — a short teaser that redirects readers to an article hosted on another
+  site (for example, the Open Home Foundation blog). If the user asks to "publish a blog that is externally linked",
+  "create a crosspost", "add an external blog post", or similar, follow the
+  [Externally linked (crosspost) blog posts](#externally-linked-crosspost-blog-posts) section instead.
+
+## Usage
+
+Place your draft blog post markdown file in the repository root `create-blog-post/` directory
+(e.g., `/workspaces/esphome-docs/create-blog-post/`), then run:
+
+```shell
+/create-blog-post
+```
+
+## What This Skill Does
+
+Automates conversion of a draft markdown file with metadata into a production-ready ESPHome blog post:
+
+- Extracts metadata (blog title, author, publish date, description)
+- Removes "# Blog notes/preparations" section and lines with ☝️ emoji
+- Removes the `### **– Summary break / Read more –**` marker (Starlight has no excerpt marker)
+- Processes an optional lead image and any additional images (optimized, imported via the `Image`/`Figure` components)
+- Sets the OpenGraph/Twitter image via the Open Home Foundation OG generator URL (based on the post's blog URL)
+- Keeps links as Markdown (internal links relative with a trailing slash; external links as standard Markdown)
+- Formats content (removes bold from headings, ensures headings start at H2, fixes link references)
+- Converts callouts to GitHub-style alerts (`> [!NOTE]`, etc.)
+- Creates a properly formatted MDX post in `src/content/docs/blog/` with Starlight front matter
+
+## Required Files in `create-blog-post/` Directory
+
+1. **Draft markdown file** (any `.md` filename)
+1. **`art.*`** - Optional lead image shown at the top of the post (any common image format: `.webp`, `.png`, `.jpg`, `.jpeg`).
+   The social/OpenGraph image is generated automatically (see below) and does not need to be supplied.
+1. **`image2.*`, `image3.*`, etc.** - Additional images (optional, any common image format)
+
+## Draft File Format
+
+```markdown
+# Metadata
+
+**Blog title:** Your Blog Title
+
+**Author:** Author Name
+
+**Publish date:** DD-MM-YYYY
+
+**Description** (used for the page meta/SEO description, ~120-158 characters):
+Concise summary that describes what readers will find. Include the main keyword.
+
+# Blog notes/preparations
+
+☝️ Any lines with the pointer emoji can be removed during processing
+
+# Blog content
+
+![][image1]
+
+Your intro paragraph here...
+
+### **– Summary break / Read more –**
+
+Rest of content...
+```
+
+**Notes:**
+
+- If present, the `![][image1]` reference at the start of the "# Blog content" section is replaced with the optional
+  `art.*` lead image. If there is no lead image, the post simply starts with text.
+- The URL slug is optional and will be auto-generated from the blog title if not provided in metadata.
+- Lines beginning with the ☝️ emoji are instructions and will be removed during processing.
+- The `### **– Summary break / Read more –**` marker will be removed (there is no Jekyll-style excerpt on this site).
+
+## Output
+
+Creates a production-ready blog post at:
+
+- `src/content/docs/blog/<slug>.mdx` - The formatted MDX blog post
+- `src/content/docs/blog/images/<slug>-hero.webp` - Optional lead image (optimized from `create-blog-post/art.*`, if provided)
+- `src/content/docs/blog/images/<slug>-2.webp`, `<slug>-3.webp`, etc. - Additional images (optimized)
+
+The social/OpenGraph image is not stored in the repo — it is generated on demand by the Open Home Foundation OG
+generator and referenced from the post's front matter (see [Build Blog Post](#6-build-blog-post)).
+
+## Conversion Process
+
+### 1. Pre-process Draft
+
+Before doing anything else, strip out embedded base64 image data from the draft file using a shell command.
+**Do not read the draft file before this step** — the base64 data can make the file extremely large.
+
+Google Docs markdown exports include image references like `![][image1]` in the content body, with corresponding
+base64 definitions at the bottom of the file in the format:
+
+```text
+[image1]: <data:image/png;base64,iVBORw0KGgo... (potentially megabytes of data)>
+```
+
+Run this `sed` command via the terminal to strip them in-place:
+
+```shell
+sed -i '/^\[image[0-9]*\]: <data:/d' "create-blog-post/draft.md"
+```
+
+- This removes all lines matching the base64 image definition pattern.
+- The `![][image1]` references in the content body are preserved — they will be replaced with proper image references later.
+- Only after this command completes should you read the draft file.
+
+### 2. Parse Metadata
+
+- Extract blog title, author, publish date, and description.
+- Auto-generate the URL slug from the blog title (lowercase, hyphens for spaces, remove special characters).
+- Remove the "# Blog notes/preparations" section and all content under it (up to "# Blog content").
+- Remove all lines that start with the ☝️ emoji (instruction lines).
+- Remove the `### **– Summary break / Read more –**` marker entirely.
+
+### 3. Process Images
+
+ESPHome follows the image conventions in [CONTRIBUTING.md](../../../CONTRIBUTING.md): single-use blog images are stored
+in a local `images/` directory next to the MDX file, optimized, and rendered through the `Image` or `Figure` component
+via an `import`.
+
+Before processing images, ensure the `cwebp` tool is installed. If not, install it:
+
+```shell
+# Check if cwebp is available, install if missing
+which cwebp || sudo apt-get install -y webp
+```
+
+**Lead image (`art.*`, optional):**
+
+This is only the in-page lead image at the top of the post — it is **not** the social/OpenGraph image (that is
+generated via a URL; see [Build Blog Post](#6-build-blog-post)). Skip this section if no `art.*` file is provided.
+
+- Find the `art` image in `create-blog-post/` (any extension: `.webp`, `.png`, `.jpg`, `.jpeg`).
+- Optimize and convert to WebP at a maximum width of 1000px (per CONTRIBUTING.md — max ~1000x800):
+  `cwebp -resize 1000 0 -q 85 input -o src/content/docs/blog/images/<slug>-hero.webp` (the `0` height preserves the aspect ratio).
+- If the source is already `.webp`, still re-encode it with the resize to keep it small.
+- At the top of the MDX file (after the front matter) add the imports:
+
+  ```mdx
+  import { Image } from 'astro:assets';
+  import heroImg from './images/<slug>-hero.webp';
+  ```
+
+- Replace the `![][image1]` reference in the "# Blog content" section with:
+
+  ```mdx
+  <Image src={heroImg} alt="Blog Title" layout="constrained" />
+  ```
+
+- Alt text uses the blog title.
+
+**Additional images (if any):**
+
+- Find `image2.*`, `image3.*`, etc. in `create-blog-post/` (any extension).
+- Optimize and convert to WebP at a maximum width of 900px:
+  `cwebp -resize 900 0 -q 85 input -o src/content/docs/blog/images/<slug>-2.webp`.
+- Import each one at the top of the MDX file:
+
+  ```mdx
+  import image2Img from './images/<slug>-2.webp';
+  ```
+
+- Replace the corresponding reference in the content. If the image has a caption, use the `Figure` component:
+
+  ```mdx
+  import Figure from '@components/Figure.astro';
+
+  <Figure src={image2Img} alt="Description" caption="Optional caption text" />
+  ```
+
+  Otherwise use `Image`:
+
+  ```mdx
+  <Image src={image2Img} alt="Description" layout="constrained" />
+  ```
+
+- Variable names follow camelCase with an `Img` suffix (e.g., `heroImg`, `image2Img`).
+
+### 4. Transform Links
+
+Per CONTRIBUTING.md, prefer Markdown over raw HTML. Keep all links as Markdown links.
+
+**Internal links** (`esphome.io`):
+
+- Convert to relative Markdown links starting with `/` and ending with a trailing slash: `[text](/components/wifi/)`.
+
+**External links** (any other domain):
+
+- Keep as standard Markdown links: `[text](https://example.com/)`.
+- Do **not** convert to raw `<a target="_blank">` tags.
+
+### 5. Clean Content
+
+- **Headings**: Remove bold formatting (`## **Title**` → `## Title`).
+- **Heading levels**: Content must start at H2. The page `title` comes from the front matter — do not add an H1 (`#`)
+  in the body. If the content starts with an H1, demote all headings one level so the body begins at H2.
+- **Backticks**: Strip erroneous escaped backtick (`` \` ``) characters (preserve real code blocks / inline code).
+- **Callouts**: Convert any blockquote-style notes/warnings to GitHub-style alerts
+  (`> [!NOTE]`, `> [!TIP]`, `> [!IMPORTANT]`, `> [!WARNING]`, `> [!CAUTION]`).
+- **Line length**: Wrap prose at a maximum of 120 characters where practical.
+- **Text content**: Do not change the author's wording, phrasing, or writing style. If you spot obvious typos or locale
+  spelling issues (such as British English instead of American English — the docs use American English), do not fix them
+  silently. Collect them and ask the user for confirmation before applying any changes.
+- **Emojis**: Preserve all emojis that appear in the blog content. Do not strip them out.
+- **Apostrophes and quotes**: Convert straight apostrophes (`'`) and speech marks (`"`) in prose — including quoted
+  statements, such as in blockquotes — to their curly equivalents (`’`, `“`/`”`). Only apply this to body text — never
+  to front matter, HTML attribute values, URLs, code blocks/inline code, component props, or import statements.
+
+### 6. Build Blog Post
+
+- Create `src/content/docs/blog/<slug>.mdx`.
+- Add Starlight front matter. `title` and `description` are required and must be quoted strings. Also set the
+  social/OpenGraph image via the OG generator, using the post's blog URL (`https://esphome.io/blog/<slug>`):
+
+  ```yaml
+  ---
+  title: "Your Blog Title"
+  description: "The description from the draft metadata."
+  head:
+    - tag: meta
+      attrs:
+        property: "og:image"
+        content: "https://assets.openhomefoundation.org/opengraph?url=https://esphome.io/blog/<slug>"
+    - tag: meta
+      attrs:
+        name: "twitter:image"
+        content: "https://assets.openhomefoundation.org/opengraph?url=https://esphome.io/blog/<slug>"
+  ---
+  ```
+
+  These `head` entries override the site-wide default OG image (set in `astro.config.mjs`) for this post. The generator
+  renders the OpenGraph image on demand from the post's URL, so no image file needs to be created or committed.
+
+- After the front matter, add the component imports (`Image`, `Figure` as needed, and each image import).
+- Add a byline line with the author and publish date near the top of the body (there is no author/date field in the
+  Starlight docs schema, so this is rendered as content), for example:
+
+  ```mdx
+  *By Author Name · 13 January 2026*
+  ```
+
+- If a lead image was provided, add it (`<Image src={heroImg} ... />`).
+- Add the intro paragraph, followed by the remaining content.
+
+## Example
+
+1. Place in the repository root `create-blog-post/`:
+   - `draft-new-feature.md` - Your draft file
+   - `art.png` - Hero image
+   - `image2.png`, `image3.png` - Additional images (if any)
+1. Run `/create-blog-post`
+
+This would create:
+
+- `src/content/docs/blog/new-feature.mdx`
+- `src/content/docs/blog/images/new-feature-hero.webp`
+- `src/content/docs/blog/images/new-feature-2.webp`, `new-feature-3.webp` (if additional images exist)
+
+## Important Notes
+
+**Image references:**
+
+- Draft: `![][image1]` (at the start of the "# Blog content" section, if present) → Output: optional `<slug>-hero.webp` lead image (max 1000px wide).
+- Draft: `![][image2]` → Look for `image2.*` (any format), optimize to `<slug>-2.webp` (max 900px wide).
+- Draft: `![][image3]` → Look for `image3.*` (any format), optimize to `<slug>-3.webp` (max 900px wide).
+- Source images can be any common format (`.webp`, `.png`, `.jpg`, `.jpeg`) — all are optimized to `.webp`.
+- All blog images live in `src/content/docs/blog/images/` and are referenced via `import` and the `Image`/`Figure` component.
+
+**Requirements:**
+
+- If a lead image is provided, its reference should appear at the start of the "# Blog content" section.
+- `cwebp` is required for optimization — the skill will auto-install it via `sudo apt-get install -y webp` if not present.
+- The OpenGraph image requires no source file; it is generated from the post URL.
+
+**Content processing:**
+
+- Remove the "# Blog notes/preparations" section entirely.
+- Remove all lines starting with the ☝️ emoji (instruction lines).
+- Remove the `### **– Summary break / Read more –**` marker.
+- Convert callouts to GitHub-style alerts.
+
+**Output format:**
+
+- Filename: `src/content/docs/blog/<slug>.mdx`.
+- Image directory: `src/content/docs/blog/images/`.
+- Front matter: quoted `title` and `description`. Do not repeat the title as an H1 in the body; body starts at H2.
+
+**OpenGraph image:**
+
+- Generated on demand by the Open Home Foundation OG generator; not stored in the repo.
+- Set per post via the front-matter `head` meta tags using
+  `https://assets.openhomefoundation.org/opengraph?url=https://esphome.io/blog/<slug>`.
+
+**Link handling:**
+
+- Internal `esphome.io` links → relative Markdown links with a trailing slash.
+- External links → standard Markdown links (no raw `<a target="_blank">`).
+
+## Externally linked (crosspost) blog posts
+
+A crosspost is a short blog entry that does not host the full article. It shows a teaser and redirects the reader to an
+article hosted on another site (for example, the Open Home Foundation blog). Use this path when the user asks to publish
+an externally linked blog, add a crosspost, or link out to an article on another site.
+
+Unlike a standard post, a crosspost has no draft file and no local images to process. It is a single MDX file whose
+front matter drives the redirect, the canonical URL, the social image, and the "shared from" badge. See the existing
+example at `src/content/docs/blog/2026/07/30/making-our-web-analytics-open-source-with-plausible.mdx`.
+
+### 1. Collect the details
+
+Gather the following from the user with the ask-questions tool (`vscode_askQuestions`), pre-filling any values already
+provided. If a source URL is available, fetch it first to pre-fill the title, description, teaser, author, and date.
+
+- **Title** — sentence-style capitalization.
+- **External URL** — the final published URL on the source site (must start with `https://`). If the user only has a
+  deploy-preview link (for example a Netlify preview), work out the live URL and confirm it before continuing — the
+  canonical link, the redirect, and the social image all depend on it.
+- **External source** — the name of the hosting site, shown on the badge (for example, `Open Home Foundation`). Stored
+  in the `crosspostSource` field.
+- **Teaser** — a short opening paragraph. Used as both the `excerpt` and the page body. Offer to draft one from the
+  article for the user's review.
+- **Description** — the SEO/OpenGraph description (~120–158 characters).
+- **Author** — must match a top-level key in [`src/authors.mjs`](../../../src/authors.mjs) (for example `darren` or
+  `jesse`). Verify it exists; if not, it must be added there before publishing.
+- **Publish date** — in `YYYY-MM-DD` format. Used for the filename path, `date`, and ordering.
+- **Category/tag** — the blog tag (for example, `Announcements`).
+- **Social image** — by default point `og:image` and `cover` at the source article's card image. For Open Home
+  Foundation articles this is usually
+  `https://www.openhomefoundation.org/assets/images/blog/<slug>/card.webp`. Confirm the URL resolves.
+
+### 2. Validate the details
+
+- Verify the **author** exists as a top-level key in `src/authors.mjs`. If missing, stop and ask the user to add it.
+- Verify the **external URL** starts with `https://` and is the final published URL, not a preview/deploy-preview link.
+- Generate the URL slug from the title (lowercase, hyphens for spaces, remove special characters), unless the user
+  provides one. If the source URL already has a clean slug in its path, prefer reusing that.
+
+### 3. Build the crosspost
+
+Create the file in the same dated location as a standard post, using the publish date:
+`src/content/docs/blog/YYYY/MM/DD/<slug>.mdx`.
+
+```mdx
+---
+head:
+  - tag: link
+    attrs:
+      rel: "canonical"
+      href: "<EXTERNAL_URL>"
+  - tag: meta
+    attrs:
+      http-equiv: "refresh"
+      content: "0; url=<EXTERNAL_URL>"
+  - tag: script
+    content: |
+      window.location.replace("<EXTERNAL_URL>");
+  - tag: meta
+    attrs:
+      property: "og:image"
+      content: "<SOCIAL_IMAGE_URL>"
+  - tag: meta
+    attrs:
+      name: "twitter:image"
+      content: "<SOCIAL_IMAGE_URL>"
+  - tag: meta
+    attrs:
+      property: "og:image:alt"
+      content: "<TITLE>"
+title: "<TITLE>"
+description: "<DESCRIPTION>"
+crosspostSource: "<EXTERNAL SOURCE>"
+cover:
+  image: "<SOCIAL_IMAGE_URL>"
+  alt: "<TITLE>"
+excerpt: "<TEASER PARAGRAPH>"
+date: YYYY-MM-DD
+authors:
+  - <authorKey>
+tags:
+  - <Category>
+---
+
+<TEASER PARAGRAPH>
+```
+
+Notes:
+
+- Keep all three redirect `head` entries: the canonical `link`, the `http-equiv="refresh"` meta, and the
+  `window.location.replace` script. Together they send visitors to the source article and tell search engines the
+  canonical version lives off-site.
+- `crosspostSource` opts the post into the "shared from &lt;source&gt;" pill on the blog grid (see
+  [`CrosspostBadges.astro`](../../../src/components/CrosspostBadges.astro)). It must be the plain source name only.
+- `cover.image` is the blog-archive thumbnail — point it at the same `<SOCIAL_IMAGE_URL>` as `og:image`.
+- The body is only the teaser paragraph (the same text as `excerpt`). Do not paste the full article — the reader is
+  redirected on load.
+- Apply the same prose rules as standard posts (curly apostrophes/quotes in body text, sentence-style title).
+- Do not add a byline or any comments markup: the page redirects immediately, so on-page content beyond the teaser is
+  never seen.
+
+### 4. Crosspost summary
+
+After creating the file, summarize for the user:
+
+- The output file path.
+- Title, external source, external URL, author (and whether verified in `src/authors.mjs`), date, and tag.
+- The teaser and description used, and the social image URL.
+- A note that the page sets its canonical to the external URL, redirects to the source on load, and shows the
+  "shared from" badge on the blog index.
+
+## Git Workflow
+
+Per CONTRIBUTING.md, target the correct base branch and use a focused branch/commit:
+
+- New content generally targets the `current` branch; new-feature content that ships with an unreleased ESPHome version
+  targets `next`. Confirm with the user which branch applies.
+- Branch from the target: `git checkout -b blog-<slug> current`.
+- Commit message format: `[blog] Add <slug> post`.
+
+## Post-processing summary
+
+After the blog post has been created, output a summary to the user covering:
+
+**Metadata:**
+
+- Title, author, publish date, description.
+
+**Images:**
+
+- Each source image, its original dimensions/format, and where it was output (with the optimization applied).
+- The OpenGraph image URL set in the front matter (generated via the OG generator).
+
+**Content transformations:**
+
+- A bulleted list of every notable transformation applied, such as:
+  - Sections/content removed (base64 data, blog notes, instruction lines, summary-break marker)
+  - Image references replaced with `Image`/`Figure` components
+  - Link handling (internal to relative Markdown with trailing slash; external left as Markdown)
+  - Callouts converted to GitHub-style alerts
+  - Heading changes (bold removed, promoted/demoted to start at H2)
+  - Escape-character cleanup
+  - Apostrophe/quote curling (straight to typographic)
+
+**Proposed text changes (requires user approval):**
+
+- If any typos or locale spelling issues were spotted (such as British to American English), list each one and ask the
+  user whether to apply them. Do not apply these changes until the user confirms.

--- a/.claude/skills/create-blog-post/SKILL.md
+++ b/.claude/skills/create-blog-post/SKILL.md
@@ -87,9 +87,9 @@ Rest of content...
 
 Creates a production-ready blog post at:
 
-- `src/content/docs/blog/<slug>.mdx` - The formatted MDX blog post
-- `src/content/docs/blog/images/<slug>-hero.webp` - Optional lead image (optimized from `create-blog-post/art.*`, if provided)
-- `src/content/docs/blog/images/<slug>-2.webp`, `<slug>-3.webp`, etc. - Additional images (optimized)
+- `src/content/docs/blog/YYYY/MM/DD/<slug>.mdx` - The formatted MDX blog post
+- `src/content/docs/blog/YYYY/MM/DD/images/<slug>-hero.webp` - Optional lead image (optimized from `create-blog-post/art.*`, if provided)
+- `src/content/docs/blog/YYYY/MM/DD/images/<slug>-2.webp`, `<slug>-3.webp`, etc. - Additional images (optimized)
 
 The social/OpenGraph image is not stored in the repo — it is generated on demand by the Open Home Foundation OG
 generator and referenced from the post's front matter (see [Build Blog Post](#6-build-blog-post)).

--- a/.claude/skills/create-blog-post/SKILL.md
+++ b/.claude/skills/create-blog-post/SKILL.md
@@ -243,7 +243,9 @@ Per CONTRIBUTING.md, prefer Markdown over raw HTML. Keep all links as Markdown l
   ```
 
   These `head` entries override the site-wide default OG image (set in `astro.config.mjs`) for this post. The generator
-  renders the OpenGraph image on demand from the post's URL, so no image file needs to be created or committed.
+  renders the OpenGraph image on demand from the post's URL, so no image file needs to be created or committed. Always
+  reference this as a remote URL — never import it through Astro (`astro:assets`/`import`), because the generator output
+  can change and must not be fingerprinted or cached. Set the same URL on the `cover.image` front-matter field too.
 
 - After the front matter, add the component imports (`Image`, `Figure` as needed, and each image import).
 - Add a byline line with the author and publish date near the top of the body (there is no author/date field in the
@@ -299,11 +301,16 @@ This would create:
 - Image directory: `src/content/docs/blog/images/`.
 - Front matter: quoted `title` and `description`. Do not repeat the title as an H1 in the body; body starts at H2.
 
-**OpenGraph image:**
+**OpenGraph / cover image:**
 
-- Generated on demand by the Open Home Foundation OG generator; not stored in the repo.
-- Set per post via the front-matter `head` meta tags using
-  `https://assets.openhomefoundation.org/opengraph?url=https://esphome.io/blog/<slug>`.
+- **Always reference a remote URL.** Never import the OpenGraph or `cover.image` through Astro (no local file,
+  no `import`, no `astro:assets`). These images are served live from a remote generator whose output can change over
+  time, so Astro must not fingerprint, optimize, or cache them.
+- **Standard posts:** use the Open Home Foundation OG generator, which renders the image on demand from the post URL:
+  `https://assets.openhomefoundation.org/opengraph?url=https://esphome.io/blog/<slug>`. Set it on both the
+  `cover.image` field and the `og:image` / `twitter:image` `head` meta tags. No source file is created or committed.
+- **Crossposts:** use the source site's own card image instead of the generator (for example, the Open Home Foundation
+  site card at `https://www.openhomefoundation.org/assets/images/blog/<slug>/card.webp`) — again as a remote URL only.
 
 **Link handling:**
 

--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,4 @@ my-secrets
 
 # Misc
 _build
-create-blog-post/
+/create-blog-post/

--- a/script/lint.mjs
+++ b/script/lint.mjs
@@ -22,7 +22,7 @@ const colors = {
 };
 
 // Folders to ignore
-const ignoreFolders = ["pagefind/", "node_modules/", "dist/", ".astro/"];
+const ignoreFolders = ["pagefind/", "node_modules/", "dist/", ".astro/", ".claude/"];
 
 // Files to ignore (skip all linting)
 const ignoreFiles = ["script/release_notes_template.mdx"];

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -14,6 +14,12 @@ const isBlogPage = Astro.url.pathname.startsWith("/blog");
 const { id } = Astro.locals.starlightRoute;
 const isBlogPost = /^blog\/(?!(\d+\/?|tags\/.+|authors\/.+)$).+$/.test(id);
 
+// Only load the Discourse comments embed on the production deploy. Netlify sets
+// CONTEXT to "production" only for the main production build; branch deploys
+// (e.g. beta/next) and deploy previews get "branch-deploy"/"deploy-preview", so
+// comments (including the heading) are hidden there.
+const isProduction = process.env.CONTEXT === "production";
+
 const footerLinks = [
   {
     name: "Documentation",
@@ -44,7 +50,7 @@ const footerLinks = [
 ---
 
 {isBlogPage && <CrosspostBadges />}
-{isBlogPost && <DiscourseComments />}
+{isBlogPost && isProduction && <DiscourseComments />}
 
 <footer class="sl-flex">
   <div class="meta sl-flex">

--- a/src/content/docs/blog/2026/08/04/simplify-your-esphome-setup-with-the-new-desktop-app.mdx
+++ b/src/content/docs/blog/2026/08/04/simplify-your-esphome-setup-with-the-new-desktop-app.mdx
@@ -1,0 +1,111 @@
+---
+title: "Simplify your ESPHome setup with the new desktop app"
+description: "Download the new ESPHome Device Builder desktop app for macOS, Windows, or Linux, and start building your own custom smart home devices in minutes."
+date: 2026-08-04
+authors:
+  - jesse
+tags:
+  - Announcements
+excerpt: "Download the new ESPHome Device Builder desktop app for macOS, Windows, or Linux, and start building your own custom smart home devices in minutes."
+cover:
+  alt: "Simplify your ESPHome setup with the new desktop app"
+  image: "https://assets.openhomefoundation.org/opengraph?url=https://esphome.io/blog/2026/08/04/simplify-your-esphome-setup-with-the-new-desktop-app"
+head:
+  - tag: meta
+    attrs:
+      property: "og:image"
+      content: "https://assets.openhomefoundation.org/opengraph?url=https://esphome.io/blog/2026/08/04/simplify-your-esphome-setup-with-the-new-desktop-app"
+  - tag: meta
+    attrs:
+      name: "twitter:image"
+      content: "https://assets.openhomefoundation.org/opengraph?url=https://esphome.io/blog/2026/08/04/simplify-your-esphome-setup-with-the-new-desktop-app"
+  - tag: meta
+    attrs:
+      property: "og:image:title1"
+      content: "Simplify your ESPHome setup"
+  - tag: meta
+    attrs:
+      property: "og:image:title2"
+      content: "with the new desktop app"
+  - tag: meta
+    attrs:
+      property: "og:image:author"
+      content: "Jesse Hills"
+  - tag: meta
+    attrs:
+      property: "og:image:category"
+      content: "Announcements"
+---
+
+Last month, we introduced the
+[ESPHome Device Builder](/blog/2026/07/02/unbox-your-creativity-with-the-esphome-device-builder/): a more visual and
+intuitive tool for configuring your smart home devices without having to write any code, unless you want to! Now we’ve
+taken a further step in our efforts to make ESPHome more approachable, by bringing the Device Builder to your desktop
+in a quick and easy way.
+
+Say hello to the [ESPHome Device Builder desktop app](/install/), available now for macOS, Windows, and Linux.
+
+## The final hurdle for beginners
+
+If you’ve already tried the Device Builder, you’ll know how much friction it removes from configuring a device. But for
+a lot of newcomers, there was still a hurdle to clear before getting started: the technical tasks of installing Python
+and typing commands in a terminal. Not that hard if you’ve done it before… but if you haven’t, it’s a process that could
+turn a Saturday afternoon project into a weekend of troubleshooting.
+
+The desktop app removes that hurdle, and is designed to be simple to set up.
+
+## All you need to do
+
+Download the app for your platform, run the installer… and that’s it. On first launch:
+
+- The app quietly sets everything up in the background: no technical steps required.
+- It opens the Device Builder automatically in your browser.
+- A small icon appears in your system tray, giving you access to reopen the Device Builder, check for updates, or quit:
+  no digging through tabs or task managers.
+
+That tray icon stays there for as long as you use ESPHome: it’s your quick way back in, every time, not just on day one.
+And because the app is designed to run locally, on your own computer, there’s no login or password to set up, so it’s
+ready to use the moment it opens.
+
+## Why this matters for beginners…
+
+Think back to the workshop metaphor from our last post: the Device Builder itself is the well-organized bench where the
+creative work happens. The desktop app is what makes it easy – and low stakes – to walk in and start that work. So if
+you’re faced with your first microcontroller (the imminent ESPHome Starter Kit perhaps 👀), there’s no technical setup
+standing between unboxing and beginning your build: just download the app, and away you go.
+
+It’s not just the start-up that’s easy. Every time you want to tweak a device or add a new one, it’s the same simple
+open-and-go experience, with no need to remember any previous commands.
+
+When you start slightly more advanced projects, the desktop app can help with other elements of your setup. For example
+if you run ESPHome on a lower-powered device, like a Raspberry Pi, you can have it send the heavy lifting of compiling
+firmware over to the app instead, then send the finished result back. It’s a handy way to speed up builds without
+changing how or where you actually flash your devices.
+
+The app is also useful for anyone helping a less technical friend or family member get started. “Download this app and
+open it” is an instruction anyone can follow. “Install Python, then pip install this, then run this command” is not.
+
+## …and for experienced users
+
+Don’t mistake the beginner focus for a lack of depth. If you’re setting up ESPHome on a new machine, spinning up a build
+environment for a demo, or just tired of manually checking the latest Device Builder version, the desktop app handles
+all that for you. Update checks live right in your system tray: no more remembering to consult the changelog yourself.
+
+What’s more, nothing about your existing workflow changes. If you’re already running ESPHome through pip, Docker, or the
+Home Assistant add-on, you’re unaffected: the desktop app is simply another door into the same Device Builder, for
+people who’d rather not open a terminal at all.
+
+## Try it this weekend
+
+Ready to give it a go? Here’s how to get started in three simple steps:
+
+1. **Download the app:** For macOS, Windows, or Linux from esphome.io/install.
+1. **Open it and let it work**: ESPHome sets itself up in the background, no configuration needed.
+1. **Start your first project:** Dive straight into the Device Builder that opens automatically, and explore the
+   Component Catalog we introduced last month.
+
+## Reminder for returning users
+
+If you’re already comfortable with pip, Docker, or the Home Assistant App, there’s nothing you need to change. The
+desktop app is an additional on-ramp, not a replacement for how you already work… it’s there for the next person who’s
+about to start exploring the wonderful world of ESPHome!


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description
- Adds the Claude blog skill
- Adds the Device Builder blog post

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
