### PR TITLE
[as734x] [1/3] Document unified AS7341/AS7343 spectral sensor component

### DIFF
--- a/src/content/docs/components/index.mdx
+++ b/src/content/docs/components/index.mdx
@@ -466,7 +466,7 @@ Sensors are organized into categories; if a given sensor fits into more than one
   ["AM43", "/components/sensor/am43/", "am43.jpg", "Lux"],
   ["APDS9306", "/components/sensor/apds9306/", "apds9306.png", "Lux"],
   ["APDS9960", "/components/sensor/apds9960/", "apds9960.jpg", "Colour & Gesture"],
-  ["AS7341 / AS7343", "/components/sensor/as734x/", "as7341.jpg", "Spectral Color Sensor"],
+  ["AS7341 / AS7343 / TCS3448", "/components/sensor/as734x/", "as7341.jpg", "Spectral Color Sensor"],
   ["BH1750", "/components/sensor/bh1750/", "bh1750.jpg", "Lux"],
   ["LTR301", "/components/sensor/ltr501/", "ltr501.jpg", "Lux"],
   ["LTR303", "/components/sensor/ltr_als_ps/", "ltr303.jpg", "Lux"],

--- a/src/content/docs/components/index.mdx
+++ b/src/content/docs/components/index.mdx
@@ -466,7 +466,7 @@ Sensors are organized into categories; if a given sensor fits into more than one
   ["AM43", "/components/sensor/am43/", "am43.jpg", "Lux"],
   ["APDS9306", "/components/sensor/apds9306/", "apds9306.png", "Lux"],
   ["APDS9960", "/components/sensor/apds9960/", "apds9960.jpg", "Colour & Gesture"],
-  ["AS7341", "/components/sensor/as7341/", "as7341.jpg", "Spectral Color Sensor"],
+  ["AS7341 / AS7343", "/components/sensor/as734x/", "as7341.jpg", "Spectral Color Sensor"],
   ["BH1750", "/components/sensor/bh1750/", "bh1750.jpg", "Lux"],
   ["LTR301", "/components/sensor/ltr501/", "ltr501.jpg", "Lux"],
   ["LTR303", "/components/sensor/ltr_als_ps/", "ltr303.jpg", "Lux"],

--- a/src/content/docs/components/sensor/as7341.mdx
+++ b/src/content/docs/components/sensor/as7341.mdx
@@ -10,8 +10,8 @@ import APIRef from '@components/APIRef.astro';
 
 > [!WARNING]
 > This platform is deprecated and will be removed in ESPHome 2027.2.0. Use the
-> [`as734x`](/components/sensor/as734x/) platform with `type: AS7341` instead, which supports both the AS7341 and
-> the AS7343. Note that the reported values change when you migrate; see
+> [`as734x`](/components/sensor/as734x/) platform with `type: AS7341` instead, which supports the AS7341, the
+> AS7343 and the TCS3448. Note that the reported values change when you migrate; see
 > [Migrating From `as7341`](/components/sensor/as734x/#migrating-from-as7341).
 
 The `as7341` sensor platform allows you to use your AS7341 spectral color sensor
@@ -93,7 +93,7 @@ $$
 ## See Also
 
 - [Sensor Filters](/components/sensor#sensor-filters)
-- [AS7341 / AS7343 Spectral Color Sensor](/components/sensor/as734x/)
+- [AS7341 / AS7343 / TCS3448 Spectral Color Sensor](/components/sensor/as734x/)
 - [Adafruit_AS7341](https://github.com/adafruit/Adafruit_AS7341)
 - [SparkFun_AS7341X_Arduino_Library](https://github.com/sparkfun/SparkFun_AS7341X_Arduino_Library)
 - <APIRef text="as7341.h" path="as7341/as7341.h" />

--- a/src/content/docs/components/sensor/as7341.mdx
+++ b/src/content/docs/components/sensor/as7341.mdx
@@ -8,6 +8,12 @@ import Figure from '@components/Figure.astro';
 import as7341FullImg from './images/as7341-full.jpg';
 import APIRef from '@components/APIRef.astro';
 
+> [!WARNING]
+> This platform is deprecated and will be removed in ESPHome 2027.2.0. Use the
+> [`as734x`](/components/sensor/as734x/) platform with `type: AS7341` instead, which supports both the AS7341 and
+> the AS7343. Note that the reported values change when you migrate; see
+> [Migrating From `as7341`](/components/sensor/as734x/#migrating-from-as7341).
+
 The `as7341` sensor platform allows you to use your AS7341 spectral color sensor
 ([datasheet](https://look.ams-osram.com/m/24266a3e584de4db/original/AS7341-DS000504.pdf),
 [Adafruit](https://www.adafruit.com/product/4698)) with ESPHome. The [I²C Bus](/components/i2c) is required to be set up in
@@ -87,6 +93,7 @@ $$
 ## See Also
 
 - [Sensor Filters](/components/sensor#sensor-filters)
+- [AS7341 / AS7343 Spectral Color Sensor](/components/sensor/as734x/)
 - [Adafruit_AS7341](https://github.com/adafruit/Adafruit_AS7341)
 - [SparkFun_AS7341X_Arduino_Library](https://github.com/sparkfun/SparkFun_AS7341X_Arduino_Library)
 - <APIRef text="as7341.h" path="as7341/as7341.h" />

--- a/src/content/docs/components/sensor/as734x.mdx
+++ b/src/content/docs/components/sensor/as734x.mdx
@@ -85,36 +85,15 @@ both models.
 
 ### AS7341
 
-| Channel | Wavelength    |
-| ------- | ------------- |
-| `f1`    | 415nm         |
-| `f2`    | 445nm         |
-| `f3`    | 480nm         |
-| `f4`    | 515nm         |
-| `f5`    | 555nm         |
-| `f6`    | 590nm         |
-| `f7`    | 630nm         |
-| `f8`    | 680nm         |
-| `nir`   | Near-infrared |
-| `clear` | Clear         |
+| Channel    | `f1`  | `f2`  | `f3`  | `f4`  | `f5`  | `f6`  | `f7`  | `f8`  | `nir` | `clear`  |
+| ---------- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | -------- |
+| Wavelength | 415nm | 445nm | 480nm | 515nm | 555nm | 590nm | 630nm | 680nm | 910nm | Wideband |
 
 ### AS7343
 
-| Channel | Wavelength    |
-| ------- | ------------- |
-| `f1`    | 405nm         |
-| `f2`    | 425nm         |
-| `fz`    | 450nm         |
-| `f3`    | 475nm         |
-| `f4`    | 515nm         |
-| `fy`    | 555nm         |
-| `f5`    | 550nm         |
-| `fxl`   | 600nm         |
-| `f6`    | 640nm         |
-| `f7`    | 690nm         |
-| `f8`    | 745nm         |
-| `nir`   | Near-infrared |
-| `clear` | Clear         |
+| Channel    | `f1`  | `f2`  | `fz`  | `f3`  | `f4`  | `fy`  | `f5`  | `fxl` | `f6`  | `f7`  | `f8`  | `nir` | `clear`  |
+| ---------- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | -------- |
+| Wavelength | 405nm | 425nm | 450nm | 475nm | 515nm | 555nm | 550nm | 600nm | 640nm | 690nm | 745nm | 855nm | Wideband |
 
 ## Raw Counts
 

--- a/src/content/docs/components/sensor/as734x.mdx
+++ b/src/content/docs/components/sensor/as734x.mdx
@@ -1,0 +1,186 @@
+---
+description: "Instructions for setting up AS7341 and AS7343 spectral color sensors."
+title: "AS7341 / AS7343 Spectral Color Sensor"
+---
+
+import Figure from '@components/Figure.astro';
+import APIRef from '@components/APIRef.astro';
+
+The `as734x` sensor platform allows you to use the AS7341
+([datasheet](https://look.ams-osram.com/m/24266a3e584de4db/original/AS7341-DS000504.pdf),
+[Adafruit](https://www.adafruit.com/product/4698)) and AS7343
+([datasheet](https://look.ams-osram.com/m/5f2d27fff9a874d2/original/AS7343-14-Channel-Multi-Spectral-Sensor.pdf))
+spectral color sensors with ESPHome. The sensor is selected with the `type` option. The
+[I²C Bus](/components/i2c/) is required to be set up in your configuration for this sensor to work.
+
+<Figure
+  src="/images/as7341.jpg"
+  alt="AS7341 Spectral Color Sensor"
+  caption="AS7341 Spectral Color Sensor"
+  layout="constrained"
+  width={250}
+  height={182}
+/>
+
+> [!NOTE]
+> This platform replaces the [`as7341`](/components/sensor/as7341/) platform, which is deprecated and will be
+> removed in ESPHome 2027.2.0. See [Migrating From `as7341`](#migrating-from-as7341) below.
+
+```yaml
+# Example configuration entry
+sensor:
+  - platform: as734x
+    type: AS7341
+    counts:
+      f1:
+        name: "415nm"
+      clear:
+        name: "Clear"
+      nir:
+        name: "NIR"
+```
+
+## Configuration variables
+
+- **type** (**Required**, string): The sensor model. Must be either `AS7341` or `AS7343`.
+- **counts** (*Optional*): The raw per-channel readings to publish. Each channel is optional; only the channels
+  you list are published. The available channels depend on `type`, see [Channels](#channels) below. Each channel
+  accepts all options from [Sensor](/components/sensor/), or just a name as a shorthand.
+- **gain** (*Optional*): The gain used by the device. A higher gain may be more suitable for lower-light
+  environments. Defaults to `X8`. Must be one of:
+
+  - `X0.5`
+  - `X1`
+  - `X2`
+  - `X4`
+  - `X8` (*default*)
+  - `X16`
+  - `X32`
+  - `X64`
+  - `X128`
+  - `X256`
+  - `X512`
+  - `X1024` (`AS7343` only)
+  - `X2048` (`AS7343` only)
+
+- **atime** (*Optional*, int): The number of integration steps. Defaults to `29`. Must be between `0` and `255`.
+- **astep** (*Optional*, int): The length of one integration step in increments of 2.78µs. Defaults to `599`.
+  Must be between `0` and `65534`.
+- **update_interval** (*Optional*, [Time](/guides/configuration-types#time)): The interval to check the sensor.
+  Defaults to `60s`.
+- **address** (*Optional*, int): The I²C address of the sensor. Defaults to `0x39`.
+- All other options from [Sensor](/components/sensor/) and [I²C Bus](/components/i2c/).
+
+> [!NOTE]
+> `atime` and `astep` must not both be `0`, as that would leave the sensor with no integration time.
+
+## Channels
+
+Each channel is a photodiode with an optical filter in front of it, centered on the wavelength listed below. The
+`clear` channel has no filter and responds to the whole visible range, and `nir` responds to near-infrared light.
+
+The AS7343 has three channels the AS7341 does not have (`fz`, `fy` and `fxl`), and the channels the two models
+share are not centered on the same wavelengths. The same channel key therefore does not mean the same thing on
+both models.
+
+### AS7341
+
+| Channel | Wavelength    |
+| ------- | ------------- |
+| `f1`    | 415nm         |
+| `f2`    | 445nm         |
+| `f3`    | 480nm         |
+| `f4`    | 515nm         |
+| `f5`    | 555nm         |
+| `f6`    | 590nm         |
+| `f7`    | 630nm         |
+| `f8`    | 680nm         |
+| `clear` | Clear         |
+| `nir`   | Near-infrared |
+
+### AS7343
+
+| Channel | Wavelength    |
+| ------- | ------------- |
+| `f1`    | 405nm         |
+| `f2`    | 425nm         |
+| `fz`    | 450nm         |
+| `f3`    | 475nm         |
+| `f4`    | 515nm         |
+| `fy`    | 555nm         |
+| `f5`    | 550nm         |
+| `fxl`   | 600nm         |
+| `f6`    | 640nm         |
+| `f7`    | 690nm         |
+| `f8`    | 745nm         |
+| `clear` | Clear         |
+| `nir`   | Near-infrared |
+
+## Raw Counts
+
+The `counts` sensors report the raw ADC counts read from the device. They are not calibrated and carry no
+physical unit, so a value is only meaningful when compared with another value taken at the same `gain`, `atime`
+and `astep`. Changing any of those three options changes the counts for the same light.
+
+The largest count a channel can reach is $(\text{ATIME} + 1) \times (\text{ASTEP} + 1)$, or 65535 if that product
+is larger. With the default `atime` and `astep` that limit is 18000. A channel sitting at the limit is saturated
+and its reading should be discarded; lower the `gain` or the integration time until it drops below the limit.
+
+## Integration Time
+
+The integration time determines how long a single channel measurement takes and depends on `atime` and `astep`.
+The formula for the total integration time is:
+
+$$
+t = (\text{ATIME} + 1) \times (\text{ASTEP} + 1) \times 2.78\mu S
+$$
+
+The defaults of `atime: 29` and `astep: 599` give an integration time of 50ms.
+
+One update does not take exactly this long. The AS7341 has more channels than it has ADCs, so it measures them
+in two passes and takes two integration times per update. The AS7343 cycles internally and takes three. The
+sensor is read without blocking the rest of the device, so a long integration time does not stall other
+components, but keep the total below your `update_interval`.
+
+## Migrating From `as7341`
+
+The `as7341` platform still works and is unchanged apart from a deprecation warning at compile time. When you
+are ready to move, change the platform name, add `type: AS7341`, and move the channels under `counts`. The
+`gain`, `atime` and `astep` options keep their names and their defaults.
+
+```yaml
+# Old configuration
+sensor:
+  - platform: as7341
+    f1:
+      name: "415nm"
+    clear:
+      name: "Clear"
+```
+
+```yaml
+# New configuration
+sensor:
+  - platform: as734x
+    type: AS7341
+    counts:
+      f1:
+        name: "415nm"
+      clear:
+        name: "Clear"
+```
+
+> [!WARNING]
+> The reported values change when you migrate. The AS7341 returns its data registers low byte first, and the
+> `as7341` platform never accounted for this, so its counts come out byte-swapped. The `as734x` platform reads
+> them correctly. In practice a reading below 256 on the old platform was reported 256 times too large, and a
+> larger reading had its two bytes the wrong way round. Any automation, filter or long-term statistic built on
+> the old values will need to be revisited.
+
+## See Also
+
+- [Sensor Filters](/components/sensor#sensor-filters)
+- [AS7341 Spectral Color Sensor (deprecated)](/components/sensor/as7341/)
+- [Adafruit_AS7341](https://github.com/adafruit/Adafruit_AS7341)
+- [SparkFun_AS7341X_Arduino_Library](https://github.com/sparkfun/SparkFun_AS7341X_Arduino_Library)
+- <APIRef text="as734x.h" path="as734x/as734x.h" />

--- a/src/content/docs/components/sensor/as734x.mdx
+++ b/src/content/docs/components/sensor/as734x.mdx
@@ -95,8 +95,8 @@ both models.
 | `f6`    | 590nm         |
 | `f7`    | 630nm         |
 | `f8`    | 680nm         |
-| `clear` | Clear         |
 | `nir`   | Near-infrared |
+| `clear` | Clear         |
 
 ### AS7343
 
@@ -113,8 +113,8 @@ both models.
 | `f6`    | 640nm         |
 | `f7`    | 690nm         |
 | `f8`    | 745nm         |
-| `clear` | Clear         |
 | `nir`   | Near-infrared |
+| `clear` | Clear         |
 
 ## Raw Counts
 

--- a/src/content/docs/components/sensor/as734x.mdx
+++ b/src/content/docs/components/sensor/as734x.mdx
@@ -132,7 +132,7 @@ The integration time determines how long a single channel measurement takes and 
 The formula for the total integration time is:
 
 $$
-t = (\text{ATIME} + 1) \times (\text{ASTEP} + 1) \times 2.78\mu S
+t = (\text{ATIME} + 1) \times (\text{ASTEP} + 1) \times 2.78\,\mu\text{s}
 $$
 
 The defaults of `atime: 29` and `astep: 599` give an integration time of 50ms.

--- a/src/content/docs/components/sensor/as734x.mdx
+++ b/src/content/docs/components/sensor/as734x.mdx
@@ -1,6 +1,6 @@
 ---
-description: "Instructions for setting up AS7341 and AS7343 spectral color sensors."
-title: "AS7341 / AS7343 Spectral Color Sensor"
+description: "Instructions for setting up AS7341, AS7343 and TCS3448 spectral color sensors."
+title: "AS7341 / AS7343 / TCS3448 Spectral Color Sensor"
 ---
 
 import Figure from '@components/Figure.astro';
@@ -10,7 +10,10 @@ The `as734x` sensor platform allows you to use the AS7341
 ([datasheet](https://look.ams-osram.com/m/24266a3e584de4db/original/AS7341-DS000504.pdf),
 [Adafruit](https://www.adafruit.com/product/4698)) and AS7343
 ([datasheet](https://look.ams-osram.com/m/5f2d27fff9a874d2/original/AS7343-14-Channel-Multi-Spectral-Sensor.pdf))
-spectral color sensors with ESPHome. The sensor is selected with the `type` option. The
+spectral color sensors with ESPHome. The TCS3448
+([datasheet](https://look.ams-osram.com/m/1c24b057e65ee61e/original/TCS3448-14-Channel-multi-spectral-sensor.pdf))
+is supported as well: it replaces the AS7343 and shares its channels, register map and calibration, so
+everything written below about the AS7343 applies to it too. The sensor is selected with the `type` option. The
 [I²C Bus](/components/i2c/) is required to be set up in your configuration for this sensor to work.
 
 <Figure
@@ -42,7 +45,7 @@ sensor:
 
 ## Configuration variables
 
-- **type** (**Required**, string): The sensor model. Must be either `AS7341` or `AS7343`.
+- **type** (**Required**, string): The sensor model. Must be `AS7341`, `AS7343` or `TCS3448`.
 - **counts** (*Optional*): The raw per-channel readings to publish. Each channel is optional; only the channels
   you list are published. The available channels depend on `type`, see [Channels](#channels) below. Each channel
   accepts all options from [Sensor](/components/sensor/), or just a name as a shorthand.
@@ -60,15 +63,16 @@ sensor:
   - `X128`
   - `X256`
   - `X512`
-  - `X1024` (`AS7343` only)
-  - `X2048` (`AS7343` only)
+  - `X1024` (`AS7343` and `TCS3448` only)
+  - `X2048` (`AS7343` and `TCS3448` only)
 
 - **atime** (*Optional*, int): The number of integration steps. Defaults to `29`. Must be between `0` and `255`.
 - **astep** (*Optional*, int): The length of one integration step in increments of 2.78µs. Defaults to `599`.
   Must be between `0` and `65534`.
 - **update_interval** (*Optional*, [Time](/guides/configuration-types#time)): The interval to check the sensor.
   Defaults to `60s`.
-- **address** (*Optional*, int): The I²C address of the sensor. Defaults to `0x39`.
+- **address** (*Optional*, int): The I²C address of the sensor. Defaults to `0x39`, or to `0x59` when `type`
+  is `TCS3448`, which answers on a different address than the AS7343.
 - All other options from [Sensor](/components/sensor/) and [I²C Bus](/components/i2c/).
 
 > [!NOTE]
@@ -81,7 +85,7 @@ Each channel is a photodiode with an optical filter in front of it, centered on 
 
 The AS7343 has three channels the AS7341 does not have (`fz`, `fy` and `fxl`), and the channels the two models
 share are not centered on the same wavelengths. The same channel key therefore does not mean the same thing on
-both models.
+both models. The TCS3448 has the same channels as the AS7343.
 
 ### AS7341
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

## Part of a three-PR set

These match the three component PRs and build on each other, so they should be reviewed and merged in order.

- **1/3** - esphome/esphome.io#7120 - new page, unified component and raw per-channel counts (esphome/esphome#17038)
- **2/3** - esphome/esphome.io#7122 - basic counts, calibration, saturation level (esphome/esphome#18011)
- **3/3** - esphome/esphome.io#7123 - illuminance, irradiance, PAR, PPFD, colour temperature, RGB (esphome/esphome#18012)

Documents the new `as734x` sensor platform, which supports both the AS7341 and the AS7343 spectral sensors and is
selected with `type: AS7341` / `type: AS7343`.

New page `components/sensor/as734x.mdx` covering:

- Configuration variables: `type`, `counts`, `gain` (including the AS7343-only `X1024`/`X2048`), `atime`, `astep`,
  `update_interval` and `address`, plus the rule that `atime` and `astep` must not both be `0`.
- Per-model channel tables. The AS7343 adds `fz`, `fy` and `fxl`, and the shared channel keys sit at different
  wavelengths on the two parts, so they are listed separately.
- Raw counts: what the values mean, and the full-scale limit of `(ATIME + 1) x (ASTEP + 1)` capped at 65535.
- Integration time, including the fact that one update takes two integration times on the AS7341 and three on the
  AS7343.
- A migration section from `as7341`, with the warning that reported values change because the old platform read
  the data registers byte-swapped.

Also updated:

- `components/sensor/as7341.mdx` - deprecation warning pointing at `as734x`, and a link in See Also. The platform
  emits a deprecation warning at compile time in the linked esphome PR and is slated for removal in 2027.2.0.
- `components/index.mdx` - the existing AS7341 card now points at the new page and is titled "AS7341 / AS7343".
  The deprecated `as7341` page stays reachable from the new page rather than holding its own card.

Two notes for reviewers:

- The index card reuses the existing `as7341.jpg` image. Happy to swap in a generated component image if
  preferred.
- This is part 1 of 3. The follow-up esphome PRs (#18011, #18012) add basic counts, calibration, saturation, LED
  control and the derived light metrics, and will be documented separately as they land.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#17038

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [x] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.
