### PR TITLE
[wifi] Fix claim that eap requires the networks list

### DIFF
--- a/src/content/docs/components/wifi.mdx
+++ b/src/content/docs/components/wifi.mdx
@@ -445,7 +445,7 @@ wifi:
 ## Enterprise Authentication
 
 WPA2_EAP Enterprise Authentication is supported on ESP32s and ESP8266s.
-In order to configure this feature you must use the [Connecting to Multiple Networks](#wifi-networks) style configuration.
+It can be configured either with a top-level `eap:` option next to `ssid:`, or per network entry when using the [Connecting to Multiple Networks](#wifi-networks) style configuration.
 The ESP32 is known to work with PEAP, EAP-TTLS, and the certificate based EAP-TLS.
 These are advanced settings and you will usually need to consult your enterprise network administrator.
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

The Enterprise Authentication section says the `networks:` list is required to configure `eap:`, but `esphome/components/wifi/__init__.py` accepts a top-level `eap:` and folds it into the generated single-network entry during validation, so `eap:` next to `ssid:`/`password:` works in released ESPHome. Reworded the sentence to cover both forms.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.
