### PR TITLE
Add ESPHome Starter Kit stream banner

### DIFF
--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -21,6 +21,11 @@ hero:
       variant: minimal
 ---
 
+<div class="starter-kit-banner not-content">
+  <p class="starter-kit-banner__text">We're launching ESPHome's first official product: the ESPHome Starter Kit! Join us live Wednesday, Aug 12 at 9pm CEST.</p>
+  <a href="https://www.youtube.com/watch?v=aK2HMY9-Tzo" class="btn btn-primary starter-kit-banner__btn" target="_blank" rel="noopener noreferrer">Watch Live</a>
+</div>
+
 <div class="feature-grid not-content">
   <div class="feature-card">
     <div class="feature-text">No Coding Required</div>

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -148,6 +148,35 @@ dialog::backdrop {
   color: #fff;
 }
 
+/* Starter Kit launch banner */
+.starter-kit-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-bottom: 2.5rem;
+  padding: 1rem 1.5rem;
+  border: 1px solid var(--sl-color-accent);
+  border-radius: 8px;
+  background-color: var(--sl-color-accent-low);
+  text-align: left;
+}
+
+.starter-kit-banner__text {
+  margin: 0;
+  flex: 1 1 16rem;
+  font-weight: 500;
+  color: var(--sl-color-white);
+  text-align: left;
+}
+
+.starter-kit-banner__btn {
+  margin-top: 0;
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
 /* Sidebar nav item spacing */
 .sidebar-content ul li summary {
   padding-block: 0.5em;

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -200,6 +200,7 @@ dialog::backdrop {
   align-items: center;
   gap: 1rem;
 }
+
 /* Vertical rule separating the nav items from the social icons, matching the
    divider Starlight renders between the social icons and the theme picker. */
 .header-nav::after {
@@ -207,6 +208,7 @@ dialog::backdrop {
   height: 2rem;
   border-inline-end: 1px solid var(--sl-color-gray-5);
 }
+
 .header-nav-link {
   display: flex;
   align-items: center;
@@ -215,6 +217,7 @@ dialog::backdrop {
   text-decoration: none;
   white-space: nowrap;
 }
+
 .header-nav-link:hover {
   color: var(--sl-color-white);
 }


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description
TSIA

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
