### PR TITLE
Add Plausible

### DIFF
--- a/public/scripts/404.js
+++ b/public/scripts/404.js
@@ -1,6 +1,10 @@
 (function () {
   "use strict";
 
+  if (typeof window.plausible === "function") {
+    window.plausible("404");
+  }
+
   var root = document.querySelector(".error-404");
   if (!root) return;
 

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -99,6 +99,18 @@ const footerLinks = [
           height="44"
         />
       </a>
+
+      <p class="analytics-note">
+        This website uses{" "}
+        <a
+          href="https://www.openhomefoundation.org/blog/making-our-web-analytics-open-source-with-plausible/"
+          rel="noopener"
+        >
+          privacy-first analytics
+        </a>{" "}
+        to help us improve the site. You can view all data in our{" "}
+        <a href="https://plausible.openhomefoundation.org/esphome.io" rel="noopener"> public dashboard </a>.
+      </p>
     </div>
   </div>
 </footer>
@@ -168,8 +180,25 @@ const footerLinks = [
 
   .footer-bottom {
     text-align: center;
-    padding: 1rem 0;
+    padding: 1rem 0 0;
     border-top: 1px solid var(--sl-color-gray-6);
+  }
+
+  .analytics-note {
+    max-width: 30rem;
+    margin: 2rem auto 0;
+    text-wrap: balance;
+    font-size: var(--sl-text-xs);
+    color: var(--sl-color-gray-3);
+  }
+
+  .analytics-note a {
+    color: inherit;
+    text-decoration: underline;
+  }
+
+  .analytics-note a:hover {
+    color: var(--sl-color-white);
   }
 
   .ohf-link {

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -101,15 +101,13 @@ const footerLinks = [
       </a>
 
       <p class="analytics-note">
-        This website uses{" "}
-        <a
+        This website uses <a
           href="https://www.openhomefoundation.org/blog/making-our-web-analytics-open-source-with-plausible/"
-          rel="noopener"
-        >
-          privacy-first analytics
-        </a>{" "}
-        to help us improve the site. You can view all data in our{" "}
-        <a href="https://plausible.openhomefoundation.org/esphome.io" rel="noopener"> public dashboard </a>.
+          rel="noopener">privacy-first analytics</a
+        > to help us improve the site. You can view all data in our <a
+          href="https://plausible.openhomefoundation.org/esphome.io"
+          rel="noopener">public dashboard</a
+        >.
       </p>
     </div>
   </div>

--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -12,3 +12,20 @@ import Default from "@astrojs/starlight/components/Head.astro";
     });
   });
 </script>
+
+<!-- prettier-ignore -->
+<script is:inline async src="https://plausible.openhomefoundation.org/js/pa-IT3qGllOk_UiNLNNQsPlX.js"></script><script
+  is:inline
+>
+  ((window.plausible =
+    window.plausible ||
+    function () {
+      (plausible.q = plausible.q || []).push(arguments);
+    }),
+    (plausible.init =
+      plausible.init ||
+      function (i) {
+        plausible.o = i || {};
+      }));
+  plausible.init();
+</script>

--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -17,7 +17,7 @@ import Default from "@astrojs/starlight/components/Head.astro";
 <script is:inline async src="https://plausible.openhomefoundation.org/js/pa-IT3qGllOk_UiNLNNQsPlX.js"></script><script
   is:inline
 >
-  ((window.plausible =
+  /* eslint-disable */ ((window.plausible =
     window.plausible ||
     function () {
       (plausible.q = plausible.q || []).push(arguments);

--- a/src/content/docs/404.mdx
+++ b/src/content/docs/404.mdx
@@ -90,3 +90,5 @@ import { allRoutes } from "virtual:esphome-route-index";
 <script id="esphome-404-routes" type="application/json" is:inline>{JSON.stringify(allRoutes)}</script>
 
 <script src="/scripts/404.js" is:inline></script>
+
+<script is:inline>document.addEventListener("DOMContentLoaded",function(){plausible("404")})</script>

--- a/src/content/docs/404.mdx
+++ b/src/content/docs/404.mdx
@@ -90,5 +90,3 @@ import { allRoutes } from "virtual:esphome-route-index";
 <script id="esphome-404-routes" type="application/json" is:inline>{JSON.stringify(allRoutes)}</script>
 
 <script src="/scripts/404.js" is:inline></script>
-
-<script is:inline>document.addEventListener("DOMContentLoaded",function(){plausible("404")})</script>


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description
- Adds Plausible
- Adds relevant footer text
- Adds 404 page handler

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
