### PR TITLE
[install] Restore the Intel Mac deprecation warning

### DIFF
--- a/src/components/InstallSelector.astro
+++ b/src/components/InstallSelector.astro
@@ -205,6 +205,10 @@ if (!urls) {
           <button type="button" data-arch="x64" aria-pressed="false"> Intel </button>
         </div>
       </div>
+      <p class="install-selector__warning" data-mac-intel-warning role="status" hidden>
+        Support for Intel Macs will be removed soon. The Python ecosystem is dropping Intel macOS; the{" "}
+        <code>cryptography</code> package no longer publishes Intel builds as of version 49.
+      </p>
       <LinkButton data-download="mac" href={urls["mac-arm64"]}> Download disk image (.dmg) </LinkButton>
       <ol class="install-selector__steps">
         <li>Open the downloaded <code>.dmg</code> file.</li>
@@ -385,6 +389,15 @@ if (!urls) {
     margin-block: 0.75rem 0;
   }
 
+  .install-selector__warning {
+    font-size: 0.9em;
+    background: var(--sl-color-orange-low);
+    border-left: 3px solid var(--sl-color-orange);
+    border-radius: 0 4px 4px 0;
+    padding: 0.6rem 0.8rem;
+    margin-block: 0 1.25rem;
+  }
+
   .install-selector__my {
     display: inline-block;
     line-height: 0;
@@ -473,8 +486,10 @@ if (!urls) {
     (() => {
       const btn = root.querySelector('[data-download="mac"]');
       if (!btn) return;
+      const intelWarning = root.querySelector("[data-mac-intel-warning]");
       const selectArch = wireSegmented("mac-arch", "arch", (arch) => {
         btn.href = urls[`mac-${arch}`];
+        if (intelWarning) intelWarning.hidden = arch !== "x64";
       });
 
       // Auto-pick Intel when the UA-CH API reports an x86 architecture.


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

The Intel Mac deprecation warning added in esphome/esphome-desktop#366 is not present on https://esphome.io/install/. That PR added the notice to the desktop app's own download page; when the install flow moved here, `InstallSelector.astro` was written as a fresh implementation of that UI and carried over the arch segmented control, the per-arch download URLs and the UA-CH Intel auto-detection, but not the warning. It looks like an oversight in the port rather than a deliberate removal.

This restores it. The toggle is hooked into the existing `wireSegmented("mac-arch", ...)` callback rather than a separate refresh function, since that callback is the single path every architecture change flows through, so manual clicks and the UA-CH auto-detect both update the warning. The note carries `role="status"` so screen readers announce it when the architecture changes, matching the upstream behaviour. Styling uses Starlight's `--sl-color-orange` / `--sl-color-orange-low` tokens instead of upstream's hardcoded amber plus a manual dark-mode override, since those are already themed here.

Verified by driving the architecture buttons locally: hidden on Apple Silicon, visible on Intel, with the download link tracking correctly. `npm run build`, `format:check`, `lint:js` and `lint` all pass.

One thing worth a maintainer's eye: the wording is taken verbatim from the upstream PR, including "no longer publishes Intel builds as of version 49". If `cryptography` has since shipped that release, this may want rephrasing into the past tense.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.