### PR TITLE
2026.7.4

### DIFF
--- a/data/version.yaml
+++ b/data/version.yaml
@@ -1,2 +1,2 @@
-release: 2026.7.3
+release: 2026.7.4
 version: '2026.7'

--- a/src/content/docs/changelog/2026.7.0.mdx
+++ b/src/content/docs/changelog/2026.7.0.mdx
@@ -881,6 +881,28 @@ For detailed migration guides and API documentation, see the
 
 </details>
 
+## Release 2026.7.4 - August 5
+
+<details>
+<summary></summary>
+
+- Bump filelock from 3.29.0 to 3.32.0 [esphome#17759](https://github.com/esphome/esphome/pull/17759) by [@dependabot[bot]](https://github.com/apps/dependabot)
+- Bump platformdirs from 4.10.0 to 4.11.0 [esphome#17756](https://github.com/esphome/esphome/pull/17756) by [@dependabot[bot]](https://github.com/apps/dependabot)
+- Bump bundled esphome-device-builder to 1.8.0 [esphome#17953](https://github.com/esphome/esphome/pull/17953) by [@esphome[bot]](https://github.com/apps/esphome)
+- Bump bundled esphome-device-builder to 1.8.1 [esphome#17964](https://github.com/esphome/esphome/pull/17964) by [@esphome[bot]](https://github.com/apps/esphome)
+- [epaper_spi] Default init sequence to empty not None [esphome#17966](https://github.com/esphome/esphome/pull/17966) by [@clydebarrow](https://github.com/clydebarrow)
+- [git] Fix device adoption failing on first attempt: lock the clone cache against concurrent resolutions [esphome#17923](https://github.com/esphome/esphome/pull/17923) by [@bdraco](https://github.com/bdraco)
+- [espidf] Use forward slashes in generated component CMakeLists [esphome#17965](https://github.com/esphome/esphome/pull/17965) by [@swoboda1337](https://github.com/swoboda1337)
+- [esp32] Restrict toolchain validation to supported values [esphome#17972](https://github.com/esphome/esphome/pull/17972) by [@jesserockz](https://github.com/jesserockz)
+- [api] Fix double free when overflow buffer drain is re-entered [esphome#17969](https://github.com/esphome/esphome/pull/17969) by [@bdraco](https://github.com/bdraco)
+- Bump bundled esphome-device-builder to 1.8.2 [esphome#17995](https://github.com/esphome/esphome/pull/17995) by [@esphome[bot]](https://github.com/apps/esphome)
+- Bump bundled esphome-device-builder to 1.9.0 [esphome#18017](https://github.com/esphome/esphome/pull/18017) by [@esphome[bot]](https://github.com/apps/esphome)
+- Bump bundled esphome-device-builder to 1.9.1 [esphome#18025](https://github.com/esphome/esphome/pull/18025) by [@esphome[bot]](https://github.com/apps/esphome)
+- Bump bundled esphome-device-builder to 1.9.2 [esphome#18051](https://github.com/esphome/esphome/pull/18051) by [@esphome[bot]](https://github.com/apps/esphome)
+- [esp32] explicitly disable BLE 5.0 [esphome#18047](https://github.com/esphome/esphome/pull/18047) by [@ssieb](https://github.com/ssieb)
+
+</details>
+
 ## Full list of changes
 
 ### New Features

--- a/src/content/docs/guides/supporters.mdx
+++ b/src/content/docs/guides/supporters.mdx
@@ -1939,6 +1939,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Ruben van Dijk (@RubenNL)](https://github.com/RubenNL)
 - [RubyBailey (@RubyBailey)](https://github.com/RubyBailey)
 - [rudgr (@rudgr)](https://github.com/rudgr)
+- [Rui Marinho (@ruimarinho)](https://github.com/ruimarinho)
 - [RunningDroid (@RunningDroid)](https://github.com/RunningDroid)
 - [Rus Ti (@Rusti-gotrage)](https://github.com/Rusti-gotrage)
 - [Ramil Valitov (@rvalitov)](https://github.com/rvalitov)
@@ -2428,4 +2429,4 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Christian Zufferey (@zuzu59)](https://github.com/zuzu59)
 - [Zynth-dev (@Zynth-dev)](https://github.com/Zynth-dev)
 
-*This page was last updated July 28, 2026.*
+*This page was last updated August 5, 2026.*


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- [light] Document light state on its own schema [docs#6976](https://github.com/esphome/esphome.io/pull/6976)
- Add cross-posting blog logic & new post [docs#7072](https://github.com/esphome/esphome.io/pull/7072)
- [docs] Remove references to removed ESPHOME_DASHBOARD_USE_PING [docs#7070](https://github.com/esphome/esphome.io/pull/7070)
- [build] Move markdown plugins onto the unified processor [docs#7076](https://github.com/esphome/esphome.io/pull/7076)
- [docs] Remove the dashboard command from the CLI page [docs#7075](https://github.com/esphome/esphome.io/pull/7075)
- [docs] Clarify fixed-address requirement for device status [docs#7073](https://github.com/esphome/esphome.io/pull/7073)
- [projects] Make the ready-made projects page data driven [docs#7061](https://github.com/esphome/esphome.io/pull/7061)
- Add install page for ESPHome Device Builder [docs#6669](https://github.com/esphome/esphome.io/pull/6669)
- [docs] Consolidate the getting started pages under /install/ [docs#7099](https://github.com/esphome/esphome.io/pull/7099)
- Add Discourse comments [docs#7108](https://github.com/esphome/esphome.io/pull/7108)
- Add dark mode comments [docs#7109](https://github.com/esphome/esphome.io/pull/7109)
- Add ESPHome Device Builder blog [docs#7110](https://github.com/esphome/esphome.io/pull/7110)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
