### PR TITLE
[bk72xx_ble_tracker] Document active scanning and bluetooth_proxy support

### DIFF
--- a/src/content/docs/components/bk72xx_ble_tracker.mdx
+++ b/src/content/docs/components/bk72xx_ble_tracker.mdx
@@ -48,11 +48,10 @@ bk72xx_ble_tracker:
   for background reading.
 
   > [!NOTE]
-  > Scanning defaults to **passive**, which is sufficient for BTHome/ATC thermometers and most
-  > beacons — they broadcast all their data in the advertisement (no scan response). Active
-  > scanning is available via `active: true`; the Beken SDK's own scan API is passive-only, so
-  > the active start goes through a lower-level path that has seen less field exposure, which is
-  > why it is opt-in for now.
+  > Scanning defaults to **active**, like the other BLE trackers. Passive scanning
+  > (`active: false`) is sufficient for BTHome/ATC thermometers and most beacons — they
+  > broadcast all their data in the advertisement (no scan response) — and keeps the radio
+  > cost of each window minimal on the single-core SoC.
 
   - **interval** (*Optional*, [Time](/guides/configuration-types#time)): The interval between
     each consecutive scan window. The scanner cycles through the three BLE advertising channels
@@ -76,15 +75,13 @@ bk72xx_ble_tracker:
     connected). Defaults to `true`.
 
   - **active** (*Optional*, boolean): Whether to send scan requests and receive scan responses
-    (device names and other data some devices only put in the scan response). Scan responses
-    are delivered as separate advertisement reports; receivers that merge per address (Home
-    Assistant does) see the combined data. Active scanning transmits during each window, which
-    adds radio cost on the single-core SoC — see
-    [Use on a single-core chip](#use-on-a-single-core-chip). Defaults to `false`, unlike the
-    other trackers: the active start bypasses the Beken SDK's passive-only scan API and is
-    opt-in until proven broadly on hardware. A scanner-mode request from Home Assistant (for
-    example through [`bluetooth_proxy`](/components/bluetooth_proxy/)) switches the mode at
-    runtime regardless of this default.
+    (device names and other data some devices only put in the scan response). An advertisement
+    and its scan response are merged and delivered as one frame, the same behavior as the
+    ESP32 tracker. Active scanning transmits during each window, which adds radio cost on the
+    single-core SoC — see [Use on a single-core chip](#use-on-a-single-core-chip). Defaults to
+    `true`. A scanner-mode request from Home Assistant (for example through
+    [`bluetooth_proxy`](/components/bluetooth_proxy/)) switches the mode at runtime regardless
+    of this setting.
 
 - **on_ble_advertise** (*Optional*, [Automation](/automations)): An automation to perform
   when a Bluetooth advertisement is received. A variable `x` of type
@@ -199,9 +196,9 @@ sensor:
 
 Unlike the ESP32 which runs BLE on a dedicated core, the BK72xx run both WiFi and BLE on the
 same single ARM CPU core. The scan `window` / `interval` ratio decides how that core is split
-between BLE and WiFi, and the default passive scanning (no scan requests) keeps the radio cost
-of each window minimal; `active: true` adds a transmission per discovered device, so prefer
-passive when scan responses are not needed:
+between BLE and WiFi. Active scanning adds a transmission per discovered device, so set
+`active: false` when scan responses are not needed (BTHome/ATC beacons) to keep the radio
+cost of each window minimal:
 
 - `interval: 100ms`, `window: 30ms` → **30/70** BLE / WiFi — the BK reference default
 - `interval: 200ms`, `window: 50ms` → **25/75** BLE / WiFi — catches fewer advertisements,

--- a/src/content/docs/components/bk72xx_ble_tracker.mdx
+++ b/src/content/docs/components/bk72xx_ble_tracker.mdx
@@ -49,9 +49,9 @@ bk72xx_ble_tracker:
 
   > [!NOTE]
   > Scanning defaults to **active**, like the other BLE trackers. Passive scanning
-  > (`active: false`) is sufficient for BTHome/ATC thermometers and most beacons — they
-  > broadcast all their data in the advertisement (no scan response) — and keeps the radio
-  > cost of each window minimal on the single-core SoC.
+  > (`scan_parameters.active: false`) is sufficient for BTHome/ATC thermometers and most
+  > beacons — they broadcast all their data in the advertisement (no scan response) — and
+  > keeps the radio cost of each window minimal on the single-core SoC.
 
   - **interval** (*Optional*, [Time](/guides/configuration-types#time)): The interval between
     each consecutive scan window. The scanner cycles through the three BLE advertising channels
@@ -172,9 +172,9 @@ api:
 
 ## With BLE sensors
 
-Sensor platforms attach to the tracker automatically (identical to ESP32). The default passive
-scanning is sufficient for BTHome/ATC-style sensors that broadcast all their data in the
-advertisement:
+Sensor platforms attach to the tracker automatically (identical to ESP32). Passive scanning
+(`scan_parameters.active: false`) is sufficient for BTHome/ATC-style sensors that broadcast
+all their data in the advertisement:
 
 ```yaml
 bk72xx_ble_tracker:
@@ -197,12 +197,16 @@ sensor:
 Unlike the ESP32 which runs BLE on a dedicated core, the BK72xx run both WiFi and BLE on the
 same single ARM CPU core. The scan `window` / `interval` ratio decides how that core is split
 between BLE and WiFi. Active scanning adds a transmission per discovered device, so set
-`active: false` when scan responses are not needed (BTHome/ATC beacons) to keep the radio
-cost of each window minimal:
+`scan_parameters.active: false` when scan responses are not needed (BTHome/ATC beacons) to
+keep the radio cost of each window minimal:
 
 - `interval: 100ms`, `window: 30ms` → **30/70** BLE / WiFi — the BK reference default
 - `interval: 200ms`, `window: 50ms` → **25/75** BLE / WiFi — catches fewer advertisements,
   but leaves more of the core for WiFi
+
+Note that `scan_parameters.active` only governs standalone configurations: with
+[`bluetooth_proxy`](/components/bluetooth_proxy/), a connected Home Assistant drives the scan
+mode at runtime.
 
 ## See Also
 

--- a/src/content/docs/components/bk72xx_ble_tracker.mdx
+++ b/src/content/docs/components/bk72xx_ble_tracker.mdx
@@ -21,8 +21,7 @@ for example [BLE RSSI](/components/sensor/ble_rssi/),
 > [!NOTE]
 > This tracker is **scan-only**: it receives advertisements but cannot open GATT connections,
 > so [`ble_client`](/components/ble_client/) is not available on this platform.
-> [`bluetooth_proxy`](/components/bluetooth_proxy/) is also unsupported for now because the
-> controller scans passive-only — see
+> [`bluetooth_proxy`](/components/bluetooth_proxy/) runs in **advertisement-only** mode — see
 > [Platform Support](/components/bluetooth_proxy/#platform-support).
 
 > [!NOTE]
@@ -49,9 +48,11 @@ bk72xx_ble_tracker:
   for background reading.
 
   > [!NOTE]
-  > The BK72xx controller scans **passive only** — there is no `active` option. Passive
-  > scanning is sufficient for BTHome/ATC thermometers and most beacons, which broadcast all
-  > their data in the advertisement (no scan response).
+  > Scanning defaults to **passive**, which is sufficient for BTHome/ATC thermometers and most
+  > beacons — they broadcast all their data in the advertisement (no scan response). Active
+  > scanning is available via `active: true`; the Beken SDK's own scan API is passive-only, so
+  > the active start goes through a lower-level path that has seen less field exposure, which is
+  > why it is opt-in for now.
 
   - **interval** (*Optional*, [Time](/guides/configuration-types#time)): The interval between
     each consecutive scan window. The scanner cycles through the three BLE advertising channels
@@ -73,6 +74,17 @@ bk72xx_ble_tracker:
     pair it with the `bk72xx_ble_tracker.start_scan` action (for example from
     `api.on_client_connected`, so the single-core radio only scans while Home Assistant is
     connected). Defaults to `true`.
+
+  - **active** (*Optional*, boolean): Whether to send scan requests and receive scan responses
+    (device names and other data some devices only put in the scan response). Scan responses
+    are delivered as separate advertisement reports; receivers that merge per address (Home
+    Assistant does) see the combined data. Active scanning transmits during each window, which
+    adds radio cost on the single-core SoC — see
+    [Use on a single-core chip](#use-on-a-single-core-chip). Defaults to `false`, unlike the
+    other trackers: the active start bypasses the Beken SDK's passive-only scan API and is
+    opt-in until proven broadly on hardware. A scanner-mode request from Home Assistant (for
+    example through [`bluetooth_proxy`](/components/bluetooth_proxy/)) switches the mode at
+    runtime regardless of this default.
 
 - **on_ble_advertise** (*Optional*, [Automation](/automations)): An automation to perform
   when a Bluetooth advertisement is received. A variable `x` of type
@@ -163,9 +175,9 @@ api:
 
 ## With BLE sensors
 
-Sensor platforms attach to the tracker automatically (identical to ESP32). The BK72xx scans
-passive-only, which is sufficient for BTHome/ATC-style sensors that broadcast all their data
-in the advertisement:
+Sensor platforms attach to the tracker automatically (identical to ESP32). The default passive
+scanning is sufficient for BTHome/ATC-style sensors that broadcast all their data in the
+advertisement:
 
 ```yaml
 bk72xx_ble_tracker:
@@ -187,8 +199,9 @@ sensor:
 
 Unlike the ESP32 which runs BLE on a dedicated core, the BK72xx run both WiFi and BLE on the
 same single ARM CPU core. The scan `window` / `interval` ratio decides how that core is split
-between BLE and WiFi, and passive-only scanning (no scan requests) keeps the radio cost of each
-window minimal:
+between BLE and WiFi, and the default passive scanning (no scan requests) keeps the radio cost
+of each window minimal; `active: true` adds a transmission per discovered device, so prefer
+passive when scan responses are not needed:
 
 - `interval: 100ms`, `window: 30ms` → **30/70** BLE / WiFi — the BK reference default
 - `interval: 200ms`, `window: 50ms` → **25/75** BLE / WiFi — catches fewer advertisements,

--- a/src/content/docs/components/bluetooth_proxy.mdx
+++ b/src/content/docs/components/bluetooth_proxy.mdx
@@ -79,23 +79,20 @@ the controller can do beyond scanning:
   the framework's prebuilt BTstack GATT client; requires the
   [RP2 BLE Tracker](/components/rp2_ble_tracker/) component. That library supports one
   concurrent GATT connection, so `connection_slots` is limited to `1`.
-- **LN882x** — **advertisement-only**. The controller does not expose the GATT client the proxy
-  needs for connections, so Home Assistant uses the device for advertisements only and will not
-  route connections through it. This is independent of the
+- **BK72xx and LN882x** — **advertisement-only**. These controllers do not expose the GATT client
+  the proxy needs for connections, so Home Assistant uses the device for advertisements only and
+  will not route connections through it. This is independent of the
   [scan mode](#passive-vs-active-scanning), which the platform's tracker controls. Advertisement
   forwarding — which is what integrations such as BTHome, Xiaomi and most sensors rely on — works
   exactly as it does on ESP32; requires the
+  [BK72xx BLE Tracker](/components/bk72xx_ble_tracker/) or
   [LN882H BLE Tracker](/components/ln882h_ble_tracker/) component.
-
-Platforms whose controller can only scan **passively** (BK72xx) are not supported yet: current
-Home Assistant releases assume every ESPHome proxy can scan actively and would drive a
-passive-only proxy incorrectly. Support follows once the API lets a proxy declare
-passive-only scanning.
 
 On the advertisement-only platforms the proxy cannot be switched to active connections: `active`
 defaults to `false` there and setting `active: true` fails validation, as do the
 connection-oriented options (`connection_slots`, `cache_services`). The platform's tracker hub
-must be part of the configuration:
+must be part of the configuration — [BK72xx BLE Tracker](/components/bk72xx_ble_tracker/) or
+[LN882H BLE Tracker](/components/ln882h_ble_tracker/):
 
 ```yaml
 # Advertisement-only proxy on an LN882x board

--- a/src/content/docs/components/bluetooth_proxy.mdx
+++ b/src/content/docs/components/bluetooth_proxy.mdx
@@ -81,12 +81,12 @@ the controller can do beyond scanning:
   concurrent GATT connection, so `connection_slots` is limited to `1`.
 - **BK72xx and LN882x** — **advertisement-only**. These controllers do not expose the GATT client
   the proxy needs for connections, so Home Assistant uses the device for advertisements only and
-  will not route connections through it. This is independent of the
+  will not route connections through it; requires the
+  [BK72xx BLE Tracker](/components/bk72xx_ble_tracker/) or
+  [LN882H BLE Tracker](/components/ln882h_ble_tracker/) component. This is independent of the
   [scan mode](#passive-vs-active-scanning), which the platform's tracker controls. Advertisement
   forwarding — which is what integrations such as BTHome, Xiaomi and most sensors rely on — works
-  exactly as it does on ESP32; requires the
-  [BK72xx BLE Tracker](/components/bk72xx_ble_tracker/) or
-  [LN882H BLE Tracker](/components/ln882h_ble_tracker/) component.
+  exactly as it does on ESP32.
 
 On the advertisement-only platforms the proxy cannot be switched to active connections: `active`
 defaults to `false` there and setting `active: true` fails validation, as do the


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Documents active scanning on `bk72xx_ble_tracker` (esphome/esphome#18169): the new `scan_parameters.active` option (default on, matching the other trackers; an advertisement and its scan response are merged on device and delivered as one frame), the single core radio cost note, and the runtime scanner mode switching from Home Assistant.

Also updates the `bluetooth_proxy` platform support section: BK72xx joins the advertisement only platforms, and the paragraph explaining its passive only exclusion is removed since the exclusion no longer applies.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#18169

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>

