### PR TITLE
[epaper_spi] Document Waveshare 2.13in-G display models

### DIFF
--- a/src/content/docs/components/display/epaper_spi.mdx
+++ b/src/content/docs/components/display/epaper_spi.mdx
@@ -46,6 +46,8 @@ the pins used to interface to the display to be specified.
 |---------------------------|---------------------|----------------------------------------------------|
 | GooDisplay-GDEY042T81-4.2 | Dalian Good Display | [https://www.good-display.com/product/386.html](https://www.good-display.com/product/386.html) |
 | Waveshare-1.54in-G        | Waveshare           | [https://www.waveshare.com/1.54inch-e-paper-g.htm](https://www.waveshare.com/1.54inch-e-paper-g.htm) |
+| Waveshare-2.13in-G        | Waveshare           | 2.13" 4-color e-paper (124x250 padded from 122, JD79660), current hardware/init revision. [https://www.waveshare.com/product/raspberry-pi/displays/e-paper/2.13inch-e-paper-hat-g.htm](https://www.waveshare.com/product/raspberry-pi/displays/e-paper/2.13inch-e-paper-hat-g.htm) |
+| Waveshare-2.13in-G-V1     | Waveshare           | Older hardware/init revision of the same panel (128x250 padded from 122). [https://www.waveshare.com/product/raspberry-pi/displays/e-paper/2.13inch-e-paper-hat-g.htm](https://www.waveshare.com/product/raspberry-pi/displays/e-paper/2.13inch-e-paper-hat-g.htm) |
 | Waveshare-2.13in-v3       | Waveshare           | [https://www.waveshare.com/pico-epaper-2.13.htm](https://www.waveshare.com/pico-epaper-2.13.htm)   |
 | Waveshare-2.13in-bv4      | Waveshare           | 2.13" 3-color e-paper (250x122, SSD1683) [https://www.waveshare.com/product/displays/e-paper/epaper-3/2.13inch-e-paper-b.htm](https://www.waveshare.com/product/displays/e-paper/epaper-3/2.13inch-e-paper-b.htm) |
 | Waveshare-3.97in          | Waveshare           | [https://www.waveshare.com/3.97inch-e-paper-hat-plus.htm](https://www.waveshare.com/3.97inch-e-paper-hat-plus.htm) |
@@ -83,7 +85,7 @@ but can be overridden if needed.
 
   > [!NOTE]
   > Some displays use inverted busy pin polarity (LOW = busy, HIGH = idle). For these models, set `inverted: true`
-  > on the busy pin. This applies to: `Waveshare-1.54in-G`, `Waveshare-7.5in-H`, `inkplate6color`.
+  > on the busy pin. This applies to: `Waveshare-1.54in-G`, `Waveshare-2.13in-G`, `Waveshare-2.13in-G-V1`, `Waveshare-7.5in-H`, `inkplate6color`.
 
 - **reset_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The RESET pin, if used.
   Make sure you pull this pin high (by connecting it to 3.3V with a resistor) if not connected to a GPIO pin.


### PR DESCRIPTION
Companion docs for esphome/esphome#18141 (adds the
Waveshare-2.13in-G and Waveshare-2.13in-G-V1 models).

<!-- markdownlint-disable -->

## Description

Documents the two new `epaper_spi` display models added in the linked esphome PR: `Waveshare-2.13in-G` (current hardware/init revision) and `Waveshare-2.13in-G-V1` (older revision of the same panel). Adds both to the "Supported display panels" table and to the inverted-busy-pin note, matching the existing entries for the other JD79660-family models (`Waveshare-1.54in-G`, `Waveshare-7.5in-H`).

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#18141

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook. — not applicable, this is an addition to an already-documented component's existing page, not a new component page.
