### PR TITLE
[esphome] Document sub-device availability

### DIFF
--- a/src/content/docs/components/esphome.mdx
+++ b/src/content/docs/components/esphome.mdx
@@ -508,6 +508,56 @@ into logical devices that appear separately in Home Assistant. This is particula
 - **name** (**Required**, string): Display name for the device.
 - **area_id** (*Optional*, string): Reference to an area ID defined in `areas`.
 
+### `device.set_available` Action
+
+Sub-devices are available by default. Use this action when a sub-device becomes unavailable or available again.
+
+When the native API client supports sub-device availability, Home Assistant marks every entity assigned to an
+unavailable sub-device as unavailable. ESPHome continues to send entity state updates. When the sub-device becomes
+available again, Home Assistant shows the latest entity states.
+
+If a connected API client does not support sub-device availability, the ESPHome node logs a warning when it cannot
+report an unavailable sub-device.
+
+Call the applicable script from the automation that detects the sub-device's availability:
+
+```yaml
+esphome:
+  name: battery-gateway
+
+  devices:
+    - id: battery_pack
+      name: "Battery Pack"
+
+script:
+  - id: mark_battery_pack_unavailable
+    then:
+      - device.set_available:
+          id: battery_pack
+          available: false
+
+  - id: mark_battery_pack_available
+    then:
+      - device.set_available:
+          id: battery_pack
+          available: true
+```
+
+Configuration variables:
+
+- **id** (**Required**, [ID](/guides/configuration-types/#id)): The ID of the sub-device.
+- **available** (**Required**, boolean, [templatable](/automations/templates/)): Whether the sub-device is available.
+
+You can also set the availability from a lambda:
+
+```cpp
+id(battery_pack).set_available(false);
+```
+
+> [!NOTE]
+> This action only reports availability. It does not power off the sub-device or stop ESPHome from updating its
+> entities.
+
 ### Example: RF Bridge Gateway
 
 ```yaml


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Documents sub-device availability and the `device.set_available` action.

**Related issue (if applicable):** Partially addresses https://github.com/esphome/feature-requests/issues/1568

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#18220

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in the `/public/images/` folder as the component resolves them to absolute paths.

</details>
