### PR TITLE
[mitsubishi_cn105] Add vertical vane control action

### DIFF
--- a/src/content/docs/components/climate/mitsubishi_cn105.mdx
+++ b/src/content/docs/components/climate/mitsubishi_cn105.mdx
@@ -213,9 +213,24 @@ mitsubishi_cn105:
 The `mitsubishi_cn105.vane.control` action changes the vane direction. Its `id` must reference the top-level
 Mitsubishi CN105 hub. The currently supported setting is `vertical.direction`, which accepts `AUTO`, `1`, `2`, `3`,
 `4`, `5`, or `SWING`. It can also be a lambda returning one of the corresponding
-`VERTICAL_VANE_MODE_*` values.
+`VERTICAL_VANE_MODE_*` values. A lambda returning `VERTICAL_VANE_MODE_UNKNOWN` is ignored and does not change the
+vane direction.
 
-### Custom vertical vane select
+```yaml
+on_...:
+  - mitsubishi_cn105.vane.control:
+      id: hp
+      vertical:
+        direction: SWING
+```
+
+Configuration variables:
+
+- **id** (**Required**, ID): The ID of the top-level `mitsubishi_cn105` hub.
+- **vertical** (*Optional*): Vertical vane settings.
+  - **direction** (*Optional*, string, templatable): One of `AUTO`, `1`, `2`, `3`, `4`, `5`, or `SWING`.
+
+### Custom Vertical Vane Select
 
 This example maps a template select to the indoor unit's vertical vane positions. Add a `vane.on_state` automation,
 as shown above, if the select should also reflect changes made using the unit's remote control.

--- a/src/content/docs/components/climate/mitsubishi_cn105.mdx
+++ b/src/content/docs/components/climate/mitsubishi_cn105.mdx
@@ -169,10 +169,9 @@ defines the hub options on the `climate:` entry.
 
 ## `vane.on_state` Trigger
 
-The `vane.on_state` trigger runs whenever the Mitsubishi CN105 hub publishes a known vane state. This includes updates
-received from the indoor unit and changes requested through ESPHome. It does not run before the indoor unit has reported
-a valid vane direction. It is a snapshot trigger, not a change-only trigger, so it can run repeatedly when the vane
-direction has not changed.
+The `vane.on_state` trigger runs whenever the Mitsubishi CN105 hub publishes a vane state. This includes updates
+received from the indoor unit and changes requested through ESPHome. It is a snapshot trigger, not a change-only
+trigger, so it can run repeatedly when the vane direction has not changed.
 
 The trigger passes a `VaneState` value named `x` to lambdas. The current vertical vane direction is available as
 `x.vertical.direction` and can have one of these values:
@@ -184,6 +183,7 @@ The trigger passes a `VaneState` value named `x` to lambdas. The current vertica
 - `VERTICAL_VANE_MODE_POSITION_4`
 - `VERTICAL_VANE_MODE_POSITION_5`
 - `VERTICAL_VANE_MODE_SWING`
+- `VERTICAL_VANE_MODE_UNKNOWN`
 
 ```yaml
 mitsubishi_cn105:
@@ -199,10 +199,57 @@ mitsubishi_cn105:
             case VERTICAL_VANE_MODE_SWING:
               ESP_LOGI("vane", "Vertical vane is swinging");
               break;
+            case VERTICAL_VANE_MODE_UNKNOWN:
+              ESP_LOGW("vane", "Vertical vane direction is unknown");
+              break;
             default:
               ESP_LOGI("vane", "Vertical vane is in a fixed position");
               break;
           }
+```
+
+## `mitsubishi_cn105.vane.control` Action
+
+The `mitsubishi_cn105.vane.control` action changes the vane direction. Its `id` must reference the top-level
+Mitsubishi CN105 hub. The currently supported setting is `vertical.direction`, which accepts `AUTO`, `1`, `2`, `3`,
+`4`, `5`, or `SWING`. It can also be a lambda returning one of the corresponding
+`VERTICAL_VANE_MODE_*` values.
+
+### Custom vertical vane select
+
+This example maps a template select to the indoor unit's vertical vane positions. Add a `vane.on_state` automation,
+as shown above, if the select should also reflect changes made using the unit's remote control.
+
+```yaml
+mitsubishi_cn105:
+  id: hp
+  # ...
+
+select:
+  - platform: template
+    id: custom_vertical_vane
+    name: "Custom Vertical Vane"
+    optimistic: true
+    options:
+      - "↑↑"
+      - "↑"
+      - "—"
+      - "↓"
+      - "↓↓"
+      - "Swing"
+      - "Auto"
+    set_action:
+      - mitsubishi_cn105.vane.control:
+          id: hp
+          vertical:
+            direction: !lambda |-
+              if (x == "↑↑") return VERTICAL_VANE_MODE_POSITION_1;
+              if (x == "↑") return VERTICAL_VANE_MODE_POSITION_2;
+              if (x == "—") return VERTICAL_VANE_MODE_POSITION_3;
+              if (x == "↓") return VERTICAL_VANE_MODE_POSITION_4;
+              if (x == "↓↓") return VERTICAL_VANE_MODE_POSITION_5;
+              if (x == "Swing") return VERTICAL_VANE_MODE_SWING;
+              return VERTICAL_VANE_MODE_AUTO;
 ```
 
 ## Remote temperature actions


### PR DESCRIPTION
## Description

Adds `mitsubishi_cn105.vane.control` automation support for the Mitsubishi CN105 climate component.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#16737

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

