### PR TITLE
Add renogy_inverter_ble sensor docs

### DIFF
--- a/src/content/docs/components/index.mdx
+++ b/src/content/docs/components/index.mdx
@@ -308,6 +308,7 @@ Sensors are organized into categories; if a given sensor fits into more than one
   ["Inkbird IBS-TH1 Mini", "/components/sensor/inkbird_ibsth1_mini/", "inkbird_isbth1_mini.jpg", "Temperature & Humidity"],
   ["Mopeka Pro Check LP", "/components/sensor/mopeka_pro_check/", "mopeka_pro_check.jpg", "Tank level"],
   ["Mopeka Standard Check LP", "/components/sensor/mopeka_std_check/", "mopeka_std_check.jpg", "Tank level"],
+  ["Renogy Inverter BLE", "/components/sensor/renogy_inverter_ble/", "bluetooth.svg", "dark-invert"],
   ["RuuviTag", "/components/sensor/ruuvitag/", "ruuvitag.jpg", "Temperature & Humidity & Accelerometer"],
   ["ThermoPro BLE", "/components/sensor/thermopro_ble/", "thermopro_tp357.jpg"],
   ["Xiaomi BLE", "/components/sensor/xiaomi_ble/", "xiaomi_mijia_logo.jpg", "Various"],

--- a/src/content/docs/components/sensor/renogy_inverter_ble.mdx
+++ b/src/content/docs/components/sensor/renogy_inverter_ble.mdx
@@ -1,0 +1,84 @@
+---
+description: "Instructions for setting up Renogy inverter sensors that read over Bluetooth Low Energy in ESPHome."
+title: "Renogy Inverter BLE Sensor"
+---
+
+The `renogy_inverter_ble` sensor platform reads live data from a **Renogy inverter with built-in Bluetooth** over Bluetooth Low Energy — for example the **Renogy PUH 12V 3000W Pure Sine Wave Inverter** (with UPS transfer switch, SKU `RIV1230PU-126`) and other units in the `RNGRIU` family.
+
+These inverters speak Modbus over BLE, but require a proprietary "wake" read on a vendor characteristic before they answer any request — which is why a generic [Modbus Controller](/components/modbus_controller) over a BLE bridge times out against them. This component performs that handshake, then reads the inverter's holding registers and publishes the values.
+
+It depends on the [BLE Client](/components/ble_client) component, which in turn requires the [ESP32 BLE Tracker](/components/esp32_ble_tracker).
+
+## Finding the inverter's MAC address
+
+The inverter's BLE MAC address is not the same as the UUID shown by some operating systems. To find it, flash a temporary tracker build and watch the logs for a device whose name starts with `RNGRIU`:
+
+```yaml
+logger:
+  level: DEBUG
+
+esp32_ble_tracker:
+  on_ble_advertise:
+    then:
+      - lambda: |-
+          ESP_LOGD("scan", "Found %s '%s'", x.address_str().c_str(), x.get_name().c_str());
+```
+
+A phone app such as nRF Connect can also be used. Once you have the MAC, remove the tracker logging and configure the component below.
+
+:::note
+The inverter accepts only **one** BLE connection at a time. If a phone app or another client is connected to it, this component cannot read it.
+:::
+
+## Configuration example
+
+```yaml
+esp32_ble_tracker:
+
+ble_client:
+  - mac_address: AA:BB:CC:DD:EE:FF  # the inverter's BLE MAC (RNGRIU…)
+    id: inverter_client
+
+renogy_inverter_ble:
+  - id: inverter0
+    ble_client_id: inverter_client
+    update_interval: 30s
+
+sensor:
+  - platform: renogy_inverter_ble
+    renogy_inverter_ble_id: inverter0
+    ac_output_voltage:
+      name: "Inverter Output Voltage"
+    battery_voltage:
+      name: "Inverter Battery Voltage"
+    load_active_power:
+      name: "Inverter Load Power"
+    temperature:
+      name: "Inverter Temperature"
+```
+
+## Hub configuration variables
+
+- **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID used for code generation.
+- **ble_client_id** (**Required**, [ID](/guides/configuration-types#id)): The ID of the [BLE Client](/components/ble_client) to read from.
+- **update_interval** (*Optional*, [Time](/guides/configuration-types#time)): The interval to poll the inverter. Defaults to `30s`.
+
+## Sensor configuration variables
+
+- **renogy_inverter_ble_id** (**Required**, [ID](/guides/configuration-types#id)): The ID of the `renogy_inverter_ble` hub to read from.
+- **ac_input_voltage** (*Optional*): AC input (grid pass-through) voltage. All options from [Sensor](/components/sensor#config-sensor).
+- **ac_output_voltage** (*Optional*): AC output voltage. All options from [Sensor](/components/sensor#config-sensor).
+- **ac_output_current** (*Optional*): AC output current. All options from [Sensor](/components/sensor#config-sensor).
+- **ac_output_frequency** (*Optional*): AC output frequency. All options from [Sensor](/components/sensor#config-sensor).
+- **input_frequency** (*Optional*): AC input (grid) frequency. All options from [Sensor](/components/sensor#config-sensor).
+- **battery_voltage** (*Optional*): Battery voltage. All options from [Sensor](/components/sensor#config-sensor).
+- **temperature** (*Optional*): Inverter temperature. All options from [Sensor](/components/sensor#config-sensor).
+- **load_current** (*Optional*): Load current. All options from [Sensor](/components/sensor#config-sensor).
+- **load_active_power** (*Optional*): Load active power (W). All options from [Sensor](/components/sensor#config-sensor).
+- **load_apparent_power** (*Optional*): Load apparent power (VA). All options from [Sensor](/components/sensor#config-sensor).
+
+## See Also
+
+- [BLE Client](/components/ble_client)
+- [ESP32 BLE Tracker](/components/esp32_ble_tracker)
+- [Sensor Component](/components/sensor)


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Documentation for the new `renogy_inverter_ble` sensor platform.

Covers the Renogy PUH 12V 3000W Pure Sine Wave Inverter (built-in Bluetooth, SKU `RIV1230PU-126`) and the rest of the `RNGRIU` family: why a generic Modbus Controller over a BLE bridge times out against these units (they need a proprietary wake read on a vendor characteristic first), how to discover the inverter's BLE MAC address, a working configuration example, and the hub/sensor configuration variables.

This replaces #6717, which was closed by the stale bot on 2026-08-09 after two months without a review and cannot be reopened by GitHub. Same branch, rebased onto current `next`, plus two fixes:

- adds the missing entry in `src/content/docs/components/index.mdx` (BLE section) — the checklist item the original PR did not cover
- `(*Required*` → `(**Required**` to match the surrounding pages

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#16754

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [x] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

Verified locally against `next` (`14bdd8a`): `npm run lint`, `node script/check_component_index.mjs` and `astro build` all pass, and the page renders at `/components/sensor/renogy_inverter_ble/`.

The index entry currently reuses `bluetooth.svg` (as `atc_mithermometer` does). Happy to swap in a generated component image if preferred.
