### PR TITLE
[internal_temperature] Note RP2350 support alongside RP2040

### DIFF
--- a/src/content/docs/components/sensor/internal_temperature.mdx
+++ b/src/content/docs/components/sensor/internal_temperature.mdx
@@ -1,5 +1,5 @@
 ---
-description: "Instructions for setting up the integrated temperature sensor of the ESP32, RP2040, BK72XX, nRF52 and LN882H."
+description: "Instructions for setting up the integrated temperature sensor of the ESP32, RP2040/RP2350, BK72XX, nRF52 and LN882H."
 title: "Internal Temperature Sensor"
 ---
 
@@ -7,7 +7,7 @@ import { Image } from 'astro:assets';
 import internalTemperatureUiImg from './images/internal_temperature-ui.png';
 
 The `internal_temperature` sensor platform allows you to use the integrated
-temperature sensor of the ESP32, RP2040, BK72XX, nRF52, and LN882H chips.
+temperature sensor of the ESP32, RP2040/RP2350, BK72XX, nRF52, and LN882H chips.
 
 > [!NOTE]
 > Some ESP32 variants return a large amount of invalid temperature


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

The Internal Temperature Sensor page described the component as supporting "RP2040", which predates the platform rename and understates what is supported. The component gates on `PLATFORM_RP2` (`cv.only_on([PLATFORM_ESP32, PLATFORM_RP2, PLATFORM_BK72XX, PLATFORM_NRF52, PLATFORM_LN882X])`) and its implementation file is `internal_temperature_rp2.cpp`, so the whole RP2 family is covered - RP2040 and RP2350.

Both sentences enumerate chips rather than platform keys, so this lists `RP2040/RP2350` rather than substituting the platform name. That matches how the rest of the docs phrase it in a chip list, e.g. `guides/understanding_boards.mdx` and `components/ethernet.mdx`.

Follows up on review feedback in esphome/esphome.io#7163.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
