### PR TITLE
[radon_eye_rd200] Document Raspberry Pi Pico W support

### DIFF
--- a/src/content/docs/components/sensor/radon_eye_ble.mdx
+++ b/src/content/docs/components/sensor/radon_eye_ble.mdx
@@ -10,6 +10,12 @@ The `radon_eye_rd200` sensor platforms lets you track the output of Radon Eye RD
 
 This component will track radon concentration.
 
+It connects through the [BLE Client](/components/ble_client/) component and runs on every platform
+with a BLE client engine: the ESP32 family with the
+[ESP32 BLE Tracker](/components/esp32_ble_tracker/), and the Raspberry Pi Pico W family
+(RP2040/RP2350) with the [RP2 BLE Tracker](/components/rp2_ble_tracker/). The examples below use
+the ESP32 tracker; on a Pico W replace `esp32_ble_tracker:` with `rp2_ble_tracker:`.
+
 ## Device Discovery
 
 RadonEye devices can be found using the `radon_eye_ble` ble scanner.
@@ -20,7 +26,7 @@ To find out your device's MAC address, add the following to your ESPHome configu
 logger:
   level: DEBUG # Required for the tracker to show the device
 
-esp32_ble_tracker:
+esp32_ble_tracker: # rp2_ble_tracker on a Pico W
 radon_eye_ble:
 ```
 


### PR DESCRIPTION
## Description:

Documents Raspberry Pi Pico W (RP2040/RP2350) support for the `radon_eye_rd200` sensor, which migrates onto the platform-neutral ble_client node interface in esphome/esphome#18325. The page gains a platform-support paragraph naming the tracker hub per platform; the examples stay ESP32-first with a one-line Pico W swap note (the YAML is otherwise identical). The `radon_eye_ble` discovery scanner already runs on the neutral listener base, so the discovery section only needed the same tracker note.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#18325

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.
