### PR TITLE
[bluetooth_proxy] Document active connections on RP2040/RP2350

### DIFF
--- a/src/content/docs/components/bluetooth_proxy.mdx
+++ b/src/content/docs/components/bluetooth_proxy.mdx
@@ -17,16 +17,17 @@ are supported.
 If you'd like to buy a ready-made Bluetooth proxy or flash your own device, see
 [ESPHome projects with Bluetooth proxy support](/projects/?type=bluetooth).
 
-## Supported platforms
+## Supported Platforms
 
 - **ESP32**: full proxy with active GATT connections; requires the
-  [ESP32 BLE Tracker](/components/esp32_ble_tracker) component.
+  [ESP32 BLE Tracker](/components/esp32_ble_tracker/) component.
 - **RP2040/RP2350** (Raspberry Pi Pico W and Pico 2 W): full proxy with active GATT connections
-  through the [RP2040 BLE](/components/rp2040_ble) BTstack stack; requires the
-  [RP2 BLE Tracker](/components/rp2_ble_tracker) component. The framework's Bluetooth library supports one concurrent GATT connection, so
-  `connection_slots` is limited to `1` on this platform.
+  through the [RP2040 BLE](/components/rp2040_ble/) BTstack stack; requires the
+  [RP2 BLE Tracker](/components/rp2_ble_tracker/) component. The framework's Bluetooth library
+  supports one concurrent GATT connection, so `connection_slots` is limited to `1` on this
+  platform.
 - **LN882x**: advertisement forwarding only (no active connections); requires the
-  `ln882h_ble_tracker` component.
+  [LN882H BLE Tracker](/components/ln882h_ble_tracker/) component.
 
 ## Configuration
 
@@ -39,12 +40,14 @@ bluetooth_proxy:
 
 - **active** (*Optional*, boolean): Enables proxying active GATT connections to BLE devices.
   This is separate from active *scanning* (configured in the BLE tracker component).
-  Defaults to `true` on ESP32 and RP2040/RP2350; LN882x supports advertisement forwarding only.
+  Defaults to `true` on ESP32 and RP2040/RP2350; LN882x supports advertisement forwarding
+  only.
   RP2040/RP2350 proxies were advertisement only before active connection support landed, so
   existing Pico W configurations that omit this option gain a connection slot on their next
   update; set `active: false` to keep an advertisement only proxy.
 - **cache_services** (*Optional*, boolean): Enables caching GATT services in NVS flash storage which
-  significantly speeds up active connections. Defaults to `true`. Only on ESP32.
+  significantly speeds up active connections. Defaults to `true`. Only available on ESP32;
+  other platforms reject the option.
 - **connection_slots** (*Optional*, int): The maximum number of BLE connection slots to use.
   Each configured slot consumes ~1KB of RAM, with a maximum of `9`. It is recommended not to exceed `5`
   connection slots to avoid stability and memory issues. Defaults to `3`.
@@ -53,15 +56,17 @@ bluetooth_proxy:
   for [ESP32 BLE](/components/esp32_ble). On RP2040/RP2350 the maximum (and default) is `1`.
 
 The Bluetooth proxy depends on the platform's BLE tracker component, so make sure to add that to your
-configuration: [ESP32 BLE Tracker](/components/esp32_ble_tracker) on ESP32, the
-[RP2 BLE Tracker](/components/rp2_ble_tracker) on RP2040/RP2350, or `ln882h_ble_tracker` on LN882x.
+configuration: [ESP32 BLE Tracker](/components/esp32_ble_tracker/) on ESP32, the
+[RP2 BLE Tracker](/components/rp2_ble_tracker/) on RP2040/RP2350, or the
+[LN882H BLE Tracker](/components/ln882h_ble_tracker/) on LN882x.
 
 ### How Active Connections Work
 
 The Bluetooth proxy provides Home Assistant with a limited number of simultaneous active GATT connections
-(configured via `connection_slots`). The default is 3 slots. Ethernet-based proxies can generally handle
-4 slots reliably since they don't share the radio with WiFi traffic. Set `connection_slots: 4` if you need
-more connections (each slot uses additional RAM).
+(configured via `connection_slots`). On ESP32 the default is 3 slots; Ethernet-based proxies can generally
+handle 4 slots reliably since they don't share the radio with WiFi traffic, so set `connection_slots: 4`
+there if you need more connections (each slot uses additional RAM). RP2040/RP2350 proxies always have a
+single slot.
 
 Devices that stay connected continuously (like some locks or thermostats) use one slot the entire time.
 Devices that connect briefly to exchange data and then disconnect (like many sensors) free up the slot

--- a/src/content/docs/components/bluetooth_proxy.mdx
+++ b/src/content/docs/components/bluetooth_proxy.mdx
@@ -39,9 +39,9 @@ bluetooth_proxy:
 - **connection_slots** (*Optional*, int): ESP32 and RP2040/RP2350. The maximum number of BLE
   connection slots to use. On RP2040/RP2350 the maximum and default are both `1`. On ESP32, each
   configured slot consumes ~1KB of RAM, with a maximum of `9`; it is recommended not to exceed `5`
-  connection slots to avoid stability and memory issues, the default is `3`, Ethernet-based
-  proxies can generally handle `4` slots reliably, and the value must not exceed the total
-  configured `max_connections` for [ESP32 BLE](/components/esp32_ble/).
+  connection slots to avoid stability and memory issues. The ESP32 default is `3`. Ethernet-based
+  proxies can generally handle `4` slots reliably. The value must not exceed the total configured
+  `max_connections` for [ESP32 BLE](/components/esp32_ble/).
 
 The Bluetooth proxy depends on the platform's BLE tracker component, so make sure to add that to your
 configuration: [ESP32 BLE Tracker](/components/esp32_ble_tracker/) on ESP32, the
@@ -257,7 +257,7 @@ is supported, please search for it in the
 ## See Also
 
 - [ESP32 Bluetooth Low Energy Tracker Hub](/components/esp32_ble_tracker/)
-- [RP2 Bluetooth Low Energy Tracker Hub](/components/rp2_ble_tracker/)
+- [RP2 BLE Tracker](/components/rp2_ble_tracker/)
 - [LN882H Bluetooth Low Energy Tracker Hub](/components/ln882h_ble_tracker/)
 - BTHome [https://bthome.io/](https://bthome.io/)
 - <APIRef text="bluetooth_proxy.h" path="bluetooth_proxy/bluetooth_proxy.h" />

--- a/src/content/docs/components/bluetooth_proxy.mdx
+++ b/src/content/docs/components/bluetooth_proxy.mdx
@@ -17,6 +17,17 @@ are supported.
 If you'd like to buy a ready-made Bluetooth proxy or flash your own device, see
 [ESPHome projects with Bluetooth proxy support](/projects/?type=bluetooth).
 
+## Supported platforms
+
+- **ESP32**: full proxy with active GATT connections; requires the
+  [ESP32 BLE Tracker](/components/esp32_ble_tracker) component.
+- **RP2040/RP2350** (Raspberry Pi Pico W and Pico 2 W): full proxy with active GATT connections
+  through the [RP2040 BLE](/components/rp2040_ble) BTstack stack; requires the
+  [RP2 BLE Tracker](/components/rp2_ble_tracker) component. The framework's Bluetooth library supports one concurrent GATT connection, so
+  `connection_slots` is limited to `1` on this platform.
+- **LN882x**: advertisement forwarding only (no active connections); requires the
+  `ln882h_ble_tracker` component.
+
 ## Configuration
 
 ```yaml
@@ -27,19 +38,23 @@ bluetooth_proxy:
 ```
 
 - **active** (*Optional*, boolean): Enables proxying active GATT connections to BLE devices.
-  This is separate from active *scanning* (configured in [ESP32 BLE Tracker](/components/esp32_ble_tracker)).
-  Defaults to `true`.
+  This is separate from active *scanning* (configured in the BLE tracker component).
+  Defaults to `true` on ESP32 and RP2040/RP2350; LN882x supports advertisement forwarding only.
+  RP2040/RP2350 proxies were advertisement only before active connection support landed, so
+  existing Pico W configurations that omit this option gain a connection slot on their next
+  update; set `active: false` to keep an advertisement only proxy.
 - **cache_services** (*Optional*, boolean): Enables caching GATT services in NVS flash storage which
-  significantly speeds up active connections. Defaults to `true`.
+  significantly speeds up active connections. Defaults to `true`. Only on ESP32.
 - **connection_slots** (*Optional*, int): The maximum number of BLE connection slots to use.
   Each configured slot consumes ~1KB of RAM, with a maximum of `9`. It is recommended not to exceed `5`
   connection slots to avoid stability and memory issues. Defaults to `3`.
   Ethernet-based proxies can generally handle `4` connection slots reliably.
   The value must not exceed the total configured `max_connections`
-  for [ESP32 BLE](/components/esp32_ble).
+  for [ESP32 BLE](/components/esp32_ble). On RP2040/RP2350 the maximum (and default) is `1`.
 
-The Bluetooth proxy depends on [ESP32 BLE Tracker](/components/esp32_ble_tracker) so make sure to add that
-to your configuration.
+The Bluetooth proxy depends on the platform's BLE tracker component, so make sure to add that to your
+configuration: [ESP32 BLE Tracker](/components/esp32_ble_tracker) on ESP32, the
+[RP2 BLE Tracker](/components/rp2_ble_tracker) on RP2040/RP2350, or `ln882h_ble_tracker` on LN882x.
 
 ### How Active Connections Work
 

--- a/src/content/docs/components/bluetooth_proxy.mdx
+++ b/src/content/docs/components/bluetooth_proxy.mdx
@@ -32,15 +32,16 @@ bluetooth_proxy:
   `false` and enabling it fails validation — see [Platform Support](#platform-support).
   RP2040/RP2350 proxies were advertisement only before active connection support landed, so
   existing Pico W configurations that omit this option gain a connection slot on their next
-  update; set `active: false` to keep an advertisement only proxy.
-- **cache_services** (*Optional*, boolean): ESP32 only. Enables caching GATT services in NVS flash
-  storage which significantly speeds up active connections. Defaults to `true`.
-- **connection_slots** (*Optional*, int): ESP32 and RP2040/RP2350. The maximum number of BLE connection slots to use.
-  Each configured slot consumes ~1KB of RAM, with a maximum of `9`. It is recommended not to exceed `5`
-  connection slots to avoid stability and memory issues. Defaults to `3`.
-  Ethernet-based proxies can generally handle `4` connection slots reliably.
-  The value must not exceed the total configured `max_connections`
-  for [ESP32 BLE](/components/esp32_ble/). On RP2040/RP2350 the maximum (and default) is `1`.
+  update; set `active: false` to keep an advertisement-only proxy.
+- **cache_services** (*Optional*, boolean): ESP32 only; setting it on any other platform is a
+  configuration error. Enables caching GATT services in NVS flash storage which significantly
+  speeds up active connections. Defaults to `true`.
+- **connection_slots** (*Optional*, int): ESP32 and RP2040/RP2350. The maximum number of BLE
+  connection slots to use. On RP2040/RP2350 the maximum and default are both `1`. On ESP32, each
+  configured slot consumes ~1KB of RAM, with a maximum of `9`; it is recommended not to exceed `5`
+  connection slots to avoid stability and memory issues, the default is `3`, Ethernet-based
+  proxies can generally handle `4` slots reliably, and the value must not exceed the total
+  configured `max_connections` for [ESP32 BLE](/components/esp32_ble/).
 
 The Bluetooth proxy depends on the platform's BLE tracker component, so make sure to add that to your
 configuration: [ESP32 BLE Tracker](/components/esp32_ble_tracker/) on ESP32, the
@@ -75,9 +76,9 @@ the controller can do beyond scanning:
   and write GATT characteristics through the device (`active: true`, `connection_slots`); requires
   the [ESP32 BLE Tracker](/components/esp32_ble_tracker/) component.
 - **RP2040/RP2350 (Raspberry Pi Pico W family)** — the full proxy, with active connections through
-  the framework's BTstack GATT client; requires the
-  [RP2 BLE Tracker](/components/rp2_ble_tracker/) component. The prebuilt Bluetooth library
-  supports one concurrent GATT connection, so `connection_slots` is limited to `1`.
+  the framework's prebuilt BTstack GATT client; requires the
+  [RP2 BLE Tracker](/components/rp2_ble_tracker/) component. That library supports one
+  concurrent GATT connection, so `connection_slots` is limited to `1`.
 - **LN882x** — **advertisement-only**. The controller does not expose the GATT client the proxy
   needs for connections, so Home Assistant uses the device for advertisements only and will not
   route connections through it. This is independent of the

--- a/src/content/docs/components/bluetooth_proxy.mdx
+++ b/src/content/docs/components/bluetooth_proxy.mdx
@@ -21,8 +21,8 @@ If you'd like to buy a ready-made Bluetooth proxy or flash your own device, see
 
 ```yaml
 bluetooth_proxy:
-  # On ESP32, active connections are enabled by default
-  # To disable active connections (previous default behavior), use:
+  # Active connections are enabled by default on ESP32 and RP2040/RP2350.
+  # For an advertisement-only proxy, use:
   # active: false
 ```
 
@@ -31,7 +31,7 @@ bluetooth_proxy:
   Defaults to `true` on ESP32 and RP2040/RP2350. On advertisement-only platforms it defaults to
   `false` and enabling it fails validation — see [Platform Support](#platform-support).
   RP2040/RP2350 proxies were advertisement only before active connection support landed, so
-  existing Pico W configurations that omit this option gain a connection slot on their next
+  existing Pico W configurations that omit this option will gain a connection slot on their next
   update; set `active: false` to keep an advertisement-only proxy.
 - **cache_services** (*Optional*, boolean): ESP32 only; setting it on any other platform is a
   configuration error. Enables caching GATT services in NVS flash storage which significantly

--- a/src/content/docs/components/bluetooth_proxy.mdx
+++ b/src/content/docs/components/bluetooth_proxy.mdx
@@ -53,7 +53,7 @@ bluetooth_proxy:
   connection slots to avoid stability and memory issues. Defaults to `3`.
   Ethernet-based proxies can generally handle `4` connection slots reliably.
   The value must not exceed the total configured `max_connections`
-  for [ESP32 BLE](/components/esp32_ble). On RP2040/RP2350 the maximum (and default) is `1`.
+  for [ESP32 BLE](/components/esp32_ble/). On RP2040/RP2350 the maximum (and default) is `1`.
 
 The Bluetooth proxy depends on the platform's BLE tracker component, so make sure to add that to your
 configuration: [ESP32 BLE Tracker](/components/esp32_ble_tracker/) on ESP32, the
@@ -222,6 +222,8 @@ is supported, please search for it in the
 
 ## See Also
 
-- [ESP32 Bluetooth Low Energy Tracker Hub](/components/esp32_ble_tracker)
+- [ESP32 Bluetooth Low Energy Tracker Hub](/components/esp32_ble_tracker/)
+- [RP2 Bluetooth Low Energy Tracker Hub](/components/rp2_ble_tracker/)
+- [LN882H Bluetooth Low Energy Tracker Hub](/components/ln882h_ble_tracker/)
 - BTHome [https://bthome.io/](https://bthome.io/)
 - <APIRef text="bluetooth_proxy.h" path="bluetooth_proxy/bluetooth_proxy.h" />

--- a/src/content/docs/components/ln882h_ble_tracker.mdx
+++ b/src/content/docs/components/ln882h_ble_tracker.mdx
@@ -17,8 +17,9 @@ ESPHome's advertisement-based BLE sensor platforms — for example
 — which attach to this tracker automatically.
 
 > [!NOTE]
-> Connection-based BLE components (`ble_client`, `bluetooth_proxy`) are not available on this
-> platform — the tracker is scan-only.
+> Connection-based BLE components (`ble_client`) are not available on this platform — the
+> tracker is scan-only. The [Bluetooth Proxy](/components/bluetooth_proxy/) is supported in
+> advertisement-only mode (no active connections).
 
 > [!NOTE]
 > The tracker builds on the [LN882H BLE](/components/ln882h_ble/) controller component and

--- a/src/content/docs/components/rp2040_ble.mdx
+++ b/src/content/docs/components/rp2040_ble.mdx
@@ -13,7 +13,7 @@ boards with this chip.
 
 > [!NOTE]
 > This component initializes the BLE stack and provides the scan primitives used by the
-> [RP2 BLE Tracker](/components/rp2_ble_tracker/). The [Bluetooth Proxy](/components/bluetooth_proxy)
+> [RP2 BLE Tracker](/components/rp2_ble_tracker/). The [Bluetooth Proxy](/components/bluetooth_proxy/)
 > supports active GATT connections on this platform through BTstack's GATT client.
 
 > [!NOTE]

--- a/src/content/docs/components/rp2040_ble.mdx
+++ b/src/content/docs/components/rp2040_ble.mdx
@@ -13,8 +13,8 @@ boards with this chip.
 
 > [!NOTE]
 > This component initializes the BLE stack and provides the scan primitives used by the
-> [RP2 BLE Tracker](/components/rp2_ble_tracker/). Additional components for connecting
-> and acting as a server will be added in future releases.
+> [RP2 BLE Tracker](/components/rp2_ble_tracker/). The [Bluetooth Proxy](/components/bluetooth_proxy)
+> supports active GATT connections on this platform through BTstack's GATT client.
 
 > [!NOTE]
 > This component uses the [BTstack](https://github.com/bluekitchen/btstack) Bluetooth stack, which is
@@ -36,4 +36,5 @@ rp2040_ble:
 ## See Also
 
 - [RP2 Platform](/components/rp2/)
+- [Bluetooth Proxy](/components/bluetooth_proxy/)
 - [ESP32 BLE Component](/components/esp32_ble/)

--- a/src/content/docs/components/rp2_ble_tracker.mdx
+++ b/src/content/docs/components/rp2_ble_tracker.mdx
@@ -23,8 +23,8 @@ cycle to leave the radio mostly free for WiFi.
 > arrives as those platforms migrate to the shared BLE layer in follow-up releases.
 
 > [!NOTE]
-> [`bluetooth_proxy`](/components/bluetooth_proxy/) works with this tracker in
-> advertisement-only mode — see
+> [`bluetooth_proxy`](/components/bluetooth_proxy/) supports active GATT connections with this
+> tracker (one connection slot) — see
 > [Platform Support](/components/bluetooth_proxy/#platform-support).
 
 ```yaml


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Documents active Bluetooth proxy connections on RP2040/RP2350: a supported platforms section, the active default and its change for existing Pico W configurations, the one connection slot limit from the framework's BTstack library, and the cache_services esp32 only note. Also refreshes the rp2040_ble page, whose scanning and connecting features are no longer future work.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#18132

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.
