### PR TITLE
Use address_str_to in BLE advertise lambda examples

### DIFF
--- a/src/content/docs/components/esp32_ble_tracker.mdx
+++ b/src/content/docs/components/esp32_ble_tracker.mdx
@@ -130,7 +130,8 @@ esp32_ble_tracker:
       then:
         - lambda: |-
             ESP_LOGD("ble_adv", "New BLE device");
-            ESP_LOGD("ble_adv", "  address: %s", x.address_str().c_str());
+            char addr[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
+            ESP_LOGD("ble_adv", "  address: %s", x.address_str_to(addr));
             ESP_LOGD("ble_adv", "  name: %s", x.get_name().c_str());
             ESP_LOGD("ble_adv", "  Advertised service UUIDs:");
             for (auto uuid : x.get_service_uuids()) {

--- a/src/content/docs/components/sensor/thermopro_ble.mdx
+++ b/src/content/docs/components/sensor/thermopro_ble.mdx
@@ -96,7 +96,9 @@ like so:
 esp32_ble_tracker:
   on_ble_advertise:
     - then:
-        - lambda: 'ESP_LOGD("ble_adv", "BLE device address: %s name: %s", x.address_str().c_str(), x.get_name().c_str());'
+        - lambda: |-
+            char addr[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
+            ESP_LOGD("ble_adv", "BLE device address: %s name: %s", x.address_str_to(addr), x.get_name().c_str());
 ```
 
 After uploading the ESP32 will immediately try to scan for BLE devices such as the ThermoPro, so


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

The `on_ble_advertise` lambda examples on the ESP32 BLE tracker and ThermoPro pages call `x.address_str()`, which is deprecated in favor of the buffer based `x.address_str_to()`; this updates both examples so new configurations copy the replacement.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#18092

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
