### PR TITLE
[wifi] Document hidden option in single-network shorthand

### DIFF
--- a/src/content/docs/components/wifi.mdx
+++ b/src/content/docs/components/wifi.mdx
@@ -51,7 +51,7 @@ wifi:
 - **hidden** (*Optional*, boolean): Set to `true` if the network does not broadcast its SSID.
   Only for the single-network shorthand and requires `ssid` to be set; with `networks`,
   set `hidden` on the network entry instead. Defaults to `false`.
-  See [Connecting to a Hidden Network](#example-connecting-to-a-hidden-network).
+  See [Connecting to a Hidden Network](#connecting-to-a-hidden-network).
 
 - **networks** (*Optional*): Configure multiple WiFi networks to connect to, the best one
   that is reachable will be connected to. See [Connecting to Multiple Networks](#wifi-networks).
@@ -132,8 +132,8 @@ wifi:
 
   > [!NOTE]
   > While `fast_connect` skips the initial scan, if the connection attempt fails, ESPHome will still perform a scan
-  > to find available networks. For hidden networks, use `hidden: true` on the network configuration (see
-  > [Connecting to Multiple Networks](#wifi-networks)) to ensure the device always connects without scanning.
+  > to find available networks. For hidden networks, set `hidden: true` (see
+  > [Connecting to a Hidden Network](#connecting-to-a-hidden-network)) to ensure the device always connects without scanning.
   > Be aware that marking networks as hidden prevents ESPHome from finding the best access point to connect to,
   > so the device may not connect to the AP with the best signal strength.
 
@@ -439,7 +439,7 @@ wifi:
   If all tracked BSSIDs have identical priorities, they are automatically reset to 0 to start fresh.
   Defaults to `0`.
 
-### Example: Connecting to a Hidden Network
+## Connecting to a Hidden Network
 
 ```yaml
 wifi:

--- a/src/content/docs/components/wifi.mdx
+++ b/src/content/docs/components/wifi.mdx
@@ -48,8 +48,9 @@ wifi:
 - **password** (*Optional*, string): The password (or PSK) for your
   WiFi network. Leave empty for no password.
 
-- **hidden** (*Optional*, boolean): Whether the network does not broadcast its SSID.
-  Requires `ssid` to be set. Defaults to `false`.
+- **hidden** (*Optional*, boolean): Set to `true` if the network does not broadcast its SSID.
+  Only for the single-network shorthand and requires `ssid` to be set; with `networks`,
+  set `hidden` on the network entry instead. Defaults to `false`.
   See [Connecting to a Hidden Network](#example-connecting-to-a-hidden-network).
 
 - **networks** (*Optional*): Configure multiple WiFi networks to connect to, the best one

--- a/src/content/docs/components/wifi.mdx
+++ b/src/content/docs/components/wifi.mdx
@@ -48,6 +48,10 @@ wifi:
 - **password** (*Optional*, string): The password (or PSK) for your
   WiFi network. Leave empty for no password.
 
+- **hidden** (*Optional*, boolean): Whether the network does not broadcast its SSID.
+  Requires `ssid` to be set. Defaults to `false`.
+  See [Connecting to a Hidden Network](#example-connecting-to-a-hidden-network).
+
 - **networks** (*Optional*): Configure multiple WiFi networks to connect to, the best one
   that is reachable will be connected to. See [Connecting to Multiple Networks](#wifi-networks).
 
@@ -435,6 +439,15 @@ wifi:
   Defaults to `0`.
 
 ### Example: Connecting to a Hidden Network
+
+```yaml
+wifi:
+  ssid: MyHiddenNetwork
+  password: VerySafePassword
+  hidden: true
+```
+
+With multiple networks, set `hidden` on the network entry instead:
 
 ```yaml
 wifi:


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Documents the top-level `hidden:` option added to the single-network `ssid:`/`password:` shorthand: a new entry in the configuration variables list, and the hidden-network example now shows the shorthand first with the multi-network form kept below.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#18157

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.
