### PR TITLE
[bluetooth_proxy] Document the internal bluetooth_connection component

### DIFF
--- a/src/content/docs/components/bluetooth_proxy.mdx
+++ b/src/content/docs/components/bluetooth_proxy.mdx
@@ -55,6 +55,10 @@ for other devices, so you can use more devices than you have slots.
 Passively broadcasted sensor data (advertised by devices without requiring active connections, such as
 many BTHome sensors) is received separately and is not limited by the number of connection slots.
 
+Active connections are handled by the internal `bluetooth_connection` component, which is loaded
+automatically and has no configuration of its own. Its log lines use the `bluetooth_connection` tag,
+which is useful when filtering logs with the [Logger](/components/logger) component.
+
 ## Improving reception performance
 
 Use a board with an Ethernet connection to the network to offload ESP32's radio module
@@ -205,3 +209,4 @@ is supported, please search for it in the
 - [ESP32 Bluetooth Low Energy Tracker Hub](/components/esp32_ble_tracker)
 - BTHome [https://bthome.io/](https://bthome.io/)
 - <APIRef text="bluetooth_proxy.h" path="bluetooth_proxy/bluetooth_proxy.h" />
+- <APIRef text="bluetooth_connection.h" path="bluetooth_connection/bluetooth_connection.h" />


### PR DESCRIPTION
## Description:

Documents the internal bluetooth_connection component on the Bluetooth proxy page: active connections are handled by this auto loaded component with no configuration of its own, its log lines use the bluetooth_connection tag, and its header is linked from See Also.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#18129

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.

  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.
