### PR TITLE
Document upload command --file, --partition-table and --bootloader options

### DIFF
--- a/src/content/docs/guides/cli.mdx
+++ b/src/content/docs/guides/cli.mdx
@@ -211,6 +211,25 @@ and `platform: web_server` are configured, the native `esphome` protocol is pref
 when the OTA password has been lost but the `web_server` `auth` credentials are still known.
 
 
+**`--file FILE`**
+: Manually specify the binary file to upload instead of the most recent build. Can be combined with
+`--partition-table` or `--bootloader` to upload a custom partition table or bootloader image.
+
+
+**`--partition-table`**
+: Only on ESP32, over OTA with the `esphome` platform. Upload the partition table instead of the firmware.
+The device must be running a firmware with `allow_partition_access: true` configured on the
+[ESPHome OTA platform](/components/ota/esphome/#updating-the-partition-table-on-esp32).
+Can't be combined with `--bootloader`.
+
+
+**`--bootloader`**
+: Only on ESP32, over OTA with the `esphome` platform. Upload the bootloader instead of the firmware.
+The device must be running a firmware with `allow_partition_access: true` configured on the
+[ESPHome OTA platform](/components/ota/esphome/#updating-the-bootloader-on-esp32).
+Can't be combined with `--partition-table`.
+
+
 ### `clean-mqtt` Command
 
 The `esphome clean-mqtt <CONFIG>` cleans retained MQTT discovery messages from the MQTT broker.


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

The upload command section in the CLI guide did not list the `--file`, `--partition-table` and `--bootloader` options, even though the partition table and bootloader OTA update features are fully documented on the ESPHome OTA platform page; this adds the three option entries in the same style as the rest of the section, linking to the detailed instructions on the OTA page.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
