### PR TITLE
Document verification_keys for external RSA signed OTA

### DIFF
--- a/src/content/docs/components/esp32.mdx
+++ b/src/content/docs/components/esp32.mdx
@@ -567,6 +567,12 @@ esp32:
     with `espsecure.py digest-sbv2-public-key --keyfile public_key.pem digest.bin`.
     **Requires `signing_scheme: rsa3072` and no `signing_key`.**
 
+    > [!NOTE]
+    > If you also enable `allow_partition_access` on the OTA platform to update the **bootloader**
+    > over-the-air, the bootloader image must be externally signed and 4 KiB-padded too — the standard
+    > build signs only the app, so an unsigned bootloader update is rejected. Pad and sign `bootloader.bin`
+    > with a trusted key (`espsecure.py sign-data --version 2 --keyfile key.pem ...`) before pushing it.
+
   - **signing_scheme** (*Optional*, string): The signing algorithm. One of `rsa3072`, `ecdsa256`, or `ecdsa_v1`.
     Defaults to `rsa3072`. **Not all schemes are supported on all variants** — see the table below.
 

--- a/src/content/docs/components/esp32.mdx
+++ b/src/content/docs/components/esp32.mdx
@@ -551,6 +551,21 @@ esp32:
     >       # Verify OTA updates against externally-applied rsa3072 signatures
     >       signed_ota_verification:
     > ```
+    >
+    > For `rsa3072` you can instead list the trusted keys explicitly with `verification_keys` (below) to enable
+    > key rotation and backup keys.
+
+  - **verification_keys** (*Optional*, list): For externally-signed `rsa3072` only: the public keys the firmware
+    trusts to verify OTA updates, compiled into the build as a fixed trust anchor. When set, ESPHome verifies each
+    update against this list itself — accepting an update signed by **any** listed key — instead of ESP-IDF's
+    built-in check, which accepts only an update signed by the single key already in the running firmware. This
+    enables **key rotation** (introduce a new key with a release signed by both the old and new key, then drop the
+    old one in a later release) and **multi-provider backup keys** (sign each release with two independent keys so
+    either one can produce an accepted update). List up to three keys — the Secure Boot V2 signature-block limit.
+    Each entry is either a path to a PEM public (or private) key, or the key's 64-character hex digest directly;
+    the digest form lets a CI pipeline inject the trusted keys without committing key files. Get a key's digest
+    with `espsecure.py digest-sbv2-public-key --keyfile public_key.pem digest.bin`.
+    **Requires `signing_scheme: rsa3072` and no `signing_key`.**
 
   - **signing_scheme** (*Optional*, string): The signing algorithm. One of `rsa3072`, `ecdsa256`, or `ecdsa_v1`.
     Defaults to `rsa3072`. **Not all schemes are supported on all variants** — see the table below.

--- a/src/content/docs/components/esp32.mdx
+++ b/src/content/docs/components/esp32.mdx
@@ -572,6 +572,8 @@ esp32:
     > over-the-air, the bootloader image must be externally signed and 4 KiB-padded too — the standard
     > build signs only the app, so an unsigned bootloader update is rejected. Pad and sign `bootloader.bin`
     > with a trusted key (`espsecure.py sign-data --version 2 --keyfile key.pem ...`) before pushing it.
+    > `verification_keys` gates the app and bootloader images; the partition-table update path is not
+    > signature-verified (partition tables carry an MD5 checksum, not a signature), so it isn't gated.
 
   - **signing_scheme** (*Optional*, string): The signing algorithm. One of `rsa3072`, `ecdsa256`, or `ecdsa_v1`.
     Defaults to `rsa3072`. **Not all schemes are supported on all variants** — see the table below.

--- a/src/content/docs/components/esp32.mdx
+++ b/src/content/docs/components/esp32.mdx
@@ -555,25 +555,16 @@ esp32:
     > For `rsa3072` you can instead list the trusted keys explicitly with `verification_keys` (below) to enable
     > key rotation and backup keys.
 
-  - **verification_keys** (*Optional*, list): For externally-signed `rsa3072` only: the public keys the firmware
-    trusts to verify OTA updates, compiled into the build as a fixed trust anchor. When set, ESPHome verifies each
-    update against this list itself — accepting an update signed by **any** listed key — instead of ESP-IDF's
-    built-in check, which accepts only an update signed by the single key already in the running firmware. This
-    enables **key rotation** (introduce a new key with a release signed by both the old and new key, then drop the
-    old one in a later release) and **multi-provider backup keys** (sign each release with two independent keys so
-    either one can produce an accepted update). List up to three keys — the Secure Boot V2 signature-block limit.
-    Each entry is either a path to a PEM public (or private) key, or the key's 64-character hex digest directly;
-    the digest form lets a CI pipeline inject the trusted keys without committing key files. Get a key's digest
-    with `espsecure.py digest-sbv2-public-key --keyfile public_key.pem digest.bin`.
+  - **verification_keys** (*Optional*, list): For externally-signed `rsa3072`, the public keys your device trusts
+    when checking OTA updates. Listing more than one lets you rotate signing keys or keep a backup key — an update
+    signed by any listed key is accepted. Each entry is a public key file, or the key's digest (handy for CI,
+    where you may not want a key file in your configuration). Up to three keys.
     **Requires `signing_scheme: rsa3072` and no `signing_key`.**
 
     > [!NOTE]
-    > If you also enable `allow_partition_access` on the OTA platform to update the **bootloader**
-    > over-the-air, the bootloader image must be externally signed and 4 KiB-padded too — the standard
-    > build signs only the app, so an unsigned bootloader update is rejected. Pad and sign `bootloader.bin`
-    > with a trusted key (`espsecure.py sign-data --version 2 --keyfile key.pem ...`) before pushing it.
-    > `verification_keys` gates the app and bootloader images; the partition-table update path is not
-    > signature-verified (partition tables carry an MD5 checksum, not a signature), so it isn't gated.
+    > Both app and bootloader OTA updates are verified. If you update the bootloader over the air (with
+    > `allow_partition_access`), sign it with one of your trusted keys first — the normal build signs only the
+    > app, so an unsigned bootloader update is rejected.
 
   - **signing_scheme** (*Optional*, string): The signing algorithm. One of `rsa3072`, `ecdsa256`, or `ecdsa_v1`.
     Defaults to `rsa3072`. **Not all schemes are supported on all variants** — see the table below.


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Documents the new `verification_keys` option under `esp32:` → `signed_ota_verification`.

For externally-signed `rsa3072`, `verification_keys` is the compiled-in set of trusted keys ESPHome verifies OTA updates against — accepting an update signed by any listed key instead of ESP-IDF's single-key check. This enables key rotation and multi-provider backup keys. The entry covers the PEM-or-digest forms, the three-key limit, the `digest-sbv2-public-key` command, and adds a cross-reference from the existing Secure Boot V2 note.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#17981

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
